### PR TITLE
Simplified Authorizer to own its scopes vector

### DIFF
--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -76,11 +76,10 @@ class Authorizer {
 
     /**
      * @brief Construct a new Authorizer object
-     * @param pd the ParamDescriptor of the object
-     * @param scope the scope of the object
+     * @param scopes Vector of authorization scopes
      */
-    Authorizer(const Scopes& clientScopes)
-        : clientScopes_{clientScopes} {}
+    explicit Authorizer(Scopes scopes)
+        : clientScopes_{std::move(scopes)} {}
 
     /**
      * @brief Authorizer does not have copy semantics
@@ -139,7 +138,7 @@ class Authorizer {
 
 
   private:
-    std::reference_wrapper<const Scopes> clientScopes_;
+    Scopes clientScopes_;  // Now owns the scopes vector directly
 };
 
 } // namespace common

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -138,7 +138,7 @@ class Authorizer {
 
 
   private:
-    Scopes clientScopes_;  // Now owns the scopes vector directly
+    Scopes clientScopes_; 
 };
 
 } // namespace common

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -46,10 +46,7 @@ bool Authorizer::hasAuthz(const std::string& scope) const {
         return true; // no authorization required
     }
 
-    if (std::find(clientScopes_.get().begin(), clientScopes_.get().end(), scope) == clientScopes_.get().end()) {
-        return false;
-    }
-    return true;
+    return std::find(clientScopes_.begin(), clientScopes_.end(), scope) != clientScopes_.end();
 }
 
 /**


### PR DESCRIPTION
- Changed constructor to take scopes by value through std::move
- Removed reference wrapper in favor of direct scope member
- Slight changes to hasAuthz to accomodate for these changes 