### PR TITLE
refactor polyglot text

### DIFF
--- a/example_device_models/device.minimal.json
+++ b/example_device_models/device.minimal.json
@@ -42,7 +42,9 @@
                     "type": "STRING"
                 },
                 "name": {
-                    "monoglot": "string example"
+                    "strings": {
+                        "en": "string example"
+                    }
                 },
                 "value": {
                     "string_value": "example"
@@ -54,13 +56,17 @@
                         "choices": [
                             {
                                 "name": {
-                                    "monoglot": "example_name"
+                                    "strings": {
+                                        "en": "example_name"
+                                    }
                                 },
                                 "value": "example"
                             },
                             {
                                 "name": {
-                                    "monoglot": "example_name2"
+                                    "strings": {
+                                        "en": "example_name2"
+                                    }
                                 },
                                 "value": "example2"
                             }
@@ -75,7 +81,9 @@
                     "type": "FLOAT32"
                 },
                 "name": {
-                    "monoglot": "Example Float Parameter"
+                    "strings": {
+                        "en": "Example Float Parameter"
+                    }
                 },
                 "value": {
                     "float32_value": 1.23
@@ -95,7 +103,9 @@
                     "type": "INT32"
                 },
                 "name": {
-                    "monoglot": "Example int32 Parameter"
+                    "strings": {
+                        "en": "Example int32 Parameter"
+                    }
                 },
                 "value": {
                     "int32_value": 123
@@ -106,13 +116,17 @@
                         "choices": [
                             {
                                 "name": {
-                                    "monoglot": "one"
+                                    "strings": {
+                                        "en": "one"
+                                    }
                                 },
                                 "value": 1
                             },
                             {
                                 "name": {
-                                    "monoglot": "two"
+                                    "strings": {
+                                        "en": "two"
+                                    }
                                 },
                                 "value": 2
                             }
@@ -127,7 +141,9 @@
                     "type": "INT32"
                 },
                 "name": {
-                    "monoglot": "Example int32 Parameter as alarm table"
+                    "strings": {
+                        "en": "Example int32 Parameter as alarm table"
+                    }
                 },
                 "value": {
                     "int32_value": 13
@@ -139,14 +155,18 @@
                             {
                                 "bit_value": 1,
                                 "description": {
-                                    "monoglot": "warning"
+                                    "strings": {
+                                        "en": "warning"
+                                    }
                                 },
                                 "severity": "WARNING"
                             },
                             {
                                 "bit_value": 3,
                                 "description": {
-                                    "monoglot": "severe"
+                                    "strings": {
+                                        "en": "severe"
+                                    }
                                 },
                                 "severity": "SEVERE"
                             }
@@ -161,7 +181,9 @@
                     "type": "INT32_ARRAY"
                 },
                 "name": {
-                    "monoglot": "The first few primes"
+                    "strings": {
+                        "en": "The first few primes"
+                    }
                 },
                 "value": {
                     "int32_array_values": {
@@ -184,7 +206,9 @@
                     "type": "STRING_ARRAY"
                 },
                 "name": {
-                    "monoglot": "The first few primes as strings"
+                    "strings": {
+                        "en": "The first few primes as strings"
+                    }
                 },
                 "value": {
                     "string_array_values": {
@@ -207,7 +231,9 @@
                     "type": "FLOAT32_ARRAY"
                 },
                 "name": {
-                    "monoglot": "The first few primes as float32"
+                    "strings": {
+                        "en": "The first few primes as float32"
+                    }
                 },
                 "value": {
                     "float32_array_values": {
@@ -230,7 +256,9 @@
                     "type": "STRUCT"
                 },
                 "name": {
-                    "monoglot": "Location"
+                    "strings": {    
+                        "en": "Location"
+                    }
                 },
                 "params": {
                     "latitude": {
@@ -239,7 +267,9 @@
                                 "type": "FLOAT32"
                             },
                             "name": {
-                                "monoglot": "Latitude"
+                                "strings": {
+                                    "en": "Latitude"
+                                }
                             },
                             "value": {
                                 "float32_value": 37.7749
@@ -252,7 +282,9 @@
                                 "type": "FLOAT32"
                             },
                             "name": {
-                                "monoglot": "Longitude"
+                                "strings": {
+                                    "en": "Longitude"
+                                }
                             },
                             "value": {
                                 "float32_value": -122.4194
@@ -284,7 +316,9 @@
                     "type": "STRUCT_ARRAY"
                 },
                 "name": {
-                    "monoglot": "Locations"
+                    "strings": {    
+                        "en": "Locations"
+                    }
                 },
                 "params": {
                     "latitude": {
@@ -293,7 +327,9 @@
                                 "type": "FLOAT32"
                             },
                             "name": {
-                                "monoglot": "Latitude"
+                                "strings": {
+                                    "en": "Latitude"
+                                }
                             },
                             "value": {
                                 "float32_value": 37.7749
@@ -306,7 +342,9 @@
                                 "type": "FLOAT32"
                             },
                             "name": {
-                                "monoglot": "Longitude"
+                                "strings": {
+                                    "en": "Longitude"
+                                }
                             },
                             "value": {
                                 "float32_value": -122.4194

--- a/example_device_models/polyglot_text.test.json
+++ b/example_device_models/polyglot_text.test.json
@@ -1,0 +1,9 @@
+{
+    "strings": {
+        "en": "Hello",
+        "es": "Hola",
+        "en-CA": "Eh?",
+        "$key": "greeting"
+    }
+
+}

--- a/interface/language.proto
+++ b/interface/language.proto
@@ -30,8 +30,8 @@ option optimize_for = CODE_SIZE;
  * in the same language.
  */
 message LanguagePack {
-  string name = 1;
-  map<string, string> words = 2;
+  string name = 1; // e.g. "Global Spanish"
+  map<string, string> words = 2; // e.g. "greeting" -> "Hola"
 }
 
 /* Language Packs
@@ -50,8 +50,7 @@ message LanguagePacks {
 /* PolyglotText
  * Text that a client can display in one of multiple languages.
  * The different options can either be defined in-line for each
- * instance of this message, or they can reference a LanguagePack,
- * or they can be defined as not having multi-language support.
+ * instance of this message, or they can reference a LanguagePack.
  *
  * When defined in-line, the keys shall be patterned on those defined at
  * https://www.mesaonline.org/language-metadata-table with "example"
@@ -62,26 +61,23 @@ message LanguagePacks {
  *    "en": "Hello",  // global English
  *    "es": "Hola",  // global Spanish
  *    "fr": "Bonjour", // global French
- *    "fr-CA": "Bonjour", // Canadian French
- * }
+ *    "en-CA": "Eh?", // Canadian English
+ * },
  *
- * And when defined by reference to a language pack the key property
+ * LanguagePack referencing example:
+ * {
+ *    "$key": "greeting"
+ * }
+ * 
+ *
+ * And when defined by reference to a language pack the $key value
  * is used to provide a look-up into the supported LanguagePack(s)
- * e.g. key = "greeting" could index to "Hello", "Hola" or "Bonjour"
+ * e.g. $key = "greeting" could index to "Hello", "Hola" or "Bonjour"
  * depending on which LanguagePack was active in the client.
  *
- * Neither the polyglot or key members need be used.
- *
- * The monoglot member is provided to allow use of this message type
- * without or before multi-language support being available. And use
- * of clients that do not provide multi-language support.
- * It should always be provided.
- * e.g. monoglot = "Hello"
  */
 message PolyglotText {
-  string monoglot = 1;             // Fallback for non-multilingual devices/clients
-  map<string, string> strings = 2; // In-line language definition
-  string key = 3;                  // Look up in a Language Pack
+  map<string, string> strings = 1; // In-line language definition
 }
 
 /* AddLanguagePayload

--- a/schema/catena.schema.json
+++ b/schema/catena.schema.json
@@ -1083,13 +1083,48 @@
             "description": "Text that a client can display in one of multiple languages",
             "type": "object",
             "properties": {
-                "monoglot": {
-                    "title": "Monoglot",
-                    "description": "Fallback for single-language devices",
+                "strings": {
+                    "type": "object",
+                    "anyOf": [
+                        {"$ref": "#/$defs/language_metadata_table"},
+                        {"$ref": "#/$defs/language_pack_reference"}
+                    ],
+                    "minProperties": 1
+                },
+                "additionalProperties": false
+            }
+        },
+        "language_metadata_table": {
+            "title": "Language Metadata Table",
+            "description": "A table of language codes",
+            "$comment": "The language codes must be valid Language Metadata Table language codes. The validation could be done as one super-long regex, but, for readabilty, we've split them into language groups.",
+            "type": "object",
+            "patternProperties": {
+                "^(en|en-AU|en-CA|en-HK|en-IE|en-MY)$": {
+                    "title": "English Language Group",
+                    "$comment": "@todo complete the regex",
+                    "type": "string"
+                },
+                "^(es|es-ES|es-AR|es-BO|es-CL|es-CO)$" : {
+                    "title": "Spanish Language Group",
+                    "$comment": "@todo complete the regex",
                     "type": "string"
                 }
             },
             "additionalProperties": false
+        },
+        "language_pack_reference": {
+            "title": "Language Pack Reference",
+            "description": "A key to look up text in a language pack",
+            "type": "object",
+            "properties": {
+                "$key": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "$key"
+            ]
         },
         "readonly": {
             "title": "Parameter access mode",
@@ -1156,13 +1191,15 @@
             "title": "Growth type to apply to INT32 and FLOAT32 range constraints",
             "description":
               "Growth type for range constraints defines how the 'step' field is interpreted.",
-            "type": {
-                "type": "string",
-                "enum": [
-                    "LINEAR",
-                    "EXPONENTIAL"
-                ],
-                "default": "LINEAR"
+              "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "LINEAR",
+                        "EXPONENTIAL"
+                    ],
+                    "default": "LINEAR"
+                }
             }
         }
     }

--- a/sdks/cpp/common/src/ParamAccessor.cpp
+++ b/sdks/cpp/common/src/ParamAccessor.cpp
@@ -108,27 +108,27 @@ std::string applyStringConstraint(catena::Param &param, std::string v) {
         int constraint_type = param.constraint().type();
 
         switch (constraint_type) {
-            case catena::Constraint_ConstraintType::Constraint_ConstraintType_STRING_CHOICE:
-                if (std::find_if(param.constraint().string_choice().choices().begin(),
-                                 param.constraint().string_choice().choices().end(),
-                                 [&](catena::PolyglotText const &c) { return c.monoglot() == v; }) ==
-                    param.constraint().string_choice().choices().end()) {
+            // case catena::Constraint_ConstraintType::Constraint_ConstraintType_STRING_CHOICE:
+            //     if (std::find_if(param.constraint().string_choice().choices().begin(),
+            //                      param.constraint().string_choice().choices().end(),
+            //                      [&](catena::PolyglotText const &c) { return c.monoglot() == v; }) ==
+            //         param.constraint().string_choice().choices().end()) {
 
-                    v = param.constraint().string_choice().choices(0).monoglot();
-                }
-                break;
-            case catena::Constraint_ConstraintType::Constraint_ConstraintType_STRING_STRING_CHOICE:
-                if (param.constraint().string_string_choice().strict()) {
-                    if (std::find_if(param.constraint().string_string_choice().choices().begin(),
-                                     param.constraint().string_string_choice().choices().end(),
-                                     [&](catena::StringStringChoiceConstraint_StringStringChoice const &c) {
-                                         return c.value() == v;
-                                     }) == param.constraint().string_string_choice().choices().end()) {
+            //         v = param.constraint().string_choice().choices(0).monoglot();
+            //     }
+            //     break;
+            // case catena::Constraint_ConstraintType::Constraint_ConstraintType_STRING_STRING_CHOICE:
+            //     if (param.constraint().string_string_choice().strict()) {
+            //         if (std::find_if(param.constraint().string_string_choice().choices().begin(),
+            //                          param.constraint().string_string_choice().choices().end(),
+            //                          [&](catena::StringStringChoiceConstraint_StringStringChoice const &c) {
+            //                              return c.value() == v;
+            //                          }) == param.constraint().string_string_choice().choices().end()) {
 
-                        v = param.constraint().string_string_choice().choices(0).value();
-                    }
-                }
-                break;
+            //             v = param.constraint().string_string_choice().choices(0).value();
+            //         }
+            //     }
+            //     break;
             default:
                 std::stringstream err;
                 err << "invalid constraint for string: " << constraint_type << '\n';


### PR DESCRIPTION
simplifies definition of the PolyglotText message to:

message PolyglotText {
  map<string, string> strings = 1; // In-line language definition
}


Some example JSON serializations that validate:

{
    "strings": {
        "en": "Hello",
        "es": "Hola",
        "en-CA": "Eh?",
        "$key": "greeting"
    }

}

The schemas enforce the use of language codes from the Language Metadata Table (SMPTE) using a divide & conquer approach so that a single, super-long, unmaintainable, unreadable regex is broken up into several shorter ones.

```
"polyglot_text": {
            "title": "Polyglot Text",
            "description": "Text that a client can display in one of multiple languages",
            "type": "object",
            "properties": {
                "strings": {
                    "type": "object",
                    "anyOf": [
                        {"$ref": "#/$defs/language_metadata_table"},
                        {"$ref": "#/$defs/language_pack_reference"}
                    ],
                    "minProperties": 1
                },
                "additionalProperties": false
            }
        },
        "language_metadata_table": {
            "title": "Language Metadata Table",
            "description": "A table of language codes",
            "$comment": "The language codes must be valid Language Metadata Table language codes. The validation could be done as one super-long regex, but, for readabilty, we've split them into language groups.",
            "type": "object",
            "patternProperties": {
                "^(en|en-AU|en-CA|en-HK|en-IE|en-MY)$": {
                    "title": "English Language Group",
                    "$comment": "@todo complete the regex",
                    "type": "string"
                },
                "^(es|es-ES|es-AR|es-BO|es-CL|es-CO)$" : {
                    "title": "Spanish Language Group",
                    "$comment": "@todo complete the regex",
                    "type": "string"
                }
            },
            "additionalProperties": false
        },
        "language_pack_reference": {
            "title": "Language Pack Reference",
            "description": "A key to look up text in a language pack",
            "type": "object",
            "properties": {
                "$key": {
                    "type": "string"
                }
            },
            "required": [
                "$key"
            ]
        },
```