### PR TITLE
fromProto deserialization of catena values

### DIFF
--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -45,7 +45,6 @@ int main() {
     // create another Location object, using the default initial value specified in the model
     Location externalToModel;
     std::cout << "Location object external to model - latitude: " << externalToModel.latitude
-
               << ", longitude: " << externalToModel.longitude << std::endl;
     locationValue = externalToModel;
 
@@ -70,6 +69,13 @@ int main() {
         }
     }
 
+    // deserialize the Location object - will be removed from this example
+    locationParam.get() = Location{0, 0};
+    std::cout << "Location from model cleared to 0 - latitude: " << locationParam.get().latitude
+              << ", longitude: " << locationParam.get().longitude << std::endl;
+    locationParam.fromProto(value);
+    std::cout << "Location from model set with protobuf deserialization - latitude: " << locationParam.get().latitude
+              << ", longitude: " << locationParam.get().longitude << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -24,6 +24,12 @@ class IParam {
      * @param value the protobuf value to serialize to
      */
     virtual void toProto(catena::Value& value) const = 0;
+    
+    /**
+     * @brief deserialize the parameter value from protobufi
+     * @param value the protobuf value to deserialize from
+     */
+    virtual void fromProto(const catena::Value& value) = 0;
 
     /**
      * @brief serialize the parameter descriptor to protobuf
@@ -33,8 +39,8 @@ class IParam {
 
     virtual ParamType type() const = 0;
 };
-
 }  // namespace lite
+
 template<>
 const inline lite::IParam::ParamType::FwdMap 
   lite::IParam::ParamType::fwdMap_ {

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -65,6 +65,11 @@ template <typename T> class Param : public IParam {
     void toProto(catena::Value& value) const override;
 
     /**
+     * @brief deserialize the parameter value from protobuf
+     */
+    void fromProto(const catena::Value& value) override;
+
+    /**
      * @brief serialize the parameter descriptor to protobuf
      */
     void toProto(catena::Param& param) const override {

--- a/sdks/cpp/lite/src/Param.cpp
+++ b/sdks/cpp/lite/src/Param.cpp
@@ -15,10 +15,14 @@ using catena::lite::StructInfo;
 using catena::lite::FieldInfo;
 
 
-
 template <>
 void Param<int32_t>::toProto(Value& value) const {
     catena::lite::toProto<int32_t>(value, &value_.get());
+}
+
+template <>
+void Param<int32_t>::fromProto(const Value& value) {
+    catena::lite::fromProto<int32_t>(&value_.get(), value);
 }
 
 template <>
@@ -27,8 +31,18 @@ void Param<std::string>::toProto(Value& value) const {
 }
 
 template <>
+void Param<std::string>::fromProto(const Value& value) {
+    catena::lite::fromProto<std::string>(&value_.get(), value);
+}
+
+template <>
 void Param<float>::toProto(Value& value) const {
     catena::lite::toProto<float>(value, &value_.get());
+}
+
+template <>
+void Param<float>::fromProto(const Value& value) {
+    catena::lite::fromProto<float>(&value_.get(), value);
 }
 
 template <>
@@ -37,13 +51,28 @@ void Param<std::vector<std::string>>::toProto(Value& value) const {
 }
 
 template <>
+void Param<std::vector<std::string>>::fromProto(const Value& value) {
+    catena::lite::fromProto<std::vector<std::string>>(&value_.get(), value);
+}
+
+template <>
 void Param<std::vector<std::int32_t>>::toProto(Value& value) const {
     catena::lite::toProto<std::vector<std::int32_t>>(value, &value_.get());
 }
 
 template <>
+void Param<std::vector<std::int32_t>>::fromProto(const Value& value) {
+    catena::lite::fromProto<std::vector<std::int32_t>>(&value_.get(), value);
+}
+
+template <>
 void Param<std::vector<float>>::toProto(Value& value) const {
     catena::lite::toProto<std::vector<float>>(value, &value_.get());
+}
+
+template <>
+void Param<std::vector<float>>::fromProto(const Value& value) {
+    catena::lite::fromProto<std::vector<float>>(&value_.get(), value);
 }
 
 

--- a/sdks/cpp/lite/src/StructInfo.cpp
+++ b/sdks/cpp/lite/src/StructInfo.cpp
@@ -4,24 +4,39 @@
 
 
 template<>
-void catena::lite::toProto<float>(catena::Value& value, const void* src) {
-    value.set_float32_value(*reinterpret_cast<const float*>(src));
+void catena::lite::toProto<float>(catena::Value& dst, const void* src) {
+    dst.set_float32_value(*reinterpret_cast<const float*>(src));
 }
 
 template<>
-void catena::lite::toProto<int32_t>(Value& value, const void* src) {
-    value.set_int32_value(*reinterpret_cast<const int32_t*>(src));
+void catena::lite::fromProto<float>(void* dst, const catena::Value& src) {
+    *reinterpret_cast<float*>(dst) = src.float32_value();
 }
 
 template<>
-void catena::lite::toProto<std::string>(Value& value, const void* src) {
-    *value.mutable_string_value() = *reinterpret_cast<const std::string*>(src);
+void catena::lite::toProto<int32_t>(Value& dst, const void* src) {
+    dst.set_int32_value(*reinterpret_cast<const int32_t*>(src));
 }
 
 template<>
-void catena::lite::toProto<std::vector<std::string>>(Value& value, const void* src) {
-    value.clear_string_array_values();
-    auto& string_array = *value.mutable_string_array_values();
+void catena::lite::fromProto<int32_t>(void* dst, const catena::Value& src) {
+    *reinterpret_cast<int32_t*>(dst) = src.int32_value();
+}
+
+template<>
+void catena::lite::toProto<std::string>(Value& dst, const void* src) {
+    *dst.mutable_string_value() = *reinterpret_cast<const std::string*>(src);
+}
+
+template<>
+void catena::lite::fromProto<std::string>(void* dst, const catena::Value& src) {
+    *reinterpret_cast<std::string*>(dst) = src.string_value();
+}
+
+template<>
+void catena::lite::toProto<std::vector<std::string>>(Value& dst, const void* src) {
+    dst.clear_string_array_values();
+    auto& string_array = *dst.mutable_string_array_values();
     const auto& vec = *reinterpret_cast<const std::vector<std::string>*>(src);
     for (const auto& s : vec) {
         string_array.add_strings(s);
@@ -29,9 +44,19 @@ void catena::lite::toProto<std::vector<std::string>>(Value& value, const void* s
 }
 
 template<>
-void catena::lite::toProto<std::vector<int32_t>>(Value& value, const void* src) {
-    value.clear_int32_array_values();
-    auto& int_array = *value.mutable_int32_array_values();
+void catena::lite::fromProto<std::vector<std::string>>(void* dst, const Value& src) {
+    auto* vec = reinterpret_cast<std::vector<std::string>*>(dst);
+    vec->clear();
+    const auto& string_array = src.string_array_values();
+    for (int i = 0; i < string_array.strings_size(); ++i) {
+        vec->push_back(string_array.strings(i));
+    }
+}
+
+template<>
+void catena::lite::toProto<std::vector<int32_t>>(Value& dst, const void* src) {
+    dst.clear_int32_array_values();
+    auto& int_array = *dst.mutable_int32_array_values();
     const auto& vec = *reinterpret_cast<const std::vector<int32_t>*>(src);
     for (const auto& i : vec) {
         int_array.add_ints(i);
@@ -39,11 +64,31 @@ void catena::lite::toProto<std::vector<int32_t>>(Value& value, const void* src) 
 }
 
 template<>
-void catena::lite::toProto<std::vector<float>>(Value& value, const void* src) {
-    value.clear_float32_array_values();
-    auto& float_array = *value.mutable_float32_array_values();
+void catena::lite::fromProto<std::vector<int32_t>>(void* dst, const Value& src) {
+    auto* vec = reinterpret_cast<std::vector<int32_t>*>(dst);
+    vec->clear();
+    const auto& int_array = src.int32_array_values();
+    for (int i = 0; i < int_array.ints_size(); ++i) {
+        vec->push_back(int_array.ints(i));
+    }
+}
+
+template<>
+void catena::lite::toProto<std::vector<float>>(Value& dst, const void* src) {
+    dst.clear_float32_array_values();
+    auto& float_array = *dst.mutable_float32_array_values();
     const auto& vec = *reinterpret_cast<const std::vector<float>*>(src);
     for (const auto& f : vec) {
         float_array.add_floats(f);
+    }
+}
+
+template<>
+void catena::lite::fromProto<std::vector<float>>(void* dst, const Value& src) {
+    auto* vec = reinterpret_cast<std::vector<float>*>(dst);
+    vec->clear();
+    const auto& float_array = src.float32_array_values();
+    for (int i = 0; i < float_array.floats_size(); ++i) {
+        vec->push_back(float_array.floats(i));
     }
 }

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -183,7 +183,7 @@ class CppGen {
                 bloc(`"${name}", {`, bodyIndent+2);
                 for (let i = 0; i < n; ++i) {
                     let indent = bodyIndent+2;
-                    bloc(`{ "${names[i]}", offsetof(${fqname}, ${names[i]}), catena::lite::toProto<${types[i]}> }`, indent);
+                    bloc(`{ "${names[i]}", offsetof(${fqname}, ${names[i]}), catena::lite::toProto<${types[i]}>, catena::lite::fromProto<${types[i]}> }`, indent);
                     if (i < n - 1) {
                         bloc(`,`, indent);
                     }
@@ -197,6 +197,12 @@ class CppGen {
                 bloc(`template<>`, indent);
                 bloc(`void catena::lite::Param<${fqname}>::toProto(catena::Value& value) const {`, indent);
                 bloc(`catena::lite::toProto<${fqname}>(value, &value_.get());`, indent+1);
+                bloc('}', indent);
+
+                // instantiate the deserialize specialization
+                bloc(`template<>`, indent);
+                bloc(`void catena::lite::Param<${fqname}>::fromProto(const catena::Value& value) {`, indent);
+                bloc(`catena::lite::fromProto<${fqname}>(&value_.get(), value);`, indent+1);
                 bloc('}', indent);
             },
             "STRING": (name, desc, indent = 0) => {


### PR DESCRIPTION
params have a fromProto method that allows deserialization from a protobuf value object. cppgen.js has been updated to now add the appropriate fromProto methods for structs and their children