### PR TITLE
add back support for setting values in full_service

### DIFF
--- a/sdks/cpp/common/examples/full_service/full_service.cpp
+++ b/sdks/cpp/common/examples/full_service/full_service.cpp
@@ -162,7 +162,7 @@ class CatenaServiceImpl final : public catena::CatenaService::Service {
         try {
             auto p = dm_.get().param(req->oid());
             authorize(context);
-            //p.setValue(req->value(), req->element_index());
+            p->setValue(req->value(), req->element_index());
             std::cout << "SetValue: " << req->oid() << ", " << req->element_index() << '\n';
             return Status::OK;
 

--- a/sdks/cpp/common/include/ParamAccessor.h
+++ b/sdks/cpp/common/include/ParamAccessor.h
@@ -127,10 +127,15 @@ class ParamAccessor {
     using VariantInfoGetter = catena::patterns::Functory<std::type_index, const VariantInfo&>;
 
     /**
-     * @brief type alias for the function that gets the Value from an array
+     * @brief type alias for the function that gets values from the device model for delivery to attached clients
      */
-    using ValueGetter = catena::patterns::Functory<catena::Value::KindCase, void, Value*, const catena::Value&, ParamIndex>;
+    using ValueGetter = catena::patterns::Functory<catena::Value::KindCase, void, Value*, const Value&, ParamIndex>;
 
+    /**
+     * @brief type alias for the function that sets values in the device model in response to client requests
+     */
+    using ValueSetter = catena::patterns::Functory<catena::Value::KindCase, void, Value&, const Value&, ParamIndex>;
+    
   public:
     /**
      * @brief Construct a new ParamAccessor object
@@ -451,6 +456,8 @@ const std::unique_ptr<ParamAccessor> subParam(const std::string& fieldName) cons
      * @param idx [in] index into the array, if set to kParamEnd, the entire array is returned
      */
     void getValue(Value *dst, [[maybe_unused]] ParamIndex idx) const; 
+
+    void setValue(const Value& src, [[maybe_unused]] ParamIndex idx);
 
   private:
     std::reference_wrapper<catena::DeviceModel> deviceModel_;


### PR DESCRIPTION
involved writing ParamAccessor::setValue(const Value& src, ParamIndex idx), and all the lambda functions, one for each supported data type.