### PR TITLE
Added support for structs and struct variants to BasicParamInfo

### DIFF
--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -167,6 +167,13 @@ class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
          */
         uint32_t max_index_{0};
 
+        /**
+         * @brief The mutex for the writer lock.
+         */
         std::mutex mtx_;
+
+        /**
+         * @brief The writer lock.
+         */
         std::unique_lock<std::mutex> writer_lock_{mtx_, std::defer_lock};
 };

--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -91,6 +91,15 @@ class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
          */
         void updateArrayLengths(const std::string& array_name, size_t length);
 
+
+        /**
+         * @brief Gets the children of the parameter.
+         * 
+         * @param param - The parameter to get the children from.
+         * @param oid - The oid of the parameter.
+         */
+       void getChildren(IParam* current_param, const std::string& current_path, catena::common::Authorizer& authz);
+
         /**
          * @brief Parent CatenaServiceImpl.
          */

--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -73,7 +73,19 @@ class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
         void proceed(CatenaServiceImpl *service, bool ok) override;
 
     private:
-
+        /**
+         * @brief Checks if the parameter is an array type.
+         * 
+         * @param type - The type of the parameter.
+         * @return True if the parameter is an array type, false otherwise.
+         */
+        static bool isArrayType(catena::ParamType type) {
+            return (type == catena::ParamType::STRUCT_ARRAY ||
+                    type == catena::ParamType::INT32_ARRAY ||
+                    type == catena::ParamType::FLOAT32_ARRAY ||
+                    type == catena::ParamType::STRING_ARRAY ||
+                    type == catena::ParamType::STRUCT_VARIANT_ARRAY);
+        }
 
         /**
          * @brief Calculates the length of the array.

--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -17,7 +17,7 @@
  * contributors may be used to endorse or promote products derived from this
  * software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -166,4 +166,7 @@ class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
          * @brief The maximum index of the parameter.
          */
         uint32_t max_index_{0};
+
+        std::mutex mtx_;
+        std::unique_lock<std::mutex> writer_lock_{mtx_, std::defer_lock};
 };


### PR DESCRIPTION
- Supports fetching struct variants both directly and recursively
- Fixed missing logic where it only supported struct arrays, not it supports various types of arrays
- Added recursive function for getting children of parent parameters 
- Added locks for writing, which was a long-standing race condition issue that exists in previous versions of BasicParamInfoRequest 
- Fixed not being able to go kFinish (rpc now exits cleanly)
- Clears responses to avoid duplicates