### PR TITLE
Param-proto

### DIFF
--- a/sdks/cpp/common/include/Enums.h
+++ b/sdks/cpp/common/include/Enums.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <patterns/EnumDecorator.h>
+#include <cstdint>
+
 
 namespace catena {
 namespace common {
@@ -32,4 +34,6 @@ inline const patterns::EnumDecorator<common::DetailLevel_e>::FwdMap
                                                              {common::DetailLevel_e::kMinimal, "MINIMAL"},
                                                              {common::DetailLevel_e::kCommands, "COMMANDS"},
                                                              {common::DetailLevel_e::kNone, "NONE"}};
+
+
 }  // namespace catena

--- a/sdks/cpp/lite/examples/start_here/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/start_here/CMakeLists.txt
@@ -73,7 +73,6 @@ target_sources(${TARGET}
 add_dependencies(${TARGET} ${TARGET}_codegen)
 
 target_link_libraries(${TARGET}
-    catena_common
     catena_lite
     ${proto_interface}
 )

--- a/sdks/cpp/lite/examples/use_structs/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/use_structs/CMakeLists.txt
@@ -76,7 +76,6 @@ add_dependencies(${TARGET} ${TARGET}_codegen)
 
 target_link_libraries(${TARGET}
     ${LIB_TARGET}
-    catena_common
     catena_lite
     ${proto_interface}
 )

--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -54,6 +54,9 @@ int main() {
     catena::Value value{};
     locationParam.toProto(value);
 
+    catena::patterns::EnumDecorator<catena::ParamType> type{locationParam.type()};
+    std::cout << "location type: " << type.toString() << std::endl;
+
     // print the serialized value
     auto& struct_value = value.struct_value();
     auto& fields = struct_value.fields();

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <lite/param.pb.h>
+
+#include <Enums.h>
+
 namespace catena {
 class Value; // forward reference
 class Param; // forward reference
 
+
 namespace lite {
 class IParam {
+  public:
+    using ParamType = catena::patterns::EnumDecorator<catena::ParamType>;
   public:
     IParam() = default;
     IParam(IParam&&) = default;
@@ -22,7 +29,30 @@ class IParam {
      * @brief serialize the parameter descriptor to protobuf
      * @param param the protobuf value to serialize to
      */
-    virtual void toProto(catena::Param& param) const = 0; 
+    virtual void toProto(catena::Param& param) const = 0;
+
+    virtual ParamType type() const = 0;
 };
+
 }  // namespace lite
+template<>
+const inline lite::IParam::ParamType::FwdMap 
+  lite::IParam::ParamType::fwdMap_ {
+  { ParamType::UNDEFINED, "undefined" },
+  { ParamType::EMPTY, "empty"},
+  { ParamType::INT32, "int32" },
+  { ParamType::FLOAT32, "float32" },
+  { ParamType::STRING, "string" },
+  { ParamType::STRUCT, "struct" },
+  { ParamType::STRUCT_VARIANT, "struct_variant" },
+  { ParamType::INT32_ARRAY, "int32_array" },
+  { ParamType::FLOAT32_ARRAY, "float32_array" },
+  { ParamType::STRING_ARRAY, "string_array" },
+  { ParamType::BINARY, "binary" },
+  { ParamType::STRUCT_ARRAY, "struct_array" },
+  { ParamType::STRUCT_VARIANT_ARRAY, "struct_variant_array" },
+  { ParamType::DATA, "data" }
+};
 }  // namespace catena
+
+ 

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -2,6 +2,8 @@
 
 namespace catena {
 class Value; // forward reference
+class Param; // forward reference
+
 namespace lite {
 class IParam {
   public:
@@ -12,8 +14,15 @@ class IParam {
 
     /**
      * @brief serialize the parameter value to protobuf
+     * @param value the protobuf value to serialize to
      */
     virtual void toProto(catena::Value& value) const = 0;
+
+    /**
+     * @brief serialize the parameter descriptor to protobuf
+     * @param param the protobuf value to serialize to
+     */
+    virtual void toProto(catena::Param& param) const = 0; 
 };
 }  // namespace lite
 }  // namespace catena

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -68,9 +68,14 @@ template <typename T> class Param : public IParam {
      * @brief serialize the parameter descriptor to protobuf
      */
     void toProto(catena::Param& param) const override {
-        param.set_type(type_);
+        param.set_type(type_());
         toProto(*param.mutable_value());
     }
+
+    /**
+     * @brief get the parameter type
+     */
+    ParamType type() const override { return type_; }
     
   private:
     ParamType type_; // ParamType is from param.pb.h

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -50,7 +50,7 @@ template <typename T> class Param : public IParam {
     /**
      * @brief the main constructor
      */
-    Param(T& value, const std::string& name, Device& dm) : IParam(), value_(value), dm_(dm) {
+    Param(catena::ParamType type, T& value, const std::string& name, Device& dm) : IParam(), type_{type}, value_{value}, dm_{dm} {
         dm.addItem<Device::ParamTag>(name, this, Device::ParamTag{});
     }
 
@@ -63,8 +63,17 @@ template <typename T> class Param : public IParam {
      * @brief serialize the parameter value to protobuf
      */
     void toProto(catena::Value& value) const override;
+
+    /**
+     * @brief serialize the parameter descriptor to protobuf
+     */
+    void toProto(catena::Param& param) const override {
+        param.set_type(type_);
+        toProto(*param.mutable_value());
+    }
     
   private:
+    ParamType type_; // ParamType is from param.pb.h
     std::reference_wrapper<T> value_;
     std::reference_wrapper<Device> dm_;
 };

--- a/sdks/cpp/lite/src/Param.cpp
+++ b/sdks/cpp/lite/src/Param.cpp
@@ -47,3 +47,4 @@ void Param<std::vector<float>>::toProto(Value& value) const {
 }
 
 
+

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -172,13 +172,12 @@ class CppGen {
 
                 // declare the getStructInfo method and typelist in the header file
                 hloc(`static const catena::lite::StructInfo& getStructInfo();`, indent+1)
-                // hloc(`using typelist = catena::meta::TypeList<${types.join(', ')}>;`, indent+1)
                 hloc(`};`, indent);
 
                 // instantiate the struct in the body file 
                 let bodyIndent = 0;
                 bloc(`${fqname} ${name} ${structInit(names, srctypes, desc)};`, bodyIndent);
-                bloc(`catena::lite::Param<${fqname}> ${name}Param(${name},"/${name}",dm);`, bodyIndent)
+                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},"/${name}",dm);`, bodyIndent)
                 bloc(`const StructInfo& ${fqname}::getStructInfo() {`, bodyIndent);
                 bloc(`static StructInfo t {`, bodyIndent+1);
                 bloc(`"${name}", {`, bodyIndent+2);
@@ -206,7 +205,7 @@ class CppGen {
                     initializer = `{"${desc.value.string_value}"}`;
                 }
                 bloc(`std::string ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::string> ${name}Param(${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},"/${name}",dm);`, indent);
             },
             "INT32": (name, desc, indent = 0) => {
                 let initializer = '{}';
@@ -214,7 +213,7 @@ class CppGen {
                     initializer = `{${desc.value.int32_value}}`;
                 }
                 bloc(`int32_t ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<int32_t> ${name}Param(${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},"/${name}",dm);`, indent);
 
             },
             "FLOAT32": (name, desc, indent = 0) => {
@@ -223,22 +222,22 @@ class CppGen {
                     initializer = `{${desc.value.float32_value}}`;
                 }
                 bloc(`float ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<float> ${name}Param(${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},"/${name}",dm);`, indent);
             },
             "STRING_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.string_array_values.strings, '"', indent);
                 bloc(`std::vector<std::string> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},"/${name}",dm);`, indent);
             },
             "INT32_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.int32_array_values.ints, '', indent);
                 bloc(`std::vector<std::int32_t> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},"/${name}",dm);`, indent);
             },
             "FLOAT32_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.float32_array_values.floats, '', indent);
                 bloc(`std::vector<float> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},"/${name}",dm);`, indent);
             }
         };
         this.init = (headerFilename, device) => {


### PR DESCRIPTION
added method to serialize IParam objects to protobufs. And added a type attribute to Param objects which is the minimum needed for DashBoard to interpret the param descriptor correctly.