### PR TITLE
Added ability to specify authorization server and realm via command line args

### DIFF
--- a/sdks/cpp/connections/docker/catena_envoy_dockerfile
+++ b/sdks/cpp/connections/docker/catena_envoy_dockerfile
@@ -1,4 +1,4 @@
-#
+# 
 # Copyright 2024 Ross Video Ltd
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -29,42 +29,20 @@
 #
 
 #
-# This cmake file is used to build some example services as docker images for
-# use in grpc_compose.yml.
+# Dockerfile to create an image which allows envoy.yaml subsitution with
+# environment variables on container creation.
+# Author: benjamin.whitten@rossvideo.com
+# Date: 25/03/17
 #
 
-cmake_minimum_required(VERSION 3.20)
-project(catena-docker-services)
+FROM envoyproxy/envoy:v1.33-latest
 
-# Ensure we have the docker app, alias it to DOCKER_CMD.
-find_program(DOCKER_CMD docker REQUIRED)
+# Installing envsubst
+RUN apt-get update && apt-get install -y gettext-base
 
-# Include the make_image function.
-include(DockerFunctions.cmake)
+# Copying envoy.yaml and entrypoint script and giving x permission.
+COPY connections/docker/envoy/envoy_entrypoint.sh etc/envoy/envoy_entrypoint.sh
+COPY connections/docker/envoy/envoy.yaml /etc/envoy/envoy_tmp.yaml
+RUN chmod +x /etc/envoy/envoy_entrypoint.sh
 
-# Make our base image.
-make_image(base . "")
-
-# Make the status update image.
-make_image(catena_status_update ${CATENA_CPP_ROOT_DIR} "base.hash;status_update")
-
-# Make the use menus image.
-make_image(catena_use_menus ${CATENA_CPP_ROOT_DIR} "base.hash;use_menus")
-
-# Make the structs with authz image.
-make_image(catena_structs_with_authz ${CATENA_CPP_ROOT_DIR} "base.hash;structs_with_authz")
-
-# Make the structs with authz image.
-make_image(catena_use_commands ${CATENA_CPP_ROOT_DIR} "base.hash;use_commands")
-
-# Pulls Envoy Proxy image v.1.33.
-execute_process (
-    COMMAND ${DOCKER_CMD} pull envoyproxy/envoy:v1.33-latest
-    RESULT_VARIABLE result
-)
-if (NOT result EQUAL 0)
-    message(FATAL_ERROR "Failed to pull the envoy image")
-endif()
-
-# Make envoy_proxy image with entrypoint envoy/envoy_entrypoint.sh.
-make_image(catena_envoy ${CATENA_CPP_ROOT_DIR} "")
+ENTRYPOINT ["etc/envoy/envoy_entrypoint.sh"]

--- a/sdks/cpp/connections/docker/catena_envoy_dockerfile
+++ b/sdks/cpp/connections/docker/catena_envoy_dockerfile
@@ -1,5 +1,5 @@
 # 
-# Copyright 2024 Ross Video Ltd
+# Copyright 2025 Ross Video Ltd
 # 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sdks/cpp/connections/docker/envoy/envoy.yaml
+++ b/sdks/cpp/connections/docker/envoy/envoy.yaml
@@ -1,5 +1,5 @@
 # 
-# Copyright 2024 Ross Video Ltd
+# Copyright 2025 Ross Video Ltd
 # 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sdks/cpp/connections/docker/envoy/envoy.yaml
+++ b/sdks/cpp/connections/docker/envoy/envoy.yaml
@@ -84,14 +84,14 @@ static_resources:
               providers:
                 jwtProvider:
                   # This is the authz server.
-                  issuer: https://auth.enterprise.rossvideo.cloud/realms/catena
+                  issuer: https://$AUTHZ_SERVER/realms/$REALM
                   audiences:
                   - st-2138.grpc.service
                   - st-2138.rest.service
                   remote_jwks:
                     http_uri:
                       # This is the path to the authz server's public keys.
-                      uri: https://auth.enterprise.rossvideo.cloud/realms/catena/protocol/openid-connect/certs
+                      uri: https://$AUTHZ_SERVER/realms/$REALM/protocol/openid-connect/certs
                       # Cluster handles authentication.
                       cluster: jwks_cluster
                       timeout: 5s
@@ -173,7 +173,7 @@ static_resources:
             address:
               socket_address:
                 # This is the authz server.
-                address: auth.enterprise.rossvideo.cloud
+                address: $AUTHZ_SERVER
                 port_value: 443 # JWKS endpoint.
     # This sets up a transport socket to communicate with the authz server via
     # TLS.
@@ -181,7 +181,7 @@ static_resources:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        sni: auth.enterprise.rossvideo.cloud
+        sni: $AUTHZ_SERVER
 
   # Cluster for handling authenticated gRPC requests to status_update.
   # Example cluster, all others are very similar.

--- a/sdks/cpp/connections/docker/envoy/envoy_entrypoint.sh
+++ b/sdks/cpp/connections/docker/envoy/envoy_entrypoint.sh
@@ -1,4 +1,6 @@
-#
+#!/bin/sh
+
+# 
 # Copyright 2024 Ross Video Ltd
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -29,42 +31,11 @@
 #
 
 #
-# This cmake file is used to build some example services as docker images for
-# use in grpc_compose.yml.
+# Entrypoint script for envoy.yaml. Subsitutes environment variables in the
+# envoy.yaml file and starts envoy.
+# Author: benjamin.whitten@rossvideo.com
+# Date: 25/03/17
 #
 
-cmake_minimum_required(VERSION 3.20)
-project(catena-docker-services)
-
-# Ensure we have the docker app, alias it to DOCKER_CMD.
-find_program(DOCKER_CMD docker REQUIRED)
-
-# Include the make_image function.
-include(DockerFunctions.cmake)
-
-# Make our base image.
-make_image(base . "")
-
-# Make the status update image.
-make_image(catena_status_update ${CATENA_CPP_ROOT_DIR} "base.hash;status_update")
-
-# Make the use menus image.
-make_image(catena_use_menus ${CATENA_CPP_ROOT_DIR} "base.hash;use_menus")
-
-# Make the structs with authz image.
-make_image(catena_structs_with_authz ${CATENA_CPP_ROOT_DIR} "base.hash;structs_with_authz")
-
-# Make the structs with authz image.
-make_image(catena_use_commands ${CATENA_CPP_ROOT_DIR} "base.hash;use_commands")
-
-# Pulls Envoy Proxy image v.1.33.
-execute_process (
-    COMMAND ${DOCKER_CMD} pull envoyproxy/envoy:v1.33-latest
-    RESULT_VARIABLE result
-)
-if (NOT result EQUAL 0)
-    message(FATAL_ERROR "Failed to pull the envoy image")
-endif()
-
-# Make envoy_proxy image with entrypoint envoy/envoy_entrypoint.sh.
-make_image(catena_envoy ${CATENA_CPP_ROOT_DIR} "")
+envsubst < /etc/envoy/envoy_tmp.yaml > /etc/envoy/envoy.yaml
+envoy -c /etc/envoy/envoy.yaml --log-level info

--- a/sdks/cpp/connections/docker/envoy/envoy_entrypoint.sh
+++ b/sdks/cpp/connections/docker/envoy/envoy_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # 
-# Copyright 2024 Ross Video Ltd
+# Copyright 2025 Ross Video Ltd
 # 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/sdks/cpp/connections/docker/grpc_compose.yml
+++ b/sdks/cpp/connections/docker/grpc_compose.yml
@@ -49,11 +49,14 @@ networks:
 # Setting up the envoyproxy container.
 services:
   envoy_API_gateway:
-    image: envoyproxy/envoy:v1.33-latest
+    image: catena_envoy
     container_name: envoy_API_gateway
     networks: # Must be a part of both pub and prv networks.
       - catena_network
       - catena_prv
+    environment:
+      - AUTHZ_SERVER=$AUTHZ_SERVER
+      - REALM=$REALM
     ports: # Mapping ports from host to container.
       - 6254:6254
       - 6256:6256
@@ -61,14 +64,8 @@ services:
       - 6260:6260
     volumes: # letsencrypt contains keys for TLS.
       - /etc/letsencrypt:/etc/letsencrypt:ro
-      - ./envoy.yaml:/etc/envoy/envoy.yaml
-    command:
-      - envoy
-      - -c
-      - /etc/envoy/envoy.yaml
-      - --log-level
-      - info
-
+    # Entrypoint defined in catena_envoy_dockerfile.
+    
   # Example service container.
   status_update:
     image: catena_status_update

--- a/sdks/cpp/docs/docker-cpp.md
+++ b/sdks/cpp/docs/docker-cpp.md
@@ -20,20 +20,23 @@ The diagram below outlines the Catena architecture for containers as well as JWS
 
 </div>
 
-Setting up a Catena service(s) with Docker requires four things:
-1. A keycloak server to generate public keys with.
-2. A container set up with Envoy proxy for recieving requests via TLS, validating JWS tokens with the keycloak server, and routing valid requests to their respective service. This can be configured via an [envoy.yaml](https://github.com/rossvideo/Catena/blob/main/sdks/cpp/connections/docker/envoy.yaml) file.
-3. A public and private Docker network for communication between containers.  
-4. A [Docker compose](https://github.com/rossvideo/Catena/blob/main/sdks/cpp/connections/docker/grpc_compose.yml) file to create the containers, connect the service containers to the private network, and connect the Envoy proxy to both networks.
+Setting up a Catena service(s) with Docker requires five things:
+1. [CMake](https://github.com/rossvideo/Catena/blob/main/sdks/cpp/connections/docker/CMakeLists.txt) and [Dockerfiles](https://github.com/rossvideo/Catena/blob/main/sdks/cpp/connections/docker/catena_status_update_dockerfile) for initializing docker images with files and entrypoints.
+2. A keycloak server to generate public keys with.
+3. A container set up with Envoy proxy for recieving requests via TLS, validating JWS tokens with the keycloak server, and routing valid requests to their respective service. This can be configured via an [envoy.yaml](https://github.com/rossvideo/Catena/blob/main/sdks/cpp/connections/docker/envoy/envoy.yaml) file.
+4. A public and private Docker network for communication between containers.  
+5. A [Docker compose](https://github.com/rossvideo/Catena/blob/main/sdks/cpp/connections/docker/grpc_compose.yml) file to create the containers, connect the service containers to the private network, and connect the Envoy proxy to both networks.
 
 For an example of Catena services set up with a Docker image, see the [connections/docker](https://github.com/rossvideo/Catena/tree/main/sdks/cpp/connections/docker) folder.
 
 ***Note:*** If you wish to run your service without authentication/authorization, you can ignore the keycloak server and Envoy proxy container and simply connect your Catena sevice(s) to the public network. In this case, your service's should also be run with ```--authz=false```.
 
+***Note:*** For setting authorization server and realm via the command line, you will need a dockerfile and entrypoint script for your envoy image which replaces the environment variables found in envoy.yaml. See example above for more info.
+
 ### Steps to run
 1. Build Catena with ```cmake -DDOCKER=on```.
 2. Navigate to the folder containing your Docker compose file.
-3. Run the file using ```docker-compose -f /path/to/your/file up -d```.
+3. Run the file using ```AUTHZ_SERVER=your.authorization.server REALM=realm docker-compose -f /path/to/your/file up -d```.
 
 Once your containers are created, you can check their status using ```docker ps -a```. You should have one container per service as well as an additional container running Envoy Proxy.
 


### PR DESCRIPTION
Title. You can now use AUTHZ_SERVER=your.authorization.server and REALM=realm before grpc-compose to specify the authorization server and realm. Updating documentation as well to reflect this addition.