### PR TITLE
Fixed getValue not working for indices. Fixed numerous error messages. Updated toParam flow.

### DIFF
--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -146,7 +146,7 @@ catena::exception_with_status Device::getValue (const std::string& jptr, catena:
      */
     try {
         catena::common::Path path(jptr);
-        if (path.back_is_index() ? path.back_as_index() == catena::common::Path::kEnd : false) {
+        if (path.back_is_index() && path.back_as_index() == catena::common::Path::kEnd) {
                 // Index is "-"
                 ans = catena::exception_with_status("Index out of bounds in path " + jptr, catena::StatusCode::OUT_OF_RANGE);
         } else {

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -146,11 +146,9 @@ catena::exception_with_status Device::getValue (const std::string& jptr, catena:
      */
     try {
         catena::common::Path path(jptr);
-        if (path.back_is_index()) {
-            if (path.back_as_index() == catena::common::Path::kEnd) {
+        if (path.back_is_index() ? path.back_as_index() == catena::common::Path::kEnd : false) {
                 // Index is "-"
                 ans = catena::exception_with_status("Index out of bounds in path " + jptr, catena::StatusCode::OUT_OF_RANGE);
-            }
         } else {
             std::unique_ptr<IParam> param = getParam(path, ans, authz);
             // we expect this to be a parameter name
@@ -184,13 +182,13 @@ catena::exception_with_status Device::addLanguage (catena::AddLanguagePayload& l
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     // Admin scope required.
     if (!authz.hasAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin) + ":w")) {
-        return catena::exception_with_status("Not authorized to add language ", catena::StatusCode::PERMISSION_DENIED);
+        return catena::exception_with_status("Not authorized to add language", catena::StatusCode::PERMISSION_DENIED);
     } else {
         auto& name = language.language_pack().name();
         auto& id = language.id();
         // Making sure LanguagePack is properly formatted.
         if (name.empty() || id.empty()) {
-            return catena::exception_with_status("Invalid language pack ", catena::StatusCode::INVALID_ARGUMENT);
+            return catena::exception_with_status("Invalid language pack", catena::StatusCode::INVALID_ARGUMENT);
         }
         // added_packs_ here to maintain ownership in device scope.
         added_packs_[id] = std::make_shared<LanguagePack>(id, name, LanguagePack::ListInitializer{}, *this);
@@ -216,7 +214,7 @@ std::unique_ptr<IParam> Device::getParam(const std::string& fqoid, catena::excep
 
 std::unique_ptr<IParam> Device::getParam(catena::common::Path& path, catena::exception_with_status& status, Authorizer& authz) const {
     if (path.empty()) {
-        status = catena::exception_with_status("Invalid json pointer ", catena::StatusCode::INVALID_ARGUMENT);
+        status = catena::exception_with_status("Invalid json pointer " + path.fqoid(), catena::StatusCode::INVALID_ARGUMENT);
         return nullptr;
     }
     if (path.front_is_string()) {
@@ -227,7 +225,7 @@ std::unique_ptr<IParam> Device::getParam(catena::common::Path& path, catena::exc
          */
         IParam* param = getItem<common::ParamTag>(path.front_as_string());
         if (!param) {
-            status = catena::exception_with_status("Param " + path.fqoid() + " does not exist ", catena::StatusCode::NOT_FOUND);
+            status = catena::exception_with_status("Param " + path.fqoid() + " does not exist", catena::StatusCode::NOT_FOUND);
             return nullptr;
         }
         if (!authz.readAuthz(*param)) {
@@ -279,7 +277,7 @@ std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exc
     try {
         catena::common::Path path(fqoid);
         if (path.empty()) {
-            status = catena::exception_with_status("Invalid json pointer ", catena::StatusCode::INVALID_ARGUMENT);
+            status = catena::exception_with_status("Invalid json pointer", catena::StatusCode::INVALID_ARGUMENT);
             return nullptr;
         }
         if (path.front_is_string()) {
@@ -292,11 +290,11 @@ std::unique_ptr<IParam> Device::getCommand(const std::string& fqoid, catena::exc
             if (path.empty()) {
                 return param->copy();
             } else {
-                status = catena::exception_with_status("sub-commands not implemented ", catena::StatusCode::UNIMPLEMENTED);
+                status = catena::exception_with_status("sub-commands not implemented", catena::StatusCode::UNIMPLEMENTED);
                 return nullptr;
             }
         } else {
-            status = catena::exception_with_status("Invalid json pointer ", catena::StatusCode::INVALID_ARGUMENT);
+            status = catena::exception_with_status("Invalid json pointer", catena::StatusCode::INVALID_ARGUMENT);
             return nullptr;
         }
     } catch (const catena::exception_with_status& why) {


### PR DESCRIPTION
Changelog:
- Fixed getValue not working for indices. Previously, an if statement oversight prevented and params with an oid ending in an index being retrieves. This has been fixed.
- Removed trailing whitespace from error messages throughout Device and ParamWithValue. Postman does not display an error message if this is present.
- Updated toParam's if else flow to resemble something like the following:
```
catena::error ans = OK
if ...
    ans = ERROR
else
    do something
return ans
```
  This is the format present in other places throughout Catena and has been previously mentioned to be the ideal formatting.