### PR TITLE
Added BasicParamInfoRequest with top-level param functionality only

### DIFF
--- a/sdks/cpp/common/include/Device.h
+++ b/sdks/cpp/common/include/Device.h
@@ -343,6 +343,15 @@ class Device {
     std::unique_ptr<IParam> getParam(const std::string& fqoid, catena::exception_with_status& status, Authorizer& authz = Authorizer::kAuthzDisabled) const;
 
     /**
+     * @brief get all top level parameters
+     * @param status the status of the operation
+     * @param authz the authorizer object
+     * @return a vector of unique pointers to the parameters
+     */
+    std::vector<std::unique_ptr<IParam>> getTopLevelParams(catena::exception_with_status& status, Authorizer& authz = Authorizer::kAuthzDisabled) const;
+
+
+    /**
      * @brief get a command by oid
      * @param fqoid the fully qualified oid of the command
      * @param authz the authorizer object

--- a/sdks/cpp/common/include/IParam.h
+++ b/sdks/cpp/common/include/IParam.h
@@ -38,6 +38,7 @@ namespace catena {
 namespace common { 
 
   class Authorizer;
+  class ParamDescriptor;  
 
 /**
  * @brief IParam is the interface for business logic and connection logic to interact with parameters
@@ -98,6 +99,14 @@ class IParam {
      */
     virtual catena::exception_with_status toProto(catena::Param& param, Authorizer& authz) const = 0;
 
+
+    /**
+     * @brief serialize the parameter descriptor to protobuf
+     * @param paramInfo the protobuf value to serialize to
+     */
+    virtual catena::exception_with_status toProto(catena::BasicParamInfoResponse& paramInfo, Authorizer& authz) const = 0;
+
+
     /**
      * @brief return the type of the param
      */
@@ -148,6 +157,12 @@ class IParam {
      * @brief execute the command for the parameter
      */
     virtual catena::CommandResponse executeCommand(const catena::Value&  value) const = 0;
+
+    /**
+     * @brief get the descriptor of the parameter
+     * @return the descriptor of the parameter
+     */
+    virtual const ParamDescriptor& getDescriptor() const = 0;
 
 };
 }  // namespace common

--- a/sdks/cpp/common/include/ParamWithValue.h
+++ b/sdks/cpp/common/include/ParamWithValue.h
@@ -17,7 +17,7 @@
  * contributors may be used to endorse or promote products derived from this
  * software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -167,6 +167,21 @@ class ParamWithValue : public catena::common::IParam {
     }
 
     /**
+     * @brief serialize the parameter descriptor to protobuf
+     * include both the descriptor and the value
+     * @param paramInfo the protobuf value to serialize to
+     * @param authz the authorization information
+     */
+    catena::exception_with_status toProto(catena::BasicParamInfoResponse& paramInfo, Authorizer& authz) const override {
+        if (!authz.readAuthz(*this)) {
+            return catena::exception_with_status("Param does not exist", catena::StatusCode::INVALID_ARGUMENT);
+        }
+        descriptor_.toProto(*paramInfo.mutable_info(), authz);
+        return catena::exception_with_status("", catena::StatusCode::OK);
+    }
+
+
+    /**
      * @brief deserialize the parameter value from protobuf if authorized
      * @param value the protobuf value to deserialize from
      * @param clientScope the client scope
@@ -253,6 +268,14 @@ class ParamWithValue : public catena::common::IParam {
      */
     catena::CommandResponse executeCommand(const catena::Value& value) const override {
         return descriptor_.executeCommand(value);
+    }
+
+    /**
+     * @brief get the descriptor of the parameter
+     * @return the descriptor of the parameter
+     */
+    const ParamDescriptor& getDescriptor() const override {
+        return descriptor_;
     }
 
   private:

--- a/sdks/cpp/common/include/ParamWithValue.h
+++ b/sdks/cpp/common/include/ParamWithValue.h
@@ -174,7 +174,7 @@ class ParamWithValue : public catena::common::IParam {
      */
     catena::exception_with_status toProto(catena::BasicParamInfoResponse& paramInfo, Authorizer& authz) const override {
         if (!authz.readAuthz(*this)) {
-            return catena::exception_with_status("Param does not exist", catena::StatusCode::INVALID_ARGUMENT);
+            return catena::exception_with_status("Authorization failed", catena::StatusCode::PERMISSION_DENIED);
         }
         descriptor_.toProto(*paramInfo.mutable_info(), authz);
         return catena::exception_with_status("", catena::StatusCode::OK);

--- a/sdks/cpp/common/include/Path.h
+++ b/sdks/cpp/common/include/Path.h
@@ -156,7 +156,7 @@ class Path {
 
     /**
      * @brief return a string representation of the Path
-     * @param leading_slash if true, include leading '/' in output (defaults to true)
+     * @param leading_slash if true, include leading '/' in output (defaults to false)
      * @return std::string the path as a string
      * 
      * any popped segments are not included in the returned string.

--- a/sdks/cpp/common/include/Path.h
+++ b/sdks/cpp/common/include/Path.h
@@ -38,8 +38,6 @@
 namespace catena {
 namespace common {
 
-using SegmentType = std::variant<std::string, size_t, int>;
-
 /**
  * @brief Converts json pointers to items within the data model to
  * a path of "segments" that can be iterated over.
@@ -103,11 +101,7 @@ class Path {
      * @brief Construct a Path from initializer list
      * @param args List of arguments that are either Index or string types
      */
-    explicit Path(std::initializer_list<SegmentType> args) : segments_{}, frontIdx_{0} {
-        for (const auto& arg : args) {
-            push_back(arg);
-        }
-    }
+    explicit Path(std::initializer_list<Segment> args) : segments_{args}, frontIdx_{0} {};
 
     /**
      * @brief return the number of segments in the Path
@@ -194,28 +188,26 @@ class Path {
     inline void unpop() noexcept {if (frontIdx_ > 0) {--frontIdx_;}}
 
     /**
-     * @brief Add a new segment to the path
-     * @param segment Either an Index or string to add as a new segment
+     * @brief Add a new string segment to the path
+     * @param segment String to add as a new segment
      */
-    void push_back(SegmentType segment) {
-        std::visit(
-            [this](const auto& val) {
-                if constexpr (std::is_same_v<std::decay_t<decltype(val)>, std::string>) {
-                    if (val == "-") {
-                        segments_.emplace_back(std::in_place_type<Index>, kEnd);
-                    } else {
-                        std::string str = val;
-                        escape(str);
-                        segments_.emplace_back(std::in_place_type<std::string>, str);
-                    }
-                } else {
-                    segments_.emplace_back(std::in_place_type<Index>, static_cast<Index>(val));
-                }
-            },
-            segment
-        );
+    void push_back(const std::string& segment) {
+        if (segment == "-") {
+            segments_.emplace_back(std::in_place_type<Index>, kEnd);
+        } else {
+            std::string str = segment;
+            escape(str);
+            segments_.emplace_back(std::in_place_type<std::string>, str);
+        }
     }
 
+    /**
+     * @brief Add a new index segment to the path
+     * @param segment Index to add as a new segment
+     */
+    void push_back(size_t segment) {
+        segments_.emplace_back(std::in_place_type<Index>, static_cast<Index>(segment));
+    }
 
   private:
     using Segments = std::vector<Segment>;

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -123,6 +123,36 @@ std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::excep
     }
 }
 
+
+std::vector<std::unique_ptr<IParam>> Device::getTopLevelParams(catena::exception_with_status& status, Authorizer& authz) const {
+    std::vector<std::unique_ptr<IParam>> result;
+    std::cout << "Checking params_ map contents:" << std::endl;
+    try {
+        for (const auto& [name, param] : params_) {
+            std::cout << "Found param in map: '" << name << "'" << std::endl;
+            if (authz.readAuthz(*param)) { 
+                Path path{name, "-"};
+                std::cout << "Checking path: '" << path.toString(true) << "'" << std::endl;
+                auto param_ptr = getParam(path.toString(true), status, authz);  
+                if (param_ptr) {
+                    std::cout << "Successfully got param: '" << path.toString(true) << "'" << std::endl;
+                    result.push_back(std::move(param_ptr));
+                }
+            }
+        }
+    } catch (const catena::exception_with_status& why) {
+        status = catena::exception_with_status(why.what(), why.status);
+    }
+    return result;
+}
+
+
+
+
+
+
+
+
 std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exception_with_status& status, Authorizer& authz) const {
    // The Path constructor will throw an exception if the json pointer is invalid, so we use a try catch block to catch it.
     try {

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -131,12 +131,14 @@ std::vector<std::unique_ptr<IParam>> Device::getTopLevelParams(catena::exception
         for (const auto& [name, param] : params_) {
             std::cout << "Found param in map: '" << name << "'" << std::endl;
             if (authz.readAuthz(*param)) { 
-                Path path{name, "-"};
+                Path path({name});
                 std::cout << "Checking path: '" << path.toString(true) << "'" << std::endl;
                 auto param_ptr = getParam(path.toString(true), status, authz);  
                 if (param_ptr) {
                     std::cout << "Successfully got param: '" << path.toString(true) << "'" << std::endl;
                     result.push_back(std::move(param_ptr));
+                } else {
+                    std::cout << "Failed to get param: " << status.what() << std::endl;
                 }
             }
         }

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -126,12 +126,10 @@ std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::excep
 
 std::vector<std::unique_ptr<IParam>> Device::getTopLevelParams(catena::exception_with_status& status, Authorizer& authz) const {
     std::vector<std::unique_ptr<IParam>> result;
-    std::cout << "Checking params_ map contents:" << std::endl;
     try {
         for (const auto& [name, param] : params_) {
-            std::cout << "Found param in map: '" << name << "'" << std::endl;
             if (authz.readAuthz(*param)) { 
-                Path path({name});
+                Path path{name};
                 std::cout << "Checking path: '" << path.toString(true) << "'" << std::endl;
                 auto param_ptr = getParam(path.toString(true), status, authz);  
                 if (param_ptr) {

--- a/sdks/cpp/connections/gRPC/CMakeLists.txt
+++ b/sdks/cpp/connections/gRPC/CMakeLists.txt
@@ -37,6 +37,7 @@ set(sources
     "src/Connect.cpp"
     "src/DeviceRequest.cpp"
     "src/ExternalObjectRequest.cpp"
+    "src/BasicParamInfoRequest.cpp"
     "src/ExecuteCommand.cpp"
     "src/SharedFlags.cpp"
     "src/ServiceCredentials.cpp"

--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -1,0 +1,138 @@
+#pragma once
+
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file GetParam.h
+ * @brief Implements Catena gRPC GetParam
+ * @author john.naylor@rossvideo.com
+ * @author zuhayr.sarker@rossvideo.com
+ * @date 2025-02-06
+ * @copyright Copyright © 2024 Ross Video Ltd
+ */
+
+// connections/gRPC
+#include <ServiceImpl.h>
+
+/**
+* @brief CallData class for the BasicParamInfoRequest RPC
+*/
+class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
+    public:
+        /**
+         * @brief Constructor for the CallData class of the BasicParamInfoRequest
+         * gRPC. Calls proceed() once initialized.
+         *
+         * @param service - Pointer to the parent CatenaServiceImpl.
+         * @param dm - Address of the device to get the value from.
+         * @param ok - Flag to check if the command was successfully executed.
+         */ 
+        BasicParamInfoRequest(CatenaServiceImpl *service, Device &dm, bool ok);
+
+        // /**
+        //  * @brief Destructor for the BasicParamInfoRequest class.
+        //  */
+        // ~BasicParamInfoRequest();
+
+        /**
+         * @brief Manages the steps of the BasicParamInfoRequest gRPC command
+         * through the state variable status. Returns the value of the
+         * parameter specified by the user.
+         *
+         * @param service - Pointer to the parent CatenaServiceImpl.
+         * @param ok - Flag to check if the command was successfully executed.
+         */
+        void proceed(CatenaServiceImpl *service, bool ok) override;
+
+    private:
+
+        /**
+         * @brief Parent CatenaServiceImpl.
+         */
+        CatenaServiceImpl *service_;
+
+        /**
+         * @brief The context of the gRPC command (ServerContext) for use in 
+         * _responder and other gRPC objects/functions.
+         */
+        ServerContext context_;
+
+        /**
+         * @brief The client's scopes.
+         */
+        std::vector<std::string> clientScopes_;
+
+        /**
+         * @brief The request payload.
+         */
+        catena::BasicParamInfoRequestPayload req_;
+
+        /**
+         * @brief The response payload.
+         */
+        catena::PushUpdates res_;
+
+        /**
+         * @brief gRPC async response writer.
+         */
+        ServerAsyncWriter<catena::BasicParamInfoResponse> writer_;
+        
+        /**
+         * @brief The gRPC command's state (kCreate, kProcess, kFinish, etc.).
+         */
+        CallStatus status_;
+
+        /**
+         * @brief The device to get the value from.
+         */
+        Device &dm_;
+        
+        /**
+         * @brief The object's unique id.
+         */
+        int objectId_;
+
+        /**
+         * @brief The object's unique id counter.
+         */
+        static int objectCounter_;  
+
+
+        /**
+         * @brief The vector of BasicParamInfoResponse objects.
+         */
+        std::vector<catena::BasicParamInfoResponse> responses_;
+
+        /**
+         * @brief The current response index.
+         */
+        size_t current_response_{0};
+};

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -176,6 +176,7 @@ class CatenaServiceImpl final : public catena::CatenaService::AsyncService {
     class Connect;
     class DeviceRequest;
     class ExternalObjectRequest;
+    class BasicParamInfoRequest;
     class GetParam;
     class ListLanguages;
     class ExecuteCommand;

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -117,6 +117,7 @@ class CatenaServiceImpl final : public catena::CatenaService::AsyncService {
 
     /**
      * @brief Gets the scopes from the provided authorization context
+     * @throw catena::exception_with_status permission denied
      */
     std::vector<std::string> getScopes(grpc::ServerContext &context);
 

--- a/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
@@ -80,7 +80,9 @@ void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *servic
             break;
 
         case CallStatus::kProcess:
+
             new BasicParamInfoRequest(service_, dm_, ok);
+            context_.AsyncNotifyWhenDone(this);
             
             try {
                 std::unique_ptr<IParam> param;

--- a/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// common
+#include <Tags.h>
+
+// connections/gRPC
+#include <BasicParamInfoRequest.h>
+
+// type aliases
+using catena::common::ParamTag;
+using catena::common::Path;
+
+#include <iostream>
+#include <thread>
+#include <fstream>
+#include <vector>
+#include <iterator>
+#include <filesystem>
+#include <filesystem>
+#include <map>
+
+int CatenaServiceImpl::BasicParamInfoRequest::objectCounter_ = 0;
+
+CatenaServiceImpl::BasicParamInfoRequest::BasicParamInfoRequest(CatenaServiceImpl *service, Device &dm, bool ok)
+    : service_{service}, dm_{dm}, writer_(&context_),
+        status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
+    service->registerItem(this);
+    objectId_ = objectCounter_++;
+    proceed(service, ok);  // start the process
+}
+
+void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *service, bool ok) {
+    if (!service || status_ == CallStatus::kFinish) {
+        return;
+    }
+
+    std::cout << "BasicParamInfoRequest proceed[" << objectId_ << "]: " << timeNow()
+              << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
+              << std::endl;
+
+    if(!ok) {
+        std::cout << "BasicParamInfoRequest[" << objectId_ << "] cancelled\n";
+        status_ = CallStatus::kFinish;
+        service->deregisterItem(this);
+        return;
+    }
+
+    switch (status_) {
+        case CallStatus::kCreate:
+            status_ = CallStatus::kProcess;
+            service_->RequestBasicParamInfoRequest(&context_, &req_, &writer_, 
+                        service_->cq_, service_->cq_, this);
+            break;
+
+        case CallStatus::kProcess:
+            new BasicParamInfoRequest(service_, dm_, ok);
+            context_.AsyncNotifyWhenDone(this);
+
+            try {
+                std::unique_ptr<IParam> param;
+                catena::exception_with_status rc{"", catena::StatusCode::OK};
+                catena::common::Authorizer authz = std::vector<std::string>{};
+
+                if (req_.oid_prefix().empty() && !req_.recursive()) {
+                    std::vector<std::unique_ptr<IParam>> top_level_params;
+
+                    Device::LockGuard lg(dm_); 
+                    if (service->authorizationEnabled()) {
+                        std::vector<std::string> scopes = service->getScopes(context_);
+                        authz = catena::common::Authorizer{scopes};
+                        top_level_params = dm_.getTopLevelParams(rc, authz);
+                    } else {
+                        top_level_params = dm_.getTopLevelParams(rc);
+                    }
+
+                    lg.~LockGuard();
+
+                    if (rc.status == catena::StatusCode::OK) {
+                        for (auto& top_level_param : top_level_params) {
+                            responses_.emplace_back();
+                            if (service->authorizationEnabled()) {
+                                top_level_param->toProto(responses_.back(), authz);
+                            } else {
+                                top_level_param->toProto(responses_.back(), catena::common::Authorizer::kAuthzDisabled);
+                            }
+                        }
+                        
+                        status_ = CallStatus::kWrite;
+                        [[fallthrough]];
+                    }
+                }
+            } catch (...){
+                status_ = CallStatus::kFinish;
+                writer_.Finish(Status::CANCELLED, this);
+                break;
+            }
+
+        case CallStatus::kWrite:
+            if (context_.IsCancelled()) {
+                std::cout << "[" << objectId_ << "] cancelled during write\n";
+                status_ = CallStatus::kFinish;
+                writer_.Finish(Status::CANCELLED, this);
+                break;
+            }
+
+            if (current_response_ < responses_.size()) {
+                writer_.Write(responses_[current_response_], this);
+                current_response_++;
+            } else {
+                std::cout << "BasicParamInfoRequest proceed[" << objectId_ << "] writing final response\n";
+                status_ = CallStatus::kFinish;
+                context_.AsyncNotifyWhenDone(this); 
+                writer_.Finish(Status::OK, this);
+            }
+            break;
+
+        case CallStatus::kFinish:
+            std::cout << "[" << objectId_ << "] finished with status: " 
+                      << (context_.IsCancelled() ? "CANCELLED" : "OK") << "\n";
+            service->deregisterItem(this);
+            break;
+
+        default:
+            status_ = CallStatus::kFinish;
+            grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
+            writer_.Finish(errorStatus, this);
+    }
+}

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -42,6 +42,7 @@
 #include <DeviceRequest.h>
 #include <GetParam.h>
 #include <ExternalObjectRequest.h>
+#include <BasicParamInfoRequest.h>
 #include <ExecuteCommand.h>
 #include <ListLanguages.h>
 
@@ -108,6 +109,7 @@ void CatenaServiceImpl::init() {
     new Connect(this, dm_, true);
     new DeviceRequest(this, dm_, true);
     new ExternalObjectRequest(this, dm_, true);
+    new BasicParamInfoRequest(this, dm_, true);
     new GetParam(this, dm_, true);
     new ExecuteCommand(this, dm_, true);
     new ListLanguages(this, dm_, true);


### PR DESCRIPTION
- Added functionality to fetch top-level parameters, the syntax in postman is as follows: 
``` javascript
{
    "slot": 0,

    // Identifies starting parameter relative to device.params
    "oid_prefix": "", 
    
    //Selects whether child params should also be returned
    "recursive": false 
}
```
- Program flow mostly follows typical state machine system observed in other RPCs, note that it is currently setup to send responses in a stream.
- Fixed the comment in Path.h where it listed the wrong default value
- Bug(?): It doesn't go to kFinish for some reason I have yet to figure out. It still completes the request, just doesn't exit it as cleanly as I'd hope. I will return to this since it isn't breaking anything that I know of (yet).
- There are also still some print statements in places, I may remove them later on when I have finished the RPC