### PR TITLE
Implemented shallow device request

### DIFF
--- a/.vscode/Catena.code-workspace
+++ b/.vscode/Catena.code-workspace
@@ -105,7 +105,8 @@
 			"scoped_allocator": "cpp",
 			"shared_mutex": "cpp",
 			"*.inc": "cpp",
-			"cassert": "cpp"
+			"cassert": "cpp",
+			"coroutine": "cpp"
 		}
 	}
 }

--- a/sdks/cpp/connections/gRPC/examples/status_update/device.status_update.json
+++ b/sdks/cpp/connections/gRPC/examples/status_update/device.status_update.json
@@ -4,6 +4,7 @@
   "detail_level": "FULL",
   "access_scopes": ["monitor", "operate", "configure", "administer"],
   "default_scope": "operate",
+  "subscriptions": true,
   "language_packs": {
     "packs": {
       "es": {

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -206,6 +206,7 @@ class CatenaServiceImpl final : public catena::CatenaService::AsyncService {
         std::vector<std::string> clientScopes_;
         catena::DeviceRequestPayload req_;
         ServerAsyncWriter<catena::DeviceComponent> writer_;
+        std::optional<Device::DeviceSerializer> serializer_ = std::nullopt; //Can't create serializer until we have client scopes
         CallStatus status_;
         Device &dm_;
         int objectId_;

--- a/sdks/cpp/lite/include/Device.h
+++ b/sdks/cpp/lite/include/Device.h
@@ -148,57 +148,137 @@ class Device {
     void toProto(::catena::LanguageList& list) const;
 
     /**
-     * This struct maintains the state of the coroutine.
+     * @brief DeviceSerializer is a coroutine that serializes the device into a stream of DeviceComponents
+     * This struct manages the state and lifetime of the coroutine. It also provides the interface for resuming the coroutine.
      */
     struct DeviceSerializer {
-        struct promise_type;
-        using handle_type = std::coroutine_handle<promise_type>;
+        struct promise_type; // forward declaration
 
+      private:
+        /**
+         * The coroutine handle is a pointer to the coroutine state
+         * 
+         * The coroutine handle provides the following operations:
+         * resume() - resumes the coroutine from where it was suspended
+         * destroy() - destroys the coroutine
+         * done() - returns true if the coroutine has completed (i.e. co_return has been called)
+         */
+        using handle_type = std::coroutine_handle<promise_type>;
+        handle_type handle_;
+
+      public:
+        /** 
+         * @brief promise_type defines the execution behaviour of the coroutine
+         * 
+         * Coroutine types are required to contain a promise_type struct that defines some special
+         * member functions that the compiler will call when the coroutine is created, destroyed,
+         * or resumed.
+         */
         struct promise_type {
 
+            /**
+             * get_return_object() is called when the coroutine is created (i.e. when getComponentSerializer() 
+             * is called). It creates the handle for the coroutine and returns the DeviceSerializer object.
+             */
             DeviceSerializer get_return_object() { 
               return DeviceSerializer(handle_type::from_promise(*this)); 
             }
-            std::suspend_always initial_suspend() { return {}; }
-            std::suspend_always final_suspend() noexcept { return {}; }
-            void return_value(catena::DeviceComponent component) { this->deviceMessage = component; }
-            void unhandled_exception() {}
 
+            /**
+             * initial_suspend() is called when the coroutine is created. It returns a std::suspend_always awaitable
+             * so that the coroutine will be immediately suspended. This means the first component will not be created
+             * until getNext() is called.
+             */
+            std::suspend_always initial_suspend() { return {}; }
+
+            /** 
+             * final_suspend() is called when the coroutine is completed. It returns a std::suspend_always awaitable
+             * causing the coroutine to be suspended before it destroys itself. The coroutine will be destroyed when
+             * the device serializer destructor is called.
+             */
+            std::suspend_always final_suspend() noexcept { return {}; }
+
+            /**
+             * yield_value() is called when the coroutine reaches a co_yield statement. It stores the yielded
+             * DeviceComponent then suspends the coroutine.
+             */
             std::suspend_always yield_value(catena::DeviceComponent& component) { 
               deviceMessage = component;
               return {}; 
             }
 
+            /**
+             * return_value() is called when the coroutine reaches a co_return statement. It stores the returned
+             * DeviceComponent. The coroutine is then set as done.
+             */
+            void return_value(catena::DeviceComponent component) { this->deviceMessage = component; }
+
+            /**
+             * unhandled_exception() is called if an exception is thrown in the coroutine. It stores the exception
+             * so that it can be rethrown by the function that resumed the coroutine.
+             */
+            void unhandled_exception() {
+              exception_ = std::current_exception();
+            }
+
+            /**
+             * rethrow_if_exception() is not called by the compiler but instead is called by the function that
+             * resumes the coroutine. It rethrows the exception that was caught by unhandled_exception().
+             */
+            void rethrow_if_exception() {
+              if (exception_) std::rethrow_exception(exception_);
+            }
+
             catena::DeviceComponent deviceMessage{};
+            std::exception_ptr exception_; 
         };
 
-        DeviceSerializer(handle_type h) : handle(h) {}
+        DeviceSerializer(handle_type h) : handle_(h) {}
+
         DeviceSerializer(const DeviceSerializer&) = delete;
         DeviceSerializer& operator=(const DeviceSerializer&) = delete;
-        DeviceSerializer(DeviceSerializer&& other) : handle(other.handle) { other.handle = nullptr; }
+
+        DeviceSerializer(DeviceSerializer&& other) : handle_(other.handle_) { other.handle_ = nullptr; }
         DeviceSerializer& operator=(DeviceSerializer&& other) { 
-          handle = other.handle; 
-          other.handle = nullptr; 
-          return *this; 
-        }
-        ~DeviceSerializer() { 
-          if (handle) handle.destroy();  
-        }
-
-        std::coroutine_handle<promise_type> handle;
-
-        bool hasMore() const { return !handle.done(); }
-
-        catena::DeviceComponent operator()() { 
-          if (handle.done()) {
-            std::cout << "DeviceSerializer::operator() called on a completed coroutine\n";
-            return {};
+          if (this != &other) {
+            if (handle_) handle_.destroy();
+            handle_ = other.handle_; 
+            other.handle_ = nullptr; 
           }
-          handle.resume();
-          return handle.promise().deviceMessage; 
+          return *this; 
+        } 
+        
+        ~DeviceSerializer() { 
+          if (handle_) handle_.destroy();  
+        }
+
+        /**
+         * @brief returns true if there are more DeviceComponents to be serialized
+         */
+        bool hasMore() const { return handle_ && !handle_.done(); }
+
+        /**
+         * @brief get the next DeviceComponent to be serialized.
+         * @return the next DeviceComponent
+         * 
+         * If the coroutine is done and there are no more components to serialize then
+         * an empty DeviceComponent is returned.
+         */
+        catena::DeviceComponent getNext() { 
+          if (hasMore()) {
+            handle_.resume();
+            handle_.promise().rethrow_if_exception();
+          }
+          return std::move(handle_.promise().deviceMessage); 
         }
     };
 
+    /**
+     * @brief get a serializer for the device
+     * @param clientScopes the scopes of the client
+     * @param shallow if true, the device will be returned in parts, otherwise the whole device will be returned in one message
+     * @return a DeviceSerializer object
+     */
     DeviceSerializer getComponentSerializer(std::vector<std::string>& clientScopes, bool shallow = false) const;
 
     /**

--- a/sdks/cpp/lite/src/Device.cpp
+++ b/sdks/cpp/lite/src/Device.cpp
@@ -205,6 +205,14 @@ void Device::toProto(::catena::LanguageList& list) const {
     }
 }
 
+catena::DeviceComponent Device::DeviceSerializer::getNext() {
+    if (hasMore()) {
+        handle_.resume();
+        handle_.promise().rethrow_if_exception();
+    }
+    return std::move(handle_.promise().deviceMessage); 
+}
+
 Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>& clientScopes, bool shallow) const {
     catena::DeviceComponent component{};
     if (!shallow) {

--- a/sdks/cpp/lite/src/Device.cpp
+++ b/sdks/cpp/lite/src/Device.cpp
@@ -232,6 +232,7 @@ Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>
 
     for (const auto& [language, language_pack] : language_packs_) {
         co_yield component; // yield the previous component before overwriting it
+        component.Clear();
         ::catena::LanguagePack* dstPack = component.mutable_language_pack()->mutable_language_pack();
         language_pack->toProto(*dstPack);
         component.mutable_language_pack()->set_language(language);
@@ -239,6 +240,7 @@ Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>
 
     for (const auto& [name, constraint] : constraints_) {
         co_yield component; // yield the previous component before overwriting it
+        component.Clear();
         ::catena::Constraint* dstConstraint = component.mutable_shared_constraint()->mutable_constraint();
         constraint->toProto(*dstConstraint);
         component.mutable_shared_constraint()->set_oid(name);
@@ -248,6 +250,7 @@ Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>
         std::string paramScope = param->getScope();
         if (clientScopes[0] == kAuthzDisabled[0] || std::find(clientScopes.begin(), clientScopes.end(), paramScope) != clientScopes.end()) {
             co_yield component; // yield the previous component before overwriting it
+            component.Clear();
             ::catena::Param* dstParam = component.mutable_param()->mutable_param();
             param->toProto(*dstParam, clientScopes[0]);
             component.mutable_param()->set_oid(name);
@@ -258,6 +261,7 @@ Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>
         std::string commandScope = command->getScope();
         if (clientScopes[0] == kAuthzDisabled[0] || std::find(clientScopes.begin(), clientScopes.end(), commandScope) != clientScopes.end()) {
             co_yield component; // yield the previous component before overwriting it
+            component.Clear();
             ::catena::Param* dstCommand = component.mutable_command()->mutable_param();
             command->toProto(*dstCommand, clientScopes[0]);
             component.mutable_command()->set_oid(name);

--- a/tools/codegen/cpp/device.js
+++ b/tools/codegen/cpp/device.js
@@ -66,8 +66,8 @@ function defaultScopeArg(desc) {
  */
 function multisetArg(desc) {
     let ans = `false`;
-    if ("multiset" in desc) {
-        ans = desc.multiset ? `true` : `false`;
+    if ("multi_set_enabled" in desc) {
+        ans = desc.multi_set_enabled ? `true` : `false`;
     }
     return ans;
 }


### PR DESCRIPTION
closes #265 

Added a coroutine that streams the device as DeviceComponents if shallow is set to true. I wasn't sure where the shallow flag is supposed to come from so, for now, I have hard coded DeviceRequest to always be shallow.

I made sure to add very thorough comments so that it hopefully makes sense to anyone who hasn't worked with coroutines before.

It is interesting to compare this to pull request #170 where I had previously implemented this same feature without coroutines. The logic is clearly much simpler now. 😃 