### PR TITLE
Made the container hosted example more scalable

### DIFF
--- a/sdks/cpp/connections/docker/envoy/envoy.yaml
+++ b/sdks/cpp/connections/docker/envoy/envoy.yaml
@@ -47,19 +47,6 @@ static_resources:
       socket_address:
         address: 0.0.0.0
         port_value: 6254
-    additional_addresses:
-    - address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 6256
-    - address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 6258
-    - address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 6260
     filter_chains:
 
     # This filten handles the http requests from the port above.
@@ -107,42 +94,42 @@ static_resources:
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+          # Routes the call based on domain. virtual_hosts are all very similar.
+          # *Note: If running locally $HOST needs to be "localhost:port".
           route_config:
             name: local_route
             virtual_hosts:
-            - name: default
-              domains: ["*"]
-              # This routes the request to the appropriate cluster depending on
-              # the port number the command was recieved on.
+            # Routes to status_update_cluster if domain starts with "status_update."
+            - name: status_update
+              domains: ["status_update.$HOST"]
               routes:
-              # Example route, all others are very similar.
-              - match: # Routes port 6254 to the status_update_cluster.
+              - match:
                   prefix: "/"
-                  headers:
-                  - name: x-forwarded-port # Set using "append_x_forwarded_port" above.
-                    string_match: { exact: "6254"} # IN port
                 route:
-                  cluster: status_update_cluster # The cluster to map it to.
-
-              - match: # Routes port 6256 to the use_menus_cluster.
+                  cluster: status_update_cluster
+            # Routes to use_menus_cluster if domain starts with "use_menus."
+            - name: use_menus
+              domains: ["use_menus.$HOST"]
+              routes:
+              - match:
                   prefix: "/"
-                  headers:
-                  - name: x-forwarded-port
-                    string_match: { exact: "6256"}
                 route:
                   cluster: use_menus_cluster
-              - match: # Routes port 6258 to the structs_with_authz_cluster.
+             # Routes to use_structs_cluster if domain starts with "use_structs."
+            - name: use_structs
+              domains: ["use_structs.$HOST"]
+              routes:
+              - match:
                   prefix: "/"
-                  headers:
-                  - name: x-forwarded-port
-                    string_match: { exact: "6258"}
                 route:
-                  cluster: structs_with_authz_cluster
-              - match: # Routes port 6260 to the status_update_cluster.
+                  cluster: use_structs_cluster
+            # Routes to use_commands_cluster if domain starts with "use_commands."
+            - name: use_commands
+              domains: ["use_commands.$HOST"]
+              routes:
+              - match:
                   prefix: "/"
-                  headers:
-                  - name: x-forwarded-port
-                    string_match: { exact: "6260"}
                 route:
                   cluster: use_commands_cluster
 
@@ -224,7 +211,7 @@ static_resources:
                 address: catena_use_menus
                 port_value: 6254
   # Cluster for handling authenticated gRPC requests to structs_with_authz.
-  - name: structs_with_authz_cluster
+  - name: use_structs_cluster
     type: STRICT_DNS
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -232,7 +219,7 @@ static_resources:
         explicit_http_config:
           http2_protocol_options: {}
     load_assignment:
-      cluster_name: structs_with_authz_cluster
+      cluster_name: use_structs_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:

--- a/sdks/cpp/connections/docker/grpc_compose.yml
+++ b/sdks/cpp/connections/docker/grpc_compose.yml
@@ -57,11 +57,9 @@ services:
     environment:
       - AUTHZ_SERVER=$AUTHZ_SERVER
       - REALM=$REALM
+      - HOST=$HOST
     ports: # Mapping ports from host to container.
       - 6254:6254
-      - 6256:6256
-      - 6258:6258
-      - 6260:6260
     volumes: # letsencrypt contains keys for TLS.
       - /etc/letsencrypt:/etc/letsencrypt:ro
     # Entrypoint defined in catena_envoy_dockerfile.

--- a/sdks/cpp/docs/docker-cpp.md
+++ b/sdks/cpp/docs/docker-cpp.md
@@ -36,7 +36,7 @@ For an example of Catena services set up with a Docker image, see the [connectio
 ### Steps to run
 1. Build Catena with ```cmake -DDOCKER=on```.
 2. Navigate to the folder containing your Docker compose file.
-3. Run the file using ```AUTHZ_SERVER=your.authorization.server REALM=realm docker-compose -f /path/to/your/file up -d```.
+3. Run the file using ```AUTHZ_SERVER=your.authorization.server REALM=realm HOST=host docker-compose -f /path/to/your/file up -d```.
 
 Once your containers are created, you can check their status using ```docker ps -a```. You should have one container per service as well as an additional container running Envoy Proxy.
 


### PR DESCRIPTION
Title. Envoy now only listen's to one port and routes based on the url (status_update.$HOST, use_menus.$HOST, etc. where $HOST is the host name). Additionally, $HOST can be specified by the command line argument $HOST=... similar to authz server and realm.

_**Note:** If running on a VM you will most likely need to go into your host machine's hosts file and add mappings for your addresses (status_update.localhost, etc...)_

_**Note:** this pull request is not actually as big as it seems. This is a sub branch of the sub branch enh-#470-b-bw as it depends on changes and would conflict otherwise. enh-#460-b-bw just needs to sign off to get merged into DEV, and as the last review was just pointing out that the copyright was out of date that will hopefully be soon._