### PR TITLE
Changed oid to non const

### DIFF
--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -16,6 +16,7 @@ class IParam {
     using ParamType = catena::patterns::EnumDecorator<catena::ParamType>;
   public:
     IParam() = default;
+    IParam(std::string oid) : oid_(oid) {};
     IParam(IParam&&) = default;
     IParam& operator=(IParam&&) = default;
     virtual ~IParam() = default;
@@ -43,7 +44,12 @@ class IParam {
     /**
      * @brief return the oid of the param
      */
-    virtual const std::string& getOid() const = 0;
+    virtual const std::string& getOid() const { return oid_; };
+
+    virtual void setOid(const std::string& oid) { oid_ = oid; };
+
+   protected:
+    std::string oid_;
 };
 }  // namespace lite
 

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -16,7 +16,6 @@ class IParam {
     using ParamType = catena::patterns::EnumDecorator<catena::ParamType>;
   public:
     IParam() = default;
-    IParam(std::string oid) : oid_(oid) {}
     IParam(IParam&&) = default;
     IParam& operator=(IParam&&) = default;
     virtual ~IParam() = default;
@@ -44,10 +43,7 @@ class IParam {
     /**
      * @brief return the oid of the param
      */
-    virtual const std::string& getOid() const { return oid_; }
-    
-  protected:
-    std::string oid_;
+    virtual const std::string& getOid() const = 0;
 };
 }  // namespace lite
 

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -15,7 +15,8 @@ class IParam {
   public:
     using ParamType = catena::patterns::EnumDecorator<catena::ParamType>;
   public:
-    IParam(const std::string oid=""): oid_{oid} {};
+    IParam() = default;
+    IParam(std::string oid) : oid_(oid) {}
     IParam(IParam&&) = default;
     IParam& operator=(IParam&&) = default;
     virtual ~IParam() = default;
@@ -46,7 +47,7 @@ class IParam {
     virtual const std::string& getOid() const { return oid_; }
     
   protected:
-    const std::string oid_;
+    std::string oid_;
 };
 }  // namespace lite
 

--- a/sdks/cpp/lite/include/IParam.h
+++ b/sdks/cpp/lite/include/IParam.h
@@ -15,8 +15,7 @@ class IParam {
   public:
     using ParamType = catena::patterns::EnumDecorator<catena::ParamType>;
   public:
-    IParam() = default;
-    IParam(std::string oid) : oid_(oid) {};
+    IParam() : oid_{} {}
     IParam(IParam&&) = default;
     IParam& operator=(IParam&&) = default;
     virtual ~IParam() = default;

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -63,7 +63,7 @@ template <typename T> class Param : public IParam {
      */
     Param(catena::ParamType type, T& value, const OidAliases& oid_aliases, const PolyglotText::ListInitializer name, const std::string& oid,
           Device& dm)
-        : oid_{oid}, type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
+        : IParam(oid), type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
         dm.addItem<Device::ParamTag>(oid, this, Device::ParamTag{});
     }
 
@@ -105,11 +105,6 @@ template <typename T> class Param : public IParam {
     ParamType type() const override { return type_; }
 
     /**
-     * @brief get the oid of the param
-     */
-    const std::string& getOid() const override { return oid_; }
-
-    /**
      * @brief get the parameter name
      */
     const PolyglotText::DisplayStrings& name() const { return name_.displayStrings(); }
@@ -131,7 +126,6 @@ template <typename T> class Param : public IParam {
 
   private:
     ParamType type_;  // ParamType is from param.pb.h
-    std::string oid_;
     std::vector<std::string> oid_aliases_;
     PolyglotText name_;
     std::reference_wrapper<T> value_;

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -63,7 +63,8 @@ template <typename T> class Param : public IParam {
      */
     Param(catena::ParamType type, T& value, const OidAliases& oid_aliases, const PolyglotText::ListInitializer name, const std::string& oid,
           Device& dm)
-        : IParam(oid), type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
+        : type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
+        setOid(oid);
         dm.addItem<Device::ParamTag>(oid, this, Device::ParamTag{});
     }
 

--- a/sdks/cpp/lite/include/Param.h
+++ b/sdks/cpp/lite/include/Param.h
@@ -63,7 +63,7 @@ template <typename T> class Param : public IParam {
      */
     Param(catena::ParamType type, T& value, const OidAliases& oid_aliases, const PolyglotText::ListInitializer name, const std::string& oid,
           Device& dm)
-        : IParam(oid), type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
+        : oid_{oid}, type_{type}, value_{value}, oid_aliases_{oid_aliases}, name_{name}, dm_{dm} {
         dm.addItem<Device::ParamTag>(oid, this, Device::ParamTag{});
     }
 
@@ -105,6 +105,11 @@ template <typename T> class Param : public IParam {
     ParamType type() const override { return type_; }
 
     /**
+     * @brief get the oid of the param
+     */
+    const std::string& getOid() const override { return oid_; }
+
+    /**
      * @brief get the parameter name
      */
     const PolyglotText::DisplayStrings& name() const { return name_.displayStrings(); }
@@ -126,6 +131,7 @@ template <typename T> class Param : public IParam {
 
   private:
     ParamType type_;  // ParamType is from param.pb.h
+    std::string oid_;
     std::vector<std::string> oid_aliases_;
     PolyglotText name_;
     std::reference_wrapper<T> value_;


### PR DESCRIPTION
Changed oid to not be const so that move constructor still works when compiling with clang. Also added default constructor back to IParam.