### PR TITLE
Replaced has_getStructInfo with C++20 concept

### DIFF
--- a/sdks/cpp/lite/include/StructInfo.h
+++ b/sdks/cpp/lite/include/StructInfo.h
@@ -54,28 +54,10 @@ struct StructInfo {
 };
 }  // namespace lite
 
-namespace meta {
-/**
- * @brief determine at compile time if a type T has a getStructInfo method.
- *
- * default is false
- *
- * @todo refactor using C++ 20 concepts to make the code a bit clearer
- *
- * @tparam T
- * @tparam typename
- */
-template <typename T, typename = void> constexpr bool has_getStructInfo{};
-
-/**
- * @brief specialization for types that do have getStructInfo method
- *
- * @tparam T
- */
 template <typename T>
-constexpr bool has_getStructInfo<T, std::void_t<decltype(std::declval<T>().getStructInfo())>> = true;
-
-}  // namespace meta
+concept CatenaStruct = requires {
+    T::getStructInfo();
+};
 
 namespace lite {
 
@@ -86,8 +68,8 @@ namespace lite {
  * 
  * @tparam T the type of the value
  */
-template <typename T>
-typename std::enable_if<meta::has_getStructInfo<T>, void>::type toProto(catena::Value& dst, const void* src) {
+template <CatenaStruct T>
+void toProto(catena::Value& dst, const void* src) {
     const auto& si = T::getStructInfo();
 
     // required so that pointer math works correctly
@@ -105,7 +87,7 @@ typename std::enable_if<meta::has_getStructInfo<T>, void>::type toProto(catena::
 
 
 template <typename T>
-typename std::enable_if<!meta::has_getStructInfo<T>, void>::type toProto(catena::Value& dst, const void* src);
+void toProto(catena::Value& dst, const void* src);
 
 
 /**
@@ -115,8 +97,8 @@ typename std::enable_if<!meta::has_getStructInfo<T>, void>::type toProto(catena:
  * 
  * @tparam T the type of the value
  */
-template <typename T>
-typename std::enable_if<meta::has_getStructInfo<T>, void>::type fromProto(void* dst, const catena::Value& src) {
+template <CatenaStruct T>
+void fromProto(void* dst, const catena::Value& src) {
     const auto& si = T::getStructInfo();
 
     // required so that pointer math works correctly
@@ -133,7 +115,7 @@ typename std::enable_if<meta::has_getStructInfo<T>, void>::type fromProto(void* 
 }
 
 template <typename T>
-typename std::enable_if<!meta::has_getStructInfo<T>, void>::type fromProto(void* dst, const catena::Value& src);
+void fromProto(void* dst, const catena::Value& src);
 
 }  // namespace lite
 }  // namespace catena

--- a/sdks/cpp/lite/src/Param.cpp
+++ b/sdks/cpp/lite/src/Param.cpp
@@ -10,7 +10,6 @@
 
 using catena::Value;
 using catena::lite::Param;
-using catena::meta::has_getStructInfo;
 using catena::lite::StructInfo;
 using catena::lite::FieldInfo;
 


### PR DESCRIPTION
Proof of concept to show how C++20 constraints and concepts could be used for Catena.

There are other functions in the meta namespace that this could be used for, but I wanted to keep this pull request simple.