### PR TITLE
toProto support for Device

### DIFF
--- a/sdks/cpp/common/include/Enums.h
+++ b/sdks/cpp/common/include/Enums.h
@@ -1,5 +1,8 @@
 #pragma once
 
+/** @todo this needs some cmake+preprocessor magic to work for both build types */
+#include <lite/device.pb.h>
+
 #include <patterns/EnumDecorator.h>
 #include <cstdint>
 
@@ -12,28 +15,29 @@ namespace common {
  */
 enum class Scopes_e : int32_t { kUndefined, kMonitor, kOperate, kConfig, kAdmin };
 
-/**
- * @brief DetailLevel_e is an enumeration of the different levels of detail that can be provided.
- */
-enum class DetailLevel_e : int32_t { kFull, kSubscriptions, kMinimal, kCommands, kNone };
 
+// instantiate the EnumDecorator for the Scopes_e and DetailLevel_e enums
+using Scopes = patterns::EnumDecorator<common::Scopes_e>;
+using DetailLevel = patterns::EnumDecorator<catena::Device_DetailLevel>;
 
 }  // namespace common
-template <>
-inline const patterns::EnumDecorator<common::Scopes_e>::FwdMap
-  patterns::EnumDecorator<common::Scopes_e>::fwdMap_ = {{common::Scopes_e::kUndefined, "undefined"},
-                                                        {common::Scopes_e::kMonitor, "monitor"},
-                                                        {common::Scopes_e::kOperate, "operate"},
-                                                        {common::Scopes_e::kConfig, "configure"},
-                                                        {common::Scopes_e::kAdmin, "administer"}};
+
 
 template <>
-inline const patterns::EnumDecorator<common::DetailLevel_e>::FwdMap
-  patterns::EnumDecorator<common::DetailLevel_e>::fwdMap_ = {{common::DetailLevel_e::kFull, "FULL"},
-                                                             {common::DetailLevel_e::kSubscriptions, "SUBSCRIPTIONS"},
-                                                             {common::DetailLevel_e::kMinimal, "MINIMAL"},
-                                                             {common::DetailLevel_e::kCommands, "COMMANDS"},
-                                                             {common::DetailLevel_e::kNone, "NONE"}};
+inline const common::Scopes::FwdMap common::Scopes::fwdMap_ = {{common::Scopes_e::kUndefined, "undefined"},
+                                               {common::Scopes_e::kMonitor, "monitor"},
+                                               {common::Scopes_e::kOperate, "operate"},
+                                               {common::Scopes_e::kConfig, "configure"},
+                                               {common::Scopes_e::kAdmin, "administer"}};
+
+
+template <>
+inline const common::DetailLevel::FwdMap common::DetailLevel::fwdMap_ = {
+  {Device_DetailLevel_FULL, "FULL"},
+  {Device_DetailLevel_SUBSCRIPTIONS, "SUBSCRIPTIONS"},
+  {Device_DetailLevel_MINIMAL, "MINIMAL"},
+  {Device_DetailLevel_COMMANDS, "COMMANDS"},
+  {Device_DetailLevel_NONE, "NONE"}};
 
 
 }  // namespace catena

--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -70,6 +70,10 @@ int main() {
         }
     }
 
+    catena::Device dstDevice{};
+    dm.toProto(dstDevice, false); // select theh deep copy option
+    std::cout << "Device model serialized to protobuf" << std::endl;
+
 
     return EXIT_SUCCESS;
 }

--- a/sdks/cpp/lite/src/Device.cpp
+++ b/sdks/cpp/lite/src/Device.cpp
@@ -7,4 +7,24 @@
 using namespace catena::lite;
 using namespace catena::common;
 
+void Device::toProto(::catena::Device& dst, bool shallow) const {
+    dst.set_slot(slot_);
+    dst.set_detail_level(detail_level_);
+    *dst.mutable_default_scope() = default_scope_.toString();
+    dst.set_multi_set_enabled(multi_set_enabled_);
+    dst.set_subscriptions(subscriptions_);
+    if (shallow) { return; }
+
+    // if we're not doing a shallow copy, we need to copy all the Items
+    /// @todo: implement deep copies for constraints, menu groups, commands, etc...
+    // for now, we can make do with just params
+    google::protobuf::Map<std::string, ::catena::Param> dstParams{};
+    for (const auto& [name, param] : params_) {
+        ::catena::Param dstParam{};
+        param->toProto(dstParam);
+        dstParams[name] = dstParam;
+    }
+    dst.mutable_params()->swap(dstParams);
+}
+
 

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -182,11 +182,8 @@ class CppGen {
                 bloc(`static StructInfo t {`, bodyIndent+1);
                 bloc(`"${name}", {`, bodyIndent+2);
                 for (let i = 0; i < n; ++i) {
-                    let indent = bodyIndent+2;
-                    bloc(`{ "${names[i]}", offsetof(${fqname}, ${names[i]}), catena::lite::toProto<${types[i]}> }`, indent);
-                    if (i < n - 1) {
-                        bloc(`,`, indent);
-                    }
+                    let indent = bodyIndent+3;
+                    bloc(`{ "${names[i]}", offsetof(${fqname}, ${names[i]}), catena::lite::toProto<${types[i]}> }${i<n-1?',':''}`, indent);
                 }
                 bloc(`}`, bodyIndent+2);
                 bloc(`};`, bodyIndent+1);
@@ -257,8 +254,8 @@ class CppGen {
             bloc(`#include <lite/include/StructInfo.h>`);
             bloc(`#include <string>`);
             bloc(`#include <vector>`);
-            bloc(`using catena::common::DetailLevel_e;`);
-            bloc(`using DetailLevel = typename catena::patterns::EnumDecorator<DetailLevel_e>;`);
+            bloc(`using catena::Device_DetailLevel;`);
+            bloc(`using DetailLevel = catena::common::DetailLevel;`);
             bloc(`using catena::common::Scopes_e;`);
             bloc(`using Scope = typename catena::patterns::EnumDecorator<Scopes_e>;`);
             let deviceInit = `${device.slot !== undefined ? device.slot : 0},`;


### PR DESCRIPTION
adds a toProto method to catena::lite::Device.
The intent is to re-enable the DeviceRequest RPC. Note that functionality is limited to just populating the params object within the protobuf device. Adding back the streaming capability is next up. John D - I'd like you to look into this. See the use_structs example for how to toProto a device.