### PR TITLE
removed warnings

### DIFF
--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -29,7 +29,7 @@ using catena::common::ParamTag;
 #include <thread>
 #include <fstream>
 #include <vector>
-#include <iterator> 
+#include <iterator>
 
 grpc::Status JWTAuthMetadataProcessor::Process(const InputMetadata& auth_metadata, grpc::AuthContext* context, 
                          OutputMetadata* consumed_auth_metadata, OutputMetadata* response_metadata) {
@@ -211,6 +211,11 @@ void CatenaServiceImpl::GetPopulatedSlots::proceed(CatenaServiceImpl *service, b
             std::cout << "GetPopulatedSlots[" << objectId_ << "] finished\n";
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            responder_.FinishWithError(errorStatus, this);
     }
 }
 
@@ -269,6 +274,11 @@ void CatenaServiceImpl::GetValue::proceed(CatenaServiceImpl *service, bool ok) {
             std::cout << "GetValue[" << objectId_ << "] finished\n";
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            responder_.FinishWithError(errorStatus, this);
     }
 }
 
@@ -334,6 +344,11 @@ void CatenaServiceImpl::SetValue::proceed(CatenaServiceImpl *service, bool ok) {
             std::cout << "SetValue[" << objectId_ << "] finished\n";
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            responder_.FinishWithError(errorStatus, this);
     }
 }
 
@@ -455,6 +470,11 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
             dm_.valueSetByServer.disconnect(valueSetByServerId_);
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            writer_.Finish(errorStatus, this);
     }
 }
 
@@ -519,6 +539,11 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
             //shutdownSignal.disconnect(shutdownSignalId_);
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            writer_.Finish(errorStatus, this);
     }
 }
 
@@ -600,6 +625,11 @@ void CatenaServiceImpl::ExternalObjectRequest::proceed(CatenaServiceImpl *servic
             std::cout << "ExternalObjectRequest[" << objectId_ << "] finished\n";
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            writer_.Finish(errorStatus, this);
     }
 }
 
@@ -751,5 +781,10 @@ void CatenaServiceImpl::ExecuteCommand::proceed(CatenaServiceImpl *service, bool
             std::cout << "ExecuteCommand[" << objectId_ << "] finished\n";
             service->deregisterItem(this);
             break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            stream_.Finish(errorStatus, this);
     }
 }

--- a/sdks/cpp/lite/include/ParamDescriptor.h
+++ b/sdks/cpp/lite/include/ParamDescriptor.h
@@ -104,11 +104,11 @@ class ParamDescriptor {
       const PolyglotText::ListInitializer name, 
       const std::string& widget,
       const std::string& scope, 
-      const bool read_only, 
+      bool read_only, 
       const std::string& oid, 
       ParamDescriptor* parent,
       Device& dev,
-      const bool isCommand)
+      bool isCommand)
       : type_{type}, oid_aliases_{oid_aliases}, name_{name}, widget_{widget}, scope_{scope}, read_only_{read_only},
         constraint_{nullptr}, parent_{parent}, dev_{dev}, isCommand_{isCommand} {
       setOid(oid);
@@ -247,7 +247,7 @@ class ParamDescriptor {
     ParamDescriptor* parent_;
     std::reference_wrapper<Device> dev_;
 
-    const bool isCommand_;
+    bool isCommand_;
 
     // default command implementation
     std::function<catena::CommandResponse(catena::Value)> commandImpl_ = [](catena::Value value) { 

--- a/sdks/cpp/lite/src/StructInfo.cpp
+++ b/sdks/cpp/lite/src/StructInfo.cpp
@@ -97,7 +97,7 @@ void toProto<std::vector<float>>(Value& dst, const std::vector<float>* src, cons
 }
 
 template<>
-void catena::lite::fromProto<std::vector<float>>(const Value& src, std::vector<float>* dst, const AuthzInfo& auth) {
+void fromProto<std::vector<float>>(const Value& src, std::vector<float>* dst, const AuthzInfo& auth) {
     dst->clear();
     const catena::Float32List& float_array = src.float32_array_values();
     for (int i = 0; i < float_array.floats_size(); ++i) {


### PR DESCRIPTION
removed 3 types of warning:

- const qualified attribute of ParamDescriptor broke move semantics
- missing default branch in several places in ServiceImpl
- overly qualified fromProto definition

