### PR TITLE
Feat-#260-jrn

### DIFF
--- a/sdks/cpp/common/src/Path.cpp
+++ b/sdks/cpp/common/src/Path.cpp
@@ -25,71 +25,8 @@
 using catena::common::Path;
 using Index = Path::Index;
 
+
 Path::Path(const std::string &jptr) : segments_{} {
-    // regex will split a well-formed json pointer into a sequence of Path Segments
-    // typed according to the regex that matches the string for th segment
-    // /- -- can be used as an array index
-    // /any_string_that_uses_only_word_chars -- i.e. letters & underscores.
-    // /string_with_~0_~1_escaped_chars -- string_with_~_/_escaped_chars
-    // /291834719 -- just numbers
-    //
-
-    std::regex path_regex("((\\/-{1})|(\\/([\\w]|~[01])*))*");
-    if (!std::regex_match(jptr, path_regex))  {
-        std::stringstream why;
-        why << __PRETTY_FUNCTION__ << "\n'" << jptr << "' is not a valid path";
-        throw catena::exception_with_status(why.str(), catena::StatusCode::INVALID_ARGUMENT);
-    }
-
-    std::regex segment_regex("(\\/-{1})|(\\/([\\w]|~[01])*)");
-    auto r_begin = std::sregex_iterator(jptr.begin(), jptr.end(), segment_regex);
-    auto r_end = std::sregex_iterator();
-    for (std::sregex_iterator it = r_begin; it != r_end; ++it) {
-        std::smatch match = *it;
-        if (it == r_begin && match.position(0) != 0) {
-            std::stringstream why;
-            why << __PRETTY_FUNCTION__ << "\n'" << jptr << " is invalid json pointer";
-            throw catena::exception_with_status(why.str(), catena::StatusCode::INVALID_ARGUMENT);
-        }
-
-        // unescape and strip off leading solidus '/'
-        std::string txt = unescape(match.str()).substr(1, std::string::npos);
-
-        if (txt.compare("-") == 0) {
-            // segment is an index with the one-past-the-end value
-            Segment seg;
-            seg.emplace<Index>(kEnd);
-            segments_.push_back(seg);
-        } else if (std::all_of(txt.cbegin(), txt.cend(), ::isdigit)) {
-            // segment is an index
-            Segment seg;
-            seg.emplace<Index>(std::stoul(txt));
-            segments_.push_back(seg);
-        } else {
-            // segment is a string
-            Segment seg;
-            seg.emplace<std::string>(txt);
-            segments_.push_back(seg);
-        }
-    }
-    front_ = cbegin();
-
-    //     if (segments_.size() >= 1) {
-    //     std::string seg = segments_[0];
-    //     if (seg.compare("-") == 0) {
-    //         // the one-past-the-end array index
-    //         ans.emplace<Index>(kEnd);
-    //     } else if (std::all_of(seg.begin(), seg.end(), ::isdigit)) {
-    //         // segment is all digits, so convert to Index
-    //         ans.emplace<Index>(std::stoul(seg));
-    //     } else {
-    //         // segment is a string
-    //         ans.emplace<std::string>(seg);
-    //     }
-    // } else {
-    //     // return empty string
-    //     ans.emplace<std::string>("");
-    // }
 }
 
 Path::Path(const char *literal) : Path(std::string(literal)) {}

--- a/sdks/cpp/lite/examples/use_templates/use_templates.cpp
+++ b/sdks/cpp/lite/examples/use_templates/use_templates.cpp
@@ -49,9 +49,9 @@ int main() {
     // lock the model
     Device::LockGuard lg(dm);
 
-    IParam* ip = dm.getItem<ParamTag>("ottawa");
+    std::unique_ptr<IParam> ip = dm.getParam("/ottawa");
     assert(ip != nullptr);
-    auto& canadasCapital = *dynamic_cast<ParamWithValue<City>*>(ip);
+    auto& canadasCapital = *dynamic_cast<ParamWithValue<City>*>(ip.get());
     City& city = canadasCapital.get();
     std::cout << "Canada's capital city is " << city.city_name
               << " at latitude " << city.latitude
@@ -59,8 +59,8 @@ int main() {
               << " with a population of " << city.population
               << std::endl;
 
-    ip = dm.getItem<ParamTag>("toronto");
-    auto& ontariosCapital = *dynamic_cast<ParamWithValue<City>*>(ip);
+    ip = dm.getParam("/toronto");
+    auto& ontariosCapital = *dynamic_cast<ParamWithValue<City>*>(ip.get());
     City& city2 = ontariosCapital.get();
     std::cout << "Ontario's capital city is " << city2.city_name
               << " at latitude " << city2.latitude

--- a/sdks/cpp/lite/include/ParamDescriptor.h
+++ b/sdks/cpp/lite/include/ParamDescriptor.h
@@ -180,7 +180,7 @@ class ParamDescriptor {
     
     std::string oid_;
     ParamDescriptor* parent_;
-    const Device& dev_;
+    std::reference_wrapper<Device> dev_;
 };
 
 }  // namespace lite

--- a/sdks/cpp/lite/include/StructInfo.h
+++ b/sdks/cpp/lite/include/StructInfo.h
@@ -75,7 +75,7 @@ void toProto(catena::Value& dst, const T* src, const AuthzInfo& auth);
 /**
  * Free standing method to stream an entire array of structured data to protobuf
  * 
- * enabled if T is a vector of struct with getStructInfo method
+ * enabled if T is a vector of CatenaStruct
  * 
  * @tparam T the type of the value
  */
@@ -94,7 +94,7 @@ void toProto(catena::Value& dst, const T* src, const AuthzInfo& auth) {
 /**
  * Free standing method to stream structured data to protobuf
  * 
- * enabled if T has a getStructInfo method
+ * enabled if T has matches the CatenaStruct concept
  * 
  * @tparam T the type of the value
  */

--- a/sdks/cpp/lite/src/ParamDescriptor.cpp
+++ b/sdks/cpp/lite/src/ParamDescriptor.cpp
@@ -60,6 +60,6 @@ const std::string ParamDescriptor::getScope() const {
       } else if (parent_) {
         return parent_->getScope();
       } else {
-        return dev_.getDefaultScope();
+        return dev_.get().getDefaultScope();
       }
     }


### PR DESCRIPTION
Originally inteded to just improve the implementation of Path's constructor. However, a few compiler errors were encountered that also needed to be addressed...

The new way of handling params/values didn't compile with clang. A few changes were necessary:

- putting template specialization of user-defined types into the header, but outside the device namespace.
- changing the Device& held by ParamDescriptor to a std::reference_wrapper<Device> to enable move semantics

I'm not too happy with putting template specializations in the header file because of the potential for code duplication it creates. However other fixes are as bad (i.e. caring about the link order). Perhaps this is a job for ... drum roll ... C++20 Modules!
