### PR TITLE
Add UI

### DIFF
--- a/sdks/cpp/common/include/IPolyglotText.h
+++ b/sdks/cpp/common/include/IPolyglotText.h
@@ -9,6 +9,7 @@ namespace common {
 class IPolyglotText {
   public:
     using DisplayStrings = std::unordered_map<std::string, std::string>;
+    using ListInitializer = std::initializer_list<std::pair<std::string, std::string>>;
   public:
     IPolyglotText() = default;
     IPolyglotText(IPolyglotText&&) = default;

--- a/sdks/cpp/common/include/IPolyglotText.h
+++ b/sdks/cpp/common/include/IPolyglotText.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "google/protobuf/message_lite.h" 
+#include <unordered_map>
+#include <string>
+
+namespace catena {
+namespace common {
+class IPolyglotText {
+  public:
+    using DisplayStrings = std::unordered_map<std::string, std::string>;
+  public:
+    IPolyglotText() = default;
+    IPolyglotText(IPolyglotText&&) = default;
+    IPolyglotText& operator=(IPolyglotText&&) = default;
+    virtual ~IPolyglotText() = default;
+
+    virtual void toProto(google::protobuf::MessageLite& msg) const = 0;
+
+    virtual const DisplayStrings& displayStrings() const = 0;
+
+};
+}  // namespace common
+}  // namespace catena

--- a/sdks/cpp/connections/gRPC/examples/status_update/device.status_update.json
+++ b/sdks/cpp/connections/gRPC/examples/status_update/device.status_update.json
@@ -34,6 +34,11 @@
             "type": "INT32",
             "name": {"display_strings": {"$key": "counter"}},
             "value": {"int32_value": 0}
+        },
+        "dashboard_UI": {
+          "type": "STRING",
+          "oid_aliases": ["0xFF0E"],
+          "value": { "string_value": "eo://status_update.grid" }
         }
     }
 }

--- a/sdks/cpp/connections/gRPC/examples/status_update/static/status_update.grid
+++ b/sdks/cpp/connections/gRPC/examples/status_update/static/status_update.grid
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<abs contexttype="opengear" id="_top" keepalive="false" style="">
+   <meta>
+      <context contexttype="opengear" id="status_update" objectid="status_update.catenamedia.tv:6254&lt;br&gt;Slot 0&lt;br&gt;Device" objecttype="Device" subscriptions="false"/>
+   </meta>
+   <label height="79" left="369" mid="0" name="Catena gRPC DashBoard Demo" oid="product" style="font:bold;size:Biggest;" top="23" width="583"/>
+   <param contextid="status_update" editable="false" expand="true" height="46" left="39" mid="0" oid="counter" showlabel="false" style="size:Bigger;font:bold;txt-align:center;" top="109" widget="label" width="585"/>
+</abs>

--- a/sdks/cpp/lite/CMakeLists.txt
+++ b/sdks/cpp/lite/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(${target} STATIC
     src/Device.cpp
     src/Param.cpp
     src/StructInfo.cpp
+    src/PolyglotText.cpp
 )
 
 add_dependencies(${target} catena_common)

--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -58,6 +58,7 @@ int main() {
     std::cout << "location type: " << type.toString() << std::endl;
 
     // print the serialized value
+    std::cout << "Location name: " << locationParam.name("en") << std::endl;
     auto& struct_value = value.struct_value();
     auto& fields = struct_value.fields();
     for (const auto& field : fields) {
@@ -76,6 +77,10 @@ int main() {
     for (const auto& alias : aliases) {
         std::cout << "Alias: " << alias << std::endl;
     }
+    auto& name = param.name();
+    for (const auto& [lang, text] : name.display_strings()) {
+        std::cout << "Language: " << lang << ", Text: " << text << std::endl;
+    }
 
 
     catena::Device dstDevice{};
@@ -91,10 +96,6 @@ int main() {
     std::cout << "Location from model set with protobuf deserialization - latitude: " << locationParam.get().latitude
               << ", longitude: " << locationParam.get().longitude << std::endl;
 
-    catena::lite::PolyglotText text {{"en", "Hello!"},{"fr", "Bonjour!"},{"es", "Hola!"}};
-    for(const auto& [lang, text] : text.displayStrings()) {
-        std::cout << "Language: " << lang << ", Text: " << text << std::endl;
-    }
-
+   
     return EXIT_SUCCESS;
 }

--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -28,6 +28,7 @@
 #include "lite/examples/use_structs/device.use_structs.json.h"  // dm
 #include <lite/include/Device.h>
 #include <lite/include/Param.h>
+#include <lite/include/PolyglotText.h>
 #include <lite/param.pb.h>
 
 using namespace catena::lite;
@@ -90,6 +91,10 @@ int main() {
     std::cout << "Location from model set with protobuf deserialization - latitude: " << locationParam.get().latitude
               << ", longitude: " << locationParam.get().longitude << std::endl;
 
+    catena::lite::PolyglotText text {{"en", "Hello!"},{"fr", "Bonjour!"},{"es", "Hola!"}};
+    for(const auto& [lang, text] : text.displayStrings()) {
+        std::cout << "Language: " << lang << ", Text: " << text << std::endl;
+    }
 
     return EXIT_SUCCESS;
 }

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -1,5 +1,6 @@
 #pragma once
 
+/// @todo some cmake + preprocessing magic to include the right file - lite or full version
 #include <lite/param.pb.h>
 
 #include <Enums.h>

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -3,6 +3,7 @@
 #include <lite/include/IParam.h>
 #include <lite/include/Device.h>
 #include <lite/include/StructInfo.h>
+#include <lite/include/PolyglotText.h>
 
 #include <lite/param.pb.h>
 
@@ -12,6 +13,8 @@
 
 namespace catena {
 namespace lite {
+
+
 
 /**
  * @brief Param provides convenient access to parameter values
@@ -58,10 +61,10 @@ template <typename T> class Param : public IParam {
     /**
      * @brief the main constructor
      */
-    Param(catena::ParamType type, T& value, const OidAliases& oid_aliases, const std::string& name,
+    Param(catena::ParamType type, T& value, const OidAliases& oid_aliases, const PolyglotText::ListInitializer name, const std::string& oid,
           Device& dm)
-        : IParam(), type_{type}, value_{value}, oid_aliases_{oid_aliases}, dm_{dm} {
-        dm.addItem<Device::ParamTag>(name, this, Device::ParamTag{});
+        : IParam(), type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
+        dm.addItem<Device::ParamTag>(oid, this, Device::ParamTag{});
     }
 
     /**
@@ -88,6 +91,11 @@ template <typename T> class Param : public IParam {
         for (const auto& oid_alias : oid_aliases_) {
             param.add_oid_aliases(oid_alias);
         }
+        catena::PolyglotText name_proto;
+        for (const auto& [lang, text] : name_.displayStrings()) {
+            (*name_proto.mutable_display_strings())[lang] = text;
+        }
+        param.mutable_name()->Swap(&name_proto);
         toProto(*param.mutable_value());
     }
 
@@ -96,9 +104,30 @@ template <typename T> class Param : public IParam {
      */
     ParamType type() const override { return type_; }
 
+    /**
+     * @brief get the parameter name
+     */
+    const PolyglotText::DisplayStrings& name() const { return name_.displayStrings(); }
+
+    /**
+     * @brief get the parameter name by language
+     * @param language the language to get the name for
+     * @return the name in the specified language, or an empty string if the language is not found
+     */
+    const std::string& name(const std::string& language) const { 
+      auto it = name_.displayStrings().find(language);
+      if (it != name_.displayStrings().end()) {
+        return it->second;
+      } else {
+        static const std::string empty;
+        return empty;
+      }
+    }
+
   private:
     ParamType type_;  // ParamType is from param.pb.h
     std::vector<std::string> oid_aliases_;
+    PolyglotText name_;
     std::reference_wrapper<T> value_;
     std::reference_wrapper<Device> dm_;
 };

--- a/sdks/cpp/lite/include/PolyglotText.h
+++ b/sdks/cpp/lite/include/PolyglotText.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <IPolyglotText.h>
+
+#include <lite/language.pb.h>
+
+#include <string>
+#include <unordered_map>
+#include <initializer_list>
+
+namespace catena {
+namespace lite {
+class PolyglotText : public catena::common::IPolyglotText {
+  public:
+    using DisplayStrings = std::unordered_map<std::string, std::string>;
+
+  public:
+    PolyglotText(const DisplayStrings& display_strings) : display_strings_(display_strings) {}
+    PolyglotText() = default;
+    PolyglotText(PolyglotText&&) = default;
+    PolyglotText& operator=(PolyglotText&&) = default;
+    virtual ~PolyglotText() = default;
+
+    // Constructor from initializer list
+    PolyglotText(std::initializer_list<std::pair<const std::string, std::string>> list)
+      : display_strings_(list.begin(), list.end()) {}
+
+
+    void toProto(google::protobuf::MessageLite& dst) const override;
+
+    inline const DisplayStrings& displayStrings() const override { return display_strings_; }
+
+  private:
+    DisplayStrings display_strings_;
+};
+}  // namespace lite
+}  // namespace catena

--- a/sdks/cpp/lite/include/PolyglotText.h
+++ b/sdks/cpp/lite/include/PolyglotText.h
@@ -22,7 +22,7 @@ class PolyglotText : public catena::common::IPolyglotText {
     virtual ~PolyglotText() = default;
 
     // Constructor from initializer list
-    PolyglotText(std::initializer_list<std::pair<const std::string, std::string>> list)
+    PolyglotText(ListInitializer list)
       : display_strings_(list.begin(), list.end()) {}
 
 

--- a/sdks/cpp/lite/src/PolyglotText.cpp
+++ b/sdks/cpp/lite/src/PolyglotText.cpp
@@ -1,0 +1,16 @@
+#include <PolyglotText.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace catena {
+namespace lite {
+void PolyglotText::toProto(google::protobuf::MessageLite& m) const {
+    auto& dst = dynamic_cast<catena::PolyglotText&>(m);
+    dst.clear_display_strings();
+    for (const auto& [key, value] : display_strings_) {
+        dst.mutable_display_strings()->insert({key, value});
+    }
+}
+}  // namespace lite
+}  // namespace catena

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -125,12 +125,34 @@ class CppGen {
                // place holder for now
             }
         },
-        this.oid_aliases = (desc) => {
-            let ans = '{}';
+        this.other_items = (desc) => {
+            let ans = '';
+
+            // add oid_aliases if they exist
+            let aliases_init = '{';
             if (desc.oid_aliases !== undefined) {
                 const aliases = desc.oid_aliases.map(alias => {return quoted(alias);});
-                ans = `{${aliases.join(',')}}`;
+                aliases_init += `${aliases.join(',')}}`;
+            } else {
+                aliases_init += '}';
             }
+            ans += `${aliases_init},`;
+
+            // add the name if it exists
+            let name_init = '{';
+            if (desc.name !== undefined) {
+                const display_strings = desc.name.display_strings;
+                const n = Object.keys(display_strings).length;
+                let i = 0;
+                for (let lang in display_strings) {
+                    name_init += `{"${lang}", ${quoted(display_strings[lang])}}`;
+                    if (i++ < n-1) {
+                        name_init += ',';
+                    }
+                }   
+            }
+            name_init += '}';
+            ans += name_init;
             return ans;
         },
         this.params = {
@@ -185,7 +207,7 @@ class CppGen {
                 // instantiate the struct in the body file 
                 let bodyIndent = 0;
                 bloc(`${fqname} ${name} ${structInit(names, srctypes, desc)};`, bodyIndent);
-                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},${this.oid_aliases(desc)},"/${name}",dm);`, bodyIndent)
+                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},${this.other_items(desc)},"/${name}",dm);`, bodyIndent)
                 bloc(`const StructInfo& ${fqname}::getStructInfo() {`, bodyIndent);
                 bloc(`static StructInfo t {`, bodyIndent+1);
                 bloc(`"${name}", {`, bodyIndent+2);
@@ -216,7 +238,7 @@ class CppGen {
                     initializer = `{"${desc.value.string_value}"}`;
                 }
                 bloc(`std::string ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},${this.other_items(desc)},"/${name}",dm);`, indent);
             },
             "INT32": (name, desc, indent = 0) => {
                 let initializer = '{}';
@@ -224,7 +246,7 @@ class CppGen {
                     initializer = `{${desc.value.int32_value}}`;
                 }
                 bloc(`int32_t ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},${this.other_items(desc)},"/${name}",dm);`, indent);
 
             },
             "FLOAT32": (name, desc, indent = 0) => {
@@ -233,22 +255,22 @@ class CppGen {
                     initializer = `{${desc.value.float32_value}}`;
                 }
                 bloc(`float ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},${this.other_items(desc)},"/${name}",dm);`, indent);
             },
             "STRING_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.string_array_values.strings, '"', indent);
                 bloc(`std::vector<std::string> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},${this.other_items(desc)},"/${name}",dm);`, indent);
             },
             "INT32_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.int32_array_values.ints, '', indent);
                 bloc(`std::vector<std::int32_t> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},${this.other_items(desc)},"/${name}",dm);`, indent);
             },
             "FLOAT32_ARRAY": (name, desc, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.float32_array_values.floats, '', indent);
                 bloc(`std::vector<float> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},${this.oid_aliases(desc)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},${this.other_items(desc)},"/${name}",dm);`, indent);
             }
         };
         this.init = (headerFilename, device) => {


### PR DESCRIPTION
adds example DashBoard custom panel to the status_update gRPC example.
adds support for PolyglotText type and gives Param objects names of this type when constructed in the lite SDK
PolyglotText objects are included in Param's `toProto(Param&)` method so the UI should be able to display parameter names as well as their values.