### PR TITLE
shared constraints and Picklist Constraints

### DIFF
--- a/schema/catena.schema.json
+++ b/schema/catena.schema.json
@@ -154,7 +154,7 @@
       "$comment": "patternProperties regex must be same as that defined in oid schema",
       "patternProperties": {
         "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
-          "$ref": "#/$defs/constraints"
+          "$ref": "#/$defs/constraint"
         }
       },
       "additionalProperties": false
@@ -208,7 +208,14 @@
           "$ref": "#/$defs/value"
         },
         "constraint": {
-          "$ref": "#/$defs/constraint"
+          "oneOf": [
+            {
+              "$ref": "#/$defs/constraint"
+            },
+            {
+              "$ref": "#/$defs/constraint_ref"
+            }
+          ]
         },
         "max_length": {
           "$ref": "#/$defs/max_length"
@@ -361,7 +368,14 @@
             "$ref": "#/$defs/float32_value"
           },
           "constraint": {
-            "$ref": "#/$defs/constraint"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/float32_constraint"
+              },
+              {
+                "$ref": "#/$defs/constraint_ref"
+              }
+            ]
           },
           "params": false,
           "commands": false,
@@ -554,7 +568,14 @@
             "$ref": "#/$defs/int32_value"
           },
           "constraint": {
-            "$ref": "#/$defs/constraint"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/int32_constraint"
+              },
+              {
+                "$ref": "#/$defs/constraint_ref"
+              }
+            ]
           },
           "params": false,
           "commands": false,
@@ -603,7 +624,14 @@
             "$ref": "#/$defs/int32_array_values"
           },
           "constraint": {
-            "$ref": "#/$defs/constraint"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/int32_constraint"
+              },
+              {
+                "$ref": "#/$defs/constraint_ref"
+              }
+            ]
           },
           "params": false
         }
@@ -648,7 +676,14 @@
             "$ref": "#/$defs/float32_array_values"
           },
           "constraint": {
-            "$ref": "#/$defs/constraint"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/float32_constraint"
+              },
+              {
+                "$ref": "#/$defs/constraint_ref"
+              }
+            ]
           },
           "params": false
         }
@@ -777,7 +812,14 @@
             "$ref": "#/$defs/string_value"
           },
           "constraint": {
-            "$ref": "#/$defs/constraint"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/string_constraint"
+              },
+              {
+                "$ref": "#/$defs/constraint_ref"
+              }
+            ]
           }
         }
       }
@@ -821,7 +863,14 @@
             "$ref": "#/$defs/string_array_values"
           },
           "constraint": {
-            "$ref": "#/$defs/constraint"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/string_constraint"
+              },
+              {
+                "$ref": "#/$defs/constraint_ref"
+              }
+            ]
           },
           "params": false
         }
@@ -1155,60 +1204,46 @@
       "default": "UNDEFINED"
     },
     "constraint": {
-        "title": "Constraint to apply to parameter value",
-        "description": "Constraints on how the value of the parameter can change. Its schema is polymorphic dependent on type",
-        "type": "object",
-        "oneOf": [
-          {
-              "properties": {
-                  "type": {
-                      "type": "string",
-                      "enum": [
-                          "UNDEFINED",
-                          "INT_RANGE",
-                          "FLOAT_RANGE",
-                          "INT_CHOICE",
-                          "STRING_CHOICE",
-                          "STRING_STRING_CHOICE",
-                          "ALARM_TABLE"
-                      ],
-                      "default": "UNDEFINED"
-                  }
-              },
-              "required": ["type"],
-              "oneOf": [
-                  {
-                  "$ref": "#/$defs/float32_constraint"
-                  },
-                  {
-                  "$ref": "#/$defs/int32_constraint"
-                  },
-                  {
-                  "$ref": "#/$defs/string_constraint"
-                  }
-              ]
-          },
-          {
-              "properties": {
-                  "ref_oid": {
-                      "type": "string",
-                      "format": "json-pointer"
-                  }
-              },
-              "required": ["ref_oid"],
-              "additionalProperties": false
-          }
-      ]
-    },
-    "constraints": {
+      "title": "Constraint to apply to parameter value",
+      "description": "Constraints on how the value of the parameter can change. Its schema is polymorphic dependent on type",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "UNDEFINED",
+            "INT_RANGE",
+            "FLOAT_RANGE",
+            "INT_CHOICE",
+            "STRING_CHOICE",
+            "STRING_STRING_CHOICE",
+            "ALARM_TABLE"
+          ],
+          "default": "UNDEFINED"
+        }
+      },
+      "required": ["type"],
       "oneOf": [
         {
-          "$ref": "#/$defs/constraint"
+          "$ref": "#/$defs/float32_constraint"
         },
         {
-          "$ref": "#/$defs/oid"
+          "$ref": "#/$defs/int32_constraint"
+        },
+        {
+          "$ref": "#/$defs/string_constraint"
         }
       ]
+    },
+    "constraint_ref": {
+      "properties": {
+        "ref_oid": {
+          "type": "string",
+          "format": "json-pointer"
+        }
+      },
+      "required": ["ref_oid"],
+      "additionalProperties": false
     },
     "apply_struct_variant": {
       "title": "STRUCT_VARIANT specialism",

--- a/schema/catena.schema.json
+++ b/schema/catena.schema.json
@@ -361,7 +361,7 @@
             "$ref": "#/$defs/float32_value"
           },
           "constraint": {
-            "$ref": "#/$defs/float32_constraint"
+            "$ref": "#/$defs/constraint"
           },
           "params": false,
           "commands": false,
@@ -554,7 +554,7 @@
             "$ref": "#/$defs/int32_value"
           },
           "constraint": {
-            "$ref": "#/$defs/int32_constraint"
+            "$ref": "#/$defs/constraint"
           },
           "params": false,
           "commands": false,
@@ -603,7 +603,7 @@
             "$ref": "#/$defs/int32_array_values"
           },
           "constraint": {
-            "$ref": "#/$defs/int32_constraint"
+            "$ref": "#/$defs/constraint"
           },
           "params": false
         }
@@ -648,7 +648,7 @@
             "$ref": "#/$defs/float32_array_values"
           },
           "constraint": {
-            "$ref": "#/$defs/float32_constraint"
+            "$ref": "#/$defs/constraint"
           },
           "params": false
         }
@@ -777,7 +777,7 @@
             "$ref": "#/$defs/string_value"
           },
           "constraint": {
-            "$ref": "#/$defs/string_constraint"
+            "$ref": "#/$defs/constraint"
           }
         }
       }
@@ -821,7 +821,7 @@
             "$ref": "#/$defs/string_array_values"
           },
           "constraint": {
-            "$ref": "#/$defs/string_constraint"
+            "$ref": "#/$defs/constraint"
           },
           "params": false
         }

--- a/sdks/cpp/connections/gRPC/examples/status_update/device.status_update.json
+++ b/sdks/cpp/connections/gRPC/examples/status_update/device.status_update.json
@@ -32,13 +32,26 @@
   "params": {
     "counter": {
       "type": "INT32",
-      "name": {"display_strings": {"en": "Counter", "es": "Contador", "fr": "Compteur"}},
-      "value": { "int32_value": 0 }
+      "name": {
+        "display_strings": {
+          "en": "Counter",
+          "es": "Contador",
+          "fr": "Compteur"
+        }
+      },
+      "value": { "int32_value": 0 },
+      "constraint": { "ref_oid": "/constraints/counter_cap" }
     },
     "hello": {
       "type": "STRING",
-      "name": {"display_strings": {"en": "Text Box", "es": "Caja de texto", "fr": "Boîte de texte"}},
-      "value": {"string_value": "Hello, World!"}
+      "name": {
+        "display_strings": {
+          "en": "Text Box",
+          "es": "Caja de texto",
+          "fr": "Boîte de texte"
+        }
+      },
+      "value": { "string_value": "Hello, World!" }
     },
     "button": {
       "type": "INT32",
@@ -88,11 +101,34 @@
         }
       }
     },
+    "screen": {
+      "type": "STRING",
+      "name": { "display_strings": { "en": "Screen" } },
+      "value": { "string_value": "screen1" },
+      "constraint": { "ref_oid": "/constraints/available_screens" }
+    },
     "dashboard_UI": {
       "type": "STRING",
       "oid_aliases": ["0xFF0E"],
       "read_only": true,
       "value": { "string_value": "eo://status_update.grid" }
+    }
+  },
+  "constraints": {
+    "counter_cap": {
+      "type": "INT_RANGE",
+      "int32_range": {
+        "min_value": 0,
+        "max_value": 150,
+        "step": 1
+      }
+    },
+    "available_screens": {
+      "type": "STRING_CHOICE",
+      "string_choice": {
+        "choices": ["screen1", "screen2", "screen3"],
+        "strict": true
+      }
     }
   }
 }

--- a/sdks/cpp/connections/gRPC/examples/status_update/static/status_update.grid
+++ b/sdks/cpp/connections/gRPC/examples/status_update/static/status_update.grid
@@ -16,12 +16,17 @@
       <tr>
          <param oid="button" showlabel="true" fill="both" widget="toggle"/>
       </tr>
-      <tr>
-         <param oid="offset" showlabel="true" fill="both" widget="slider-horizontal"/>
-      </tr>
+      
       <tr>
          <param oid="button" showlabel="true" fill="both" widget="combo"/>
       </tr>
 
+      <tr>
+         <param oid="offset" showlabel="true" fill="both" widget="slider-horizontal"/>
+      </tr>
+
+      <tr>
+         <param oid="screen" showlabel="true" fill="both" widget="toggle"/>
+      </tr>
    </table>
 </abs>

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -120,7 +120,7 @@ void statusUpdateExample(){
              */
             std::cout << "signal recieved: " << p->getOid() << " has been changed by client" << '\n';
         });
-        Param<int32_t>& aNumber = *dynamic_cast<Param<int32_t>*>(dm.getItem("/counter", Device::ParamTag{}));
+        Param<int32_t>& aNumber = *dynamic_cast<Param<int32_t>*>(dm.getItem("/counter", ParamTag{}));
         while (globalLoop) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
             {

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -217,7 +217,7 @@ void CatenaServiceImpl::GetValue::proceed(CatenaServiceImpl *service, bool ok) {
             try {
                 // std::vector<std::string> clientScopes = getScopes(context_);
                 catena::Value ans;
-                catena::lite::IParam* param = dm_.getItem(req_.oid(), Device::ParamTag{});
+                catena::lite::IParam* param = dm_.getItem(req_.oid(), catena::lite::ParamTag{});
                     if (param == nullptr) {
                     std::stringstream why;
                     why << __PRETTY_FUNCTION__ << "\nparam '" << req_.oid() << "' not found";
@@ -283,7 +283,7 @@ void CatenaServiceImpl::SetValue::proceed(CatenaServiceImpl *service, bool ok) {
             context_.AsyncNotifyWhenDone(this);
             try {
                 //std::vector<std::string> clientScopes = getScopes(context_);
-                auto dstParam = dm_.getItem(req_.oid(), Device::ParamTag{});
+                auto dstParam = dm_.getItem(req_.oid(), catena::lite::ParamTag{});
                 if (dstParam == nullptr) {
                     std::stringstream why;
                     why << __PRETTY_FUNCTION__ << "\nparam '" << req_.oid() << "' not found";

--- a/sdks/cpp/lite/CMakeLists.txt
+++ b/sdks/cpp/lite/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${target} STATIC
     src/Param.cpp
     src/StructInfo.cpp
     src/PolyglotText.cpp
+    src/PicklistConstraint.cpp
 )
 
 add_dependencies(${target} catena_common)

--- a/sdks/cpp/lite/examples/start_here/start_here.cpp
+++ b/sdks/cpp/lite/examples/start_here/start_here.cpp
@@ -30,6 +30,7 @@
 // folder structure.
 #include <lite/include/Device.h> // catena::lite::Device, LockGuard
 #include <lite/include/Param.h> // catena::lite::Param
+#include <lite/include/Collection.h> // catena::lite::Collection
 
 // this include header was generated from the protobuf definition
 // it's in the BINARY folder structure, not SOURCE.
@@ -52,7 +53,7 @@ int main () {
     // and we also know its value type - std::string
     // so we can get a reference to its Param object by casting it from 
     // an IParam* supplied by the Device's look up method
-    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.getItem("/hello", Device::ParamTag()));
+    auto& helloParam = *dynamic_cast<Param<std::string>*>(dm.getItem("/hello", ParamTag()));
 
     // With the Param object we can get a reference to the parameter's value object
     std::string& helloValue = helloParam.get();
@@ -68,21 +69,21 @@ int main () {
     std::cout << helloValue << std::endl;
 
     // Example with a parameter of type int
-    auto& countParam = *dynamic_cast<Param<int>*>(dm.getItem("/count", Device::ParamTag()));
+    auto& countParam = *dynamic_cast<Param<int>*>(dm.getItem("/count", ParamTag()));
     int32_t& countValue = countParam.get();
     std::cout << "counter initial value: " << countValue << std::endl;
     countValue++;
     std::cout << "counter incremented value: " << countValue << std::endl;
 
     // Example with a parameter of type float
-    auto& gainParam = *dynamic_cast<Param<float>*>(dm.getItem("/gain", Device::ParamTag()));
+    auto& gainParam = *dynamic_cast<Param<float>*>(dm.getItem("/gain", ParamTag()));
     float& gainValue = gainParam.get();
     std::cout << "gain initial value: " << gainValue << std::endl;
     gainValue *= gainValue;
     std::cout << "gain squared value: " << gainValue << std::endl;
 
     // Example with array of strings
-    auto& phonetic_alphabetParam = *dynamic_cast<Param<std::vector<std::string>>*>(dm.getItem("/phonetic_alphabet", Device::ParamTag()));
+    auto& phonetic_alphabetParam = *dynamic_cast<Param<std::vector<std::string>>*>(dm.getItem("/phonetic_alphabet", ParamTag()));
     std::vector<std::string>& phonetic_alphabetValue = phonetic_alphabetParam.get();
     std::cout << "phonetic alphabet initial value: ";
     for (const auto& s : phonetic_alphabetValue) {
@@ -98,7 +99,7 @@ int main () {
     std::cout << std::endl;
 
     // Example with array of integers
-    auto& primesParam = *dynamic_cast<Param<std::vector<int>>*>(dm.getItem("/primes", Device::ParamTag()));
+    auto& primesParam = *dynamic_cast<Param<std::vector<int>>*>(dm.getItem("/primes", ParamTag()));
     std::vector<int>& primesValue = primesParam.get();
     std::cout << "primes initial value: ";
     for (const auto& i : primesValue) {
@@ -114,7 +115,7 @@ int main () {
     std::cout << std::endl;
 
     // example with array of floats that's initially empty
-    auto& physical_constantsParam = *dynamic_cast<Param<std::vector<float>>*>(dm.getItem("/physical_constants", Device::ParamTag()));
+    auto& physical_constantsParam = *dynamic_cast<Param<std::vector<float>>*>(dm.getItem("/physical_constants", ParamTag()));
     std::vector<float>& physical_constantsValue = physical_constantsParam.get();
     std::cout << "physical constants " << (physical_constantsValue.size() == 0 ? "is empty" : "is not empty") << std::endl;
     physical_constantsValue.push_back(3.14159);

--- a/sdks/cpp/lite/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/lite/examples/use_structs/use_structs.cpp
@@ -39,7 +39,7 @@ int main() {
     // lock the model
     Device::LockGuard lg(dm);
 
-    auto& locationParam = *dynamic_cast<Param<Location>*>(dm.getItem("/location", Device::ParamTag()));
+    auto& locationParam = *dynamic_cast<Param<Location>*>(dm.getItem("/location", ParamTag()));
     Location& locationValue = locationParam.get();
     std::cout << "Location from model - latitude: " << locationValue.latitude
               << ", longitude: " << locationValue.longitude << std::endl;

--- a/sdks/cpp/lite/examples/use_templates/use_templates.cpp
+++ b/sdks/cpp/lite/examples/use_templates/use_templates.cpp
@@ -39,7 +39,7 @@ int main() {
     // lock the model
     Device::LockGuard lg(dm);
 
-    Param<City>& canadasCapital = *dynamic_cast<Param<City>*>(dm.getItem("/ottawa", Device::ParamTag()));
+    Param<City>& canadasCapital = *dynamic_cast<Param<City>*>(dm.getItem("/ottawa", ParamTag()));
     City& city = canadasCapital.get();
     std::cout << "Canada's capital city is " << city.city_name
               << " at latitude " << city.latitude
@@ -47,7 +47,7 @@ int main() {
               << " with a population of " << city.population
               << std::endl;
 
-    Param<City>& ontariosCapital = *dynamic_cast<Param<City>*>(dm.getItem("/toronto", Device::ParamTag()));
+    Param<City>& ontariosCapital = *dynamic_cast<Param<City>*>(dm.getItem("/toronto", ParamTag()));
     City& city2 = ontariosCapital.get();
     std::cout << "Ontario's capital city is " << city2.city_name
               << " at latitude " << city2.latitude

--- a/sdks/cpp/lite/include/Collection.h
+++ b/sdks/cpp/lite/include/Collection.h
@@ -1,0 +1,126 @@
+#pragma once
+
+/**
+ * @file Collection.h
+ * @brief Collection class for storing and retrieving items by name 
+ * @author isaac.robert@rossvideo.com
+ * @date 2024-08-14
+ * @copyright Copyright (c) 2024 Ross Video
+ */
+
+#include <unordered_map>
+
+namespace catena::common {
+  class IConstraint;    // forward reference
+} 
+
+namespace catena {
+namespace lite {
+
+class IParam;         // forward reference
+class IMenuGroup;     // forward reference
+class ILanguagePack;  // forward reference
+
+/**
+ * @brief ParamTag type for addItem and getItem, and tag-dispatched methods
+ */
+struct ParamTag {
+    using type = IParam;
+};
+
+/**
+ * @brief CommandTag type for addItem and getItem, and tag-dispatched methods
+ */
+struct CommandTag {
+    using type = IParam;
+};
+
+/**
+ * @brief ConstraintTag type for addItem and getItem, and tag-dispatched methods
+ */
+struct ConstraintTag {
+    using type = catena::common::IConstraint;
+};
+
+/**
+ * @brief MenuGroupTag type for addItem and getItem, and tag-dispatched methods
+ */
+struct MenuGroupTag {
+    using type = IMenuGroup;
+};
+
+/**
+ * @brief LanguagePackTag type for addItem and getItem, and tag-dispatched methods
+ */
+struct LanguagePackTag {
+    using type = ILanguagePack;
+};
+
+/**
+ * @brief Collection provides a way to store and retrieve items by name
+ * @tparam T constraint, parameter, command, menu group, or language pack
+ */
+template <typename T>
+class Collection {
+public:
+    /**
+     * @brief default constructor
+     */
+    Collection() = default;
+
+    /**
+     * @brief default destructor
+     */
+    virtual ~Collection() = default;
+
+    /**
+     * @brief add an item to the colllection by name
+     * @param name the name of the item
+     * @param item the item to add
+     */
+    void addItem(const std::string name, T* item) {
+        collection_[name] = item;
+    }
+
+    /**
+     * @brief get an item from the colllection by name
+     * @param name the name of the item
+     * @return the item
+     */
+    T* getItem(const std::string& name) const {
+        auto it = collection_.find(name);
+        if (it != collection_.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
+
+    /**
+     * @brief get the underlying map for iteration purposes
+     * @return unordered_map used by this collection
+     */
+    const std::unordered_map<std::string, T*>& getMap() const {
+        return collection_;
+    }
+
+    /**
+     * @brief check if the collection is empty
+     * @return true if empty, false otherwise
+     */
+    bool empty() const {
+        return collection_.empty();
+    }
+
+    /// temporary function to get the first item in the collection
+    /// needed for param to get its constraint until paramDescriptor separation
+    T* first() const {
+        return collection_.begin()->second;
+    }
+
+private:
+    std::unordered_map<std::string, T*> collection_;
+};
+
+}  // namespace lite
+}  // namespace catena
+

--- a/sdks/cpp/lite/include/Device.h
+++ b/sdks/cpp/lite/include/Device.h
@@ -13,11 +13,14 @@
 #include <cassert>
 #include <type_traits>
 
+namespace catena::common {
+  class IConstraint;    // forward reference
+} 
+
 namespace catena {
 namespace lite {
   
 class IParam;         // forward reference
-class IConstraint;    // forward reference
 class IMenuGroup;     // forward reference
 class ILanguagePack;  // forward reference
 
@@ -63,7 +66,7 @@ class Device {
      * @brief ConstraintTag type for addItem and getItem, and tag-dispatched methods
      */
     struct ConstraintTag {
-        using type = IConstraint;
+        using type = catena::common::IConstraint;
     };
     
     /**
@@ -203,7 +206,7 @@ class Device {
   private:
     uint32_t slot_;
     Device_DetailLevel detail_level_;
-    std::unordered_map<std::string, IConstraint*> constraints_;
+    std::unordered_map<std::string, catena::common::IConstraint*> constraints_;
     std::unordered_map<std::string, IParam*> params_;
     std::unordered_map<std::string, IMenuGroup*> menu_groups_;
     std::unordered_map<std::string, IParam*> commands_;

--- a/sdks/cpp/lite/include/NamedChoiceConstraint.h
+++ b/sdks/cpp/lite/include/NamedChoiceConstraint.h
@@ -11,9 +11,13 @@
 #include <common/include/IConstraint.h>
 #include <google/protobuf/message_lite.h>
 #include <lite/include/PolyglotText.h>
+#include <lite/include/Collection.h>
 
 #include <string>
 #include <unordered_map>
+
+namespace catena {
+namespace lite {
 
 /**
  * @brief Named choice constraint, ensures a value is within a named choice
@@ -48,9 +52,11 @@ public:
      * @param shared is the constraint shared
      * @note  the first choice provided will be the default for the constraint
      */
-    NamedChoiceConstraint(ListInitializer init, bool strict, std::string oid, bool shared)
+    NamedChoiceConstraint(ListInitializer init, bool strict, std::string oid, bool shared, Collection<IConstraint>& parent)
         : IConstraint{oid, shared}, choices_{init.begin(), init.end()}, 
-        strict_{strict}, default_{init.begin()->first} {}
+        strict_{strict}, default_{init.begin()->first} {
+            parent.addItem(oid, this);
+        }
 
     /**
      * @brief default destructor
@@ -116,3 +122,6 @@ private:
     bool strict_;     ///< should the value be constrained on apply
     T default_;       ///< the default value to constrain to
 };
+
+} // namespace lite
+} // namespace catena

--- a/sdks/cpp/lite/include/NamedChoiceConstraint.h
+++ b/sdks/cpp/lite/include/NamedChoiceConstraint.h
@@ -12,6 +12,9 @@
 #include <google/protobuf/message_lite.h>
 #include <lite/include/PolyglotText.h>
 
+#include <string>
+#include <unordered_map>
+
 /**
  * @brief Named choice constraint, ensures a value is within a named choice
  * @tparam T int or string
@@ -50,6 +53,11 @@ public:
         strict_{strict}, default_{init.begin()->first} {}
 
     /**
+     * @brief default destructor
+     */
+    virtual ~NamedChoiceConstraint() = default;
+
+    /**
      * @brief applies choice constraint to a catena::Value if strict
      * @param src a catena::Value to apply the constraint to
      */
@@ -71,7 +79,7 @@ public:
             if (!src_val.has_string_value()) { return; }
 
             // constrain if strict and src is not in choices
-            if (strict_ && !choices_.contains(src_val.float32_value())) {
+            if (strict_ && !choices_.contains(src_val.string_value())) {
                 src_val.set_string_value(default_);
             }
         } 

--- a/sdks/cpp/lite/include/PicklistConstraint.h
+++ b/sdks/cpp/lite/include/PicklistConstraint.h
@@ -1,0 +1,70 @@
+#pragma once
+
+/**
+ * @file PicklistConstraint.h
+ * @brief A constraint that checks if a value is in a list of strings
+ * @author isaac.robert@rossvideo.com
+ * @date 2024-08-09
+ * @copyright Copyright (c) 2024 Ross Video
+ */
+
+#include <common/include/IConstraint.h>
+#include <google/protobuf/message_lite.h>
+
+#include <string>
+#include <unordered_set>
+#include <initializer_list>
+
+/**
+ * @brief Picklist constraint, ensures a value is in a list of strings
+ */
+class PicklistConstraint : public catena::common::IConstraint {
+public:
+    /**
+     * @brief local alias for IConstraint
+     */
+    using IConstraint = catena::common::IConstraint;
+    /**
+     * @brief map of choices with their display names
+     */
+    using Choices = std::unordered_set<std::string>;
+    /**
+     * @brief initializer list for choices
+     */
+    using ListInitializer = std::initializer_list<std::string>;
+
+public:
+    /**
+     * @brief Construct a new Picklist Constraint object
+     * @param init the list of choices
+     * @param strict should the value be constrained if not in choices
+     * @param oid the oid of the constraint
+     * @param shared is the constraint shared
+     * @note  the first choice provided will be the default for the constraint
+     */
+    PicklistConstraint(ListInitializer init, bool strict, std::string oid, bool shared)
+        : IConstraint{oid, shared}, choices_{init.begin(), init.end()}, 
+        strict_{strict}, default_{*init.begin()} {}
+
+    /**
+     * @brief default destructor
+     */
+    virtual ~PicklistConstraint() = default;
+
+    /**
+     * @brief applies choice constraint to a catena::Value if strict
+     * @param src a catena::Value to apply the constraint to
+     */
+    void apply(void* src) const override;
+
+    /**
+     * @brief serialize the constraint to a protobuf message
+     * @param msg the protobuf message to populate
+     */
+    void toProto(google::protobuf::MessageLite& msg) const override;
+
+private:
+    Choices choices_;     ///< the choices
+    bool strict_;         ///< should the value be constrained on apply
+    std::string default_; ///< the default value to constrain to
+};

--- a/sdks/cpp/lite/include/PicklistConstraint.h
+++ b/sdks/cpp/lite/include/PicklistConstraint.h
@@ -40,16 +40,15 @@ public:
      * @param strict should the value be constrained if not in choices
      * @param oid the oid of the constraint
      * @param shared is the constraint shared
+     * @param dm the device to add the constraint to
      * @note  the first choice provided will be the default for the constraint
      */
-    PicklistConstraint(ListInitializer init, bool strict, std::string oid, bool shared)
-        : IConstraint{oid, shared}, choices_{init.begin(), init.end()}, 
-        strict_{strict}, default_{*init.begin()} {}
+    PicklistConstraint(ListInitializer init, bool strict, std::string oid, bool shared);
 
     /**
      * @brief default destructor
      */
-    virtual ~PicklistConstraint() = default;
+    virtual ~PicklistConstraint();
 
     /**
      * @brief applies choice constraint to a catena::Value if strict

--- a/sdks/cpp/lite/include/PicklistConstraint.h
+++ b/sdks/cpp/lite/include/PicklistConstraint.h
@@ -10,10 +10,14 @@
 
 #include <common/include/IConstraint.h>
 #include <google/protobuf/message_lite.h>
+#include <lite/include/Collection.h>
 
 #include <string>
 #include <unordered_set>
 #include <initializer_list>
+
+namespace catena {
+namespace lite {
 
 /**
  * @brief Picklist constraint, ensures a value is in a list of strings
@@ -43,7 +47,7 @@ public:
      * @param dm the device to add the constraint to
      * @note  the first choice provided will be the default for the constraint
      */
-    PicklistConstraint(ListInitializer init, bool strict, std::string oid, bool shared);
+    PicklistConstraint(ListInitializer init, bool strict, std::string oid, bool shared, Collection<IConstraint>& parent);
 
     /**
      * @brief default destructor
@@ -67,3 +71,6 @@ private:
     bool strict_;         ///< should the value be constrained on apply
     std::string default_; ///< the default value to constrain to
 };
+
+} // namespace lite
+} // namespace catena

--- a/sdks/cpp/lite/include/RangeConstraint.h
+++ b/sdks/cpp/lite/include/RangeConstraint.h
@@ -10,7 +10,11 @@
  */
 
 #include <common/include/IConstraint.h>
-#include  <google/protobuf/message_lite.h>
+#include <google/protobuf/message_lite.h>
+#include <lite/include/Collection.h>
+
+namespace catena {
+namespace lite {
 
 /**
  * @brief Range constraint, ensures a value is within a range
@@ -32,9 +36,11 @@ public:
      * @param oid the oid of the constraint
      * @param shared is the constraint shared
      */
-    RangeConstraint(T min, T max, std::string oid, bool shared)
+    RangeConstraint(T min, T max, std::string oid, bool shared, Collection<IConstraint>& parent)
         : IConstraint{oid, shared}, min_(min), max_(max), step_{1}, 
-        display_min_{min}, display_max_{max} {}
+        display_min_{min}, display_max_{max} {
+            parent.addItem(oid, this);
+        }
 
     /**
      * @brief default destructor
@@ -51,9 +57,12 @@ public:
      * @param oid the oid of the constraint
      * @param shared is the constraint shared
      */
-    RangeConstraint(T min, T max, T step, T display_min, T display_max, std::string oid, bool shared)
+    RangeConstraint(T min, T max, T step, T display_min, T display_max, std::string oid, 
+        bool shared, Collection<IConstraint>& parent)
         : IConstraint{oid, shared}, min_(min), max_(max), step_(step),
-        display_min_{display_min}, display_max_{display_max} {}
+        display_min_{display_min}, display_max_{display_max} {
+            parent.addItem(oid, this);
+        }
 
     /**
      * @brief applies range constraint to a catena::Value
@@ -120,3 +129,6 @@ private:
     T display_min_; ///< the minimum value to display
     T display_max_; ///< the maximum value to display
 };
+
+} // namespace lite
+} // namespace catena

--- a/sdks/cpp/lite/include/RangeConstraint.h
+++ b/sdks/cpp/lite/include/RangeConstraint.h
@@ -37,6 +37,11 @@ public:
         display_min_{min}, display_max_{max} {}
 
     /**
+     * @brief default destructor
+     */
+    virtual ~RangeConstraint() = default;
+
+    /**
      * @brief Construct a new Range Constraint object
      * @param min the minimum value
      * @param max the maximum value

--- a/sdks/cpp/lite/src/Device.cpp
+++ b/sdks/cpp/lite/src/Device.cpp
@@ -19,7 +19,7 @@ void Device::toProto(::catena::Device& dst, bool shallow) const {
     /// @todo: implement deep copies for constraints, menu groups, commands, etc...
     // for now, we can make do with just params
     google::protobuf::Map<std::string, ::catena::Param> dstParams{};
-    for (const auto& [name, param] : params_) {
+    for (const auto& [name, param] : params_.getMap()) {
         ::catena::Param dstParam{};
         param->toProto(dstParam);
         dstParams[name] = dstParam;

--- a/sdks/cpp/lite/src/Param.cpp
+++ b/sdks/cpp/lite/src/Param.cpp
@@ -21,8 +21,8 @@ void Param<int32_t>::toProto(Value& dst) const {
 
 template <>
 void Param<int32_t>::fromProto(Value& src) {
-    if (constraint_) {
-        constraint_->apply(&src);
+    if (!constraints_.empty()) {
+        constraints_.first()->apply(&src);
     }
     catena::lite::fromProto<int32_t>(&value_.get(), src);
 }
@@ -34,8 +34,8 @@ void Param<std::string>::toProto(Value& dst) const {
 
 template <>
 void Param<std::string>::fromProto(Value& src) {
-    if (constraint_) {
-        constraint_->apply(&src);
+    if (!constraints_.empty()) {
+        constraints_.first()->apply(&src);
     }
     catena::lite::fromProto<std::string>(&value_.get(), src);
 }
@@ -47,8 +47,8 @@ void Param<float>::toProto(Value& dst) const {
 
 template <>
 void Param<float>::fromProto(Value& src) {
-    if (constraint_) {
-        constraint_->apply(&src);
+    if (!constraints_.empty()) {
+        constraints_.first()->apply(&src);
     }
     catena::lite::fromProto<float>(&value_.get(), src);
 }

--- a/sdks/cpp/lite/src/PicklistConstraint.cpp
+++ b/sdks/cpp/lite/src/PicklistConstraint.cpp
@@ -2,10 +2,15 @@
 
 #include <lite/param.pb.h>
 
+namespace catena {
+namespace lite {
+
 PicklistConstraint::PicklistConstraint(ListInitializer init, bool strict, std::string oid, 
-    bool shared)
+    bool shared, Collection<IConstraint>& parent)
     : IConstraint{oid, shared}, choices_{init.begin(), init.end()}, 
-    strict_{strict}, default_{*init.begin()} {}
+    strict_{strict}, default_{*init.begin()} {
+        parent.addItem(oid, this);
+    }
 
 PicklistConstraint::~PicklistConstraint() = default;
 
@@ -29,3 +34,6 @@ void PicklistConstraint::toProto(google::protobuf::MessageLite& msg) const {
         constraint.mutable_string_choice()->add_choices(choice);
     }
 }
+
+} // namespace lite
+} // namespace catena

--- a/sdks/cpp/lite/src/PicklistConstraint.cpp
+++ b/sdks/cpp/lite/src/PicklistConstraint.cpp
@@ -1,0 +1,24 @@
+#include <PicklistConstraint.h>
+
+#include <lite/param.pb.h>
+
+void PicklistConstraint::apply(void* src) const {
+    auto& src_val = *reinterpret_cast<catena::Value*>(src);
+
+    // ignore the request if src is not valid
+    if (!src_val.has_string_value()) { return; }
+
+    // constrain if strict and src is not in choices
+    if (strict_ && !choices_.contains(src_val.string_value())) {
+        src_val.set_string_value(default_);
+    }
+}
+
+void PicklistConstraint::toProto(google::protobuf::MessageLite& msg) const {
+    auto& constraint = dynamic_cast<catena::Constraint&>(msg);
+
+    constraint.set_type(catena::Constraint::STRING_STRING_CHOICE);
+    for (std::string choice : choices_) {
+        constraint.mutable_string_choice()->add_choices(choice);
+    }
+}

--- a/sdks/cpp/lite/src/PicklistConstraint.cpp
+++ b/sdks/cpp/lite/src/PicklistConstraint.cpp
@@ -2,6 +2,13 @@
 
 #include <lite/param.pb.h>
 
+PicklistConstraint::PicklistConstraint(ListInitializer init, bool strict, std::string oid, 
+    bool shared)
+    : IConstraint{oid, shared}, choices_{init.begin(), init.end()}, 
+    strict_{strict}, default_{*init.begin()} {}
+
+PicklistConstraint::~PicklistConstraint() = default;
+
 void PicklistConstraint::apply(void* src) const {
     auto& src_val = *reinterpret_cast<catena::Value*>(src);
 

--- a/tools/codegen/cppgen.js
+++ b/tools/codegen/cppgen.js
@@ -122,56 +122,62 @@ class CppGen {
         this.namespace = namespace;
         this.constraints = {
             "INT_RANGE": (name, desc, shared = false, indent = 0) => {
-                let cons, constraint_name, constraint_owner; 
+                let cons, constraint_name, constraint_owner, parent; 
                 // is this a shared or param constraint 
                 if (shared) {
                     cons = desc.int32_range;
                     constraint_name = `${name}`;
-                    constraint_owner = `/constraints/${name}` 
+                    constraint_owner = `/constraints/${name}`;
+                    parent = 'dm.getCollection(ConstraintTag{})';
                 } else {
                     cons = desc.constraint.int32_range;
                     constraint_name = `${name}ParamConstraint`;
                     constraint_owner = `/param/${name}`;
+                    parent = `${name}Param.getCollection(ConstraintTag{})`;
                 }
                 // collect range bounds
                 let fields = `${cons.min_value},${cons.max_value}`;
                 fields += cons.steps !== undefined ? `,${cons.steps}` : ',1';
                 fields += cons.display_min !== undefined ? `,${cons.display_min}` : `,${cons.min_value}`;
                 fields += cons.display_max !== undefined ? `,${cons.display_max}` : `,${cons.max_value}`;
-                bloc(`RangeConstraint<int32_t> ${constraint_name}{${fields},${quoted(constraint_owner)},${shared}};`, indent);
+                bloc(`RangeConstraint<int32_t> ${constraint_name}{${fields},${quoted(constraint_owner)},${shared},${parent}};`, indent);
                 return constraint_name;
             }, 
             "FLOAT_RANGE": (name, desc, shared = false, indent = 0) => {
-                let cons, constraint_name, constraint_owner; 
+                let cons, constraint_name, constraint_owner, parent; 
                 // is this a shared or param constraint 
                 if (shared) {
                     cons = desc.float_range;
                     constraint_name = `${name}`;
-                    constraint_owner = `/constraints/${name}` 
+                    constraint_owner = `/constraints/${name}`;
+                    parent = 'dm.getCollection(ConstraintTag{})';
                 } else {
                     cons = desc.constraint.float_range;
                     constraint_name = `${name}ParamConstraint`;
                     constraint_owner = `/param/${name}`;
+                    parent = `${name}Param.getCollection(ConstraintTag{})`;
                 }
                 // collect range bounds
                 let fields = `${cons.min_value},${cons.max_value}`;
                 fields += cons.steps !== undefined ? `,${cons.steps}` : ',1';
                 fields += cons.display_min !== undefined ? `,${cons.display_min}` : `,${cons.min_value}`;
                 fields += cons.display_max !== undefined ? `,${cons.display_max}` : `,${cons.max_value}`;
-                bloc(`RangeConstraint<float> ${constraint_name}{${fields},${quoted(constraint_owner)},${shared}};`, indent);
+                bloc(`RangeConstraint<float> ${constraint_name}{${fields},${quoted(constraint_owner)},${shared},${parent}};`, indent);
                 return constraint_name;
             }, 
             "INT_CHOICE": (name, desc, shared = false, indent = 0) => {
-                let cons, constraint_name, constraint_owner; 
+                let cons, constraint_name, constraint_owner, parent; 
                 // is this a shared or param constraint 
                 if (shared) {
                     cons = desc.int32_choice;
                     constraint_name = `${name}`;
-                    constraint_owner = `/constraints/${name}` 
+                    constraint_owner = `/constraints/${name}`;
+                    parent = 'dm.getCollection(ConstraintTag{})';
                 } else {
                     cons = desc.constraint.int32_choice;
                     constraint_name = `${name}ParamConstraint`;
                     constraint_owner = `/param/${name}`;
+                    parent = `${name}Param.getCollection(ConstraintTag{})`;
                 }
                 // collect the polyglot names and value pairs
                 let fields = '';
@@ -191,20 +197,22 @@ class CppGen {
                     }
                 }
                 let strict = true;
-                bloc(`NamedChoiceConstraint<int32_t> ${constraint_name}{{${fields}},${strict},${quoted(constraint_owner)},${shared}};`, indent);
+                bloc(`NamedChoiceConstraint<int32_t> ${constraint_name}{{${fields}},${strict},${quoted(constraint_owner)},${shared},${parent}};`, indent);
                 return constraint_name;
             },
             "STRING_STRING_CHOICE": (name, desc, shared = false, indent = 0) => {
-                let cons, constraint_name, constraint_owner; 
+                let cons, constraint_name, constraint_owner, parent; 
                 // is this a shared or param constraint 
                 if (shared) {
                     cons = desc.int32_choice;
                     constraint_name = `${name}`;
-                    constraint_owner = `/constraints/${name}` 
+                    constraint_owner = `/constraints/${name}`;
+                    parent = 'dm.getCollection(ConstraintTag{})';
                 } else {
                     cons = desc.constraint.int32_choice;
                     constraint_name = `${name}ParamConstraint`;
                     constraint_owner = `/param/${name}`;
+                    parent = `${name}Param.getCollection(ConstraintTag{})`;
                 }
                 // collect the polyglot names and value pairs
                 let fields = '';
@@ -224,20 +232,22 @@ class CppGen {
                     }
                 }
                 let strict = cons.strict !== undefined ? cons.strict : false;
-                bloc(`NamedChoiceConstraint<std::string> ${constraint_name}{{${fields}},${strict},${quoted(constraint_owner)},${shared}};`, indent);
+                bloc(`NamedChoiceConstraint<std::string> ${constraint_name}{{${fields}},${strict},${quoted(constraint_owner)},${shared},${parent}};`, indent);
                 return constraint_name;
             },
             "STRING_CHOICE": (name, desc, shared = false, indent = 0) => {
-                let cons, constraint_name, constraint_owner; 
+                let cons, constraint_name, constraint_owner, parent; 
                 // is this a shared or param constraint 
                 if (shared) {
                     cons = desc.string_choice;
                     constraint_name = `${name}`;
-                    constraint_owner = `/constraints/${name}` 
+                    constraint_owner = `/constraints/${name}`;
+                    parent = 'dm.getCollection(ConstraintTag{})';
                 } else {
                     cons = desc.constraint.string_choice;
                     constraint_name = `${name}ParamConstraint`;
                     constraint_owner = `/param/${name}`;
+                    parent = `${name}Param.getCollection(ConstraintTag{})`;
                 }
                 // collect the string list 
                 let fields = '';
@@ -248,7 +258,7 @@ class CppGen {
                     }
                 }
                 let strict = cons.strict !== undefined ? cons.strict : false;
-                bloc(`PicklistConstraint ${constraint_name}{{${fields}},${strict},${quoted(constraint_owner)},${shared}};`, indent);
+                bloc(`PicklistConstraint ${constraint_name}{{${fields}},${strict},${quoted(constraint_owner)},${shared},${parent}};`, indent);
                 return constraint_name;
             },
             "ALARM_TABLE": (name, desc, shared = false, indent = 0) => {
@@ -296,23 +306,10 @@ class CppGen {
 
             // add the read_only flag
             if (desc.read_only !== undefined && desc.read_only) {
-                ans += 'true,';
+                ans += 'true';
             } else {
-                ans += 'false,';
+                ans += 'false';
             }
-            
-            // add the constraint if it exists
-            let constraint_init = '&';
-            if (desc.constraint !== undefined && desc.constraint.ref_oid === undefined) {
-                // construct and reference the param constraint
-                constraint_init += this.constraints[desc.constraint.type](name, desc);
-            } else if (desc.constraint !== undefined) {
-                // just reference the shared constraint
-                constraint_init += desc.constraint.ref_oid.split('/').pop();
-            } else {
-                constraint_init = 'nullptr';
-            }
-            ans += `${constraint_init}`;
 
             return ans;
         },
@@ -377,7 +374,7 @@ class CppGen {
                 // instantiate the struct in the body file 
                 let bodyIndent = 0;
                 bloc(`${fqname} ${name} ${structInit(names, srctypes, desc)};`, bodyIndent);
-                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},${this.other_items(name, desc)},"/${name}",dm);`, bodyIndent)
+                bloc(`catena::lite::Param<${fqname}> ${name}Param(catena::ParamType::STRUCT,${name},${this.other_items(name, desc)},"/${name}",dm.getCollection(ParamTag{}));`, bodyIndent)
                 if (template !== undefined) {
                     // Support functions for user defined types have already been generated
                     return;
@@ -413,7 +410,7 @@ class CppGen {
                     initializer = `{"${desc.value.string_value}"}`;
                 }
                 bloc(`std::string ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},${this.other_items(name, desc, template)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::string> ${name}Param(catena::ParamType::STRING,${name},${this.other_items(name, desc, template)},"/${name}",dm.getCollection(ParamTag{}));`, indent);
             },
             "INT32": (name, desc, template, indent = 0) => {
                 let initializer = '{}';
@@ -421,7 +418,7 @@ class CppGen {
                     initializer = `{${desc.value.int32_value}}`;
                 }
                 bloc(`int32_t ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},${this.other_items(name, desc, template)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<int32_t> ${name}Param(catena::ParamType::INT32,${name},${this.other_items(name, desc, template)},"/${name}",dm.getCollection(ParamTag{}));`, indent);
             },
             "FLOAT32": (name, desc, template, indent = 0) => {
                 let initializer = '{}';
@@ -429,22 +426,22 @@ class CppGen {
                     initializer = `{${desc.value.float32_value}}`;
                 }
                 bloc(`float ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},${this.other_items(name, desc, template)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<float> ${name}Param(catena::ParamType::FLOAT32,${name},${this.other_items(name, desc, template)},"/${name}",dm.getCollection(ParamTag{}));`, indent);
             },
             "STRING_ARRAY": (name, desc, template, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.string_array_values.strings, '"', indent);
                 bloc(`std::vector<std::string> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},${this.other_items(name, desc, template)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::string>> ${name}Param(catena::ParamType::STRING_ARRAY,${name},${this.other_items(name, desc, template)},"/${name}",dm.getCollection(ParamTag{}));`, indent);
             },
             "INT32_ARRAY": (name, desc, template, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.int32_array_values.ints, '', indent);
                 bloc(`std::vector<std::int32_t> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},${this.other_items(name, desc, template)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<std::int32_t>> ${name}Param(catena::ParamType::INT32_ARRAY,${name},${this.other_items(name, desc, template)},"/${name}",dm.getCollection(ParamTag{}));`, indent);
             },
             "FLOAT32_ARRAY": (name, desc, template, indent = 0) => {
                 let initializer = this.arrayInitializer(name, desc, desc.value.float32_array_values.floats, '', indent);
                 bloc(`std::vector<float> ${name}${initializer};`, indent);
-                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},${this.other_items(name, desc, template)},"/${name}",dm);`, indent);
+                bloc(`catena::lite::Param<std::vector<float>> ${name}Param(catena::ParamType::FLOAT32_ARRAY,${name},${this.other_items(name, desc, template)},"/${name}",dm.getCollection(ParamTag{}));`, indent);
             }
         };
         this.init = (headerFilename, device) => {
@@ -484,7 +481,11 @@ class CppGen {
             bloc(`catena::lite::Device dm{${deviceInit}};`)
             bloc(`using catena::lite::StructInfo;`);
             bloc(`using catena::lite::FieldInfo;`);
-            bloc(`std::unordered_map<std::string, catena::common::IConstraint*> constraints;`);
+            bloc(`using catena::lite::RangeConstraint;`);
+            bloc(`using catena::lite::NamedChoiceConstraint;`);
+            bloc(`using catena::lite::PicklistConstraint;`);
+            bloc(`using catena::lite::ParamTag;`);
+            bloc(`using catena::lite::ConstraintTag;`);
         },
         this.finish = () => {
             hloc(`} // namespace ${namespace}`);
@@ -509,7 +510,16 @@ class CppGen {
                 throw new Error(`Param ${oid} is based off a template so it can't have params`);
             }
         } 
-        return this.params[desc.type](oid, desc, template_param);
+        this.params[desc.type](oid, desc, template_param);
+        // add the constraint if it exists
+        if (desc.constraint !== undefined && desc.constraint.ref_oid === undefined) {
+            // construct and reference the param constraint
+            this.constraints[desc.constraint.type](oid, desc);
+        } else if (desc.constraint !== undefined) {
+            // just reference the shared constraint
+            desc.constraint.ref_oid.split('/').pop();
+        }
+        return 
     }
 
     constraint (oid, desc) {


### PR DESCRIPTION
Shared constraints are now supported in the json schema through ref_oid along with the codegen. 
Picklist Constraints are now implemented.

Additional note - we lost type checking in the json schema since each type would check its own special constraint directly and this was not able to have a ref_oid without a lot of code duplication (adding the oneOf to each constraint) so for now I just switched it to the general constraint reference. maybe think of a way to add constraint type checking back?

Concern to think about - how to add the shared constraints to the global constraints map in the gen'd code.