### PR TITLE
Adds package.json which was missing from the develop branch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "dependencies": {
+        "ajv": "^8.8.2",
+        "ajv-formats": "^2.1.1",
+        "commander": "^9.2.0",
+        "json-source-map": "^0.6.1",
+        "node": "^20.7.0"
+    },
+    "scripts": {
+        "clang-format": "find . -regex '.*\\.\\(cpp\\|h\\|js\\|json\\|java\\)' -exec clang-format -style=file -i {} \\;",
+        "clang-format-windows": "powershell -NoProfile -ExecutionPolicy Unrestricted -Command scripts/clang-format.ps1"
+    }
+}


### PR DESCRIPTION
The package.json file was missing from the develop branch.

I took the package.json from the main branch (which apparently was committed with merge errors) and copied it into the develop branch, and fixed the merge errors. I also added "commander" to the dependencies as the c++ build seems to require it.