### PR TITLE
Language keys are now set to their respective language code rather than name.

### DIFF
--- a/sdks/cpp/common/include/LanguagePack.h
+++ b/sdks/cpp/common/include/LanguagePack.h
@@ -98,7 +98,7 @@ class LanguagePack : public common::ILanguagePack {
      * @param list the list of key/word pairs
      * @param dev the device model to which this language pack belongs
      */
-    LanguagePack(const std::string& name, ListInitializer list, Device& dev);
+    LanguagePack(const std::string& languageCode, const std::string& name, ListInitializer list, Device& dev);
 
     /**
      * @brief deserialize a language pack from a protobuf message

--- a/sdks/cpp/common/src/LanguagePack.cpp
+++ b/sdks/cpp/common/src/LanguagePack.cpp
@@ -34,9 +34,9 @@
 using namespace catena::common;
 using catena::common::LanguagePackTag;
 
-LanguagePack::LanguagePack(const std::string& name, ListInitializer list, Device& dev)
+LanguagePack::LanguagePack(const std::string& languageCode, const std::string& name, ListInitializer list, Device& dev)
     : name_{name}, words_(list.begin(), list.end()) {
-    dev.addItem<LanguagePackTag>(name, this);
+    dev.addItem<LanguagePackTag>(languageCode, this);
 }
 
 void LanguagePack::fromProto(const catena::LanguagePack& pack) {

--- a/tools/codegen/cpp/cppgen.js
+++ b/tools/codegen/cpp/cppgen.js
@@ -188,6 +188,7 @@ class CppGen {
       let lang = packs[pack];
       let keyWordPairs = Object.keys(lang.words);
       bloc(`LanguagePack ${pack} {`);
+      bloc(`"${pack}",`, 1);
       bloc(`"${lang.name}",`, 1);
       bloc(`{`, 1);
       bloc(keyWordPairs.map((key) => { return `{ "${key}", "${lang.words[key]}" }` }).join(",\n    "), 2);


### PR DESCRIPTION
Title. Language code is equivalent to the field's id in JSON file.