### PR TITLE
Couple of logic issues resolved in BasicParamInfo

### DIFF
--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -161,11 +161,6 @@ class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
         uint32_t current_response_{0};
 
         /**
-         * @brief The maximum index of the parameter.
-         */
-        uint32_t max_index_{0};
-
-        /**
          * @brief The mutex for the writer lock.
          */
         std::mutex mtx_;

--- a/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/BasicParamInfoRequest.h
@@ -73,13 +73,6 @@ class CatenaServiceImpl::BasicParamInfoRequest : public CallData {
         void proceed(CatenaServiceImpl *service, bool ok) override;
 
     private:
-        /**
-         * @brief Calculates the length of the array.
-         * 
-         * @param base_path - The base path of the array.
-         * @return The length of the array.
-         */
-        uint32_t calculateArrayLength(const std::string& base_path);
 
         /**
          * @brief Updates the array lengths of the responses.

--- a/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
@@ -112,15 +112,8 @@ void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *servic
                         responses_.clear();  
                         // Process each top-level parameter
                         for (auto& top_level_param : top_level_params) {
-                            max_index_ = 0;
-                            
                             // Create a path for the parameter and check if it's an array type
                             Path top_level_path{top_level_param->getOid()};
-                            
-                            // For array types, calculate how many elements exist
-                            if (top_level_param->isArrayType()) {
-                                max_index_ = calculateArrayLength(top_level_path.toString(true));
-                            }
                             
                             // Add the parameter to our response list
                             responses_.emplace_back();
@@ -130,9 +123,12 @@ void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *servic
                                 top_level_param->toProto(responses_.back(), catena::common::Authorizer::kAuthzDisabled);
                             }
 
-                            // Update array length information in the response if needed
-                            if (max_index_ > 0) {
-                                updateArrayLengths(responses_.back().info().oid(), max_index_);
+                            // For array types, calculate and update array length
+                            if (top_level_param->isArrayType()) {
+                                uint32_t array_length = calculateArrayLength(top_level_path.toString(true));
+                                if (array_length > 0) {
+                                    updateArrayLengths(top_level_param->getOid(), array_length);
+                                }
                             }   
                         }
                         
@@ -159,14 +155,7 @@ void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *servic
                         param = dm_.getParam(req_.oid_prefix(), rc);
                     }
 
-                    max_index_ = 0;
- 
                     if (rc.status == catena::StatusCode::OK && param) {
-                        // Calculate array length if this parameter is an array
-                        if (param->isArrayType()) {
-                            max_index_ = calculateArrayLength(req_.oid_prefix());
-                        }
-
                         // Add the main parameter to the response list
                         responses_.emplace_back();
                         if (service->authorizationEnabled()) {
@@ -175,9 +164,12 @@ void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *servic
                             param->toProto(responses_.back(), catena::common::Authorizer::kAuthzDisabled);
                         }
 
-                        // Update array length information if needed
-                        if (max_index_ > 0) {
-                            updateArrayLengths(responses_.back().info().oid(), max_index_);
+                        // Calculate and update array length if this parameter is an array
+                        if (param->isArrayType()) {
+                            uint32_t array_length = calculateArrayLength(Path{param->getOid()}.toString(true));
+                            if (array_length > 0) {
+                                updateArrayLengths(param->getOid(), array_length);
+                            }
                         }   
 
                         // If recursive flag is set, get all children of this parameter
@@ -287,7 +279,8 @@ uint32_t CatenaServiceImpl::BasicParamInfoRequest::calculateArrayLength(const st
 void CatenaServiceImpl::BasicParamInfoRequest::updateArrayLengths(const std::string& array_name, uint32_t length) {
     if (length > 0) {
         for (auto it = responses_.rbegin(); it != responses_.rend(); ++it) {
-            if (it->info().oid().find(array_name) != std::string::npos) {
+            // Only update if the OID exactly matches the array name
+            if (it->info().oid() == array_name) {
                 it->set_array_length(length);
             }
         }
@@ -311,7 +304,7 @@ void CatenaServiceImpl::BasicParamInfoRequest::getChildren(IParam* current_param
             auto sub_param = dm_.getParam(child_path.toString(), rc);
             
             if (rc.status == catena::StatusCode::OK && sub_param) {
-                
+                // Add all parameters (array or not) when found as children
                 responses_.emplace_back();
                 if (service_->authorizationEnabled()) {
                     Device::LockGuard lg(dm_);
@@ -321,28 +314,35 @@ void CatenaServiceImpl::BasicParamInfoRequest::getChildren(IParam* current_param
                     sub_param->toProto(responses_.back(), catena::common::Authorizer::kAuthzDisabled);
                 }
 
-                if (max_index_ > 0) {
-                    updateArrayLengths(responses_.back().info().oid(), max_index_);
+                // If this child is an array, calculate and update its length
+                if (sub_param->isArrayType()) {
+                    // Process array children if we're not already inside an array element
+                    if (!Path{parent_path}.back_is_index()) {
+                        getChildren(sub_param.get(), child_path.toString(), authz);
+                    } else {
+                    }
                 }
-
-                getChildren(sub_param.get(), child_path.toString(), authz);
             }
         }
     };
 
-    
     // Check if current parameter is an array type
     if (current_param->isArrayType()) {
-        max_index_ = calculateArrayLength(current_path);
-
+        uint32_t array_length = calculateArrayLength(current_path);
         
         // Process each array element's children
-        for (uint32_t i = 0; i < max_index_; i++) {
+        for (uint32_t i = 0; i < array_length; i++) {
             Path indexed_path{current_path, i};
             auto indexed_param = dm_.getParam(indexed_path.toString(), rc);
             if (!indexed_param) continue;
-            
+
+            // Process children of this array element
             processChildren(indexed_path.toString());
+        }
+
+        // Update the array length for the array itself
+        if (array_length > 0) {
+            updateArrayLengths(current_param->getOid(), array_length);
         }
     } else {
         // For non-array types, process children normally


### PR DESCRIPTION
- max_index_ was incredibly problematic, so I removed it and gave each array it's own local length variable
- it now supports taking a prefix like "/audio_deck/0", before it only worked to take "/audio_deck" because it was calculating array length solely based on the provided path and not if it found a parameter or not
- when running the audio_deck example, there were both duplicate and missing parent array parameters - this has been addressed 