### PR TITLE
templated_oid checks only happen once per param

### DIFF
--- a/example_device_models/device.one_of_everything.json
+++ b/example_device_models/device.one_of_everything.json
@@ -139,6 +139,18 @@
     },
     "template_oid_int_recursive_example": {
       "template_oid": "/ref_struct/num_2"
+    },
+    "nested_struct_layer_1": {
+      "type": "STRUCT",
+      "params": {
+        "nested_struct_layer_2": {
+          "template_oid": "/ref_struct"
+        },
+        "num_2": {
+          "template_oid": "/ref_int",
+          "name": { "display_strings": { "en": "Int Already Inside Struct Layer 1" } }
+        }
+      }
     }
   },
   "menu_groups": {

--- a/sdks/cpp/common/include/DeviceModel.h
+++ b/sdks/cpp/common/include/DeviceModel.h
@@ -187,11 +187,19 @@ class DeviceModel {
      * @param params the params to import into
      */
     void importSubParams_(std::filesystem::path &current_folder, ParamsMap &params);
+    
+    /**
+     * @brief fill sub-params with template data
+     *
+     * @param p [in-out] parent whose children are to be walked
+     * @param p_oid [in] oid of parent param
+     * */
+    void checkSubParamTemplates_(catena::Param &p, const std::string &p_oid);
 
     /**
      * @brief get template data from the device model
      *
-     * @param dst [out] destination for the data
+     * @param p [in-out] param to be copied into
      * @param path [in] template_oid to look up
      */
     void checkTemplateData_(catena::Param &p, const std::string &path);
@@ -200,6 +208,7 @@ class DeviceModel {
     catena::Device device_;                  /**< the protobuf device model */
     mutable Mutex mutex_;                    /**< used to mediate access */
     static catena::Value noValue_;           /**< to flag undefined values */
+    std::unordered_set<std::string> built_;  /**< params that have been built at least once */ 
 
   public:
 

--- a/sdks/cpp/common/include/DeviceModel.h
+++ b/sdks/cpp/common/include/DeviceModel.h
@@ -205,10 +205,10 @@ class DeviceModel {
     void checkTemplateData_(catena::Param &p, const std::string &path);
 
   private:
-    catena::Device device_;                  /**< the protobuf device model */
-    mutable Mutex mutex_;                    /**< used to mediate access */
-    static catena::Value noValue_;           /**< to flag undefined values */
-    std::unordered_set<std::string> built_;  /**< params that have been built at least once */ 
+    catena::Device device_;                    /**< the protobuf device model */
+    mutable Mutex mutex_;                      /**< used to mediate access */
+    static catena::Value noValue_;             /**< to flag undefined values */
+    std::unordered_set<std::string> accessed_; /**< params that have been built at least once */ 
 
   public:
 

--- a/sdks/cpp/common/src/DeviceModel.cpp
+++ b/sdks/cpp/common/src/DeviceModel.cpp
@@ -143,11 +143,11 @@ std::unique_ptr<ParamAccessor> catena::DeviceModel::param(const std::string &jpt
     // build the data needed to create the ParamAccessor
     catena::Param &p = device_.mutable_params()->at(oid);
     // put any one-time behaviour here
-    if (!built_.contains(oid)) {
+    if (!accessed_.contains(oid)) {
         // look for missing fields in the template
         checkTemplateData_(p, p.template_oid());
         checkSubParamTemplates_(p, oid);
-        built_.insert(oid); // mark this param as templated
+        accessed_.insert(oid); // mark this param as templated
     }
 
     ParamAccessorData pad;
@@ -178,7 +178,7 @@ void DeviceModel::checkSubParamTemplates_(catena::Param &p, const std::string &p
 
     for (auto &[child_oid, child_param] : *p.mutable_params()) {
         std::string qualified_child_oid = p_oid + "/" + child_oid;
-        if (built_.contains(qualified_child_oid)) {
+        if (accessed_.contains(qualified_child_oid)) {
             continue;
         }
         checkTemplateData_(child_param, child_param.template_oid());
@@ -189,7 +189,7 @@ void DeviceModel::checkSubParamTemplates_(catena::Param &p, const std::string &p
         field.mutable_value()->CopyFrom(child_param.value());
         p.mutable_value()->mutable_struct_value()->mutable_fields()->insert({child_oid, field});
         // if this subparam is ever retrieved alone, it will be considered built
-        built_.insert(qualified_child_oid); 
+        accessed_.insert(qualified_child_oid); 
     }
 }
 


### PR DESCRIPTION
use an unordered set to store oids of params that have been accessed at least once from the device model. This avoids copying from template_oids and building sub-params every time the param is checked. Additionally sub-param checks for building a param the first time now go through infinite levels of nesting.