### PR TITLE
Oid-aliases

### DIFF
--- a/sdks/cpp/lite/examples/use_structs/device.use_structs.json
+++ b/sdks/cpp/lite/examples/use_structs/device.use_structs.json
@@ -52,7 +52,8 @@
                         "longitude": {"value": {"float32_value": -122.4194}}
                     }
                 }
-            }
+            },
+            "oid_aliases": ["mary", "had", "a little lamb"]
         }
     }
 }

--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -69,6 +69,13 @@ int main() {
         }
     }
 
+    catena::Param param{};
+    locationParam.toProto(param);
+    auto& aliases = param.oid_aliases();
+    for (const auto& alias : aliases) {
+        std::cout << "Alias: " << alias << std::endl;
+    }
+
 
     catena::Device dstDevice{};
     dm.toProto(dstDevice, false); // select the deep copy option

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -6,7 +6,9 @@
 
 #include <lite/param.pb.h>
 
-#include <functional> // reference_wrapper
+#include <functional>  // reference_wrapper
+#include <vector>
+#include <string>
 
 namespace catena {
 namespace lite {
@@ -16,6 +18,12 @@ namespace lite {
  * @tparam T the parameter's value type
  */
 template <typename T> class Param : public IParam {
+  public:
+    /**
+     * @brief OidAliases is a vector of strings
+     */
+    using OidAliases = std::vector<std::string>;
+
   public:
     /**
      * @brief Param does not have a default constructor
@@ -50,7 +58,9 @@ template <typename T> class Param : public IParam {
     /**
      * @brief the main constructor
      */
-    Param(catena::ParamType type, T& value, const std::string& name, Device& dm) : IParam(), type_{type}, value_{value}, dm_{dm} {
+    Param(catena::ParamType type, T& value, const OidAliases& oid_aliases, const std::string& name,
+          Device& dm)
+        : IParam(), type_{type}, value_{value}, oid_aliases_{oid_aliases}, dm_{dm} {
         dm.addItem<Device::ParamTag>(name, this, Device::ParamTag{});
     }
 
@@ -74,6 +84,10 @@ template <typename T> class Param : public IParam {
      */
     void toProto(catena::Param& param) const override {
         param.set_type(type_());
+        param.mutable_oid_aliases()->Reserve(oid_aliases_.size());
+        for (const auto& oid_alias : oid_aliases_) {
+            param.add_oid_aliases(oid_alias);
+        }
         toProto(*param.mutable_value());
     }
 
@@ -81,9 +95,10 @@ template <typename T> class Param : public IParam {
      * @brief get the parameter type
      */
     ParamType type() const override { return type_; }
-    
+
   private:
-    ParamType type_; // ParamType is from param.pb.h
+    ParamType type_;  // ParamType is from param.pb.h
+    std::vector<std::string> oid_aliases_;
     std::reference_wrapper<T> value_;
     std::reference_wrapper<Device> dm_;
 };

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -128,7 +128,7 @@ class CppGen {
         this.oid_aliases = (desc) => {
             let ans = '{}';
             if (desc.oid_aliases !== undefined) {
-                const aliases = desc.oid_aliases.map(alias => quoted(alias));
+                const aliases = desc.oid_aliases.map(alias => {return quoted(alias);});
                 ans = `{${aliases.join(',')}}`;
             }
             return ans;
@@ -191,7 +191,7 @@ class CppGen {
                 bloc(`"${name}", {`, bodyIndent+2);
                 for (let i = 0; i < n; ++i) {
                     let indent = bodyIndent+3;
-                    bloc(`{ "${names[i]}", offsetof(${fqname}, ${names[i]}), catena::lite::toProto<${types[i]}> }${i<n-1?',':''}`, indent);
+                    bloc(`{ "${names[i]}", offsetof(${fqname}, ${names[i]}), catena::lite::toProto<${types[i]}>, catena::lite::fromProto<${types[i]}> }${i<n-1?',':''}`, indent);
                 }
                 bloc(`}`, bodyIndent+2);
                 bloc(`};`, bodyIndent+1);

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -125,6 +125,13 @@ class CppGen {
                // place holder for now
             }
         },
+        this.oid_aliases = (desc) => {
+            let ans = '{}';
+            if (desc.oid_aliases !== undefined) {
+                ans = `{ ${desc.oid_aliases.join(',')} }`;
+            }
+            return ans;
+        },
         this.params = {
             "STRUCT": (name, desc, scope = undefined, indent = 0) => {
                 const params = desc.params;
@@ -157,11 +164,11 @@ class CppGen {
                     } else {
                         defaults.push('{}');
                     }
-                    if ("value" in params[p]) {
-                        defaults.push(`= ${getFieldInit[type](params[p].value)}`);
-                    } else {
-                        defaults.push('{}');
-                    }
+                    // if ("value" in params[p]) {
+                    //     defaults.push(`= ${getFieldInit[type](params[p].value)}`);
+                    // } else {
+                    //     defaults.push('{}');
+                    // }
                     ++n;
                 }
                 
@@ -177,7 +184,7 @@ class CppGen {
                 // instantiate the struct in the body file 
                 let bodyIndent = 0;
                 bloc(`${fqname} ${name} ${structInit(names, srctypes, desc)};`, bodyIndent);
-                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},"/${name}",dm);`, bodyIndent)
+                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},${this.oid_aliases(desc)},"/${name}",dm);`, bodyIndent)
                 bloc(`const StructInfo& ${fqname}::getStructInfo() {`, bodyIndent);
                 bloc(`static StructInfo t {`, bodyIndent+1);
                 bloc(`"${name}", {`, bodyIndent+2);
@@ -208,7 +215,7 @@ class CppGen {
                     initializer = `{"${desc.value.string_value}"}`;
                 }
                 bloc(`std::string ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
             },
             "INT32": (name, desc, indent = 0) => {
                 let initializer = '{}';
@@ -216,7 +223,7 @@ class CppGen {
                     initializer = `{${desc.value.int32_value}}`;
                 }
                 bloc(`int32_t ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
 
             },
             "FLOAT32": (name, desc, indent = 0) => {
@@ -225,22 +232,22 @@ class CppGen {
                     initializer = `{${desc.value.float32_value}}`;
                 }
                 bloc(`float ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
             },
             "STRING_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.string_array_values.strings, '"', indent);
                 bloc(`std::vector<std::string> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
             },
             "INT32_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.int32_array_values.ints, '', indent);
                 bloc(`std::vector<std::int32_t> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
             },
             "FLOAT32_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.float32_array_values.floats, '', indent);
                 bloc(`std::vector<float> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
             }
         };
         this.init = (headerFilename, device) => {

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -128,7 +128,8 @@ class CppGen {
         this.oid_aliases = (desc) => {
             let ans = '{}';
             if (desc.oid_aliases !== undefined) {
-                ans = `{ ${desc.oid_aliases.join(',')} }`;
+                const aliases = desc.oid_aliases.map(alias => quoted(alias));
+                ans = `{${aliases.join(',')}}`;
             }
             return ans;
         },

--- a/tools/codegen/index.js
+++ b/tools/codegen/index.js
@@ -174,9 +174,9 @@ try {
         let bloc = bodyLoc.write.bind(bodyLoc);
         let codegen = new CppGen(hloc, bloc, namespace);
         codegen.init(headerFilename, data);
-        for (let c in data.constraints) {
-            codegen.constraint(c, data.constraints[c]);
-        }
+        // for (let c in data.constraints) {
+        //     codegen.constraint(c, data.constraints[c]);
+        // }
         for (let p in data.params) {
             codegen.param(p, data.params[p]);
         }


### PR DESCRIPTION
adds ability to convert the oid_aliases attribute of catena::lite::Param (which is new in this PR) to a catena::Param.

This is a step towards being able to use custom panels.

the device model needs lines like this to serve the custom panel UI as an external object:

```json
    "dashboard_icon": {
      "type": "STRING",
      "oid_aliases": ["0xFF0C"],
      "value": { "string_value": "eo://icon.png" }
    },
    "dashboard_UI": {
      "type": "STRING",
      "oid_aliases": ["0xFF0E"],
      "value": { "string_value": "eo://custom_UI.grid" }
    },
```