### PR TITLE
ParamDescriptor now works with parameter templates

### DIFF
--- a/sdks/cpp/common/include/ParamDescriptor.h
+++ b/sdks/cpp/common/include/ParamDescriptor.h
@@ -109,7 +109,11 @@ class ParamDescriptor {
      * @param widget the parameter's widget
      * @param read_only the parameter's read-only status
      * @param oid the parameter's oid
-     * @param collection the parameter belongs to
+     * @param template_oid the parameter's template oid
+     * @param constraint the parameter's constraint
+     * @param isCommand the parameter's command status
+     * @param dm the device that the parameter belongs to
+     * @param parent the parent parameter
      */
     ParamDescriptor(
       catena::ParamType type, 
@@ -119,12 +123,13 @@ class ParamDescriptor {
       const std::string& scope, 
       bool read_only, 
       const std::string& oid, 
+      const std::string& template_oid,
       catena::common::IConstraint* constraint,
       bool isCommand,
       Device& dm,
       ParamDescriptor* parent)
       : type_{type}, oid_aliases_{oid_aliases}, name_{name}, widget_{widget}, scope_{scope}, read_only_{read_only},
-        constraint_{constraint}, isCommand_{isCommand}, dev_{dm}, parent_{parent} {
+        template_oid_{template_oid}, constraint_{constraint}, isCommand_{isCommand}, dev_{dm}, parent_{parent} {
       setOid(oid);
       if (parent_ != nullptr) {
         parent_->addSubParam(oid, this);
@@ -150,6 +155,17 @@ class ParamDescriptor {
      * @brief set the parameter oid
      */
     void setOid(const std::string& oid) { oid_ = oid; }
+
+
+    /**
+     * @brief return true if the parameter has a template oid
+     */
+    bool has_template_oid() const;
+
+    /**
+     * @brief get the parameter's template oid
+     */
+    const std::string& template_oid() const;
 
     /**
      * @brief return the readOnly status of the parameter
@@ -177,6 +193,17 @@ class ParamDescriptor {
      */
     void toProto(catena::Param &param, Authorizer& authz) const;
 
+
+    /**
+     * @brief serialize param meta data in to protobuf message
+     * @param paramInfo the protobuf message to serialize to
+     * @param authz the authorization information
+     * 
+     * this function will populate all non-value fields of the protobuf param message 
+     * with the information from the ParamDescriptor
+     */
+    void toProto(catena::BasicParamInfo &paramInfo, Authorizer& authz) const;
+
     /**
      * @brief get the parameter name by language
      * @param language the language to get the name for
@@ -199,6 +226,15 @@ class ParamDescriptor {
      */
     ParamDescriptor& getSubParam(const std::string& oid) const {
       return *subParams_.at(oid);
+    }
+
+
+    /**
+     * @brief return all sub parameters
+     * @return a map of all sub parameters
+     */
+    const std::unordered_map<std::string, ParamDescriptor*>& getAllSubParams() const {
+        return subParams_;
     }
 
     /**
@@ -251,6 +287,7 @@ class ParamDescriptor {
     common::IConstraint* constraint_;
     
     std::string oid_;
+    std::string template_oid_;
     ParamDescriptor* parent_;
     std::reference_wrapper<Device> dev_;
 

--- a/sdks/cpp/common/src/ParamDescriptor.cpp
+++ b/sdks/cpp/common/src/ParamDescriptor.cpp
@@ -36,15 +36,19 @@
 using catena::common::ParamDescriptor;
 
 void ParamDescriptor::toProto(catena::Param &param, Authorizer& authz) const {
+    
     param.set_type(type_);
+    param.set_read_only(read_only_);
+    param.set_widget(widget_);
+
     for (const auto& oid_alias : oid_aliases_) {
         param.add_oid_aliases(oid_alias);
     }
     for (const auto& [lang, text] : name_.displayStrings()) {
         (*param.mutable_name()->mutable_display_strings())[lang] = text;
     }
-    param.set_widget(widget_);
-    param.set_read_only(read_only_);
+    
+    
     if (constraint_) {
         if (constraint_->isShared()) {
             *param.mutable_constraint()->mutable_ref_oid() = constraint_->getOid();
@@ -58,6 +62,19 @@ void ParamDescriptor::toProto(catena::Param &param, Authorizer& authz) const {
         if (authz.readAuthz(*subParam)) {
             subParam->toProto((*dstParams)[oid], authz);
         }
+    }
+
+    param.set_template_oid(template_oid_);
+}
+
+
+void ParamDescriptor::toProto(catena::BasicParamInfo &paramInfo, Authorizer& authz) const {
+    paramInfo.set_type(type_);
+    paramInfo.set_oid(oid_);
+    paramInfo.set_template_oid(template_oid_);
+
+    for (const auto& [lang, text] : name_.displayStrings()) {
+        (*paramInfo.mutable_name()->mutable_display_strings())[lang] = text;
     }
 }
 

--- a/tools/codegen/cpp/param.js
+++ b/tools/codegen/cpp/param.js
@@ -128,6 +128,9 @@ class Descriptor {
       oid: () => {
         return `"${oid}"`;
       },
+      template_oid: () => {
+        return ("template_oid" in desc) ? `"${desc.template_oid}"` : `""`;
+      },
       constraint: () => {
         return constraint ? `&${constraint.variableName()}` : "nullptr";
       },


### PR DESCRIPTION
- Added some missing comments
- Added template_oid to be set in toProto
- Added template_oid into constructor
- Added template_oid_ as a member
- Added getter for template_oid
- Added flag for template_oid existing
- Added overloaded toProto function for BasicParamInfo (for the future)
- Added function that returns all subparameters 
- Modified codegen for new constructor with template_oid