### PR TITLE
Split the json schema into separate device and param schemas

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,7 +104,7 @@
       "program": "${workspaceFolder}/tools/codegen/index.js",
       "args": [
           "--schema",
-          "${workspaceFolder}/schema/catena.schema.json",
+          "${workspaceFolder}/schema",
           "--device-model",
           "${workspaceFolder}/sdks/cpp/${input:pickDeviceModel}",
           "--output",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,15 @@
                 "/sdks/cpp/lite/examples/*/device.*.json",
                 "/sdks/cpp/connections/gRPC/examples/*/device.*.json"
             ],
-            "url": "./schema/catena.schema.json"
+            "url": "./schema/catena.device_schema.json"
+        },
+        {
+            "fileMatch": [
+                "/example_device_models/**/param.*.json",
+                "/sdks/cpp/lite/examples/**/param.*.json",
+                "/sdks/cpp/connections/gRPC/examples/**/param.*.json"
+            ],
+            "url": "./schema/catena.param_schema.json"
         }
     ],
     "git.ignoreLimitWarning": true,

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Learn more about Ross Video [here](https://www.rossvideo.com/company/about-ross/
 * `/example_device_models/`: Example json device models 
   * `/import1/`: Device model with external param imports
 * `/interface/`: Contains the Catena protobuf source
-* `./schema/catena.schema.json`: JSON schema for Catena device models
+* `./schema/catena.device_schema.json`: JSON schema for Catena device models
 * `/scripts/`: Collection of useful scripts
   * `./validate.js`: Tool to validate device models using schema
 * `/sdks/`: SDK source

--- a/docs/DeviceModel.md
+++ b/docs/DeviceModel.md
@@ -16,15 +16,23 @@ There are some example device models in JSON such as `device.minimal.json`.
 
 ![Alt](images/device.minimal.png)
 
-It's possible to validate the JSON device models against a set of schemata in `schema/catena.schema.json`. This defines the top-level schema for device models, and many sub-schemata for the many different objects that compose a device model.
+It's possible to validate the JSON device models against a set of schemata in the `schema` directory. This defines the top-level schema for device models and param.
 
 If you're using `vscode` it's possible to have intellisense mark up device models by including this snippet in your `settings.json`.
 
 ```json
 "json.schemas": [
   {
-    "fileMatch": ["/example_device_models/device.*.json"],
-    "url": "./schema/catena.schema.json"
+    "fileMatch": [
+      "/example_device_models/device.*.json",
+    ],
+    "url": "./schema/catena.device_schema.json"
+  },
+  {
+    "fileMatch": [
+      "/example_device_models/**/param.*.json",
+    ],
+    "url": "./schema/catena.param_schema.json"
   }
 ]
 ```

--- a/interface/openapi/paths/PopulatedSlots.yaml
+++ b/interface/openapi/paths/PopulatedSlots.yaml
@@ -37,5 +37,5 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../../../schema/catena.schema.json#/$defs/slot_list"
+            $ref: "../../../schema/catena.device_schema.json#/$defs/slot_list"
           example: [1, 2, 3]

--- a/schema/catena.device_schema.json
+++ b/schema/catena.device_schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Catena Device Model Schema",
+  "description": "Intended to assist humans to author Catena device models as JSON files as some IDEs can use schemata such as this one to lint models.",
+  "type": "object",
+  "properties": {
+    "slot": {
+      "$ref": "#/$defs/slot"
+    },
+    "detail_level": {
+      "$ref": "#/$defs/detail_level"
+    },
+    "multi_set_enabled": {
+      "title": "Multi Set Message Enabled Flag",
+      "description": "Enables use of the multi-value message to report multiple parameter changes in one message. Otherwise changes will be reported individually using the value message. Defaults to true.",
+      "type": "boolean"
+    },
+    "subscriptions": {
+      "title": "Subscriptions Flag",
+      "description": "When true, indicates that the device supports subscription-based access to subsets of parameters.",
+      "type": "boolean"
+    },
+    "constraints": {
+      "$ref": "#/$defs/constraint_map"
+    },
+    "params": {
+      "$ref": "catena.param_schema.json/#/$defs/param_map"
+    },
+    "commands": {
+      "$ref": "catena.param_schema.json/#/$defs/param_map"
+    },
+    "access_scopes": {
+      "title": "Access Scopes",
+      "description": "The access scopes recognised by this device",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "uniqueItems": true,
+        "maxItems": 5,
+        "$comment": "discussion needed on min & max items"
+      },
+      "additionalItems": false
+    },
+    "default_scope": {
+      "$id": "Default Access Scope",
+      "description": "Objects in the model will have this access scope unless overridden explicitly, or implicitly by inheritance",
+      "type": "string"
+    },
+    "language_packs": {
+      "$ref": "#/$defs/language_packs",
+      "additionalProperties": true,
+      "description": "The devices language packs"
+    },
+    "menu_groups": { "$ref": "#/$defs/menu_groups" }
+  },
+  "required": ["slot"],
+  "additionalProperties": false,
+  "$defs": {
+    "menu_groups": {
+      "title": "Menu Groups",
+      "description": "An operationally logical grouping of menus.",
+      "type": "object",
+      "patternProperties": {
+        "^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$": {
+          "$ref": "#/$defs/menu_group"
+        }
+      },
+      "additionalProperties": false
+    },
+    "menu_group": {
+      "title": "Menu Group",
+      "description": "A group of menus",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "catena.param_schema.json/#/$defs/polyglot_text" },
+        "menus": { "$ref": "#/$defs/menus" }
+      },
+      "additionalProperties": false
+    },
+    "menus": {
+      "title": "Menus",
+      "description": "The menus recognised by this device",
+      "type": "object",
+      "patternProperties": {
+        "^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$": {
+          "$ref": "#/$defs/menu"
+        }
+      },
+      "additionalProperties": false
+    },
+    "menu": {
+      "title": "Menu",
+      "description": "A menu",
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "catena.param_schema.json/#/$defs/polyglot_text" },
+        "param_oids": { "$ref": "#/$defs/oids_list" },
+        "command_oids": { "$ref": "#/$defs/oids_list" },
+        "client_hints": { "$ref": "catena.param_schema.json/#/$defs/client_hints" },
+        "hidden": {
+          "type": "boolean",
+          "default": false
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "oids_list": {
+      "title": "OIDs List",
+      "description": "A list of Fully Qualified Object IDs",
+      "type": "array",
+      "items": { "type": "string", "format": "json-pointer" },
+      "additionalItems": false
+    },
+    "language_pack": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "words": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object",
+      "title": "Language Pack",
+      "description": "Language Pack A map of string identifiers, e.g. \"greeting\" to strings which are all in the same language."
+    },
+    "language_packs": {
+      "properties": {
+        "packs": {
+          "additionalProperties": {
+            "$ref": "#/$defs/language_pack",
+            "additionalProperties": true
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": true,
+      "type": "object",
+      "title": "Language Packs",
+      "description": "Language Packs A map of language identifiers to resource dictionaries or language packs for each language supported. The keys shall be patterned on those defined in https://www.mesaonline.org/language-metadata-table, e.g. \"es\" for Global Spanish. \"es-CO\" for Colombian Spanish. \"pl\" for Jezyk polski"
+    },
+    "constraint_map": {
+      "title": "map of constraints used for top-level shared constraints",
+      "description": "Defines the collection of constraints that are able to be shared amongst params or commands within a device.",
+      "type": "object",
+      "$comment": "patternProperties regex must be same as that defined in oid schema",
+      "patternProperties": {
+        "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
+          "$ref": "catena.param_schema.json/#/$defs/constraint"
+        }
+      },
+      "additionalProperties": false
+    },
+    "slot": {
+      "title": "Slot ID",
+      "description": "Uniquely identifies the device within the scope of its Catena connection",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 65535,
+      "default": 0
+    },
+    "slot_list": {
+      "title": "Slot List",
+      "description": "A list of slot IDs",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": {
+        "$ref": "#/$defs/slot"
+      },
+      "additionalItems": false
+    },
+    "detail_level": {
+      "title": "Level of Detail",
+      "description": "The level of detail in device messages and parameter updates. 'full' indicates that all parameters are reported, 'minimal' that only the minimal set is, 'subscription' reports the minimal set plus identified subscribed parameters, 'commands' reports only descriptors for commands and not for parameters, and 'none' indicates that no parameters or commands should be automatically reported by the device (parameter descriptors, command descriptors, and values can still be pulled). ",
+      "type": "string",
+      "enum": ["FULL", "SUBSCRIPTIONS", "MINIMAL", "COMMANDS", "NONE"],
+      "default": "FULL"
+    }
+  }
+}

--- a/schema/catena.device_schema.json
+++ b/schema/catena.device_schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "catena.device_schema.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Catena Device Model Schema",
   "description": "Intended to assist humans to author Catena device models as JSON files as some IDEs can use schemata such as this one to lint models.",
@@ -24,10 +25,10 @@
       "$ref": "#/$defs/constraint_map"
     },
     "params": {
-      "$ref": "catena.param_schema.json/#/$defs/param_map"
+      "$ref": "catena.param_schema.json#/$defs/param_map"
     },
     "commands": {
-      "$ref": "catena.param_schema.json/#/$defs/param_map"
+      "$ref": "catena.param_schema.json#/$defs/param_map"
     },
     "access_scopes": {
       "title": "Access Scopes",
@@ -72,7 +73,7 @@
       "description": "A group of menus",
       "type": "object",
       "properties": {
-        "name": { "$ref": "catena.param_schema.json/#/$defs/polyglot_text" },
+        "name": { "$ref": "catena.param_schema.json#/$defs/polyglot_text" },
         "menus": { "$ref": "#/$defs/menus" }
       },
       "additionalProperties": false
@@ -93,10 +94,10 @@
       "description": "A menu",
       "type": "object",
       "properties": {
-        "name": { "$ref": "catena.param_schema.json/#/$defs/polyglot_text" },
+        "name": { "$ref": "catena.param_schema.json#/$defs/polyglot_text" },
         "param_oids": { "$ref": "#/$defs/oids_list" },
         "command_oids": { "$ref": "#/$defs/oids_list" },
-        "client_hints": { "$ref": "catena.param_schema.json/#/$defs/client_hints" },
+        "client_hints": { "$ref": "catena.param_schema.json#/$defs/client_hints" },
         "hidden": {
           "type": "boolean",
           "default": false
@@ -154,7 +155,7 @@
       "$comment": "patternProperties regex must be same as that defined in oid schema",
       "patternProperties": {
         "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
-          "$ref": "catena.param_schema.json/#/$defs/constraint"
+          "$ref": "catena.param_schema.json#/$defs/constraint"
         }
       },
       "additionalProperties": false

--- a/schema/catena.param_schema.json
+++ b/schema/catena.param_schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "catena.param_schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Catena Param Schema",
   "description": "Defines the type, value, constraints, UI, access modes and configuration options of a parameter.",

--- a/schema/catena.param_schema.json
+++ b/schema/catena.param_schema.json
@@ -1,357 +1,111 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Catena Device Model Schema",
-  "description": "Intended to assist humans to author Catena device models as JSON files as some IDEs can use schemata such as this one to lint models.",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Catena Param Schema",
+  "description": "Defines the type, value, constraints, UI, access modes and configuration options of a parameter.",
   "type": "object",
   "properties": {
-    "slot": {
-      "$ref": "#/$defs/slot"
+    "template_oid": {
+      "$ref": "#/$defs/template_oid"
     },
-    "detail_level": {
-      "$ref": "#/$defs/detail_level"
+    "name": {
+      "$ref": "#/$defs/polyglot_text"
     },
-    "multi_set_enabled": {
-      "title": "Multi Set Message Enabled Flag",
-      "description": "Enables use of the multi-value message to report multiple parameter changes in one message. Otherwise changes will be reported individually using the value message. Defaults to true.",
-      "type": "boolean"
+    "type": {
+      "$ref": "#/$defs/param_type"
     },
-    "subscriptions": {
-      "title": "Subscriptions Flag",
-      "description": "When true, indicates that the device supports subscription-based access to subsets of parameters.",
-      "type": "boolean"
+    "read_only": {
+      "$ref": "#/$defs/read_only"
     },
-    "constraints": {
-      "$ref": "#/$defs/constraint_map"
+    "widget": {
+      "$ref": "#/$defs/widget"
     },
-    "params": {
-      "$ref": "#/$defs/param_map"
+    "precision": {
+      "$ref": "#/$defs/precision"
+    },
+    "value": {
+      "$ref": "#/$defs/value"
+    },
+    "constraint": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/constraint"
+        },
+        {
+          "$ref": "#/$defs/constraint_ref"
+        }
+      ]
+    },
+    "max_length": {
+      "$ref": "#/$defs/max_length"
+    },
+    "total_length": {
+      "$ref": "#/$defs/total_length"
+    },
+    "access_scope": {
+      "$ref": "#/$defs/access_scope"
+    },
+    "client_hints": {
+      "$ref": "#/$defs/client_hints"
     },
     "commands": {
       "$ref": "#/$defs/param_map"
     },
-    "access_scopes": {
-      "title": "Access Scopes",
-      "description": "The access scopes recognised by this device",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "uniqueItems": true,
-        "maxItems": 5,
-        "$comment": "discussion needed on min & max items"
-      },
-      "additionalItems": false
-    },
-    "default_scope": {
-      "$id": "Default Access Scope",
-      "description": "Objects in the model will have this access scope unless overridden explicitly, or implicitly by inheritance",
-      "type": "string"
-    },
-    "language_packs": {
-      "$ref": "#/$defs/language_packs",
-      "additionalProperties": true,
-      "description": "The devices language packs"
-    },
-    "menu_groups": { "$ref": "#/$defs/menu_groups" }
-  },
-  "required": ["slot"],
-  "additionalProperties": false,
-  "$defs": {
-    "menu_groups": {
-      "title": "Menu Groups",
-      "description": "An operationally logical grouping of menus.",
-      "type": "object",
-      "patternProperties": {
-        "^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$": {
-          "$ref": "#/$defs/menu_group"
-        }
-      },
-      "additionalProperties": false
-    },
-    "menu_group": {
-      "title": "Menu Group",
-      "description": "A group of menus",
-      "type": "object",
-      "properties": {
-        "name": { "$ref": "#/$defs/polyglot_text" },
-        "menus": { "$ref": "#/$defs/menus" }
-      },
-      "additionalProperties": false
-    },
-    "menus": {
-      "title": "Menus",
-      "description": "The menus recognised by this device",
-      "type": "object",
-      "patternProperties": {
-        "^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$": {
-          "$ref": "#/$defs/menu"
-        }
-      },
-      "additionalProperties": false
-    },
-    "menu": {
-      "title": "Menu",
-      "description": "A menu",
-      "type": "object",
-      "properties": {
-        "name": { "$ref": "#/$defs/polyglot_text" },
-        "param_oids": { "$ref": "#/$defs/oids_list" },
-        "command_oids": { "$ref": "#/$defs/oids_list" },
-        "client_hints": { "$ref": "#/$defs/client_hints" },
-        "hidden": {
-          "type": "boolean",
-          "default": false
-        },
-        "disabled": {
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "oids_list": {
-      "title": "OIDs List",
-      "description": "A list of Fully Qualified Object IDs",
-      "type": "array",
-      "items": { "type": "string", "format": "json-pointer" },
-      "additionalItems": false
-    },
-    "language_pack": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "words": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object"
-        }
-      },
-      "additionalProperties": true,
-      "type": "object",
-      "title": "Language Pack",
-      "description": "Language Pack A map of string identifiers, e.g. \"greeting\" to strings which are all in the same language."
-    },
-    "language_packs": {
-      "properties": {
-        "packs": {
-          "additionalProperties": {
-            "$ref": "#/$defs/language_pack",
-            "additionalProperties": true
-          },
-          "type": "object"
-        }
-      },
-      "additionalProperties": true,
-      "type": "object",
-      "title": "Language Packs",
-      "description": "Language Packs A map of language identifiers to resource dictionaries or language packs for each language supported. The keys shall be patterned on those defined in https://www.mesaonline.org/language-metadata-table, e.g. \"es\" for Global Spanish. \"es-CO\" for Colombian Spanish. \"pl\" for Jezyk polski"
-    },
-    "constraint_map": {
-      "title": "map of constraints used for top-level shared constraints",
-      "description": "Defines the collection of constraints that are able to be shared amongst params or commands within a device.",
-      "type": "object",
-      "$comment": "patternProperties regex must be same as that defined in oid schema",
-      "patternProperties": {
-        "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
-          "$ref": "#/$defs/constraint"
-        }
-      },
-      "additionalProperties": false
-    },
-    "param_map": {
-      "title": "map of params used for top-level params and commands objects",
-      "description": "Defines the collection of parameter and command descriptors for a device, or a subset if the payload of a 'params' message.",
-      "type": "object",
-      "$comment": "patternProperties regex must be same as that defined in oid schema",
-      "patternProperties": {
-        "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
-          "$ref": "#/$defs/param"
-        }
-      },
-      "additionalProperties": false
+    "params": {
+      "$ref": "#/$defs/param_map"
     },
     "response": {
-      "title": "Response Flag",
-      "description": "When true, indicates that the command associated with the parameter produces a response to the client.",
-      "type": "boolean"
+      "$ref": "#/$defs/response"
     },
     "minimal_set": {
-      "title": "Minimal Set Flag",
-      "description": "When true, indicates that the parameter is part of the minimal set of parameters that should be reported by the device.",
-      "type": "boolean"
+      "$ref": "#/$defs/minimal_set"
     },
-    "param_inner": {
-      "title": "Parameter Descriptor",
-      "description": "Defines the type, value, constraints, UI, access modes and configuration options of a parameter.",
-      "type": "object",
-      "properties": {
-        "template_oid": {
-          "$ref": "#/$defs/template_oid"
-        },
-        "name": {
-          "$ref": "#/$defs/polyglot_text"
-        },
-        "type": {
-          "$ref": "#/$defs/param_type"
-        },
-        "read_only": {
-          "$ref": "#/$defs/read_only"
-        },
-        "widget": {
-          "$ref": "#/$defs/widget"
-        },
-        "precision": {
-          "$ref": "#/$defs/precision"
-        },
-        "value": {
-          "$ref": "#/$defs/value"
-        },
-        "constraint": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/constraint"
-            },
-            {
-              "$ref": "#/$defs/constraint_ref"
-            }
-          ]
-        },
-        "max_length": {
-          "$ref": "#/$defs/max_length"
-        },
-        "total_length": {
-          "$ref": "#/$defs/total_length"
-        },
-        "access_scope": {
-          "$ref": "#/$defs/access_scope"
-        },
-        "client_hints": {
-          "$ref": "#/$defs/client_hints"
-        },
-        "commands": {
-          "$ref": "#/$defs/param_map"
-        },
-        "params": {
-          "$ref": "#/$defs/param_map"
-        },
-        "response": {
-          "$ref": "#/$defs/response"
-        },
-        "minimal_set": {
-          "$ref": "#/$defs/minimal_set"
-        },
-        "help": {
-          "$ref": "#/$defs/polyglot_text"
-        },
-        "import": {
-          "$ref": "#/$defs/import"
-        },
-        "oid_aliases": {
-          "$ref": "#/$defs/oid_aliases"
-        },
-        "stateless": {
-          "$ref": "#/$defs/stateless"
-        }
-      },
-      "additionalProperties": false
+    "help": {
+      "$ref": "#/$defs/polyglot_text"
     },
-    "param": {
-      "$ref": "#/$defs/param_inner",
-      "required": ["type"],
-      "allOf": [
-        {
-          "$ref": "#/$defs/apply_float32"
-        },
-        {
-          "$ref": "#/$defs/apply_int32"
-        },
-        {
-          "$ref": "#/$defs/apply_struct"
-        },
-        {
-          "$ref": "#/$defs/apply_string"
-        },
-        {
-          "$ref": "#/$defs/apply_int32_array"
-        },
-        {
-          "$ref": "#/$defs/apply_float32_array"
-        },
-        {
-          "$ref": "#/$defs/apply_string_array"
-        },
-        {
-          "$ref": "#/$defs/apply_struct_array"
-        },
-        {
-          "$ref": "#/$defs/apply_struct_variant"
-        },
-        {
-          "$ref": "#/$defs/apply_struct_variant_array"
-        }
-      ]
+    "import": {
+      "$ref": "#/$defs/import"
     },
-    "template_oid": {
-      "title": "Template Object ID",
-      "description": "JSON pointer to a parameter descriptor that to provide default information for all fields of this parameter.",
-      "type": "string",
-      "format": "json-pointer"
+    "oid_aliases": {
+      "$ref": "#/$defs/oid_aliases"
     },
-    "value": {
-      "title": "Parameter value",
-      "description": "Value of the parameter. Its schema is polymorphic dependent on type."
+    "stateless": {
+      "$ref": "#/$defs/stateless"
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "#/$defs/apply_float32"
     },
-    "float32": {
-      "type": "number",
-      "minimum": -3.402823466385e38,
-      "maximum": 3.402823466385e38,
-      "default": 0
+    {
+      "$ref": "#/$defs/apply_int32"
     },
-    "float32_value": {
-      "title": "FLOAT32",
-      "description": "Defines FLOAT32 as a primitive number type",
-      "type": "object",
-      "properties": {
-        "float32_value": {
-          "$ref": "#/$defs/float32"
-        }
-      },
-      "required": ["float32_value"]
+    {
+      "$ref": "#/$defs/apply_struct"
     },
-    "float32_constraint": {
-      "title": "Float32 Constraint",
-      "description": "Range constraint with step size and display min/max",
-      "type": "object",
-      "properties": {
-        "type": {
-          "const": "FLOAT_RANGE"
-        },
-        "float_range": {
-          "type": "object",
-          "properties": {
-            "min_value": {
-              "$ref": "#/$defs/float32"
-            },
-            "max_value": {
-              "$ref": "#/$defs/float32"
-            },
-            "step": {
-              "$ref": "#/$defs/float32"
-            },
-            "display_min": {
-              "$ref": "#/$defs/float32"
-            },
-            "display_max": {
-              "$ref": "#/$defs/float32"
-            }
-          },
-          "required": ["min_value", "max_value"],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
+    {
+      "$ref": "#/$defs/apply_string"
     },
+    {
+      "$ref": "#/$defs/apply_int32_array"
+    },
+    {
+      "$ref": "#/$defs/apply_float32_array"
+    },
+    {
+      "$ref": "#/$defs/apply_string_array"
+    },
+    {
+      "$ref": "#/$defs/apply_struct_array"
+    },
+    {
+      "$ref": "#/$defs/apply_struct_variant"
+    },
+    {
+      "$ref": "#/$defs/apply_struct_variant_array"
+    }
+  ],
+  "$defs": {
     "apply_float32": {
       "title": "FLOAT32 specialism",
       "description": "Applies FLOAT32 values & constraints, disables properties that don't work with FLOAT32",
@@ -950,7 +704,7 @@
               "$ref": "#/$defs/field_value"
             },
             {
-              "$ref": "#/$defs/param"
+              "$ref": "#"
             }
           ]
         }
@@ -1022,6 +776,9 @@
         "url": {
           "type": "string"
         },
+        "file": {
+          "type": "string"
+        },
         "excluding": {
           "type": "array",
           "items": {
@@ -1030,33 +787,8 @@
           "uniqueItems": true
         }
       },
+      "oneOf": [{ "required": ["url"] }, { "required": ["file"] }],
       "additionalProperties": false
-    },
-    "slot": {
-      "title": "Slot ID",
-      "description": "Uniquely identifies the device within the scope of its Catena connection",
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 65535,
-      "default": 0
-    },
-    "slot_list": {
-      "title": "Slot List",
-      "description": "A list of slot IDs",
-      "type": "array",
-      "minItems": 1,
-      "maxItems": 32,
-      "items": {
-        "$ref": "#/$defs/slot"
-      },
-      "additionalItems": false
-    },
-    "detail_level": {
-      "title": "Level of Detail",
-      "description": "The level of detail in device messages and parameter updates. 'full' indicates that all parameters are reported, 'minimal' that only the minimal set is, 'subscription' reports the minimal set plus identified subscribed parameters, 'commands' reports only descriptors for commands and not for parameters, and 'none' indicates that no parameters or commands should be automatically reported by the device (parameter descriptors, command descriptors, and values can still be pulled). ",
-      "type": "string",
-      "enum": ["FULL", "SUBSCRIPTIONS", "MINIMAL", "COMMANDS", "NONE"],
-      "default": "FULL"
     },
     "basic_param_info": {
       "title": "Basic Param Info",
@@ -1367,6 +1099,88 @@
       "description": "When true, indicates that the parameter is stateless and does not require to be persisted. This is useful for values that are transient in nature: current time, audio meters, ...",
       "type": "boolean",
       "default": false
+    },
+    "value": {
+      "title": "Parameter value",
+      "description": "Value of the parameter. Its schema is polymorphic dependent on type."
+    },
+    "template_oid": {
+      "title": "Template Object ID",
+      "description": "JSON pointer to a parameter descriptor that to provide default information for all fields of this parameter.",
+      "type": "string",
+      "format": "json-pointer"
+    },
+    "float32": {
+      "type": "number",
+      "minimum": -3.402823466385e38,
+      "maximum": 3.402823466385e38,
+      "default": 0
+    },
+    "float32_value": {
+      "title": "FLOAT32",
+      "description": "Defines FLOAT32 as a primitive number type",
+      "type": "object",
+      "properties": {
+        "float32_value": {
+          "$ref": "#/$defs/float32"
+        }
+      },
+      "required": ["float32_value"]
+    },
+    "float32_constraint": {
+      "title": "Float32 Constraint",
+      "description": "Range constraint with step size and display min/max",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "FLOAT_RANGE"
+        },
+        "float_range": {
+          "type": "object",
+          "properties": {
+            "min_value": {
+              "$ref": "#/$defs/float32"
+            },
+            "max_value": {
+              "$ref": "#/$defs/float32"
+            },
+            "step": {
+              "$ref": "#/$defs/float32"
+            },
+            "display_min": {
+              "$ref": "#/$defs/float32"
+            },
+            "display_max": {
+              "$ref": "#/$defs/float32"
+            }
+          },
+          "required": ["min_value", "max_value"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "response": {
+      "title": "Response Flag",
+      "description": "When true, indicates that the command associated with the parameter produces a response to the client.",
+      "type": "boolean"
+    },
+    "minimal_set": {
+      "title": "Minimal Set Flag",
+      "description": "When true, indicates that the parameter is part of the minimal set of parameters that should be reported by the device.",
+      "type": "boolean"
+    },
+    "param_map": {
+      "title": "map of params used for top-level params and commands objects",
+      "description": "Defines the collection of parameter and command descriptors for a device, or a subset if the payload of a 'params' message.",
+      "type": "object",
+      "$comment": "patternProperties regex must be same as that defined in oid schema",
+      "patternProperties": {
+        "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
+          "$ref": "#"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ project(Catena_cpp VERSION 0.0.1 LANGUAGES C CXX)
 include(${CMAKE_CURRENT_SOURCE_DIR}/CatenaFunctions.cmake)
 
 get_filename_component(CODEGEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/codegen" ABSOLUTE) 
-get_filename_component(SCHEMA_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/../../schema/catena.schema.json" ABSOLUTE)
+get_filename_component(SCHEMA_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/../../schema" ABSOLUTE)
 
 # install node modules if it hasn't been done yet
 if(NOT EXISTS "${CODEGEN_DIR}/node_modules")

--- a/sdks/cpp/CatenaCodegen.cmake
+++ b/sdks/cpp/CatenaCodegen.cmake
@@ -68,6 +68,7 @@ function(generate_catena_device)
 
     # Get all files in the CODEGEN_DIR
     file(GLOB CODEGEN_FILES "${CATENA_CODEGEN}/*.js" "${CATENA_CODEGEN}/cpp/*.js")
+    file(GLOB SCHEMA_FILES "${CATENA_SCHEMA}/*.json")
 
     # convert json to cpp
     find_program(NODE node REQUIRED)
@@ -75,7 +76,7 @@ function(generate_catena_device)
         OUTPUT ${_OUT_DIR}/${HEADER}
             ${_OUT_DIR}/${BODY}
         COMMAND ${NODE} ${CATENA_CODEGEN} --schema ${CATENA_SCHEMA} --device-model "${_DEVICE_MODEL_JSON}" --output ${_OUT_DIR}
-        DEPENDS ${_DEVICE_MODEL_JSON} ${CATENA_SCHEMA} ${CODEGEN_FILES}
+        DEPENDS ${_DEVICE_MODEL_JSON} ${SCHEMA_FILES} ${CODEGEN_FILES}
         COMMENT "Generating ${HEADER} and ${BODY} from ${_DEVICE_MODEL_JSON}"
     )
 

--- a/sdks/cpp/CatenaFunctions.cmake
+++ b/sdks/cpp/CatenaFunctions.cmake
@@ -62,10 +62,11 @@ function(install_catena_codegen)
 
     #install the Catena device validation schema file
     install(
-        FILES ${CATENA_ROOT_DIR}/schema/catena.schema.json
+        FILES ${CATENA_ROOT_DIR}/schema/catena.device_schema.json
+            ${CATENA_ROOT_DIR}/schema/catena.param_schema.json
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Catena_cpp
     )
-    set(CATENA_SCHEMA_JSON ${CMAKE_INSTALL_DATAROOTDIR}/Catena_cpp/catena.schema.json PARENT_SCOPE)
+    set(CATENA_SCHEMA_JSON ${CMAKE_INSTALL_DATAROOTDIR}/Catena_cpp PARENT_SCOPE)
 
     # Ensure the custom target runs during the installation process
     find_program(NPM_EXECUTABLE npm REQUIRED)

--- a/sdks/cpp/lite/examples/import_params/CMakeLists.txt
+++ b/sdks/cpp/lite/examples/import_params/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Copyright 2024 Ross Video Ltd
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# cmake build file for the read_model_from_file example.
+#
+#
+
+cmake_minimum_required(VERSION 3.20)
+
+
+
+get_filename_component(TARGET ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${TARGET} C CXX)
+
+add_executable(${TARGET})
+
+include (${CATENA_CPP_ROOT_DIR}/CatenaCodegen.cmake)
+
+generate_catena_device(
+    DEVICE_MODEL_JSON ${CMAKE_CURRENT_SOURCE_DIR}/device.${TARGET}.json
+    TARGET ${TARGET}
+)
+
+target_sources(${TARGET}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TARGET}.cpp>  
+)
+
+target_link_libraries(${TARGET} catena_lite)
+
+target_compile_features(${TARGET}
+    PUBLIC
+        cxx_std_20
+)
+
+
+

--- a/sdks/cpp/lite/examples/import_params/device.import_params.json
+++ b/sdks/cpp/lite/examples/import_params/device.import_params.json
@@ -10,38 +10,6 @@
   ],
   "default_scope": "operate",
   "params": {
-    "eiffel_tower": {
-      "import": {"file": "params/param.location.json"},
-      "type": "STRUCT",
-      "value": {
-        "struct_value": {
-          "fields": {
-            "latitude": {
-              "value": {
-                "struct_value": {
-                  "fields": {
-                    "degrees": {"value": {"int32_value": 48}},
-                    "minutes": {"value": {"int32_value": 51}},
-                    "seconds": {"value": {"int32_value": 29}}
-                  }
-                }
-              }
-            },
-            "longitude": {
-              "value": {
-                "struct_value": {
-                  "fields": {
-                    "degrees": {"value": {"int32_value": 2}},
-                    "minutes": {"value": {"int32_value": 17}},
-                    "seconds": {"value": {"int32_value": 40}}
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "city": {
       "import": {"file": "params/param.city.json"}
     },

--- a/sdks/cpp/lite/examples/import_params/device.import_params.json
+++ b/sdks/cpp/lite/examples/import_params/device.import_params.json
@@ -1,0 +1,109 @@
+{
+  "slot": 1,
+  "multi_set_enabled": true,
+  "detail_level": "FULL",
+  "access_scopes": [
+    "monitor",
+    "operate",
+    "configure",
+    "administer"
+  ],
+  "default_scope": "operate",
+  "params": {
+    "eiffel_tower": {
+      "import": {"file": "params/param.location.json"},
+      "type": "STRUCT",
+      "value": {
+        "struct_value": {
+          "fields": {
+            "latitude": {
+              "value": {
+                "struct_value": {
+                  "fields": {
+                    "degrees": {"value": {"int32_value": 48}},
+                    "minutes": {"value": {"int32_value": 51}},
+                    "seconds": {"value": {"int32_value": 29}}
+                  }
+                }
+              }
+            },
+            "longitude": {
+              "value": {
+                "struct_value": {
+                  "fields": {
+                    "degrees": {"value": {"int32_value": 2}},
+                    "minutes": {"value": {"int32_value": 17}},
+                    "seconds": {"value": {"int32_value": 40}}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "city": {
+      "import": {"file": "params/param.city.json"}
+    },
+    "plane_ticket": {
+      "type": "STRUCT",
+      "params": {
+        "departure": {
+          "import": {"file": "params/param.city.json"}
+        },
+        "destination": {
+          "type": "STRUCT",
+          "template_oid": "city"
+        }
+      },
+      "value": {
+        "struct_value": {
+          "fields": {
+            "departure": {
+              "value": {}
+            },
+            "destination": {
+              "value": {
+                "struct_value": {
+                  "fields": {
+                    "name": {"value": {"string_value": "Paris"}},
+                    "location": {
+                      "value": {
+                        "struct_value": {
+                          "fields": {
+                            "latitude": {
+                              "value": {
+                                "struct_value": {
+                                  "fields": {
+                                    "degrees": {"value": {"int32_value": 48}},
+                                    "minutes": {"value": {"int32_value": 51}},
+                                    "seconds": {"value": {"int32_value": 29}}
+                                  }
+                                }
+                              }
+                            },
+                            "longitude": {
+                              "value": {
+                                "struct_value": {
+                                  "fields": {
+                                    "degrees": {"value": {"int32_value": 2}},
+                                    "minutes": {"value": {"int32_value": 17}},
+                                    "seconds": {"value": {"int32_value": 40}}
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }       
+      }
+    }
+  }
+}

--- a/sdks/cpp/lite/examples/import_params/import_params.cpp
+++ b/sdks/cpp/lite/examples/import_params/import_params.cpp
@@ -1,0 +1,120 @@
+/** Copyright 2024 Ross Video Ltd
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or
+ promote products derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ DAMAGE.
+*/
+//
+
+/**
+ * @file import_params.cpp
+ * @author john.naylor@rossvideo.com
+ * @brief Demo's a device model that uses imported params
+ *
+ * The buisness logic here is the same as use_structs.cpp, but the json device model uses imported params.
+ *
+ * @copyright Copyright © 2024 Ross Video Ltd
+ */
+
+// device model
+#include "device.tree.json.h"
+
+
+// lite
+#include <Device.h>
+#include <ParamWithValue.h>
+#include <PolyglotText.h>
+
+// protobuf interface
+#include <interface/param.pb.h>
+
+using namespace catena::lite;
+using namespace catena::common;
+using namespace use_structs;
+using catena::common::ParamTag;
+#include <iostream>
+int main() {
+    // lock the model
+    Device::LockGuard lg(dm);
+    catena::exception_with_status err{"", catena::StatusCode::OK};
+
+    std::unique_ptr<IParam> ip = dm.getParam("/location", err);
+    if (ip == nullptr) {
+        std::cerr << "Error: " << err.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    auto& locationParam = *dynamic_cast<ParamWithValue<Location>*>(ip.get());
+    Location& loc = locationParam.get();
+
+    std::cout << "Location: lat(" << loc.latitude.degrees << "˚ " << loc.latitude.minutes << "' "
+              << loc.latitude.seconds << "\") lon(" << loc.longitude.degrees << "˚ " << loc.longitude.minutes
+              << "' " << loc.longitude.seconds << "\")" << std::endl;
+
+    catena::Value value;
+    std::string clientScope = "operate";
+    ip->toProto(value, clientScope);
+    std::cout << "Location: " << value.DebugString() << std::endl;
+
+    // this line is for demonstrating the fromProto method
+    // this should never be done in a real device
+    value.mutable_struct_value()
+      ->mutable_fields()
+      ->at("latitude")
+      .mutable_value()
+      ->mutable_struct_value()
+      ->mutable_fields()
+      ->at("degrees")
+      .mutable_value()
+      ->set_float32_value(100);
+    ip->fromProto(value, clientScope);
+
+    std::cout << "New Location: lat(" << loc.latitude.degrees << "˚ " << loc.latitude.minutes << "' "
+              << loc.latitude.seconds << "\") lon(" << loc.longitude.degrees << "˚ " << loc.longitude.minutes
+              << "' " << loc.longitude.seconds << "\")" << std::endl;
+
+    ip = dm.getParam("/location/latitude", err);
+    if (ip == nullptr) {
+        std::cerr << "Error: " << err.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    value.Clear();
+    ip->toProto(value, clientScope);
+    std::cout << "Latitude: " << value.DebugString() << std::endl;
+
+    ip = dm.getParam("/location/latitude/degrees", err);
+    if (ip == nullptr) {
+        std::cerr << "Error: " << err.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    value.Clear();
+    ip->toProto(value, clientScope);
+    std::cout << "Latitude degrees: " << value.DebugString() << std::endl;
+
+    ip = dm.getParam("/location/longitude/seconds", err);
+    if (ip == nullptr) {
+        std::cerr << "Error: " << err.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    value.Clear();
+    ip->toProto(value, clientScope);
+    std::cout << "Longitude seconds: " << value.DebugString() << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/sdks/cpp/lite/examples/import_params/params/param.city.json
+++ b/sdks/cpp/lite/examples/import_params/params/param.city.json
@@ -10,43 +10,6 @@
         "location": {
             "import": { "file": "param.location.json" }
         }
-    },
-    "value": {
-        "struct_value": {
-            "fields": {
-                "name": { "value": { "string_value": "Ottawa" } },
-                "location": {
-                    "value": {
-                        "struct_value": {
-                            "fields": {
-                                "latitude": {
-                                    "value": {
-                                        "struct_value": {
-                                            "fields": {
-                                                "degrees": { "value": { "int32_value": 45 } },
-                                                "minutes": { "value": { "int32_value": 25 } },
-                                                "seconds": { "value": { "int32_value": 29 } }
-                                            }
-                                        }
-                                    }
-                                },
-                                "longitude": {
-                                    "value": {
-                                        "struct_value": {
-                                            "fields": {
-                                                "degrees": { "value": { "int32_value": 75 } },
-                                                "minutes": { "value": { "int32_value": 42 } },
-                                                "seconds": { "value": { "int32_value": 14 } }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } 
     }
 }
   

--- a/sdks/cpp/lite/examples/import_params/params/param.city.json
+++ b/sdks/cpp/lite/examples/import_params/params/param.city.json
@@ -1,0 +1,52 @@
+{
+    "type": "STRUCT",
+    "read_only": false,
+    "name": { "display_strings": { "en": "City" } },
+    "params": {
+        "name": {
+            "type": "STRING",
+            "name": { "display_strings": { "en": "City Name" } }
+        },
+        "location": {
+            "import": { "file": "param.location.json" }
+        }
+    },
+    "value": {
+        "struct_value": {
+            "fields": {
+                "name": { "value": { "string_value": "Ottawa" } },
+                "location": {
+                    "value": {
+                        "struct_value": {
+                            "fields": {
+                                "latitude": {
+                                    "value": {
+                                        "struct_value": {
+                                            "fields": {
+                                                "degrees": { "value": { "int32_value": 45 } },
+                                                "minutes": { "value": { "int32_value": 25 } },
+                                                "seconds": { "value": { "int32_value": 29 } }
+                                            }
+                                        }
+                                    }
+                                },
+                                "longitude": {
+                                    "value": {
+                                        "struct_value": {
+                                            "fields": {
+                                                "degrees": { "value": { "int32_value": 75 } },
+                                                "minutes": { "value": { "int32_value": 42 } },
+                                                "seconds": { "value": { "int32_value": 14 } }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } 
+    }
+}
+  

--- a/sdks/cpp/lite/examples/import_params/params/param.location.json
+++ b/sdks/cpp/lite/examples/import_params/params/param.location.json
@@ -1,0 +1,71 @@
+{
+  "type": "STRUCT",
+  "read_only": false,
+  "name": { "display_strings": { "en": "Location" } },
+  "params": {
+    "latitude": {
+      "type": "STRUCT",
+      "params": {
+        "degrees": {
+          "type": "FLOAT32",
+          "name": { "display_strings": { "en": "Degrees" } }
+        },
+        "minutes": {
+          "type": "INT32",
+          "name": { "display_strings": { "en": "Minutes" } }
+        },
+        "seconds": {
+          "type": "INT32",
+          "name": { "display_strings": { "en": "Seconds" } }
+        }
+      },
+      "name": { "display_strings": { "en": "Latitude" } }
+    },
+    "longitude": {
+      "type": "STRUCT",
+      "params": {
+        "degrees": {
+          "type": "FLOAT32",
+          "name": { "display_strings": { "en": "Degrees" } }
+        },
+        "minutes": {
+          "type": "INT32",
+          "name": { "display_strings": { "en": "Minutes" } }
+        },
+        "seconds": {
+          "type": "INT32",
+          "name": { "display_strings": { "en": "Seconds" } }
+        }
+      },
+      "name": { "display_strings": { "en": "Longitude" } }
+    }
+  },
+  "value": {
+    "struct_value": {
+      "fields": {
+        "latitude": {
+          "value": {
+            "struct_value": {
+              "fields": {
+                "degrees": { "value": { "int32_value": 1 } },
+                "minutes": { "value": { "int32_value": 2 } },
+                "seconds": { "value": { "int32_value": 3 } }
+              }
+            }
+          }
+        },
+        "longitude": {
+          "value": {
+            "struct_value": {
+              "fields": {
+                "degrees": { "value": { "int32_value": 4 } },
+                "minutes": { "value": { "int32_value": 5 } },
+                "seconds": { "value": { "int32_value": 6 } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdks/cpp/lite/examples/import_params/params/param.ottawa.json
+++ b/sdks/cpp/lite/examples/import_params/params/param.ottawa.json
@@ -1,0 +1,74 @@
+{
+    "name": {
+        "display_strings": {
+            "en": "Ottawa"
+        }
+    },
+    "type": "STRUCT",
+    "template_oid": "/city",
+    "value": {
+        "struct_value": {
+            "fields": {
+                "name": {
+                    "value": {
+                        "string_value": "Ottawa"
+                    }
+                },
+                "location": {
+                    "value": {
+                        "struct_value": {
+                            "fields": {
+                                "latitude": {
+                                    "value": {
+                                        "struct_value": {
+                                            "fields": {
+                                                "degrees": {
+                                                    "value": {
+                                                        "int32_value": 45
+                                                    }
+                                                },
+                                                "minutes": {
+                                                    "value": {
+                                                        "int32_value": 25
+                                                    }
+                                                },
+                                                "seconds": {
+                                                    "value": {
+                                                        "int32_value": 0
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "longitude": {
+                                    "value": {
+                                        "struct_value": {
+                                            "fields": {
+                                                "degrees": {
+                                                    "value": {
+                                                        "int32_value": 75
+                                                    }
+                                                },
+                                                "minutes": {
+                                                    "value": {
+                                                        "int32_value": 42
+                                                    }
+                                                },
+                                                "seconds": {
+                                                    "value": {
+                                                        "int32_value": 0
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/codegen/index.js
+++ b/tools/codegen/index.js
@@ -21,7 +21,7 @@
 // load the command line parser
 const { program } = require('commander');
 program
-    .option('-s, --schema <string>', 'path to schema definitions', '../../schema/catena.schema.json')
+    .option('-s, --schema <string>', 'path to schema definitions', '../../schema')
     .option('-d, --device-model <string>', 'Catena device model to process', '../../example_device_models/device.minimal.json')
     .option('-l, --language <string>', 'Language to generate code for', 'cpp')
     .option('-o, --output <string>', 'Output folder for generated code', '.');
@@ -66,7 +66,7 @@ try {
  
     // read the file to validate
     const data = JSON.parse(fs.readFileSync(options.deviceModel));
-    if (validator.validate('device', data)) {
+    if (validator.validate(data)) {
         const CodeGen =  require(`./${options.language}/${options.language}gen.js`);
         const codeGen = new CodeGen(options.deviceModel, options.output, validator, data);
         codeGen.generate();

--- a/tools/validate/validate.js
+++ b/tools/validate/validate.js
@@ -16,7 +16,7 @@
 
 //
 // Validates .json files against Catena schemata defined in
-// ./schema/catena.schema.json
+// ./schema/catena.device_schema.json
 //
 
 const Ajv = require('ajv');
@@ -52,7 +52,7 @@ if (!fs.existsSync(testfile)) {
 const schemaName = path.parse(testfile).name.split('.')[0];
 
 // read the schema definition file
-const schemaFilename = '../../schema/catena.schema.json';
+const schemaFilename = '../../schema/catena.device_schema.json';
 if (!fs.existsSync(schemaFilename)) {
     console.log(`Cannot open schema file at: ${schemaFilename}`);
     process.exit(1);


### PR DESCRIPTION
Moved param validation into a separate schema so that param json files that are imported by devices can be validated. This ended up being a pretty large change, so I am making a pull request now instead of waiting until codegen imports were fully implemented.