### PR TITLE
Feat-#339-jrn

### DIFF
--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -28,8 +28,22 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "14.5" CACHE STRING "Minimum OS X deployment ver
 
 project(Catena_cpp VERSION 0.0.1 LANGUAGES C CXX)
 
+# set up the CATENA_CPP_ROOT_DIR variable for use in the rest of the build
 get_filename_component(CATENA_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../.. ABSOLUTE)
 set(CATENA_CPP_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# set up the CATENA_CPP_VERSION and CATENA_CPP_TIMESTAMP variables for use
+# in the rest of the build.
+# The format of the version string is "cpp-vX.Y.Z-0-<timestamp>"
+# We want to extract the version number and the timestamp.
+file(READ ${CATENA_CPP_ROOT_DIR}/VERSION.txt VERSION_STRING)
+string(STRIP ${VERSION_STRING} VERSION_STRING) # strip any whitespace
+string(FIND "${VERSION_STRING}" "-" SPLIT_AT REVERSE)
+string(SUBSTRING "${VERSION_STRING}" 0 ${SPLIT_AT} CATENA_CPP_VERSION)
+math(EXPR TIMESTAMP_START "${SPLIT_AT} + 1")
+string(SUBSTRING "${VERSION_STRING}" ${TIMESTAMP_START} -1 CATENA_CPP_TIMESTAMP)
+message(STATUS "Catena C++ SDK version: ${CATENA_CPP_VERSION}")
+message(STATUS "Catena C++ SDK timestamp: ${CATENA_CPP_TIMESTAMP}")
 
 # pull in Catena build functions
 include(${CATENA_CPP_ROOT_DIR}/CatenaFunctions.cmake)
@@ -90,6 +104,10 @@ include_directories("$ENV{HOME}/.local/include")
 # find the c preprocessor and set the options to use with it
 if (APPLE)
   set(CPP clang)
+
+  # clang complains (a lot!) about braced scalar initialization, so disable that warning
+  add_compile_options(-Wno-braced-scalar-init)
+
   set(cpp_opts -E -P -x c)
 else()
   find_program(CPP cpp)

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -70,7 +70,7 @@ class Authorizer {
      * @param pd the ParamDescriptor of the object
      * @param scope the scope of the object
      */
-    Authorizer(std::vector<std::string>& clientScopes)
+    Authorizer(const Scopes& clientScopes)
         : clientScopes_{clientScopes} {}
 
     /**
@@ -123,7 +123,7 @@ class Authorizer {
     bool writeAuthz(const ParamDescriptor& pd) const;
 
   private:
-    std::reference_wrapper<Scopes> clientScopes_;
+    std::reference_wrapper<const Scopes> clientScopes_;
 };
 
 } // namespace common

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -44,6 +44,8 @@
 #include <IParam.h>
 #include <ParamDescriptor.h>
 
+#include <functional>
+
 
 namespace catena {
 namespace common {
@@ -52,6 +54,11 @@ namespace common {
  * @brief Class for handling authorization information
  */
 class Authorizer {
+  public:
+    /**
+     * @brief The scopes of the object
+     */
+    using Scopes = std::vector<std::string>;
   public:
     /**
      * @brief Special Authorizer object that disables authorization
@@ -63,7 +70,7 @@ class Authorizer {
      * @param pd the ParamDescriptor of the object
      * @param scope the scope of the object
      */
-    Authorizer(const std::vector<std::string>& clientScopes)
+    Authorizer(std::vector<std::string>& clientScopes)
         : clientScopes_{clientScopes} {}
 
     /**
@@ -116,7 +123,7 @@ class Authorizer {
     bool writeAuthz(const ParamDescriptor& pd) const;
 
   private:
-    const std::vector<std::string>& clientScopes_;
+    std::reference_wrapper<Scopes> clientScopes_;
 };
 
 } // namespace common

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -36,7 +36,7 @@
 using catena::common::Authorizer;
 
 // placeholder for disabled authorization
-static const std::vector<std::string> kAuthzDisabledScope = {""};
+static std::vector<std::string> kAuthzDisabledScope = {""};
 
 // initialize the disabled authorization object
 Authorizer Authorizer::kAuthzDisabled = {kAuthzDisabledScope};
@@ -51,7 +51,7 @@ bool Authorizer::readAuthz(const IParam& param) const {
     }
 
     const std::string& scope = param.getScope();
-    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+    if (std::find(clientScopes_.get().begin(), clientScopes_.get().end(), scope) == clientScopes_.get().end()) {
         return false;
     }
     return true;
@@ -63,7 +63,7 @@ bool Authorizer::readAuthz(const ParamDescriptor& pd) const {
     }
 
     const std::string& scope = pd.getScope();
-    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+    if (std::find(clientScopes_.get().begin(), clientScopes_.get().end(), scope) == clientScopes_.get().end()) {
         return false;
     }
     return true;
@@ -83,7 +83,7 @@ bool Authorizer::writeAuthz(const IParam& param) const {
     }
 
     const std::string scope = param.getScope() + ":w";
-    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+    if (std::find(clientScopes_.get().begin(), clientScopes_.get().end(), scope) == clientScopes_.get().end()) {
         return false;
     }
     return true;
@@ -99,7 +99,7 @@ bool Authorizer::writeAuthz(const ParamDescriptor& pd) const {
     }
 
     const std::string scope = pd.getScope() + ":w";
-    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
+    if (std::find(clientScopes_.get().begin(), clientScopes_.get().end(), scope) == clientScopes_.get().end()) {
         return false;
     }
     return true;

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -36,7 +36,7 @@
 using catena::common::Authorizer;
 
 // placeholder for disabled authorization
-static std::vector<std::string> kAuthzDisabledScope = {""};
+static const std::vector<std::string> kAuthzDisabledScope = {""};
 
 // initialize the disabled authorization object
 Authorizer Authorizer::kAuthzDisabled = {kAuthzDisabledScope};


### PR DESCRIPTION
#339

started integrating versioning into cmake tree
also addresses a couple of compiler issues shown up by clang:

- it's fussier than gcc about list initializers and warns about unneccessary braces, so this warning is suppressed for clang
- it detected a problem with move semantics being on, but a member of Authorizer being const qualified which implicitly deletes them



