### PR TITLE
Enh #363 1 jrn

### DIFF
--- a/sdks/cpp/connections/docker/catena_structs_with_authz_dockerfile
+++ b/sdks/cpp/connections/docker/catena_structs_with_authz_dockerfile
@@ -29,29 +29,11 @@
 #
 
 #
-# cmake file to build some example services as docker images
+# Dockerfile to create an image for the status_update example service
 #
 
-cmake_minimum_required(VERSION 3.20)
-project(catena-docker-services)
+FROM base
 
-# ensure we have the docker app, alias it to DOCKER_CMD
-find_program(DOCKER_CMD docker REQUIRED)
+COPY build/connections/gRPC/examples/structs_with_authz/structs_with_authz /opt/structs_with_authz
 
-# include the make_image function
-include(DockerFunctions.cmake)
-
-# make our base image
-make_image(base . "")
-
-# make the status update image
-make_image(catena_status_update ${CATENA_CPP_ROOT_DIR} "base.hash;status_update")
-
-# make the use menus image
-make_image(catena_use_menus ${CATENA_CPP_ROOT_DIR} "base.hash;use_menus")
-
-# make the structs with authz image
-make_image(catena_structs_with_authz ${CATENA_CPP_ROOT_DIR} "base.hash;structs_with_authz")
-
-# make the structs with authz image
-make_image(catena_use_commands ${CATENA_CPP_ROOT_DIR} "base.hash;use_commands")
+ENTRYPOINT ["/opt/structs_with_authz"]

--- a/sdks/cpp/connections/docker/catena_use_commands_dockerfile
+++ b/sdks/cpp/connections/docker/catena_use_commands_dockerfile
@@ -29,29 +29,12 @@
 #
 
 #
-# cmake file to build some example services as docker images
+# Dockerfile to create an image for the status_update example service
 #
 
-cmake_minimum_required(VERSION 3.20)
-project(catena-docker-services)
+FROM base
 
-# ensure we have the docker app, alias it to DOCKER_CMD
-find_program(DOCKER_CMD docker REQUIRED)
+COPY build/connections/gRPC/examples/use_commands/use_commands /opt/use_commands
+COPY connections/gRPC/examples/use_commands/static /env/use_commands
 
-# include the make_image function
-include(DockerFunctions.cmake)
-
-# make our base image
-make_image(base . "")
-
-# make the status update image
-make_image(catena_status_update ${CATENA_CPP_ROOT_DIR} "base.hash;status_update")
-
-# make the use menus image
-make_image(catena_use_menus ${CATENA_CPP_ROOT_DIR} "base.hash;use_menus")
-
-# make the structs with authz image
-make_image(catena_structs_with_authz ${CATENA_CPP_ROOT_DIR} "base.hash;structs_with_authz")
-
-# make the structs with authz image
-make_image(catena_use_commands ${CATENA_CPP_ROOT_DIR} "base.hash;use_commands")
+ENTRYPOINT ["/opt/use_commands", "--static_root=/env/use_commands"]

--- a/sdks/cpp/connections/docker/grpc_compose.yml
+++ b/sdks/cpp/connections/docker/grpc_compose.yml
@@ -1,0 +1,89 @@
+version: '3.8'  # Docker Compose file format version
+
+networks:
+  catena_network:
+    driver: bridge
+
+services:
+  status_update:
+    image: catena_status_update
+    container_name: catena_status_update
+    networks:
+      - catena_network
+    ports:
+      - "6254:6254"  # Map port 6254 on host to 6254 in container
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    command:
+      - "--certs=/etc/letsencrypt/live/catena.rossvideo.com"
+      - "--secure_comms=tls"
+      - "--cert_file=fullchain.pem"
+      - "--key_file=privkey.pem"
+
+
+  use_menus:
+    image: catena_use_menus
+    container_name: catena_use_menus
+    networks:
+      - catena_network
+    ports:
+      - "6256:6254"  # Map port 6256 on host to 6254 in container
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    command:
+      - "--certs=/etc/letsencrypt/live/catena.rossvideo.com"
+      - "--secure_comms=tls"
+      - "--cert_file=fullchain.pem"
+      - "--key_file=privkey.pem"
+
+  use_structs:
+    image: catena_structs_with_authz
+    container_name: catena_structs_with_authz
+    networks:
+      - catena_network
+    ports:
+      - "6258:6254"  # Map port 6258 on host to 6254 in container
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    command:
+      - "--certs=/etc/letsencrypt/live/catena.rossvideo.com"
+      - "--secure_comms=tls"
+      - "--cert_file=fullchain.pem"
+      - "--key_file=privkey.pem"
+      - "--authz=true"
+
+  use_commands:
+    image: catena_use_commands
+    container_name: catena_use_commands
+    networks:
+      - catena_network
+    ports:
+      - "6260:6254"  # Map port 6258 on host to 6254 in container
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    command:
+      - "--certs=/etc/letsencrypt/live/catena.rossvideo.com"
+      - "--secure_comms=tls"
+      - "--cert_file=fullchain.pem"
+      - "--key_file=privkey.pem"
+

--- a/sdks/cpp/connections/gRPC/CMakeLists.txt
+++ b/sdks/cpp/connections/gRPC/CMakeLists.txt
@@ -27,7 +27,13 @@ endif(APPLE)
 
 set(target catena_connections_grpc)
 
-set(sources "src/PeerInfo.cpp" "src/ServiceImpl.cpp")
+set(sources 
+    "src/PeerInfo.cpp"
+    "src/ServiceImpl.cpp" 
+    "src/SharedFlags.cpp"
+    "src/ServiceCredentials.cpp"
+)
+
 add_library(${target} STATIC ${sources})
 
 find_package(jwt-cpp CONFIG REQUIRED)

--- a/sdks/cpp/connections/gRPC/examples/CMakeLists.txt
+++ b/sdks/cpp/connections/gRPC/examples/CMakeLists.txt
@@ -23,6 +23,6 @@ cmake_minimum_required(VERSION 3.20)
 project(CATENA_LITE_EXAMPLES C CXX)
 
 add_subdirectory("status_update")
-add_subdirectory("structs_with_authz")
-add_subdirectory("use_commands")
+# add_subdirectory("structs_with_authz")
+# add_subdirectory("use_commands")
 add_subdirectory("use_menus")

--- a/sdks/cpp/connections/gRPC/examples/CMakeLists.txt
+++ b/sdks/cpp/connections/gRPC/examples/CMakeLists.txt
@@ -23,6 +23,6 @@ cmake_minimum_required(VERSION 3.20)
 project(CATENA_LITE_EXAMPLES C CXX)
 
 add_subdirectory("status_update")
-# add_subdirectory("structs_with_authz")
-# add_subdirectory("use_commands")
+add_subdirectory("structs_with_authz")
+add_subdirectory("use_commands")
 add_subdirectory("use_menus")

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -1,18 +1,32 @@
-// Copyright 2024 Ross Video Ltd
-//
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-//
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-//
-// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
  * @brief Example program to demonstrate setting up a full Catena service.
@@ -31,16 +45,16 @@
 #include <ParamWithValue.h>
 
 // connections/gRPC
+#include <SharedFlags.h>
 #include <ServiceImpl.h>
+#include <ServiceCredentials.h>
 
-// protobuf interface
-#include <interface/service.grpc.pb.h>
 
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 
-#include "absl/flags/flag.h"
+
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
 #include "absl/strings/str_format.h"
@@ -60,17 +74,6 @@ using grpc::Server;
 
 using namespace catena::common;
 
-// set up the command line parameters
-ABSL_FLAG(uint16_t, port, 6254, "Catena service port");
-ABSL_FLAG(std::string, certs, "${HOME}/test_certs", "path/to/certs/files");
-ABSL_FLAG(std::string, secure_comms, "off", "Specify type of secure comms, options are: \"off\", \"tls\"");
-ABSL_FLAG(std::string, cert_file, "server.crt", "Specify the certificate file");
-ABSL_FLAG(std::string, key_file, "server.key", "Specify the key file");
-ABSL_FLAG(std::string, ca_file, "ca.crt", "Specify the CA file if using a private CA");
-ABSL_FLAG(bool, private_ca, false, "Specify if using a private CA");
-ABSL_FLAG(bool, mutual_authc, false, "use this to require client to authenticate");
-ABSL_FLAG(bool, authz, false, "use OAuth token authorization");
-ABSL_FLAG(std::string, static_root, getenv("HOME"), "Specify the directory to search for external objects");
 
 Server *globalServer = nullptr;
 std::atomic<bool> globalLoop = true;
@@ -86,66 +89,6 @@ void handle_signal(int sig) {
         }
     });
     t.join();
-}
-
-
-// expand env variables
-void expandEnvVariables(std::string &str) {
-    static std::regex env{"\\$\\{([^}]+)\\}"};
-    std::smatch match;
-    while (std::regex_search(str, match, env)) {
-        const char *s = getenv(match[1].str().c_str());
-        const std::string var(s == nullptr ? "" : s);
-        str.replace(match[0].first, match[0].second, var);
-    }
-}
-
-// creates a Security Credentials object based on the command line options
-std::shared_ptr<grpc::ServerCredentials> getServerCredentials() {
-    std::shared_ptr<grpc::ServerCredentials> ans;
-    if (absl::GetFlag(FLAGS_secure_comms).compare("off") == 0) {
-        // run without secure comms
-        ans = grpc::InsecureServerCredentials();
-    } else if (absl::GetFlag(FLAGS_secure_comms).compare("tls") == 0) {
-        // create our server credentials options
-        grpc::SslServerCredentialsOptions ssl_opts(
-          absl::GetFlag(FLAGS_mutual_authc) ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
-                                            : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
-
-        // get path to the files we'll need
-        std::string path_to_certs(absl::GetFlag(FLAGS_certs));
-        expandEnvVariables(path_to_certs);
-
-        // read the CA cert if we are using a private CA, use to set ssl options
-        if (absl::GetFlag(FLAGS_private_ca)) {
-            std::string ca_cert_fn(path_to_certs + "/" + absl::GetFlag(FLAGS_ca_file));
-            std::string ca_cert = catena::readFile(ca_cert_fn);
-            ssl_opts.pem_root_certs = ca_cert;
-        }
-        
-        // read the server key and cert, use to set ssl options
-        std::string server_key_fn(path_to_certs + "/" + absl::GetFlag(FLAGS_key_file));
-        std::string server_certfn(path_to_certs + "/" + absl::GetFlag(FLAGS_cert_file));
-        std::string server_key = catena::readFile(server_key_fn);
-        std::string server_cert = catena::readFile(server_certfn);
-        ssl_opts.pem_key_cert_pairs.push_back(
-          grpc::SslServerCredentialsOptions::PemKeyCertPair{server_key, server_cert});
-
-        // create the credentials object
-        ans = grpc::SslServerCredentials(ssl_opts);
-
-        // attach the authz processor if needed
-        if (absl::GetFlag(FLAGS_authz)) {
-            const std::shared_ptr<grpc::AuthMetadataProcessor> authzProcessor(new JWTAuthMetadataProcessor());
-            ans->SetAuthMetadataProcessor(authzProcessor);
-        }
-
-    } else {
-        std::stringstream why;
-        why << std::quoted(absl::GetFlag(FLAGS_secure_comms)) << " is not a valid secure_comms option";
-        throw std::invalid_argument(why.str());
-    }
-    return ans;
 }
 
 void counterUpdateHandler(const std::string& oid, const IParam* p, const int32_t idx) {
@@ -241,7 +184,7 @@ void RunRPCServer(std::string addr)
         // set some grpc options
         grpc::EnableDefaultHealthCheckService(true);
 
-        builder.AddListeningPort(addr, getServerCredentials());
+        builder.AddListeningPort(addr, catena::getServerCredentials());
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);

--- a/sdks/cpp/connections/gRPC/examples/use_commands/device.video_player.json
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/device.video_player.json
@@ -10,7 +10,7 @@
       "type": "STRING",
       "oid_aliases": ["0xFF0E"],
       "read_only": true,
-      "value": { "string_value": "eo://status_update.grid" }
+      "value": { "string_value": "eo://use_commands.grid" }
     },
     "state": {
       "type": "STRING",

--- a/sdks/cpp/connections/gRPC/examples/use_commands/static/use_commands.grid
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/static/use_commands.grid
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<abs id="_top" keepalive="false" style="">
+   <table width="750" >
+      <tr>
+         <label name="Catena gRPC Use Commands Example"/>
+      </tr>
+
+   </table>
+</abs>

--- a/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
@@ -30,7 +30,9 @@
 #include <ParamWithValue.h>
 
 // connections/gRPC
+#include <SharedFlags.h>
 #include <ServiceImpl.h>
+#include <ServiceCredentials.h>
 
 // protobuf interface
 #include <interface/service.grpc.pb.h>
@@ -39,7 +41,6 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 
-#include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
 #include "absl/strings/str_format.h"
@@ -58,15 +59,6 @@ using grpc::Server;
 
 using namespace catena::common;
 
-// set up the command line parameters
-ABSL_FLAG(uint16_t, port, 6254, "Catena service port");
-ABSL_FLAG(std::string, certs, "${HOME}/test_certs", "path/to/certs/files");
-ABSL_FLAG(std::string, secure_comms, "off", "Specify type of secure comms, options are: \
-  \"off\", \"ssl\", \"tls\"");
-ABSL_FLAG(bool, mutual_authc, false, "use this to require client to authenticate");
-ABSL_FLAG(bool, authz, false, "use OAuth token authorization");
-ABSL_FLAG(std::string, static_root, getenv("HOME"), "Specify the directory to search for external objects");
-
 Server *globalServer = nullptr;
 std::atomic<bool> globalLoop = true;
 
@@ -84,54 +76,6 @@ void handle_signal(int sig) {
 }
 
 
-// expand env variables
-void expandEnvVariables(std::string &str) {
-    static std::regex env{"\\$\\{([^}]+)\\}"};
-    std::smatch match;
-    while (std::regex_search(str, match, env)) {
-        const char *s = getenv(match[1].str().c_str());
-        const std::string var(s == nullptr ? "" : s);
-        str.replace(match[0].first, match[0].second, var);
-    }
-}
-
-// creates a Security Credentials object based on the command line options
-std::shared_ptr<grpc::ServerCredentials> getServerCredentials() {
-    std::shared_ptr<grpc::ServerCredentials> ans;
-    if (absl::GetFlag(FLAGS_secure_comms).compare("off") == 0) {
-        // run without secure comms
-        ans = grpc::InsecureServerCredentials();
-    } else if (absl::GetFlag(FLAGS_secure_comms).compare("ssl") == 0) {
-        // run with Secure Sockets Layer comms
-        std::string path_to_certs(absl::GetFlag(FLAGS_certs));
-        expandEnvVariables(path_to_certs);
-        std::string root_cert = catena::readFile(path_to_certs + "/ca.crt");
-        std::string server_key = catena::readFile(path_to_certs + "/server.key");
-        std::string server_cert = catena::readFile(path_to_certs + "/server.crt");
-        grpc::SslServerCredentialsOptions ssl_opts(
-          absl::GetFlag(FLAGS_mutual_authc) ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
-                                            : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
-        ssl_opts.pem_root_certs = root_cert;
-        ssl_opts.pem_key_cert_pairs.push_back(
-          grpc::SslServerCredentialsOptions::PemKeyCertPair{server_key, server_cert});
-        ans = grpc::SslServerCredentials(ssl_opts);
-
-        if (absl::GetFlag(FLAGS_authz)) {
-            const std::shared_ptr<grpc::AuthMetadataProcessor> authzProcessor(new JWTAuthMetadataProcessor());
-            ans->SetAuthMetadataProcessor(authzProcessor);
-        }
-
-    } else if (absl::GetFlag(FLAGS_secure_comms).compare("tls") == 0) {
-        std::stringstream why;
-        why << "tls support has not been implemented yet, sorry.";
-        throw std::runtime_error(why.str());
-    } else {
-        std::stringstream why;
-        why << std::quoted(absl::GetFlag(FLAGS_secure_comms)) << " is not a valid secure_comms option";
-        throw std::invalid_argument(why.str());
-    }
-    return ans;
-}
 
 void statusUpdate(){   
     std::thread loop([]() {
@@ -164,7 +108,7 @@ void RunRPCServer(std::string addr)
         // set some grpc options
         grpc::EnableDefaultHealthCheckService(true);
 
-        builder.AddListeningPort(addr, getServerCredentials());
+        builder.AddListeningPort(addr, catena::getServerCredentials());
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);

--- a/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
@@ -33,6 +33,8 @@
 
 // connections/gRPC
 #include <ServiceImpl.h>
+#include <SharedFlags.h>
+#include <ServiceCredentials.h>
 
 // protobuf interface
 #include <interface/service.grpc.pb.h>
@@ -41,7 +43,6 @@
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 
-#include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
 #include "absl/strings/str_format.h"
@@ -60,14 +61,6 @@ using grpc::Server;
 
 using namespace catena::common;
 
-// set up the command line parameters
-ABSL_FLAG(uint16_t, port, 6254, "Catena service port");
-ABSL_FLAG(std::string, certs, "${HOME}/test_certs", "path/to/certs/files");
-ABSL_FLAG(std::string, secure_comms, "off", "Specify type of secure comms, options are: \
-  \"off\", \"ssl\", \"tls\"");
-ABSL_FLAG(bool, mutual_authc, false, "use this to require client to authenticate");
-ABSL_FLAG(bool, authz, false, "use OAuth token authorization");
-ABSL_FLAG(std::string, static_root, getenv("HOME"), "Specify the directory to search for external objects");
 
 Server *globalServer = nullptr;
 std::atomic<bool> globalLoop = true;
@@ -85,55 +78,6 @@ void handle_signal(int sig) {
     t.join();
 }
 
-
-// expand env variables
-void expandEnvVariables(std::string &str) {
-    static std::regex env{"\\$\\{([^}]+)\\}"};
-    std::smatch match;
-    while (std::regex_search(str, match, env)) {
-        const char *s = getenv(match[1].str().c_str());
-        const std::string var(s == nullptr ? "" : s);
-        str.replace(match[0].first, match[0].second, var);
-    }
-}
-
-// creates a Security Credentials object based on the command line options
-std::shared_ptr<grpc::ServerCredentials> getServerCredentials() {
-    std::shared_ptr<grpc::ServerCredentials> ans;
-    if (absl::GetFlag(FLAGS_secure_comms).compare("off") == 0) {
-        // run without secure comms
-        ans = grpc::InsecureServerCredentials();
-    } else if (absl::GetFlag(FLAGS_secure_comms).compare("ssl") == 0) {
-        // run with Secure Sockets Layer comms
-        std::string path_to_certs(absl::GetFlag(FLAGS_certs));
-        expandEnvVariables(path_to_certs);
-        std::string root_cert = catena::readFile(path_to_certs + "/ca.crt");
-        std::string server_key = catena::readFile(path_to_certs + "/server.key");
-        std::string server_cert = catena::readFile(path_to_certs + "/server.crt");
-        grpc::SslServerCredentialsOptions ssl_opts(
-          absl::GetFlag(FLAGS_mutual_authc) ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
-                                            : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
-        ssl_opts.pem_root_certs = root_cert;
-        ssl_opts.pem_key_cert_pairs.push_back(
-          grpc::SslServerCredentialsOptions::PemKeyCertPair{server_key, server_cert});
-        ans = grpc::SslServerCredentials(ssl_opts);
-
-        if (absl::GetFlag(FLAGS_authz)) {
-            const std::shared_ptr<grpc::AuthMetadataProcessor> authzProcessor(new JWTAuthMetadataProcessor());
-            ans->SetAuthMetadataProcessor(authzProcessor);
-        }
-
-    } else if (absl::GetFlag(FLAGS_secure_comms).compare("tls") == 0) {
-        std::stringstream why;
-        why << "tls support has not been implemented yet, sorry.";
-        throw std::runtime_error(why.str());
-    } else {
-        std::stringstream why;
-        why << std::quoted(absl::GetFlag(FLAGS_secure_comms)) << " is not a valid secure_comms option";
-        throw std::invalid_argument(why.str());
-    }
-    return ans;
-}
 
 void statusUpdateExample(){   
     std::thread loop([]() {
@@ -177,18 +121,12 @@ void RunRPCServer(std::string addr)
     signal(SIGKILL, handle_signal);
 
     try {
-        // // check that static_root is a valid file path
-        // if (!std::filesystem::exists(absl::GetFlag(FLAGS_static_root))) {
-        //     std::stringstream why;
-        //     why << std::quoted(absl::GetFlag(FLAGS_static_root)) << " is not a valid file path";
-        //     throw std::invalid_argument(why.str());
-        // }
 
         grpc::ServerBuilder builder;
         // set some grpc options
         grpc::EnableDefaultHealthCheckService(true);
 
-        builder.AddListeningPort(addr, getServerCredentials());
+        builder.AddListeningPort(addr, catena::getServerCredentials());
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);

--- a/sdks/cpp/connections/gRPC/include/ServiceCredentials.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceCredentials.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+// protobuf interface
+#include <interface/service.grpc.pb.h>
+
+
+#include <string>
+#include <memory>
+
+namespace catena {
+
+/**
+ * @brief expands any environment variables in str.
+ * 
+ * N.B. this is done in-place and the value of str is likely different after execution.
+ * 
+ * @param str the string in which to expand any environment variables it contains.
+ */
+void expandEnvVariables(std::string &str);
+
+
+/**
+ * @brief sets up a ServerCredentials object from the cli flags
+ * 
+ * @return initialized ServerCredentials
+ */
+std::shared_ptr<grpc::ServerCredentials> getServerCredentials();
+
+} // namespace catena

--- a/sdks/cpp/connections/gRPC/include/SharedFlags.h
+++ b/sdks/cpp/connections/gRPC/include/SharedFlags.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <absl/flags/flag.h>
+
+/**
+ *  @brief specify the port for the gRPC service, default is 6254.
+ */ 
+extern absl::Flag<uint16_t> FLAGS_port;
+
+/**
+ *  @brief specify the path to the server's certificate and private key default is ${HOME}/test_certs
+ */ 
+extern absl::Flag<std::string> FLAGS_certs;
+
+/**
+ *  @brief turn secure comms on, options are: off, tls; default is off
+ */ 
+extern absl::Flag<std::string> FLAGS_secure_comms;
+
+/**
+ *  @brief name of the certificate file, default is server.crt
+ */ 
+extern absl::Flag<std::string> FLAGS_cert_file;
+
+/**
+ *  @brief name of private key file, default is server.key
+ */ 
+extern absl::Flag<std::string> FLAGS_key_file;
+
+/**
+ *  @brief name of private CA certificate file, default is ca.crt, ignored if private_ca is false.
+ */ 
+extern absl::Flag<std::string> FLAGS_ca_file;
+
+/**
+ *  @brief specify whether to use a private CA, default is no
+ */ 
+extern absl::Flag<bool> FLAGS_private_ca;
+
+/**
+ *  @brief require mutual TLS, default is no, ignored if secure_comms is off
+ */ 
+extern absl::Flag<bool> FLAGS_mutual_authc;
+
+/**
+ *  @brief require access control, default is off
+ */ 
+extern absl::Flag<bool> FLAGS_authz;
+
+/**
+ *  @brief path to the folder from which static objects can be served, default ${HOME}
+ */ 
+extern absl::Flag<std::string> FLAGS_static_root;
+

--- a/sdks/cpp/connections/gRPC/src/ServiceCredentials.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceCredentials.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <SharedFlags.h>
+#include <ServiceCredentials.h>
+
+// catena
+#include <utils.h>
+
+#include <ServiceImpl.h> // JWTMetaAuthMetadataProcessor
+#include <regex>
+
+using catena::readFile;
+
+// expand env variables
+void catena::expandEnvVariables(std::string &str) {
+    static std::regex env{"\\$\\{([^}]+)\\}"};
+    std::smatch match;
+    while (std::regex_search(str, match, env)) {
+        const char *s = getenv(match[1].str().c_str());
+        const std::string var(s == nullptr ? "" : s);
+        str.replace(match[0].first, match[0].second, var);
+    }
+}
+
+// creates a Security Credentials object based on the command line options
+std::shared_ptr<grpc::ServerCredentials> catena::getServerCredentials() {
+    std::shared_ptr<grpc::ServerCredentials> ans;
+    if (absl::GetFlag(FLAGS_secure_comms).compare("off") == 0) {
+        // run without secure comms
+        ans = grpc::InsecureServerCredentials();
+    } else if (absl::GetFlag(FLAGS_secure_comms).compare("tls") == 0) {
+        // create our server credentials options
+        grpc::SslServerCredentialsOptions ssl_opts(
+          absl::GetFlag(FLAGS_mutual_authc) ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
+                                            : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
+
+        // get path to the files we'll need
+        std::string path_to_certs(absl::GetFlag(FLAGS_certs));
+        catena::expandEnvVariables(path_to_certs);
+
+        // read the CA cert if we are using a private CA, use to set ssl options
+        if (absl::GetFlag(FLAGS_private_ca)) {
+            std::string ca_cert_fn(path_to_certs + "/" + absl::GetFlag(FLAGS_ca_file));
+            std::string ca_cert = catena::readFile(ca_cert_fn);
+            ssl_opts.pem_root_certs = ca_cert;
+        }
+        
+        // read the server key and cert, use to set ssl options
+        std::string server_key_fn(path_to_certs + "/" + absl::GetFlag(FLAGS_key_file));
+        std::string server_certfn(path_to_certs + "/" + absl::GetFlag(FLAGS_cert_file));
+        std::string server_key = catena::readFile(server_key_fn);
+        std::string server_cert = catena::readFile(server_certfn);
+        ssl_opts.pem_key_cert_pairs.push_back(
+          grpc::SslServerCredentialsOptions::PemKeyCertPair{server_key, server_cert});
+
+        // create the credentials object
+        ans = grpc::SslServerCredentials(ssl_opts);
+
+        // attach the authz processor if needed
+        if (absl::GetFlag(FLAGS_authz)) {
+            const std::shared_ptr<grpc::AuthMetadataProcessor> authzProcessor(new JWTAuthMetadataProcessor());
+            ans->SetAuthMetadataProcessor(authzProcessor);
+        }
+
+    } else {
+        std::stringstream why;
+        why << std::quoted(absl::GetFlag(FLAGS_secure_comms)) << " is not a valid secure_comms option";
+        throw std::invalid_argument(why.str());
+    }
+    return ans;
+}

--- a/sdks/cpp/connections/gRPC/src/SharedFlags.cpp
+++ b/sdks/cpp/connections/gRPC/src/SharedFlags.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <absl/flags/flag.h>
+#include <cstdlib>
+
+ABSL_FLAG(uint16_t, port, 6254, "Catena service port");
+ABSL_FLAG(std::string, certs, "${HOME}/test_certs", "path/to/certs/files");
+ABSL_FLAG(std::string, secure_comms, "off", "Specify type of secure comms, options are: \"off\", \"tls\"");
+ABSL_FLAG(std::string, cert_file, "server.crt", "Specify the certificate file");
+ABSL_FLAG(std::string, key_file, "server.key", "Specify the key file");
+ABSL_FLAG(std::string, ca_file, "ca.crt", "Specify the CA file if using a private CA");
+ABSL_FLAG(bool, private_ca, false, "Specify if using a private CA");
+ABSL_FLAG(bool, mutual_authc, false, "use this to require client to authenticate");
+ABSL_FLAG(bool, authz, false, "use OAuth token authorization");
+ABSL_FLAG(std::string, static_root, getenv("HOME"), "Specify the directory to search for external objects");

--- a/tools/codegen/cpp/cppgen.js
+++ b/tools/codegen/cpp/cppgen.js
@@ -251,7 +251,7 @@ class CppGen {
       if (oid == "product") {
         // we need to add code to overwrite the value of catena_sdk_version with
         // whatever's up-to-date in the SDK.
-        // this is done by adding some code to the postscript
+        // this is done by adding some code to the coda
         cloc(`#define STRINGIFY(x) #x`);
         cloc(`#define TO_STRING(x) STRINGIFY(x)`);
         cloc(`constexpr const char* real_sdk_version = TO_STRING(CATENA_CPP_VERSION);`);


### PR DESCRIPTION
- completes containerization of gRPC examples
- uses certificates signed by a public CA (lets encrypt)
- provides a docker-compose script to start/stop/log the services and run them at different port numbers
- refactors the service security and cli flags into the shared connections library