### PR TITLE
Enforce scopes when running in secure mode with oauth

### DIFF
--- a/sdks/java/src/main/java/com/rossvideo/catena/device/impl/ParamManager.java
+++ b/sdks/java/src/main/java/com/rossvideo/catena/device/impl/ParamManager.java
@@ -38,6 +38,8 @@ public interface ParamManager
     }
     
     Param.Builder createOrGetParam(String oid);
+    
+    public Param.Builder getParam(String oid);
 
     public void clearParams();
 

--- a/sdks/java/src/main/java/com/rossvideo/catena/device/impl/params/BasicParamManager.java
+++ b/sdks/java/src/main/java/com/rossvideo/catena/device/impl/params/BasicParamManager.java
@@ -243,6 +243,44 @@ public class BasicParamManager implements ParamManager
         return existingBuilder;
     }
     
+    
+    
+    @Override
+    public Builder getParam(String oid)
+    {
+        if (uncommittedParams.containsKey(oid))
+        {
+            return uncommittedParams.get(oid);
+        }
+        
+        if (isTopLevel(oid))
+        {
+            Param p = deviceBuilder.getParamsOrDefault(oid, null);
+            if (p == null)
+            {
+                return null;
+            }
+            return p.toBuilder();
+        }
+        else
+        {
+            String[] parts = splitOid(oid);
+            PathToComponent path = pathToParam(parts, 0, null, false);
+            if (path == null)
+            {
+                return null;
+            }
+
+            Param p = path.getParam();
+            if (p == null)
+            {
+                return null;
+            }
+            
+            return p.toBuilder();
+        }
+    }
+
     @Override
     public Builder createOrGetParam(String oid)
     {

--- a/sdks/java/src/main/java/com/rossvideo/catena/example/device/MyCatenaDevice.java
+++ b/sdks/java/src/main/java/com/rossvideo/catena/example/device/MyCatenaDevice.java
@@ -71,7 +71,9 @@ public class MyCatenaDevice extends BasicCatenaDevice {
     }
     
     protected void init() {
-        super.init();        
+        super.init();
+        getDeviceBuilder().setAccessScopes(0, "monitor")
+        .setDefaultScope("monitor");
         buildMenus();
         buildParams();
         buildCommands();


### PR DESCRIPTION
Currently not stripping-out parameters of checking for a param scope up the hierarchy (only directly) but it is a starting point.