### PR TITLE
applies slightly different schema for template_oid vs type params

### DIFF
--- a/example_device_models/device.minimal.json
+++ b/example_device_models/device.minimal.json
@@ -89,6 +89,26 @@
       "oid_aliases": ["0xFF0E"],
       "value": { "string_value": "eo://custom_UI.grid" }
     },
+    "types": {
+      "type": "STRUCT",
+      "params": {
+        "string": {
+          "type": "STRING",
+          "name": {
+            "display_strings": {
+              "en": "String"
+            }
+          },
+          "value": {
+            "string_value": "Hello, World!"
+          }
+        }
+      }
+    },
+    "a_string": {
+      "template_oid": "/types/string",
+      "value":  {"string_value": "Goodbye, Cruel World!"}
+    },
     "a_number": {
       "type": "INT32",
       "name": {

--- a/schema/catena.schema.json
+++ b/schema/catena.schema.json
@@ -181,7 +181,7 @@
       "description": "When true, indicates that the parameter is part of the minimal set of parameters that should be reported by the device.",
       "type": "boolean"
     },
-    "param": {
+    "param_inner": {
       "title": "Parameter Descriptor",
       "description": "Defines the type, value, constraints, UI, access modes and configuration options of a parameter.",
       "type": "object",
@@ -246,41 +246,86 @@
         "stateless": {
           "$ref": "#/$defs/stateless"
         }
-      },
-      "required": ["type"],
-      "allOf": [
+      }
+    },
+    "param": {
+      "oneOf": [
         {
-          "$ref": "#/$defs/apply_float32"
+          "$ref": "#/$defs/param_inner",
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/apply_float32"
+            },
+            {
+              "$ref": "#/$defs/apply_int32"
+            },
+            {
+              "$ref": "#/$defs/apply_struct"
+            },
+            {
+              "$ref": "#/$defs/apply_string"
+            },
+            {
+              "$ref": "#/$defs/apply_int32_array"
+            },
+            {
+              "$ref": "#/$defs/apply_float32_array"
+            },
+            {
+              "$ref": "#/$defs/apply_string_array"
+            },
+            {
+              "$ref": "#/$defs/apply_struct_array"
+            },
+            {
+              "$ref": "#/$defs/apply_struct_variant"
+            },
+            {
+              "$ref": "#/$defs/apply_struct_variant_array"
+            }
+          ],
+          "additionalProperties": false
         },
         {
-          "$ref": "#/$defs/apply_int32"
-        },
-        {
-          "$ref": "#/$defs/apply_struct"
-        },
-        {
-          "$ref": "#/$defs/apply_string"
-        },
-        {
-          "$ref": "#/$defs/apply_int32_array"
-        },
-        {
-          "$ref": "#/$defs/apply_float32_array"
-        },
-        {
-          "$ref": "#/$defs/apply_string_array"
-        },
-        {
-          "$ref": "#/$defs/apply_struct_array"
-        },
-        {
-          "$ref": "#/$defs/apply_struct_variant"
-        },
-        {
-          "$ref": "#/$defs/apply_struct_variant_array"
+          "$ref": "#/$defs/param_inner",
+          "required": ["template_oid"],
+          "allOf": [{
+            "properties": {
+              "value": {
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/float32_value"
+                  },
+                  {
+                    "$ref": "#/$defs/int32_value"
+                  },
+                  {
+                    "$ref": "#/$defs/string_value"
+                  },
+                  {
+                    "$ref": "#/$defs/struct_value"
+                  },
+                  {
+                    "$ref": "#/$defs/int32_array_values"
+                  },
+                  {
+                    "$ref": "#/$defs/float32_array_values"
+                  },
+                  {
+                    "$ref": "#/$defs/string_array_values"
+                  },
+                  {
+                    "$ref": "#/$defs/struct_array_values"
+                  }
+                ]
+              },
+              "type": false
+            }
+          }],
+          "additionalProperties": false
         }
-      ],
-      "additionalProperties": false
+      ]
     },
     "template_oid": {
       "title": "Template Object ID",


### PR DESCRIPTION
fixes an issue with the json-schema where params with a template_oid would be flagged as errors because they didn't have a "type" field. Introduces two different schemas for params that are selected according to whether a type, or template_oid field is present. Note it does _not_ check of they both are, which would be an error/confusing. Also will produce misleading error message "missing type property" if the template_oid field is missing/misspelled.