### PR TITLE
Added scope checking when authorization is enabled

### DIFF
--- a/.vscode/Catena.code-workspace
+++ b/.vscode/Catena.code-workspace
@@ -107,7 +107,11 @@
 			"*.inc": "cpp",
 			"cassert": "cpp",
 			"coroutine": "cpp",
-			"source_location": "cpp"
+			"source_location": "cpp",
+			"*.ipp": "cpp",
+			"cerrno": "cpp",
+			"cfloat": "cpp",
+			"climits": "cpp"
 		}
 	}
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,7 +91,10 @@
         "type": "cppdbg",
         "request": "launch",
         "program": "${workspaceFolder}/sdks/cpp/build/connections/gRPC/examples/${input:pickService}/${input:pickService}", // Path to the full_service executable
-        "args": ["--static_root", "${workspaceFolder}/sdks/cpp/connections/gRPC/examples/${input:pickService}/static"], // Any command-line arguments go here
+        "args": ["--static_root", "${workspaceFolder}/sdks/cpp/connections/gRPC/examples/${input:pickService}/static", 
+                 "--secure_comms", "ssl",
+                 "--authz"
+        ], // Any command-line arguments go here
         "stopAtEntry": false,
         "cwd": "${workspaceFolder}",
         "environment": [],

--- a/sdks/cpp/common/CMakeLists.txt
+++ b/sdks/cpp/common/CMakeLists.txt
@@ -28,6 +28,7 @@ set(sources
     "src/utils.cpp" 
     "src/vdk/signals.cpp" 
     "src/Path.cpp"
+    "src/Authorization.cpp"
     "src/Device.cpp"
     "src/ParamDescriptor.cpp"
     "src/StructInfo.cpp"

--- a/sdks/cpp/common/examples/use_struct_arrays/use_struct_arrays.cpp
+++ b/sdks/cpp/common/examples/use_struct_arrays/use_struct_arrays.cpp
@@ -52,14 +52,13 @@ int main() {
         return EXIT_FAILURE;
     }
     catena::Value value;
-    std::string clientScope = "operate";
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "audio_deck: " << value.DebugString() << std::endl;
 
     // this line is for demonstrating the fromProto method
     // this should never be done in a real device
     value.mutable_struct_array_values()->mutable_struct_values()->at(2).mutable_fields()->at("eq_list").mutable_value()->mutable_struct_array_values()->mutable_struct_values()->at(1).mutable_fields()->at("q_factor").mutable_value()->set_float32_value(2.5);
-    ip->fromProto(value, clientScope);
+    ip->fromProto(value, Authorizer::kAuthzDisabled);
 
     ip = dm.getParam("/audio_deck/2", err);
     if (ip == nullptr){
@@ -67,8 +66,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    clientScope = "operate";
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "audio_deck[2]: " << value.DebugString() << std::endl;
 
 
@@ -79,8 +77,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    clientScope = "operate";
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "new audio channel: " << value.DebugString() << std::endl;
 
     ip = dm.getParam("/audio_deck/3/eq_list/0/response", err);
@@ -89,8 +86,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    clientScope = "operate";
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "/audio_deck/1/eq_list/1/response: " << value.DebugString() << std::endl;
 
     ip = dm.getParam("/audio_deck/2/eq_list/1/q_factor", err);
@@ -99,8 +95,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    clientScope = "operate";
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "/audio_deck/2/eq_list/1/q_factor: " << value.DebugString() << std::endl;
 
     return EXIT_SUCCESS;

--- a/sdks/cpp/common/examples/use_structs/use_structs.cpp
+++ b/sdks/cpp/common/examples/use_structs/use_structs.cpp
@@ -63,14 +63,13 @@ int main() {
               << "' " << loc.longitude.seconds << "\")" << std::endl;
 
     catena::Value value;
-    std::string clientScope = "operate";
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "Location: " << value.DebugString() << std::endl;
 
     // this line is for demonstrating the fromProto method
     // this should never be done in a real device
     value.mutable_struct_value()->mutable_fields()->at("latitude").mutable_value()->mutable_struct_value()->mutable_fields()->at("degrees").mutable_value()->set_float32_value(100);
-    ip->fromProto(value, clientScope);
+    ip->fromProto(value, Authorizer::kAuthzDisabled);
 
     std::cout << "New Location: lat(" << loc.latitude.degrees << "˚ " << loc.latitude.minutes << "' "
               << loc.latitude.seconds << "\") lon(" << loc.longitude.degrees << "˚ " << loc.longitude.minutes
@@ -82,7 +81,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "Latitude: " << value.DebugString() << std::endl;
 
     ip = dm.getParam("/location/latitude/degrees", err);
@@ -91,7 +90,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "Latitude degrees: " << value.DebugString() << std::endl;
 
     ip = dm.getParam("/location/longitude/seconds", err);
@@ -100,7 +99,7 @@ int main() {
         return EXIT_FAILURE;
     }
     value.Clear();
-    ip->toProto(value, clientScope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << "Longitude seconds: " << value.DebugString() << std::endl;
 
     return EXIT_SUCCESS;

--- a/sdks/cpp/common/examples/use_variants/use_variants.cpp
+++ b/sdks/cpp/common/examples/use_variants/use_variants.cpp
@@ -65,7 +65,6 @@ int main() {
     Device::LockGuard lg(dm);
     catena::exception_with_status err{"", catena::StatusCode::OK};
     std::unique_ptr<IParam> ip;
-    std::string scope{"monitor"};
     
     // get the number param
     ip = dm.getParam("/number", err);
@@ -74,12 +73,12 @@ int main() {
         return EXIT_FAILURE;
     }
     catena::Param numberParam;
-    ip->toProto(numberParam, scope);
+    ip->toProto(numberParam, Authorizer::kAuthzDisabled);
     std::cout << numberParam.DebugString() << std::endl;
 
     use_variants::Number& number = getParamValue<use_variants::Number>(ip.get());
     number = "five";
-    ip->toProto(numberParam, scope);
+    ip->toProto(numberParam, Authorizer::kAuthzDisabled);
     std::cout << "Updated Number:\n" << numberParam.DebugString() << std::endl;
 
     // get the coordinates param
@@ -89,7 +88,7 @@ int main() {
         return EXIT_FAILURE;
     }
     catena::Param coordinatesParam;
-    ip->toProto(coordinatesParam, scope);
+    ip->toProto(coordinatesParam, Authorizer::kAuthzDisabled);
     std::cout << coordinatesParam.DebugString() << std::endl;
 
     ip = dm.getParam("/coordinates/2", err);
@@ -121,7 +120,7 @@ int main() {
         std::cerr << "Error: " << err.what() << std::endl;
         return EXIT_FAILURE;
     }
-    ip->toProto(value, scope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << value.DebugString() << std::endl;
 
     value.set_int32_value(42);
@@ -134,7 +133,7 @@ int main() {
         std::cerr << "Error: " << err.what() << std::endl;
         return EXIT_FAILURE;
     }
-    ip->toProto(value, scope);
+    ip->toProto(value, Authorizer::kAuthzDisabled);
     std::cout << value.DebugString() << std::endl;
     use_variants::Cartesian& cartesian = getParamValue<use_variants::Cartesian>(ip.get());
     std::cout << "Updated Coordinates/0/cartesian: ";

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -66,9 +66,24 @@ class Authorizer {
     Authorizer(const std::vector<std::string>& clientScopes)
         : clientScopes_{clientScopes} {}
 
+    /**
+     * @brief Authorizer does not have copy semantics
+     */
     Authorizer(const Authorizer&) = delete;
+
+    /**
+     * @brief Authorizer does not have copy semantics
+     */
     Authorizer& operator=(const Authorizer&) = delete;
+
+    /**
+     * @brief Authorizer has move semantics
+     */
     Authorizer(Authorizer&&) = default;
+
+    /**
+     * @brief Authorizer has move semantics
+     */
     Authorizer& operator=(Authorizer&&) = default;
 
     /**

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -30,7 +30,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * @file AuthzInfo.h
+ * @file Authorization.h
  * @brief Class for handling authorization information
  * @author John R. Naylor john.naylor@rossvideo.com
  * @author John Danen
@@ -41,6 +41,7 @@
 // common
 #include <Path.h>
 #include <Enums.h>
+#include <IParam.h>
 #include <ParamDescriptor.h>
 
 
@@ -50,64 +51,57 @@ namespace common {
 /**
  * @brief Class for handling authorization information
  */
-class AuthzInfo {
-    using ParamDescriptor = catena::common::ParamDescriptor;
+class Authorizer {
   public:
+    /**
+     * @brief Special Authorizer object that disables authorization
+     */
+    static Authorizer kAuthzDisabled;
 
     /**
-     * @brief Construct a new AuthzInfo object
+     * @brief Construct a new Authorizer object
      * @param pd the ParamDescriptor of the object
      * @param scope the scope of the object
      */
-    AuthzInfo(const ParamDescriptor& pd, const std::string& scope)
-      : pd_{pd}, clientScope_{scope}{}
+    Authorizer(const std::vector<std::string>& clientScopes)
+        : clientScopes_{clientScopes} {}
+
+    Authorizer(const Authorizer&) = delete;
+    Authorizer& operator=(const Authorizer&) = delete;
+    Authorizer(Authorizer&&) = default;
+    Authorizer& operator=(Authorizer&&) = default;
 
     /**
-     * @brief Destroy the AuthzInfo object
+     * @brief Destroy the Authorizer object
      */
-    virtual ~AuthzInfo() = default;
-
-    /**
-     * @brief Creates a AuthzInfo object for a sub parameter
-     * @param oid the oid of the sub parameter
-     * @return AuthzInfo the AuthzInfo object for the sub parameter
-     */
-    AuthzInfo subParamInfo(std::string oid) const {
-        return AuthzInfo(pd_.getSubParam(oid), clientScope_);
-    }
+    virtual ~Authorizer() = default;
 
     /**
      * @brief Check if the client has read authorization
      * @return true if the client has read authorization
      */
-    bool readAuthz() const {
-        /**
-         * @todo implement readAuthz
-         */
-        return true;
-    }
+    bool readAuthz(const IParam& param) const;
+
+    /**
+     * @brief Check if the client has read authorization
+     * @return true if the client has read authorization
+     */
+    bool readAuthz(const ParamDescriptor& pd) const;
 
     /**
      * @brief Check if the client has write authorization
      * @return true if the client has write authorization
      */
-    bool writeAuthz() const {
-        if (pd_.readOnly()) {
-            return false;
-        }
-        /**
-         * @todo implement writeAuthz
-         */
-        return true;
-    }
+    bool writeAuthz(const IParam& param) const;
 
-    const catena::common::IConstraint* getConstraint() const {
-        return pd_.getConstraint();
-    }
+    /**
+     * @brief Check if the client has write authorization
+     * @return true if the client has write authorization
+     */
+    bool writeAuthz(const ParamDescriptor& pd) const;
 
   private:
-    const ParamDescriptor& pd_;
-    const std::string clientScope_; /**< the scope of the object */
+    const std::vector<std::string>& clientScopes_;
 };
 
 } // namespace common

--- a/sdks/cpp/common/include/Device.h
+++ b/sdks/cpp/common/include/Device.h
@@ -100,8 +100,8 @@ class Device {
     /**
      * @brief Construct a new Device object
      */
-    Device(uint32_t slot, Device_DetailLevel detail_level, std::vector<Scopes> access_scopes,
-      Scopes_e default_scope, bool multi_set_enabled, bool subscriptions)
+    Device(uint32_t slot, Device_DetailLevel detail_level, std::vector<std::string> access_scopes,
+      std::string default_scope, bool multi_set_enabled, bool subscriptions)
       : slot_{slot}, detail_level_{detail_level}, access_scopes_{access_scopes},
       default_scope_{default_scope}, multi_set_enabled_{multi_set_enabled}, subscriptions_{subscriptions} {}
 
@@ -134,7 +134,7 @@ class Device {
      */
     inline DetailLevel_e detail_level() const { return detail_level_; }
 
-    inline const std::string& getDefaultScope() const { return default_scope_.toString(); }
+    inline const std::string& getDefaultScope() const { return default_scope_; }
 
     /**
      * @brief Create a protobuf representation of the device.
@@ -393,8 +393,8 @@ class Device {
     std::unordered_map<std::string, common::IMenuGroup*> menu_groups_;
     std::unordered_map<std::string, IParam*> commands_;
     std::unordered_map<std::string, common::ILanguagePack*> language_packs_;
-    std::vector<Scopes> access_scopes_;
-    Scopes default_scope_;
+    std::vector<std::string> access_scopes_;
+    std::string default_scope_;
     bool multi_set_enabled_;
     bool subscriptions_;
     

--- a/sdks/cpp/common/include/IParam.h
+++ b/sdks/cpp/common/include/IParam.h
@@ -37,6 +37,8 @@
 namespace catena {
 namespace common { 
 
+  class Authorizer;
+
 /**
  * @brief IParam is the interface for business logic and connection logic to interact with parameters
  * 
@@ -81,20 +83,20 @@ class IParam {
      * @brief serialize the parameter value to protobuf
      * @param dst the protobuf value to serialize to
      */
-    virtual catena::exception_with_status toProto(catena::Value& dst, std::string& clientScope) const = 0;
+    virtual catena::exception_with_status toProto(catena::Value& dst, Authorizer& authz) const = 0;
     
     /**
      * @brief deserialize the parameter value from protobuf
      * @param src the protobuf value to deserialize from
      * @note this method may constrain the source value and modify it
      */
-    virtual catena::exception_with_status fromProto(const catena::Value& src, std::string& clientScope) = 0;
+    virtual catena::exception_with_status fromProto(const catena::Value& src, Authorizer& authz) = 0;
 
     /**
      * @brief serialize the parameter descriptor to protobuf
      * @param param the protobuf value to serialize to
      */
-    virtual catena::exception_with_status toProto(catena::Param& param, std::string& clientScope) const = 0;
+    virtual catena::exception_with_status toProto(catena::Param& param, Authorizer& authz) const = 0;
 
     /**
      * @brief return the type of the param
@@ -125,19 +127,17 @@ class IParam {
     /**
      * @brief get a child parameter by name
      */
-    virtual std::unique_ptr<IParam> getParam(Path& oid, catena::exception_with_status& status) = 0;
-
-    /**
-     * @brief add a child parameter
-     */
-    // virtual void addParam(const std::string& oid, IParam* param) = 0;
+    virtual std::unique_ptr<IParam> getParam(Path& oid, Authorizer& authz, catena::exception_with_status& status) = 0;
 
     /**
      * @brief get a constraint by oid
      */
     virtual const IConstraint* getConstraint() const = 0;
 
-    virtual const std::string getScope() const = 0;
+    /**
+     * @brief get the parameter access scope
+     */
+    virtual const std::string& getScope() const = 0;
 
     /**
      * @brief define a command for the parameter

--- a/sdks/cpp/common/include/ParamDescriptor.h
+++ b/sdks/cpp/common/include/ParamDescriptor.h
@@ -42,7 +42,6 @@
 #include <Tags.h>
 #include <IParam.h>
 #include <IConstraint.h>
-#include <Device.h>
 #include <PolyglotText.h>
 
 // meta
@@ -61,7 +60,8 @@
 namespace catena {
 namespace common {
 
-class AuthzInfo; // forward declaration
+class Authorizer; // forward declaration
+class Device; // forward declaration
 
 /**
  * @brief ParamDescriptor provides information about a parameter
@@ -164,18 +164,18 @@ class ParamDescriptor {
     /**
      * @brief get the access scope of the parameter
      */
-    const std::string getScope() const;
+    const std::string& getScope() const;
 
     /**
      * @brief serialize param meta data in to protobuf message
      * @param param the protobuf message to serialize to
-     * @param auth the authorization information
+     * @param authz the authorization information
      * 
      * this function will populate all non-value fields of the protobuf param message 
      * with the information from the ParamDescriptor
      * 
      */
-    void toProto(catena::Param &param, AuthzInfo& auth) const;
+    void toProto(catena::Param &param, Authorizer& authz) const;
 
     /**
      * @brief get the parameter name by language

--- a/sdks/cpp/common/include/ParamWithValue.h
+++ b/sdks/cpp/common/include/ParamWithValue.h
@@ -144,7 +144,7 @@ class ParamWithValue : public catena::common::IParam {
      * @param clientScope the client scope
      */
     catena::exception_with_status toProto(catena::Value& value, Authorizer& authz) const override {
-        if (authz.readAuthz(*this)) {
+        if (!authz.readAuthz(*this)) {
             return catena::exception_with_status("Param does not exist", catena::StatusCode::INVALID_ARGUMENT);
         }
         catena::common::toProto<T>(value, &value_.get(), descriptor_, authz);

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -1,0 +1,106 @@
+/** Copyright 2024 Ross Video Ltd
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or
+ promote products derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ DAMAGE.
+*/
+//
+
+/**
+ * @file Authorization.cpp
+ * @brief Implements the Authorizer class
+ * @author John Danen
+ * @date 2024-12-06
+ * @copyright Copyright (c) 2024 Ross Video
+ */
+
+#include <Authorization.h>
+
+using catena::common::Authorizer;
+
+// placeholder for disabled authorization
+static const std::vector<std::string> kAuthzDisabledScope = {""};
+
+// initialize the disabled authorization object
+Authorizer Authorizer::kAuthzDisabled = {kAuthzDisabledScope};
+
+/**
+ * @brief Check if the client has read authorization
+ * @return true if the client has read authorization
+ */
+bool Authorizer::readAuthz(const IParam& param) const {
+    if (this == &kAuthzDisabled) {
+        return true; // no authorization required
+    }
+
+    const std::string& scope = param.getScope();
+    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+        return false;
+    }
+    return true;
+}
+
+bool Authorizer::readAuthz(const ParamDescriptor& pd) const {
+    if (this == &kAuthzDisabled) {
+        return true; // no authorization required
+    }
+
+    const std::string& scope = pd.getScope();
+    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @brief Check if the client has write authorization
+ * @return true if the client has write authorization
+ */
+bool Authorizer::writeAuthz(const IParam& param) const {
+    if (param.readOnly()) {
+        return false;
+    }
+
+    if (this == &kAuthzDisabled) {
+        return true; // no authorization required
+    }
+
+    const std::string scope = param.getScope() + ":w";
+    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+        return false;
+    }
+    return true;
+}
+
+bool Authorizer::writeAuthz(const ParamDescriptor& pd) const {
+    if (pd.readOnly()) {
+        return false;
+    }
+
+    if (this == &kAuthzDisabled) {
+        return true; // no authorization required
+    }
+
+    const std::string scope = pd.getScope() + ":w";
+    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+        return false;
+    }
+    return true;
+}

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -44,35 +44,29 @@
 
 using namespace catena::common;
 
-// Initialize the special AUTHZ_DISABLED scope
-const std::vector<std::string> Device::kAuthzDisabled = {"__AUTHZ_DISABLED__"};
-
-catena::exception_with_status Device::setValue (const std::string& jptr, catena::Value& src) {
+catena::exception_with_status Device::setValue (const std::string& jptr, catena::Value& src, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
-    std::unique_ptr<IParam> param = getParam(jptr, ans);
-    // we expect this to be a parameter name
+    std::unique_ptr<IParam> param = getParam(jptr, ans, authz);
     if (param != nullptr) {
-        std::string clientScope = "operate"; // temporary until we implement authz
-        ans = param->fromProto(src, clientScope);
+        ans = param->fromProto(src, authz);
         valueSetByClient.emit(jptr, param.get(), 0);
     }
     return ans;
 }
 
-catena::exception_with_status Device::getValue (const std::string& jptr, catena::Value& dst) {
+catena::exception_with_status Device::getValue (const std::string& jptr, catena::Value& dst, Authorizer& authz) const {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
-    std::unique_ptr<IParam> param = getParam(jptr, ans);
+    std::unique_ptr<IParam> param = getParam(jptr, ans, authz);
     
     // we expect this to be a parameter name
     if (param != nullptr) {
-        std::string clientScope = "operate"; // temporary until we implement authz
         // we have reached the end of the path, deserialize the value
-        param->toProto(dst, clientScope);
+        param->toProto(dst, authz);
     }
     return ans;
 }
 
-std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::exception_with_status& status) const {
+std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::exception_with_status& status, Authorizer& authz) const {
     // The Path constructor will throw an exception if the json pointer is invalid, so we use a try catch block to catch it.
     try {
         catena::common::Path path(fqoid);
@@ -88,7 +82,7 @@ std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::excep
              */
             IParam* param = getItem<common::ParamTag>(path.front_as_string());
             path.pop();
-            if (!param) {
+            if (!param || !authz.readAuthz(*param)) {
                 status = catena::exception_with_status("Param does not exist", catena::StatusCode::INVALID_ARGUMENT); 
                 return nullptr;
             }
@@ -103,7 +97,7 @@ std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::excep
                 /**
                  * Sub-param objects are created by the getParam function so the lifetime of the object is managed by the caller.
                  */
-                return param->getParam(path, status);
+                return param->getParam(path, authz, status);
             }
         } else {
             status = catena::exception_with_status("Invalid json pointer", catena::StatusCode::INVALID_ARGUMENT);
@@ -115,7 +109,7 @@ std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::excep
     }
 }
 
-std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exception_with_status& status) const {
+std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exception_with_status& status, Authorizer& authz) const {
    // The Path constructor will throw an exception if the json pointer is invalid, so we use a try catch block to catch it.
     try {
         catena::common::Path path(fqoid);
@@ -146,7 +140,7 @@ std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exc
     }
 }
 
-void Device::toProto(::catena::Device& dst, std::vector<std::string>& clientScopes, bool shallow) const {
+void Device::toProto(::catena::Device& dst, Authorizer& authz, bool shallow) const {
     dst.set_slot(slot_);
     dst.set_detail_level(detail_level_);
     *dst.mutable_default_scope() = default_scope_.toString();
@@ -155,13 +149,11 @@ void Device::toProto(::catena::Device& dst, std::vector<std::string>& clientScop
     if (shallow) { return; }
 
     // if we're not doing a shallow copy, we need to copy all the Items
-    /// @todo: implement deep copies for constraints, menu groups, commands, etc...
     google::protobuf::Map<std::string, ::catena::Param> dstParams{};
     for (const auto& [name, param] : params_) {
-        std::string paramScope = param->getScope();
-        if (clientScopes[0] == kAuthzDisabled[0] || std::find(clientScopes.begin(), clientScopes.end(), paramScope) != clientScopes.end()) {
+        if (authz.readAuthz(*param)) {
             ::catena::Param dstParam{};
-            param->toProto(dstParam, clientScopes[0]);
+            param->toProto(dstParam, authz);
             dstParams[name] = dstParam;
         }
     }
@@ -170,10 +162,9 @@ void Device::toProto(::catena::Device& dst, std::vector<std::string>& clientScop
     // make deep copy of the commands
     google::protobuf::Map<std::string, ::catena::Param> dstCommands{};
     for (const auto& [name, command] : commands_) {
-        std::string commandScope = command->getScope();
-        if (clientScopes[0] == kAuthzDisabled[0] || std::find(clientScopes.begin(), clientScopes.end(), commandScope) != clientScopes.end()) {
+        if (authz.readAuthz(*command)) {
             ::catena::Param dstCommand{};
-            command->toProto(dstCommand, clientScopes[0]); // uses param's toProto method
+            command->toProto(dstCommand, authz); // uses param's toProto method
             dstCommands[name] = dstCommand;
         }
     }
@@ -233,11 +224,11 @@ catena::DeviceComponent Device::DeviceSerializer::getNext() {
     return std::move(handle_.promise().deviceMessage); 
 }
 
-Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>& clientScopes, bool shallow) const {
+Device::DeviceSerializer Device::getComponentSerializer(Authorizer& authz, bool shallow) const {
     catena::DeviceComponent component{};
     if (!shallow) {
         // If not shallow, send the whole device as a single message
-        toProto(*component.mutable_device(), clientScopes, shallow);
+        toProto(*component.mutable_device(), authz, shallow);
         co_return component; 
     }
 
@@ -276,23 +267,21 @@ Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>
     }
 
     for (const auto& [name, param] : params_) {
-        std::string paramScope = param->getScope();
-        if (clientScopes[0] == kAuthzDisabled[0] || std::find(clientScopes.begin(), clientScopes.end(), paramScope) != clientScopes.end()) {
+        if (authz.readAuthz(*param)) {
             co_yield component; // yield the previous component before overwriting it
             component.Clear();
             ::catena::Param* dstParam = component.mutable_param()->mutable_param();
-            param->toProto(*dstParam, clientScopes[0]);
+            param->toProto(*dstParam, authz);
             component.mutable_param()->set_oid(name);
         }
     }
 
     for (const auto& [name, command] : commands_) {
-        std::string commandScope = command->getScope();
-        if (clientScopes[0] == kAuthzDisabled[0] || std::find(clientScopes.begin(), clientScopes.end(), commandScope) != clientScopes.end()) {
+        if (authz.readAuthz(*command)) {
             co_yield component; // yield the previous component before overwriting it
             component.Clear();
             ::catena::Param* dstCommand = component.mutable_command()->mutable_param();
-            command->toProto(*dstCommand, clientScopes[0]);
+            command->toProto(*dstCommand,authz);
             component.mutable_command()->set_oid(name);
         }
     }
@@ -307,11 +296,7 @@ Device::DeviceSerializer Device::getComponentSerializer(std::vector<std::string>
             component.mutable_menu()->set_oid(oid);
         }
     }
-
-    /**
-     * @todo send menu components
-     */
-
+    
     // return the last component
     co_return component;
 }

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -143,7 +143,7 @@ std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exc
 void Device::toProto(::catena::Device& dst, Authorizer& authz, bool shallow) const {
     dst.set_slot(slot_);
     dst.set_detail_level(detail_level_);
-    *dst.mutable_default_scope() = default_scope_.toString();
+    *dst.mutable_default_scope() = default_scope_;
     dst.set_multi_set_enabled(multi_set_enabled_);
     dst.set_subscriptions(subscriptions_);
     if (shallow) { return; }
@@ -237,12 +237,12 @@ Device::DeviceSerializer Device::getComponentSerializer(Authorizer& authz, bool 
     catena::Device* dst = component.mutable_device();
     dst->set_slot(slot_);
     dst->set_detail_level(detail_level_);
-    *dst->mutable_default_scope() = default_scope_.toString();
+    *dst->mutable_default_scope() = default_scope_;
     dst->set_multi_set_enabled(multi_set_enabled_);
     dst->set_subscriptions(subscriptions_);
 
     for (auto& scope : access_scopes_) {
-        dst->add_access_scopes(scope.toString());
+        dst->add_access_scopes(scope);
     }
 
     for (auto& [menu_group_name, menu_group] : menu_groups_) {

--- a/sdks/cpp/common/src/StructInfo.cpp
+++ b/sdks/cpp/common/src/StructInfo.cpp
@@ -35,30 +35,30 @@
 // protobuf interface
 #include <interface/param.pb.h>
 
-using catena::common::AuthzInfo;
+using catena::common::Authorizer;
 using catena::common::EmptyValue;
 using ::catena::Value;
 
 EmptyValue catena::common::emptyValue;
 
 template<>
-void catena::common::toProto<EmptyValue>(::catena::Value& dst, const EmptyValue* src, const AuthzInfo& auth) {
+void catena::common::toProto<EmptyValue>(::catena::Value& dst, const EmptyValue* src, const ParamDescriptor& pd, const Authorizer& authz) {
     // do nothing
 }
 
 template<>
-void catena::common::fromProto<EmptyValue>(const catena::Value& src, EmptyValue* dst, const AuthzInfo& auth) {
+void catena::common::fromProto<EmptyValue>(const catena::Value& src, EmptyValue* dst, const ParamDescriptor& pd, const Authorizer& authz) {
     // do nothing
 }
 
 template<>
-void catena::common::toProto<int32_t>(Value& dst, const int32_t* src, const AuthzInfo& auth) {
+void catena::common::toProto<int32_t>(Value& dst, const int32_t* src, const ParamDescriptor& pd, const Authorizer& authz) {
     dst.set_int32_value(*src);
 }
 
 template<>
-void catena::common::fromProto<int32_t>(const catena::Value& src, int32_t* dst, const AuthzInfo& auth) {
-    const catena::common::IConstraint* constraint = auth.getConstraint();
+void catena::common::fromProto<int32_t>(const catena::Value& src, int32_t* dst, const ParamDescriptor& pd, const Authorizer& authz) {
+    const catena::common::IConstraint* constraint = pd.getConstraint();
 
     if (!src.has_int32_value()) {
         return;
@@ -74,13 +74,13 @@ void catena::common::fromProto<int32_t>(const catena::Value& src, int32_t* dst, 
 }
 
 template<>
-void catena::common::toProto<float>(catena::Value& dst, const float* src, const AuthzInfo& auth) {
+void catena::common::toProto<float>(catena::Value& dst, const float* src, const ParamDescriptor& pd, const Authorizer& authz) {
     dst.set_float32_value(*src);
 }
 
 template<>
-void catena::common::fromProto<float>(const catena::Value& src, float* dst, const AuthzInfo& auth) {
-    const catena::common::IConstraint* constraint = auth.getConstraint();
+void catena::common::fromProto<float>(const catena::Value& src, float* dst, const ParamDescriptor& pd, const Authorizer& authz) {
+    const catena::common::IConstraint* constraint = pd.getConstraint();
 
     if (!src.has_float32_value()) {
         return;
@@ -95,13 +95,13 @@ void catena::common::fromProto<float>(const catena::Value& src, float* dst, cons
 }
 
 template<>
-void catena::common::toProto<std::string>(Value& dst, const std::string* src, const AuthzInfo& auth) {
+void catena::common::toProto<std::string>(Value& dst, const std::string* src, const ParamDescriptor& pd, const Authorizer& authz) {
     dst.set_string_value(*src);
 }
 
 template<>
-void catena::common::fromProto<std::string>(const catena::Value& src, std::string* dst, const AuthzInfo& auth) {
-    const catena::common::IConstraint* constraint = auth.getConstraint();
+void catena::common::fromProto<std::string>(const catena::Value& src, std::string* dst, const ParamDescriptor& pd, const Authorizer& authz) {
+    const catena::common::IConstraint* constraint = pd.getConstraint();
 
     if (!src.has_string_value()) {
         return;
@@ -115,7 +115,7 @@ void catena::common::fromProto<std::string>(const catena::Value& src, std::strin
 }
 
 template<>
-void catena::common::toProto<std::vector<int32_t>>(Value& dst, const std::vector<int32_t>* src, const AuthzInfo& auth) {
+void catena::common::toProto<std::vector<int32_t>>(Value& dst, const std::vector<int32_t>* src, const ParamDescriptor& pd, const Authorizer& authz) {
     dst.clear_int32_array_values();
     catena::Int32List& int_array = *dst.mutable_int32_array_values();
     for (const int32_t& i : *src) {
@@ -124,12 +124,12 @@ void catena::common::toProto<std::vector<int32_t>>(Value& dst, const std::vector
 }
 
 template<>
-void catena::common::fromProto<std::vector<int32_t>>(const Value& src, std::vector<int32_t>* dst, const AuthzInfo& auth) {
+void catena::common::fromProto<std::vector<int32_t>>(const Value& src, std::vector<int32_t>* dst, const ParamDescriptor& pd, const Authorizer& authz) {
     if (!src.has_int32_array_values()) {
         return;
     }
     const catena::Int32List& int_array = src.int32_array_values();
-    const catena::common::IConstraint* constraint = auth.getConstraint();
+    const catena::common::IConstraint* constraint = pd.getConstraint();
     catena::Value item;
     
     // Right now from proto is able to append any number of values to the vector
@@ -155,7 +155,7 @@ void catena::common::fromProto<std::vector<int32_t>>(const Value& src, std::vect
 }
 
 template<>
-void catena::common::toProto<std::vector<float>>(Value& dst, const std::vector<float>* src, const AuthzInfo& auth) {
+void catena::common::toProto<std::vector<float>>(Value& dst, const std::vector<float>* src, const ParamDescriptor& pd, const Authorizer& authz) {
     dst.clear_float32_array_values();
     catena::Float32List& float_array = *dst.mutable_float32_array_values();
     for (const float& f : *src) {
@@ -164,13 +164,13 @@ void catena::common::toProto<std::vector<float>>(Value& dst, const std::vector<f
 }
 
 template<>
-void catena::common::fromProto<std::vector<float>>(const Value& src, std::vector<float>* dst, const AuthzInfo& auth) {
+void catena::common::fromProto<std::vector<float>>(const Value& src, std::vector<float>* dst, const ParamDescriptor& pd, const Authorizer& authz) {
     if (!src.has_float32_array_values()) {
         return;
     }
     dst->clear();
     const catena::Float32List& float_array = src.float32_array_values();
-    const catena::common::IConstraint* constraint = auth.getConstraint();
+    const catena::common::IConstraint* constraint = pd.getConstraint();
     catena::Value item;
 
     // Right now from proto is able to append any number of values to the vector
@@ -189,7 +189,7 @@ void catena::common::fromProto<std::vector<float>>(const Value& src, std::vector
 }
 
 template<>
-void catena::common::toProto<std::vector<std::string>>(Value& dst, const std::vector<std::string>* src, const AuthzInfo& auth) {
+void catena::common::toProto<std::vector<std::string>>(Value& dst, const std::vector<std::string>* src, const ParamDescriptor& pd, const Authorizer& authz) {
     dst.clear_string_array_values();
     catena::StringList& string_array = *dst.mutable_string_array_values();
     for (const std::string& s :*src) {
@@ -198,13 +198,13 @@ void catena::common::toProto<std::vector<std::string>>(Value& dst, const std::ve
 }
 
 template<>
-void catena::common::fromProto<std::vector<std::string>>(const Value& src, std::vector<std::string>* dst, const AuthzInfo& auth) {
+void catena::common::fromProto<std::vector<std::string>>(const Value& src, std::vector<std::string>* dst, const ParamDescriptor& pd, const Authorizer& authz) {
     if (!src.has_string_array_values()) {
         return;
     }
     dst->clear();
     const catena::StringList& string_array = src.string_array_values();
-    const catena::common::IConstraint* constraint = auth.getConstraint();
+    const catena::common::IConstraint* constraint = pd.getConstraint();
     catena::Value item;
 
     for (int i = 0; i < string_array.strings_size(); ++i) {

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
@@ -3,7 +3,7 @@
   "multi_set_enabled": true,
   "detail_level": "FULL",
   "access_scopes": ["monitor", "operate", "configure", "administer"],
-  "default_scope": "operate",
+  "default_scope": "monitor",
   "language_packs": {},
   "params": {
     "eq": {
@@ -12,19 +12,23 @@
       "params": {
         "response": {
           "type": "INT32",
-          "name": { "display_strings": { "en": "Response" } }
+          "name": { "display_strings": { "en": "Response" } },
+          "access_scope": "monitor"
         },
         "frequency": {
           "type": "FLOAT32",
-          "name": { "display_strings": { "en": "Frequency" } }
+          "name": { "display_strings": { "en": "Frequency" } },
+          "access_scope": "operate"
         },
         "gain": {
           "type": "FLOAT32",
-          "name": { "display_strings": { "en": "Gain" } }
+          "name": { "display_strings": { "en": "Gain" } },
+          "access_scope": "configure"
         },
         "q_factor": {
           "type": "FLOAT32",
-          "name": { "display_strings": { "en": "Q Factor" } }
+          "name": { "display_strings": { "en": "Q Factor" } },
+          "access_scope": "administer"
         }
       }
     },

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -31,6 +31,7 @@
 #include <vdk/signals.h>
 #include <IParam.h>
 #include <Device.h>
+#include <Authorization.h>
 
 // gRPC interface
 #include <interface/service.grpc.pb.h>
@@ -92,13 +93,15 @@ class CatenaServiceImpl final : public catena::CatenaService::AsyncService {
     ServerCompletionQueue* cq_;
     Device &dm_;
     std::string& EOPath_;
-    bool authz_;
+    bool authorizationEnabled_;
 
   public:
 
     void registerItem(CallData *cd);
 
     void deregisterItem(CallData *cd);
+
+    inline bool authorizationEnabled() const { return authorizationEnabled_; }
 
     class GetPopulatedSlots : public CallData{
         public:
@@ -178,7 +181,6 @@ class CatenaServiceImpl final : public catena::CatenaService::AsyncService {
         Device &dm_;
         std::mutex mtx_;
         std::condition_variable cv_;
-        std::vector<std::string> clientScopes_;
         bool hasUpdate_{false};
         int objectId_;
         static int objectCounter_;
@@ -202,6 +204,7 @@ class CatenaServiceImpl final : public catena::CatenaService::AsyncService {
         CatenaServiceImpl *service_;
         ServerContext context_;
         std::vector<std::string> clientScopes_;
+        std::unique_ptr<catena::common::Authorizer> authz_ = nullptr;
         catena::DeviceRequestPayload req_;
         ServerAsyncWriter<catena::DeviceComponent> writer_;
         std::optional<Device::DeviceSerializer> serializer_ = std::nullopt; //Can't create serializer until we have client scopes

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -388,7 +388,6 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
                             this->res_.mutable_value()->set_element_index(idx);
 
                             catena::Value* value = this->res_.mutable_value()->mutable_value();
-                            Device::LockGuard lg(dm_);
                             p->toProto(*value, authz);
                             this->hasUpdate_ = true;
                             this->cv_.notify_one();
@@ -398,7 +397,6 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
                         this->res_.mutable_value()->set_element_index(idx);
 
                         catena::Value* value = this->res_.mutable_value()->mutable_value();
-                        Device::LockGuard lg(dm_);
                         p->toProto(*value, catena::common::Authorizer::kAuthzDisabled);
                         this->hasUpdate_ = true;
                         this->cv_.notify_one();
@@ -423,7 +421,6 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
                             this->res_.mutable_value()->set_element_index(idx);
 
                             catena::Value* value = this->res_.mutable_value()->mutable_value();
-                            Device::LockGuard lg(dm_);
                             p->toProto(*value, authz);
                             this->hasUpdate_ = true;
                             this->cv_.notify_one();
@@ -433,7 +430,6 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
                         this->res_.mutable_value()->set_element_index(idx);
 
                         catena::Value* value = this->res_.mutable_value()->mutable_value();
-                        Device::LockGuard lg(dm_);
                         p->toProto(*value, catena::common::Authorizer::kAuthzDisabled);
                         this->hasUpdate_ = true;
                         this->cv_.notify_one();

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -67,7 +67,7 @@ std::string timeNow() {
 
 
 CatenaServiceImpl::CatenaServiceImpl(ServerCompletionQueue *cq, Device &dm, std::string& EOPath, bool authz)
-        : catena::CatenaService::AsyncService{}, cq_{cq}, dm_{dm}, EOPath_{EOPath}, authz_{authz} {}
+        : catena::CatenaService::AsyncService{}, cq_{cq}, dm_{dm}, EOPath_{EOPath}, authorizationEnabled_{authz} {}
 
 void CatenaServiceImpl::init() {
     new GetPopulatedSlots(this, dm_, true);
@@ -125,9 +125,9 @@ void CatenaServiceImpl::deregisterItem(CallData *cd) {
 }
 
 std::vector<std::string> CatenaServiceImpl::getScopes(ServerContext &context) {
-    if(!authz_){
-        // Authorization is disabled
-        return Device::kAuthzDisabled;
+    if(!authorizationEnabled_){
+        // there won't be any scopes if authorization is disabled
+        return {};
     }
 
     auto authContext = context.auth_context();
@@ -154,10 +154,6 @@ std::vector<std::string> CatenaServiceImpl::getScopes(ServerContext &context) {
             std::string scopeClaim = it->second.get<std::string>();
             std::istringstream iss(scopeClaim);
             while (std::getline(iss, scopeClaim, ' ')) {
-                // check that reserved scope is not used
-                if (scopeClaim == Device::kAuthzDisabled[0]) {
-                    throw catena::exception_with_status("Invalid scope", catena::StatusCode::PERMISSION_DENIED);
-                }
                 scopes.push_back(scopeClaim);
             }
         }
@@ -237,7 +233,17 @@ void CatenaServiceImpl::GetValue::proceed(CatenaServiceImpl *service, bool ok) {
             context_.AsyncNotifyWhenDone(this);
             try {
                 catena::Value ans;
-                catena::exception_with_status rc = dm_.getValue(req_.oid(), ans);
+                catena::exception_with_status rc{"", catena::StatusCode::OK};
+                if(service->authorizationEnabled()) {
+                    std::vector<std::string> clientScopes = service->getScopes(context_);  
+                    catena::common::Authorizer authz{clientScopes};
+                    Device::LockGuard lg(dm_);
+                    rc = dm_.getValue(req_.oid(), ans, authz);
+                } else {
+                    Device::LockGuard lg(dm_);
+                    rc = dm_.getValue(req_.oid(), ans, catena::common::Authorizer::kAuthzDisabled);
+                }
+                
                 status_ = CallStatus::kFinish;
                 if (rc.status == catena::StatusCode::OK) {
                     responder_.Finish(ans, Status::OK, this);
@@ -290,17 +296,23 @@ void CatenaServiceImpl::SetValue::proceed(CatenaServiceImpl *service, bool ok) {
             new SetValue(service_, dm_, ok);
             context_.AsyncNotifyWhenDone(this);
             try {
-                catena::exception_with_status ans{"", catena::StatusCode::OK};
-                {   // block to minimize time lock is held
+                catena::exception_with_status rc{"", catena::StatusCode::OK};
+
+                if (service->authorizationEnabled()) {
+                    std::vector<std::string> clientScopes = service->getScopes(context_);  
+                    catena::common::Authorizer authz{clientScopes};
                     Device::LockGuard lg(dm_);
-                    catena::exception_with_status why = dm_.setValue(req_.oid(), *req_.mutable_value());
-                    ans = std::move(why);
+                    rc = dm_.setValue(req_.oid(), *req_.mutable_value(), authz);
+                } else {
+                    Device::LockGuard lg(dm_);
+                    rc = dm_.setValue(req_.oid(), *req_.mutable_value(), catena::common::Authorizer::kAuthzDisabled);
                 }
-                if (ans.status == catena::StatusCode::OK) {
+
+                if (rc.status == catena::StatusCode::OK) {
                     status_ = CallStatus::kFinish;
                     responder_.Finish(catena::Empty{}, Status::OK, this);
                 } else {
-                    errorStatus_ = Status(static_cast<grpc::StatusCode>(ans.status), ans.what());
+                    errorStatus_ = Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
                     status_ = CallStatus::kFinish;
                     responder_.Finish(::catena::Empty{}, errorStatus_, this);
                 }
@@ -362,44 +374,74 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
             });
             valueSetByServerId_ = dm_.valueSetByServer.connect([this](const std::string& oid, const IParam* p, const int32_t idx){
                 try{
-                    // std::string paramScope = p->getScope();
-                    // if (std::find(clientScopes_.begin(), clientScopes_.end(), paramScope) != clientScopes_.end()){
-                        if (!this->context_.IsCancelled()){
+                    if (this->context_.IsCancelled()){
+                        this->hasUpdate_ = true;
+                        this->cv_.notify_one();
+                        return;
+                    }
+
+                    if(service_->authorizationEnabled()){
+                        std::vector<std::string> clientScopes = service_->getScopes(context_);
+                        catena::common::Authorizer authz{clientScopes};
+                        if (authz.readAuthz(*p)){
                             this->res_.mutable_value()->set_oid(oid);
                             this->res_.mutable_value()->set_element_index(idx);
 
-                            std::string clientScope = "operate"; // temporary until we implement authz
                             catena::Value* value = this->res_.mutable_value()->mutable_value();
-                            p->toProto(*value, clientScope);
+                            Device::LockGuard lg(dm_);
+                            p->toProto(*value, authz);
+                            this->hasUpdate_ = true;
+                            this->cv_.notify_one();
                         }
+                    } else {
+                        this->res_.mutable_value()->set_oid(oid);
+                        this->res_.mutable_value()->set_element_index(idx);
+
+                        catena::Value* value = this->res_.mutable_value()->mutable_value();
+                        Device::LockGuard lg(dm_);
+                        p->toProto(*value, catena::common::Authorizer::kAuthzDisabled);
                         this->hasUpdate_ = true;
                         this->cv_.notify_one();
-                    // }
+                    }
                 }catch(catena::exception_with_status& why){
-                    // Error is thrown for connected clients without authorization
-                    // Don't need to send any updates to unauthorized clients
+                    // if an error is thrown, no update is pushed to the client
                 } 
             });
             valueSetByClientId_ = dm_.valueSetByClient.connect([this](const std::string& oid, const IParam* p, const int32_t idx){
                 try{
-                    // std::string paramScope = p->getScope();
-                    // if (std::find(clientScopes_.begin(), clientScopes_.end(), paramScope) != clientScopes_.end()){
-                        if (!this->context_.IsCancelled()){
-                            this->res_.mutable_value()->set_oid(oid);
-                            this->res_.mutable_value()->set_element_index(idx);
-                            std::string clientScope = "operate"; // temporary until we implement authz
-                            p->toProto(*this->res_.mutable_value()->mutable_value(), clientScope);
-                        }
+                    if (this->context_.IsCancelled()){
                         this->hasUpdate_ = true;
                         this->cv_.notify_one();
-                    // }
+                        return;
+                    }
+
+                    if (service_->authorizationEnabled()){
+                        std::vector<std::string> clientScopes = service_->getScopes(context_);
+                        catena::common::Authorizer authz{clientScopes};
+                        if (authz.readAuthz(*p)){
+                            this->res_.mutable_value()->set_oid(oid);
+                            this->res_.mutable_value()->set_element_index(idx);
+
+                            catena::Value* value = this->res_.mutable_value()->mutable_value();
+                            Device::LockGuard lg(dm_);
+                            p->toProto(*value, authz);
+                            this->hasUpdate_ = true;
+                            this->cv_.notify_one();
+                        }
+                    } else {
+                        this->res_.mutable_value()->set_oid(oid);
+                        this->res_.mutable_value()->set_element_index(idx);
+
+                        catena::Value* value = this->res_.mutable_value()->mutable_value();
+                        Device::LockGuard lg(dm_);
+                        p->toProto(*value, catena::common::Authorizer::kAuthzDisabled);
+                        this->hasUpdate_ = true;
+                        this->cv_.notify_one();
+                    }
                 }catch(catena::exception_with_status& why){
-                    // Error is thrown for connected clients without authorization
-                    // Don't need to send any updates to unauthorized clients
+                    // if an error is thrown, no update is pushed to the client
                 } 
             });
-
-            clientScopes_ = service_->getScopes(context_);
 
             // send client a empty update with slot of the device
             {
@@ -469,14 +511,20 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
         case CallStatus::kProcess:
             new DeviceRequest(service_, dm_, ok);  // to serve other clients
             context_.AsyncNotifyWhenDone(this);
-            //clientScopes_ = getScopes(context_);
-            // deviceStream_.attachClientScopes(clientScopes_);
             // shutdownSignalId_ = shutdownSignal.connect([this](){
             //     context_.TryCancel();
             //     std::cout << "DeviceRequest[" << objectId_ << "] cancelled\n";
             // });
-            clientScopes_ = service_->getScopes(context_);
-            serializer_ = dm_.getComponentSerializer(clientScopes_, true); // select the shallow copy option
+            {
+                bool shallowCopy = true; // controls whether shallow copy or deep copy is used
+                if (service->authorizationEnabled()) {
+                    clientScopes_ = service->getScopes(context_);  
+                    authz_ = std::make_unique<catena::common::Authorizer>(clientScopes_);
+                    serializer_ = dm_.getComponentSerializer(*authz_, shallowCopy);
+                } else {
+                    serializer_ = dm_.getComponentSerializer(catena::common::Authorizer::kAuthzDisabled, shallowCopy);
+                }
+            }
             status_ = CallStatus::kWrite;
             // fall thru to start writing
 
@@ -492,7 +540,6 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
                 
                 try {     
                     catena::DeviceComponent component{};
-                    std::vector<std::string> clientScopes = service_->getScopes(context_);
                     {
                         Device::LockGuard lg(dm_);
                         component = serializer_->getNext();
@@ -730,7 +777,15 @@ void CatenaServiceImpl::ExecuteCommand::proceed(CatenaServiceImpl *service, bool
         case CallStatus::kRead: // should always tranistion to this state after calling stream_.Read()
         {
             catena::exception_with_status rc{"", catena::StatusCode::OK};
-            std::unique_ptr<IParam> command = dm_.getCommand(req_.oid(), rc);
+            std::unique_ptr<IParam> command = nullptr;
+            if (service_->authorizationEnabled()) {
+                std::vector<std::string> clientScopes = service->getScopes(context_);
+                catena::common::Authorizer authz{clientScopes};
+                command = dm_.getCommand(req_.oid(), rc, authz);
+            } else {
+                command = dm_.getCommand(req_.oid(), rc, catena::common::Authorizer::kAuthzDisabled);
+            }
+
             if (command == nullptr) {
                 status_ = CallStatus::kFinish;
                 stream_.Finish(Status(static_cast<grpc::StatusCode>(rc.status), rc.what()), this);

--- a/tools/codegen/cpp/device.js
+++ b/tools/codegen/cpp/device.js
@@ -38,7 +38,7 @@ function detailLevelArg(desc) {
  */
 function accessScopesArg(desc) {
     if ("access_scopes" in desc) {
-        return `{${desc.access_scopes.map(scope => `Scope("${scope}")()`).join(', ')}}`;
+        return `{${desc.access_scopes.map(scope => `"${scope}"`).join(', ')}}`;
     } else {
         return `{}`;
     }
@@ -50,9 +50,9 @@ function accessScopesArg(desc) {
  * @returns initializer for default_scope member
  */
 function defaultScopeArg(desc) {
-    let ans = `{}`;
+    let ans = `""`;
     if ("default_scope" in desc) {
-        ans = `Scope("${desc.default_scope}")()`;
+        ans = `"${desc.default_scope}"`;
     }
     return ans;
 }


### PR DESCRIPTION
closes #175 

Added scope checking for all types. Request without the required access scopes will be blocked. If writing to a struct, if the struct value has an unauthorized sub-param then only that sub-param is ignored and the rest of the write operation succeeds.