### PR TITLE
Lite start here

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,17 @@
 {
     "version": "0.2.0",
     "configurations": [
-
+      {
+        "type": "cppdbg",
+        "name": "Debug start_here with lldb",
+        "request": "launch",
+        "program": "${workspaceFolder}/sdks/cpp/build/lite/examples/start_here/start_here",
+        "args": [],
+        "cwd": "${workspaceFolder}/sdks/cpp/build",
+        "preLaunchTask": "",
+        "externalConsole": true,
+        "MIMode": "lldb"
+      },
       {
         "type": "cppdbg",
         "name": "Debug Full Service with lldb",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,13 +10,15 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}/sdks/cpp/build",
         "${env:HOME}/.local/include",
-        "${workspaceFolder}/sdks/cpp/common/include"
+        "${workspaceFolder}/sdks/cpp/common/include",
+        "${workspaceFolder}/sdks/cpp"
     ],
     "json.schemas": [
         {
             "fileMatch": [
                 "/example_device_models/device.*.json",
-                "/nab_2024/device.*.json"
+                "/nab_2024/device.*.json",
+                "/sdks/cpp/lite/examples/start_here/device.*.json"
             ],
             "url": "./schema/catena.schema.json"
         }
@@ -85,6 +87,7 @@
         "unordered_set": "cpp",
         "variant": "cpp",
         "vector": "cpp",
-        "algorithm": "cpp"
+        "algorithm": "cpp",
+        "forward_list": "cpp"
     }
 }

--- a/schema/catena.schema.json
+++ b/schema/catena.schema.json
@@ -246,7 +246,8 @@
         "stateless": {
           "$ref": "#/$defs/stateless"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "param": {
       "oneOf": [
@@ -284,8 +285,7 @@
             {
               "$ref": "#/$defs/apply_struct_variant_array"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         {
           "$ref": "#/$defs/param_inner",
@@ -322,8 +322,7 @@
               },
               "type": false
             }
-          }],
-          "additionalProperties": false
+          }]
         }
       ]
     },

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@
 #
 
 cmake_minimum_required(VERSION 3.20)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "14.5" CACHE STRING "Minimum OS X deployment version")
 
 project(CATENA_CPP_SDK VERSION 0.0.1 LANGUAGES C CXX)
 
@@ -54,6 +55,7 @@ if (APPLE)
   # set up for MacOS
   set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
   set(CMAKE_OSX_FRAMEWORK_PATH "${CMAKE_OSX_SYSROOT}/System/Library/Frameworks")
+
   set(CPP_OPTS -E -x c -P)
 endif (APPLE)
 

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -57,6 +57,11 @@ if (APPLE)
   set(CPP_OPTS -E -x c -P)
 endif (APPLE)
 
+get_filename_component(CATENA_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../.. ABSOLUTE)
+set(CATENA_CPP_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+message(STATUS "CATENA_ROOT_DIR: ${CATENA_ROOT_DIR}")
+message(STATUS "CATENA_CPP_ROOT_DIR: ${CATENA_CPP_ROOT_DIR}")
+
 # Find Protobuf installation
 # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
 set(protobuf_MODULE_COMPATIBLE TRUE)
@@ -197,6 +202,9 @@ add_custom_target(clean-proto
 
 # include the common part of the Catena C++ SDK
 add_subdirectory("common")
+
+#include the lite part of the Catena C++ SDK
+add_subdirectory("lite")
 
 # doxygen
 #

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -59,8 +59,7 @@ endif (APPLE)
 
 get_filename_component(CATENA_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../.. ABSOLUTE)
 set(CATENA_CPP_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-message(STATUS "CATENA_ROOT_DIR: ${CATENA_ROOT_DIR}")
-message(STATUS "CATENA_CPP_ROOT_DIR: ${CATENA_CPP_ROOT_DIR}")
+set(GRPC_INSTALL_INCLUDE_DIR "$ENV{HOME}/.local/include")
 
 # Find Protobuf installation
 # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
@@ -175,7 +174,7 @@ foreach(_model ${CATENA_MODELS})
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${_model}"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${_model}"
   )
-  target_include_directories(${libtarget} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/${model} "~/.local/include")
+  target_include_directories(${libtarget} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/${model} ${GRPC_INSTALL_INCLUDE_DIR})
   target_compile_features(${libtarget} PUBLIC cxx_std_20)
   
 

--- a/sdks/cpp/common/CMakeLists.txt
+++ b/sdks/cpp/common/CMakeLists.txt
@@ -26,7 +26,7 @@ endif(APPLE)
 
 set(target catena_common)
 
-set(sources "src/utils.cpp" "src/vdk/signals.cpp")
+set(sources "src/utils.cpp" "src/vdk/signals.cpp" "src/Path.cpp")
 add_library(${target} STATIC ${sources})
 
 target_include_directories(

--- a/sdks/cpp/common/CMakeLists.txt
+++ b/sdks/cpp/common/CMakeLists.txt
@@ -32,10 +32,12 @@ add_library(${target} STATIC ${sources})
 target_include_directories(
     ${target}
     PUBLIC
+        $<BUILD_INTERFACE:${CATENA_CPP_ROOT_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/vdk>
         $<BUILD_INTERFACE:${CMAKE_PREFIX_PATH}>
 )
+message(STATUS "CMAKE_CPP_ROOT_DIR: ${CMAKE_CPP_ROOT_DIR}")
 target_compile_features(${target} PUBLIC cxx_std_20)
 
 add_subdirectory(examples)

--- a/sdks/cpp/common/include/Path.h
+++ b/sdks/cpp/common/include/Path.h
@@ -33,7 +33,7 @@
 #include <memory>
 
 namespace catena {
-namespace full {
+namespace common {
 /**
  * @brief Handles Path objects used to uniquely identify and access OIDs
  *
@@ -167,4 +167,4 @@ class Path {
 }  // namespace full
 }  // namespace catena
 
-std::unique_ptr<catena::full::Path> operator"" _path(const char* lit, std::size_t sz);
+std::unique_ptr<catena::common::Path> operator"" _path(const char* lit, std::size_t sz);

--- a/sdks/cpp/common/include/Path.h
+++ b/sdks/cpp/common/include/Path.h
@@ -167,4 +167,4 @@ class Path {
 }  // namespace full
 }  // namespace catena
 
-std::unique_ptr<catena::common::Path> operator"" _path(const char* lit, std::size_t sz);
+catena::common::Path operator"" _path(const char* lit, std::size_t sz);

--- a/sdks/cpp/common/src/Path.cpp
+++ b/sdks/cpp/common/src/Path.cpp
@@ -12,9 +12,9 @@
 // limitations under the License.
 //
 
-#include <Path.h>
-#include <utils.h>
-#include <Status.h>
+#include <common/include/Path.h>
+#include <common/include/utils.h>
+#include <common/include/Status.h>
 
 #include <regex>
 
@@ -114,6 +114,6 @@ std::string Path::fqoid() {
     return ans.str();
 }
 
-std::unique_ptr<Path> operator"" _path(const char *lit, std::size_t sz) {
-    return std::make_unique<Path>(lit);
+Path operator"" _path(const char *lit, std::size_t sz) {
+    return Path(lit);
 }

--- a/sdks/cpp/common/src/Path.cpp
+++ b/sdks/cpp/common/src/Path.cpp
@@ -18,7 +18,7 @@
 
 #include <regex>
 
-using Path;
+using catena::common::Path;
 
 Path::Path(const std::string &path) : segments_{} {
     // regex will split a well-formed json pointer into a sequence of strings

--- a/sdks/cpp/lite/CMakeLists.txt
+++ b/sdks/cpp/lite/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright © 2023 Ross Video Ltd
+#
+# Licensed under the Creative Commons Attribution NoDerivatives 4.0 International Licensing (CC-BY-ND-4.0);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#  https://creativecommons.org/licenses/by-nd/4.0/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for C++ SDKs and examples.
+#
+#
+# Copyright © 2023 Ross Video Ltd
+#
+# Licensed under the Creative Commons Attribution NoDerivatives 4.0 International Licensing (CC-BY-ND-4.0);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#  https://creativecommons.org/licenses/by-nd/4.0/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for C++ SDKs and examples.
+#
+#
+
+cmake_minimum_required(VERSION 3.20)
+
+project(LITE C CXX)
+
+if(APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -F${CMAKE_OSX_SYSROOT}/System/Library/Frameworks")
+endif(APPLE)
+
+
+set(target catena_lite)
+
+add_library(${target} STATIC 
+    src/DeviceModel.cpp
+    src/Param.cpp
+)
+
+add_dependencies(${target} catena_common)
+
+target_include_directories(
+    ${target}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CATENA_CPP_ROOT_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_PREFIX_PATH}>
+)
+
+target_compile_features(${target} PUBLIC cxx_std_20)
+
+add_subdirectory(examples)
+

--- a/sdks/cpp/lite/CMakeLists.txt
+++ b/sdks/cpp/lite/CMakeLists.txt
@@ -57,6 +57,8 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CATENA_CPP_ROOT_DIR}>
         $<BUILD_INTERFACE:${CMAKE_PREFIX_PATH}>
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+        $<BUILD_INTERFACE:${GRPC_INSTALL_INCLUDE_DIR}>
 )
 
 target_compile_features(${target} PUBLIC cxx_std_20)

--- a/sdks/cpp/lite/examples/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright © 2023 Ross Video Ltd
+#
+# Licensed under the Creative Commons Attribution NoDerivatives 4.0 International Licensing (CC-BY-ND-4.0);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#  https://creativecommons.org/licenses/by-nd/4.0/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for Catena C++ examples.
+#
+#
+
+cmake_minimum_required(VERSION 3.20)
+
+project(CATENA_LITE_EXAMPLES C CXX)
+
+add_subdirectory("start_here")
+
+
+
+

--- a/sdks/cpp/lite/examples/start_here/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/start_here/CMakeLists.txt
@@ -26,8 +26,8 @@ project(${TARGET} C CXX)
 add_executable(${TARGET})
 
 # set up some directory names
-set(HEADER device.start_here.json.h)
-set(BODY device.start_here.json.cpp)
+set(HEADER device.${TARGET}.json.h)
+set(BODY device.${TARGET}.json.cpp)
 get_filename_component(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} ABSOLUTE)
 set(CATENA_COMMON_INCLUDE ${CATENA_CPP_ROOT_DIR}/common/include)
 set(CATENA_LITE_INCLUDE ${CATENA_CPP_ROOT_DIR}/lite/include)
@@ -40,17 +40,17 @@ set(CODEGEN_OUTPUT ${HEADER} ${BODY})
 
 
 # convert json to cpp
-
+set(HEADER device.${TARGET}.json.h)
+set(BODY device.${TARGET}.json.cpp)
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${HEADER}
-           ${CMAKE_CURRENT_BINARY_DIR}/{${BODY}}
+           ${CMAKE_CURRENT_BINARY_DIR}/${BODY}
     COMMAND node ${CODEGEN} --schema ${SCHEMA} --device-model "${DEVICE_MODEL_JSON}" --output ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${DEVICE_MODEL_JSON} ${SCHEMA} ${CODEGEN}
-    COMMENT "Generating device.start_here.h and device.start_here.cpp"
+    COMMENT "Generating ${HEADER} and ${BODY} from ${DEVICE_MODEL_JSON} and ${SCHEMA} using ${CODEGEN}"
 )
 
-set(HEADER device.start_here.json.h)
-set(BODY device.start_here.json.cpp)
+
 
 # Step 2: Create a custom target that depends on the output of the custom command
 add_custom_target(${TARGET}_codegen
@@ -70,14 +70,14 @@ message(STATUS "GRP_INSTALL_INCLUDE_DIR: ${GRPC_INSTALL_INCLUDE_DIR}")
 target_sources(${TARGET}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${BODY}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TARGET}.cpp>
-        
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TARGET}.cpp>      
 )
 
 add_dependencies(${TARGET} ${TARGET}_codegen)
 
 target_link_libraries(${TARGET}
     ${LIB_TARGET}
+    catena_common
     catena_lite
     catena_lite_grpc
 )

--- a/sdks/cpp/lite/examples/start_here/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/start_here/CMakeLists.txt
@@ -1,0 +1,88 @@
+# Copyright © 2024 Ross Video Ltd
+#
+# Licensed under the Creative Commons Attribution NoDerivatives 4.0 International Licensing (CC-BY-ND-4.0);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#  https://creativecommons.org/licenses/by-nd/4.0/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for the read_model_from_file example.
+#
+#
+
+cmake_minimum_required(VERSION 3.20)
+
+
+
+get_filename_component(TARGET ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${TARGET} C CXX)
+
+add_executable(${TARGET})
+
+# set up some directory names
+set(HEADER device.start_here.json.h)
+set(BODY device.start_here.json.cpp)
+get_filename_component(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} ABSOLUTE)
+set(CATENA_COMMON_INCLUDE ${CATENA_CPP_ROOT_DIR}/common/include)
+set(CATENA_LITE_INCLUDE ${CATENA_CPP_ROOT_DIR}/lite/include)
+set(DEVICE_MODEL_JSON ${CMAKE_CURRENT_SOURCE_DIR}/device.${TARGET}.json)
+set(TOOLS_DIR ${CATENA_ROOT_DIR}/tools)
+set(CODEGEN ${TOOLS_DIR}/codegen/index.js)
+set(SCHEMA_DIR ${CATENA_ROOT_DIR}/schema)
+set(SCHEMA ${SCHEMA_DIR}/catena.schema.json)
+set(CODEGEN_OUTPUT ${HEADER} ${BODY})
+
+
+# convert json to cpp
+
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${HEADER}
+           ${CMAKE_CURRENT_BINARY_DIR}/{${BODY}}
+    COMMAND node ${CODEGEN} --schema ${SCHEMA} --device-model "${DEVICE_MODEL_JSON}" --output ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${DEVICE_MODEL_JSON} ${SCHEMA} ${CODEGEN}
+    COMMENT "Generating device.start_here.h and device.start_here.cpp"
+)
+
+set(HEADER device.start_here.json.h)
+set(BODY device.start_here.json.cpp)
+
+# Step 2: Create a custom target that depends on the output of the custom command
+add_custom_target(${TARGET}_codegen
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${HEADER} ${CMAKE_CURRENT_BINARY_DIR}/${BODY}
+)
+
+set_source_files_properties(${CODEGEN_OUTPUT} PROPERTIES GENERATED TRUE)
+target_include_directories(${TARGET}
+    PUBLIC
+        $<BUILD_INTERFACE:${CATENA_COMMON_INCLUDE}>
+        $<BUILD_INTERFACE:${PARENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_PREFIX_PATH}>
+)
+
+target_sources(${TARGET}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${BODY}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TARGET}.cpp>
+        
+)
+
+add_dependencies(${TARGET} ${TARGET}_codegen)
+
+target_link_libraries(${TARGET}
+    ${LIB_TARGET}
+    catena_lite
+)
+
+target_compile_features(${TARGET}
+    PUBLIC
+        cxx_std_20
+)
+
+
+

--- a/sdks/cpp/lite/examples/start_here/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/start_here/CMakeLists.txt
@@ -63,7 +63,9 @@ target_include_directories(${TARGET}
         $<BUILD_INTERFACE:${CATENA_COMMON_INCLUDE}>
         $<BUILD_INTERFACE:${PARENT_BINARY_DIR}>
         $<BUILD_INTERFACE:${CMAKE_PREFIX_PATH}>
+        $<BUILD_INTERFACE:${GRPC_INSTALL_INCLUDE_DIR}>
 )
+message(STATUS "GRP_INSTALL_INCLUDE_DIR: ${GRPC_INSTALL_INCLUDE_DIR}")
 
 target_sources(${TARGET}
     PUBLIC
@@ -77,6 +79,7 @@ add_dependencies(${TARGET} ${TARGET}_codegen)
 target_link_libraries(${TARGET}
     ${LIB_TARGET}
     catena_lite
+    catena_lite_grpc
 )
 
 target_compile_features(${TARGET}

--- a/sdks/cpp/lite/examples/start_here/device.start_here.json
+++ b/sdks/cpp/lite/examples/start_here/device.start_here.json
@@ -32,8 +32,8 @@
     "params": {
         "hello": {
             "type": "STRING",
-            "value": { "string_value": "Hello, World!" },
-            "name": {"display_strings": {"$key": "greeting"}}
+            "name": {"display_strings": {"$key": "greeting"}},
+            "value": {"string_value": "Hello, World!"}
         }
     }
 }

--- a/sdks/cpp/lite/examples/start_here/device.start_here.json
+++ b/sdks/cpp/lite/examples/start_here/device.start_here.json
@@ -1,0 +1,39 @@
+{
+    "slot": 1,
+    "multi_set_enabled": true,
+    "detail_level": "FULL",
+    "access_scopes": ["monitor", "operate", "configure", "administer"],
+    "default_scope": "operate",
+    "language_packs": {
+      "packs": {
+        "es": {
+          "name": "Spanish",
+          "words": {
+            "greeting": "Hola",
+            "parting": "Adiós"
+          }
+        },
+        "en": {
+          "name": "English",
+          "words": {
+            "greeting": "Hello",
+            "parting": "Goodbye"
+          }
+        },
+        "fr": {
+          "name": "French",
+          "words": {
+            "greeting": "Bonjour",
+            "parting": "Adieu"
+          }
+        }
+      }
+    },
+    "params": {
+        "hello": {
+            "type": "STRING",
+            "value": { "string_value": "Hello, World!" },
+            "name": {"display_strings": {"$key": "greeting"}}
+        }
+    }
+}

--- a/sdks/cpp/lite/examples/start_here/start_here.cpp
+++ b/sdks/cpp/lite/examples/start_here/start_here.cpp
@@ -50,8 +50,7 @@ int main () {
     // because we designed the device model, we know it contains a parameter, hello
     // and we also know its value type - std::string
     // so we can get a reference to its Param object
-    Path helloPath("/hello");
-    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.GetParam(helloPath));
+    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.GetParam("/hello"));
 
     // With the Param object we can get a reference to the parameter's value object
     std::string& helloValue = helloParam.Get();

--- a/sdks/cpp/lite/examples/start_here/start_here.cpp
+++ b/sdks/cpp/lite/examples/start_here/start_here.cpp
@@ -1,0 +1,46 @@
+// Licensed under the Creative Commons Attribution NoDerivatives 4.0
+// International Licensing (CC-BY-ND-4.0);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// https://creativecommons.org/licenses/by-nd/4.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * @file start_here.cpp
+ * @author john.naylor@rossvideo.com
+ * @brief Demonstrates how to create a trivially simple device model
+ * and access a parameter within it from your business logic.
+ */
+
+#include "build/lite/examples/start_here/device.start_here.json.h"
+#include <lite/include/DeviceModel.h>
+#include <lite/include/Param.h>
+
+using namespace catena::lite;
+#include <iostream>
+int main () {
+    // because we designed the device model, we know it contains a parameter, hello
+    // and we also know its type - std::string
+    // so we can get a reference to it
+    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.GetParam("hello"));
+
+    // and we can get a reference to the parameter's value
+    std::string& helloValue = helloParam.Get();
+
+    // and then read it, directly - which is nice and simple but prone to race conditions
+    // if more than one thread is accessing the value
+    std::cout << helloValue << std::endl;
+
+    // and we can change the value - with the same caveat as race conditions
+    helloValue = "Goodbye, Cruel World!";
+    std::cout << helloValue << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/sdks/cpp/lite/examples/start_here/start_here.cpp
+++ b/sdks/cpp/lite/examples/start_here/start_here.cpp
@@ -17,36 +17,57 @@
  * @author john.naylor@rossvideo.com
  * @brief Demonstrates how to create a trivially simple device model
  * and access a parameter within it from your business logic.
+ * 
+ * It does not support any connections so is not a complete example
+ * of a working device.
  */
 
-#include "build/lite/examples/start_here/device.start_here.json.h"
-#include <lite/include/DeviceModel.h>
-#include <lite/include/Param.h>
-#include <lite/param.pb.h>
+// this include header was generated from the json device model
+// it's in the BINARY folder structure, not SOURCE.
+#include "lite/examples/start_here/device.start_here.json.h" // dm
+
+// these includes are from the LITE SDK, they're in the SOURCE
+// folder structure.
+#include <lite/include/DeviceModel.h> // catena::lite::DeviceModel, LockGuard
+#include <lite/include/Param.h> // catena::lite::Param
+
+// this include header was generated from the protobuf definition
+// it's in the BINARY folder structure, not SOURCE.
+#include <lite/param.pb.h> // catena::Value
 
 using namespace catena::lite;
+using namespace catena::common;
 #include <iostream>
 int main () {
-    // because we designed the device model, we know it contains a parameter, hello
-    // and we also know its type - std::string
-    // so we can get a reference to it
-    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.GetParam("hello"));
+    // The client code, below, directly accesses parts of the device model
+    // so we assert a lock on the device model's mutex to ensure threadsafe 
+    // behaviour. This is a simple example, and in a real-world application
+    // client code should strive to a) use locks like this, b) assert them
+    // for the shortest possible time, c) avoid deadlock using DeviceModel 
+    // methods that try to assert the its mutex (deadlock).
+    DeviceModel::LockGuard lg(dm); 
 
-    // and we can get a reference to the parameter's value
+    // because we designed the device model, we know it contains a parameter, hello
+    // and we also know its value type - std::string
+    // so we can get a reference to its Param object
+    Path helloPath("/hello");
+    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.GetParam(helloPath));
+
+    // With the Param object we can get a reference to the parameter's value object
     std::string& helloValue = helloParam.Get();
 
-    // and then read it, directly - which is nice and simple but prone to race conditions
-    // if more than one thread is accessing the value
+    // and then read it, directly - which is simple and should be performant
+    // The assertion of the lock, above is essential to thread safety because
+    // asynchronous access by connected client will also change the Device Model's 
+    // state.
     std::cout << helloValue << std::endl;
 
-    // and we can change the value - with the same caveat as race conditions
+    // and we can change the value
     helloValue = "Goodbye, Cruel World!";
     std::cout << helloValue << std::endl;
 
-    // for grins, lets serialize to a catena::Value
-    // this wouldn't be in the business logic, but in the gRPC service implementation
-    catena::Value value{};
-    helloParam.serialize(value);
-
     return EXIT_SUCCESS;
+
+    // The DeviceModel::LockGuard object will automatically release the lock
+    // upon its destruction, when it goes out of scope here.
 }

--- a/sdks/cpp/lite/examples/start_here/start_here.cpp
+++ b/sdks/cpp/lite/examples/start_here/start_here.cpp
@@ -22,6 +22,7 @@
 #include "build/lite/examples/start_here/device.start_here.json.h"
 #include <lite/include/DeviceModel.h>
 #include <lite/include/Param.h>
+#include <lite/param.pb.h>
 
 using namespace catena::lite;
 #include <iostream>
@@ -41,6 +42,11 @@ int main () {
     // and we can change the value - with the same caveat as race conditions
     helloValue = "Goodbye, Cruel World!";
     std::cout << helloValue << std::endl;
+
+    // for grins, lets serialize to a catena::Value
+    // this wouldn't be in the business logic, but in the gRPC service implementation
+    catena::Value value{};
+    helloParam.serialize(value);
 
     return EXIT_SUCCESS;
 }

--- a/sdks/cpp/lite/include/DeviceModel.h
+++ b/sdks/cpp/lite/include/DeviceModel.h
@@ -1,0 +1,24 @@
+#pragma once
+
+
+#include <unordered_map>
+#include <string>
+
+
+namespace catena {
+namespace lite {
+class IParam;  // forward reference
+class DeviceModel {
+  public:
+    DeviceModel() = default;
+    virtual ~DeviceModel() = default;
+
+    void AddParam(const std::string& name, IParam* param);
+
+    IParam* GetParam(const std::string& name);
+
+  private:
+    std::unordered_map<std::string, IParam*> params_;
+};
+}  // namespace lite
+}  // namespace catena

--- a/sdks/cpp/lite/include/DeviceModel.h
+++ b/sdks/cpp/lite/include/DeviceModel.h
@@ -33,6 +33,8 @@ class DeviceModel {
 
     IParam* GetParam(catena::common::Path& path);
 
+    IParam* GetParam(const std::string& name);
+
   private:
     std::unordered_map<std::string, IParam*> params_;
     mutable std::mutex mutex_;

--- a/sdks/cpp/lite/include/DeviceModel.h
+++ b/sdks/cpp/lite/include/DeviceModel.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <common/include/Path.h>
 
 #include <unordered_map>
 #include <string>
+#include <mutex>
 
 
 namespace catena {
@@ -10,15 +12,30 @@ namespace lite {
 class IParam;  // forward reference
 class DeviceModel {
   public:
+    class LockGuard {
+      public:
+        LockGuard(DeviceModel& dm) : dm_(dm) {
+          dm_.mutex_.lock();
+        }
+        ~LockGuard() {
+          dm_.mutex_.unlock();
+        }
+      private:
+        DeviceModel& dm_;
+    };
+  friend class LockGuard;
+
+  public:
     DeviceModel() = default;
     virtual ~DeviceModel() = default;
 
     void AddParam(const std::string& name, IParam* param);
 
-    IParam* GetParam(const std::string& name);
+    IParam* GetParam(catena::common::Path& path);
 
   private:
     std::unordered_map<std::string, IParam*> params_;
+    mutable std::mutex mutex_;
 };
 }  // namespace lite
 }  // namespace catena

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace catena {
+namespace lite {
+class IParam {
+  public:
+    IParam() = default;
+    IParam(IParam&&) = default;
+    IParam& operator=(IParam&&) = default;
+    virtual ~IParam() = default;
+};
+}  // namespace lite
+}  // namespace catena

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -1,6 +1,7 @@
 #pragma once
 
 namespace catena {
+class Value; // forward reference
 namespace lite {
 class IParam {
   public:
@@ -8,6 +9,11 @@ class IParam {
     IParam(IParam&&) = default;
     IParam& operator=(IParam&&) = default;
     virtual ~IParam() = default;
+
+    /**
+     * @brief serialize the parameter value to protobuf
+     */
+    virtual void serialize(catena::Value& value) const = 0;
 };
 }  // namespace lite
 }  // namespace catena

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <lite/include/IParam.h>
+#include <lite/include/DeviceModel.h>
+
+#include <functional> // reference_wrapper
+
+namespace catena {
+namespace lite {
+
+/**
+ * @brief Param provides convenient access to parameter values
+ * @tparam T the parameter's value type
+ */
+template <typename T> class Param : public IParam {
+  public:
+    /**
+     * @brief Param does not have a default constructor
+     */
+    Param() = delete;
+
+    /**
+     * @brief Param does not have copy semantics
+     */
+    Param(T& value) = delete;
+
+    /**
+     * @brief Param does not have copy semantics
+     */
+    T& operator=(const T& value) = delete;
+
+    /**
+     * @brief Param has move semantics
+     */
+    Param(Param&& value) = default;
+
+    /**
+     * @brief Param has move semantics
+     */
+    Param& operator=(Param&& value) = default;
+
+    /**
+     * @brief default destructor
+     */
+    virtual ~Param() = default;
+
+    /**
+     * @brief the main constructor
+     */
+    Param(T& value, const std::string& name, DeviceModel& dm) : IParam(), value_(value), dm_(dm) {
+        dm.AddParam(name, this);
+    }
+
+    /**
+     * @brief get the value of the parameter
+     */
+    T& Get() { return value_.get(); }
+
+  private:
+    std::reference_wrapper<T> value_;
+    std::reference_wrapper<DeviceModel> dm_;
+};
+}  // namespace lite
+}  // namespace catena

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -56,6 +56,11 @@ template <typename T> class Param : public IParam {
      */
     T& Get() { return value_.get(); }
 
+    /**
+     * @brief serialize the parameter value to protobuf
+     */
+    void serialize(catena::Value& value) const override;
+
   private:
     std::reference_wrapper<T> value_;
     std::reference_wrapper<DeviceModel> dm_;

--- a/sdks/cpp/lite/src/DeviceModel.cpp
+++ b/sdks/cpp/lite/src/DeviceModel.cpp
@@ -1,12 +1,18 @@
 #include <lite/include/DeviceModel.h>
 #include <lite/include/IParam.h>
 
+#include <cassert>
+
 using namespace catena::lite;
+using namespace catena::common;
 
 void DeviceModel::AddParam(const std::string& name, IParam* param) {
     params_[name] = param;
 }
 
-IParam* DeviceModel::GetParam(const std::string& name) {
-    return params_[name];
+IParam* DeviceModel::GetParam(Path& path)  {
+    const Path::Segment& name = path.front();
+    assert(std::holds_alternative<std::string>(name));
+    
+    return params_[std::get<std::string>(name)];
 }

--- a/sdks/cpp/lite/src/DeviceModel.cpp
+++ b/sdks/cpp/lite/src/DeviceModel.cpp
@@ -16,3 +16,8 @@ IParam* DeviceModel::GetParam(Path& path)  {
     
     return params_[std::get<std::string>(name)];
 }
+
+IParam* DeviceModel::GetParam(const std::string& name)  {
+    Path path(name);
+    return GetParam(path);
+}

--- a/sdks/cpp/lite/src/DeviceModel.cpp
+++ b/sdks/cpp/lite/src/DeviceModel.cpp
@@ -1,0 +1,12 @@
+#include <lite/include/DeviceModel.h>
+#include <lite/include/IParam.h>
+
+using namespace catena::lite;
+
+void DeviceModel::AddParam(const std::string& name, IParam* param) {
+    params_[name] = param;
+}
+
+IParam* DeviceModel::GetParam(const std::string& name) {
+    return params_[name];
+}

--- a/sdks/cpp/lite/src/Param.cpp
+++ b/sdks/cpp/lite/src/Param.cpp
@@ -1,0 +1,10 @@
+#include <lite/include/Param.h>
+#include <lite/param.pb.h>
+
+using catena::Value;
+using catena::lite::Param;
+
+template <>
+void Param<std::string>::serialize(Value& value) const {
+    *value.mutable_string_value() = value_.get();
+}

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -92,6 +92,14 @@ class CppGen {
                 }
                 bloc(`return t;`, bodyIndent+1)
                 bloc('}', bodyIndent);
+            },
+            "STRING": (name, desc, indent = 0) => {
+                let initializer = '';
+                if ("value" in desc) {
+                    initializer = `{"${desc.value.string_value}"}`;
+                }
+                bloc(`std::string ${name}${initializer};`, indent);
+                bloc(`catena::lite::Param<std::string> ${name}Param(${name},"${name}",dm);`, indent);
             }
         };
     }

--- a/tools/codegen/index.js
+++ b/tools/codegen/index.js
@@ -175,13 +175,15 @@ try {
         const warning = `// This file was auto-generated. Do not modify by hand.`;
         hloc(`#pragma once`);
         hloc(warning);
-        hloc(`#include <Meta.h>`);
-        hloc(`#include <TypeTraits.h>`);
-        hloc(`#include <string>`);
-        hloc(`#include <vector>`);
+        hloc(`#include <lite/include/DeviceModel.h>`);
+        hloc(`extern catena::lite::DeviceModel dm;`);
         hloc(`namespace ${namespace} {`)
         bloc(warning);
-        bloc(`#include <${headerFilename}>`);
+        bloc(`#include "${headerFilename}"`);
+        bloc(`#include <lite/include/IParam.h>`);
+        bloc(`#include <lite/include/Param.h>`);
+        bloc(`#include <lite/include/DeviceModel.h>`);
+        bloc(`catena::lite::DeviceModel dm{};`)
         let codegen = new CppGen(hloc, bloc, namespace);
         for (p in data.params) {
             codegen.convert(p, data.params[p]);


### PR DESCRIPTION
adds an example app to the lite SDK, moves Path back into the common part of the SDK as it turned out to be useful/needed by lite too.