### PR TITLE
[BREAKING] Fixed SetValue messages in param.proto and updated gRPCs to reflect this.

### DIFF
--- a/interface/param.proto
+++ b/interface/param.proto
@@ -283,8 +283,8 @@ message GetValuePayload {
 }
 
 message MultiSetValuePayload {
-  uint32 slot = 1;                      // Uniquely identifies the device at node scope.
-  repeated SetValue values = 2;  // The param oids and values to apply
+  uint32 slot = 1;              // Uniquely identifies the device at node scope.
+  repeated SetValue values = 2; // The param oids and values to apply
 }
 
 message UpdateSubscriptionsPayload {

--- a/interface/param.proto
+++ b/interface/param.proto
@@ -265,11 +265,15 @@ message BasicParamInfoRequestPayload {
   bool recursive = 3;
 }
 
-message SetValuePayload {
-  uint32 slot = 1;          // Uniquely identifies the device at node scope.
+message SetValue {
   string oid = 2;           // Uniquely identifies the param at device scope
   uint32 element_index = 3; // When setting single elements of array parameters, the element in the array to update
   Value value = 4;          // The value to apply
+}
+
+message SetValuePayload {
+  uint32 slot = 1;          // Uniquely identifies the device at node scope.
+  SetValue value = 2;       // The param oid and value to apply
 }
 
 message GetValuePayload {
@@ -278,7 +282,10 @@ message GetValuePayload {
   uint32 element_index = 3; // When requesting single elements of array parameters, the element in the array to get
 }
 
-message MultiSetValuePayload { repeated SetValuePayload values = 1; }
+message MultiSetValuePayload {
+  uint32 slot = 2;                      // Uniquely identifies the device at node scope.
+  repeated SetValue values = 1;  // The param oids and values to apply
+}
 
 message UpdateSubscriptionsPayload {
   uint32 slot = 1;                  // Uniquely identifies the device at node scope.

--- a/interface/param.proto
+++ b/interface/param.proto
@@ -265,15 +265,15 @@ message BasicParamInfoRequestPayload {
   bool recursive = 3;
 }
 
-message SetValue {
+message SetValuePayload {
   string oid = 1;           // Uniquely identifies the param at device scope
   uint32 element_index = 2; // When setting single elements of array parameters, the element in the array to update
   Value value = 3;          // The value to apply
 }
 
-message SetValuePayload {
+message SingleSetValuePayload {
   uint32 slot = 1;          // Uniquely identifies the device at node scope.
-  SetValue value = 2;       // The param oid and value to apply
+  SetValuePayload value = 2;       // The param oid and value to apply
 }
 
 message GetValuePayload {
@@ -284,7 +284,7 @@ message GetValuePayload {
 
 message MultiSetValuePayload {
   uint32 slot = 1;              // Uniquely identifies the device at node scope.
-  repeated SetValue values = 2; // The param oids and values to apply
+  repeated SetValuePayload values = 2; // The param oids and values to apply
 }
 
 message UpdateSubscriptionsPayload {

--- a/interface/param.proto
+++ b/interface/param.proto
@@ -266,9 +266,9 @@ message BasicParamInfoRequestPayload {
 }
 
 message SetValue {
-  string oid = 2;           // Uniquely identifies the param at device scope
-  uint32 element_index = 3; // When setting single elements of array parameters, the element in the array to update
-  Value value = 4;          // The value to apply
+  string oid = 1;           // Uniquely identifies the param at device scope
+  uint32 element_index = 2; // When setting single elements of array parameters, the element in the array to update
+  Value value = 3;          // The value to apply
 }
 
 message SetValuePayload {

--- a/interface/param.proto
+++ b/interface/param.proto
@@ -283,8 +283,8 @@ message GetValuePayload {
 }
 
 message MultiSetValuePayload {
-  uint32 slot = 2;                      // Uniquely identifies the device at node scope.
-  repeated SetValue values = 1;  // The param oids and values to apply
+  uint32 slot = 1;                      // Uniquely identifies the device at node scope.
+  repeated SetValue values = 2;  // The param oids and values to apply
 }
 
 message UpdateSubscriptionsPayload {

--- a/interface/service.proto
+++ b/interface/service.proto
@@ -43,7 +43,7 @@ service CatenaService {
 
   rpc BasicParamInfoRequest(BasicParamInfoRequestPayload) returns (stream BasicParamInfoResponse);
 
-  rpc SetValue(SetValuePayload) returns (catena.Empty);
+  rpc SetValue(SingleSetValuePayload) returns (catena.Empty);
 
   rpc GetValue(GetValuePayload) returns (Value);
 

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -50,7 +50,7 @@ bool Device::tryMultiSetValue (catena::MultiSetValuePayload src, catena::excepti
         ans = catena::exception_with_status("Multi-set is disabled for the device in slot " + slot_, catena::StatusCode::PERMISSION_DENIED);
     } else {
         // Looping through and validating set value requests.
-        for (const catena::SetValue& setValuePayload : src.values()) {
+        for (const catena::SetValuePayload& setValuePayload : src.values()) {
             try {
                 // Getting param, or parent param if the final segment is an index.
                 Path path(setValuePayload.oid());
@@ -72,7 +72,7 @@ bool Device::tryMultiSetValue (catena::MultiSetValuePayload src, catena::excepti
             }
         }
         // Resetting trackers regardless of whether something went wrong or not.
-        for (const catena::SetValue& setValuePayload : src.values()) {
+        for (const catena::SetValuePayload& setValuePayload : src.values()) {
             // Creating another exception_with_status as to not overwrite ans.
             catena::exception_with_status status{"", catena::StatusCode::OK};
             // Resetting param's trackers, or parent param's if back is index.
@@ -89,7 +89,7 @@ bool Device::tryMultiSetValue (catena::MultiSetValuePayload src, catena::excepti
 catena::exception_with_status Device::commitMultiSetValue (catena::MultiSetValuePayload src, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     // Looping through and commiting all setValue operations.
-    for (const catena::SetValue& setValuePayload : src.values()) {
+    for (const catena::SetValuePayload& setValuePayload : src.values()) {
         try {
             // Figuring out parent param for appends and resetValidate().
             Path path(setValuePayload.oid());
@@ -128,7 +128,7 @@ catena::exception_with_status Device::commitMultiSetValue (catena::MultiSetValue
 catena::exception_with_status Device::setValue (const std::string& jptr, catena::Value& src, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     catena::MultiSetValuePayload setValues;
-    catena::SetValue* setValuePayload = setValues.add_values();
+    catena::SetValuePayload* setValuePayload = setValues.add_values();
     setValuePayload->set_oid(jptr);
     setValuePayload->mutable_value()->CopyFrom(src);
     if (tryMultiSetValue(setValues, ans, authz)) {

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -50,7 +50,7 @@ bool Device::tryMultiSetValue (catena::MultiSetValuePayload src, catena::excepti
         ans = catena::exception_with_status("Multi-set is disabled for the device in slot " + slot_, catena::StatusCode::PERMISSION_DENIED);
     } else {
         // Looping through and validating set value requests.
-        for (const catena::SetValuePayload& setValuePayload : src.values()) {
+        for (const catena::SetValue& setValuePayload : src.values()) {
             try {
                 // Getting param, or parent param if the final segment is an index.
                 Path path(setValuePayload.oid());
@@ -72,7 +72,7 @@ bool Device::tryMultiSetValue (catena::MultiSetValuePayload src, catena::excepti
             }
         }
         // Resetting trackers regardless of whether something went wrong or not.
-        for (const catena::SetValuePayload& setValuePayload : src.values()) {
+        for (const catena::SetValue& setValuePayload : src.values()) {
             // Creating another exception_with_status as to not overwrite ans.
             catena::exception_with_status status{"", catena::StatusCode::OK};
             // Resetting param's trackers, or parent param's if back is index.
@@ -89,7 +89,7 @@ bool Device::tryMultiSetValue (catena::MultiSetValuePayload src, catena::excepti
 catena::exception_with_status Device::commitMultiSetValue (catena::MultiSetValuePayload src, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     // Looping through and commiting all setValue operations.
-    for (const catena::SetValuePayload& setValuePayload : src.values()) {
+    for (const catena::SetValue& setValuePayload : src.values()) {
         try {
             // Figuring out parent param for appends and resetValidate().
             Path path(setValuePayload.oid());
@@ -128,7 +128,7 @@ catena::exception_with_status Device::commitMultiSetValue (catena::MultiSetValue
 catena::exception_with_status Device::setValue (const std::string& jptr, catena::Value& src, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     catena::MultiSetValuePayload setValues;
-    catena::SetValuePayload* setValuePayload = setValues.add_values();
+    catena::SetValue* setValuePayload = setValues.add_values();
     setValuePayload->set_oid(jptr);
     setValuePayload->mutable_value()->CopyFrom(src);
     if (tryMultiSetValue(setValues, ans, authz)) {

--- a/sdks/cpp/connections/gRPC/include/MultiSetValue.h
+++ b/sdks/cpp/connections/gRPC/include/MultiSetValue.h
@@ -68,32 +68,39 @@ class CatenaServiceImpl::MultiSetValue : public CallData {
          */
         void proceed(CatenaServiceImpl *service, bool ok) override;
     protected:
-        // Helper functions to allow child setValue to use proceed()
         /**
          * @brief Constructor class for child classes.
+         *   
+         * Helper function to allow reuse of proceed().
          *
-         * @param service - Pointer to the parent CatenaServiceImpl.
-         * @param dm - Address of the device to get the value from.
-         * @param ok - Flag to check if the command was successfully executed.
-         * @param objectId - objectCounter_ + 1
+         * @param service Pointer to the parent CatenaServiceImpl.
+         * @param dm Address of the device to get the value from.
+         * @param ok Flag to check if the command was successfully executed.
+         * @param objectId objectCounter_ + 1
          */ 
         MultiSetValue(CatenaServiceImpl *service, Device &dm, bool ok, int objectId);
         /**
          * @brief Requests Multi Set Value from the system and sets the
          * request to the MultiSetValuePayload.
+         *   
+         * Helper function to allow reuse of proceed().
          */
         virtual void request();
         /**
          * @brief Creates a new MultiSetValue object to serve other clients
          * while processing.
+         *   
+         * Helper function to allow reuse of proceed().
          *
-         * @param service - Pointer to the parent CatenaServiceImpl.
-         * @param dm - Address of the device to get the value from.
-         * @param ok - Flag to check if the command was successfully executed.
+         * @param service Pointer to the parent CatenaServiceImpl.
+         * @param dm Address of the device to get the value from.
+         * @param ok Flag to check if the command was successfully executed.
          */ 
         virtual void create(CatenaServiceImpl *service, Device &dm, bool ok);
         /**
          * @brief Converts req_ to a MultiSetValuePayload reqs_.
+         *   
+         * Helper function to allow reuse of proceed().
          * 
          * @note Does nothing in MultiSetValue.
          */

--- a/sdks/cpp/connections/gRPC/include/MultiSetValue.h
+++ b/sdks/cpp/connections/gRPC/include/MultiSetValue.h
@@ -68,6 +68,7 @@ class CatenaServiceImpl::MultiSetValue : public CallData {
          */
         void proceed(CatenaServiceImpl *service, bool ok) override;
     protected:
+        // Helper functions to allow child setValue to use proceed()
         /**
          * @brief Constructor class for child classes.
          *
@@ -91,6 +92,13 @@ class CatenaServiceImpl::MultiSetValue : public CallData {
          * @param ok - Flag to check if the command was successfully executed.
          */ 
         virtual void create(CatenaServiceImpl *service, Device &dm, bool ok);
+        /**
+         * @brief Converts req_ to a MultiSetValuePayload reqs_.
+         * 
+         * @note Does nothing in MultiSetValue.
+         */
+        virtual void toMulti() { return; }
+
         /**
          * @brief Name of childclass to specify gRPC in console notifications.
          */

--- a/sdks/cpp/connections/gRPC/include/SetValue.h
+++ b/sdks/cpp/connections/gRPC/include/SetValue.h
@@ -61,6 +61,8 @@ class CatenaServiceImpl::SetValue : public MultiSetValue {
         /**
          * @brief Requests Set Value from the system and adds the request to
          * the MultiSetValuePayload in MultiSetValue.
+         * 
+         * Helper function to allow reuse of MultiSetValue's proceed().
          */
         void request() override;
         /**
@@ -70,10 +72,14 @@ class CatenaServiceImpl::SetValue : public MultiSetValue {
          * @param service - Pointer to the parent CatenaServiceImpl.
          * @param dm - Address of the device to get the value from.
          * @param ok - Flag to check if the command was successfully executed.
+         *  
+         * Helper function to allow reuse of MultiSetValue's proceed().
          */ 
         void create(CatenaServiceImpl *service, Device &dm, bool ok) override;
         /**
          * @brief Converts req_ to a MultiSetValuePayload reqs_.
+         *  
+         * Helper function to allow reuse of MultiSetValue's proceed().
          */
         void toMulti() override;
 

--- a/sdks/cpp/connections/gRPC/include/SetValue.h
+++ b/sdks/cpp/connections/gRPC/include/SetValue.h
@@ -80,7 +80,7 @@ class CatenaServiceImpl::SetValue : public MultiSetValue {
         /**
          * @brief The SetValuePayload recieved from request().
          */
-        catena::SetValuePayload req_;
+        catena::SingleSetValuePayload req_;
         /**
          * @brief The total # of SetValue objects.
          */

--- a/sdks/cpp/connections/gRPC/include/SetValue.h
+++ b/sdks/cpp/connections/gRPC/include/SetValue.h
@@ -73,6 +73,15 @@ class CatenaServiceImpl::SetValue : public MultiSetValue {
          */ 
         void create(CatenaServiceImpl *service, Device &dm, bool ok) override;
         /**
+         * @brief Converts req_ to a MultiSetValuePayload reqs_.
+         */
+        void toMulti() override;
+
+        /**
+         * @brief The SetValuePayload recieved from request().
+         */
+        catena::SetValuePayload req_;
+        /**
          * @brief The total # of SetValue objects.
          */
         static int objectCounter_;

--- a/sdks/cpp/connections/gRPC/src/MultiSetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/MultiSetValue.cpp
@@ -94,6 +94,8 @@ void CatenaServiceImpl::MultiSetValue::proceed(CatenaServiceImpl *service, bool 
             create(service_, dm_, ok);
             context_.AsyncNotifyWhenDone(this);
             try {
+                // Convert to MultiSetValuePayload if not already.
+                toMulti();
                 /**
                  * Creating authorization object depending on client scopes.
                  * Shared ptr to maintain lifetime of object. Raw ptr ensures

--- a/sdks/cpp/connections/gRPC/src/SetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/SetValue.cpp
@@ -56,10 +56,14 @@ CatenaServiceImpl::SetValue::SetValue(CatenaServiceImpl *service, Device &dm, bo
 }
 
 void CatenaServiceImpl::SetValue::request() {
-    catena::SetValuePayload* req = reqs_.add_values();
-    service_->RequestSetValue(&context_, req, &responder_, service_->cq_, service_->cq_, this);
+    service_->RequestSetValue(&context_, &req_, &responder_, service_->cq_, service_->cq_, this);
 }
 
 void CatenaServiceImpl::SetValue::create(CatenaServiceImpl *service, Device &dm, bool ok) {
     new SetValue(service, dm, ok);
+}
+
+void CatenaServiceImpl::SetValue::toMulti() {
+    reqs_.set_slot(req_.slot());
+    reqs_.add_values()->CopyFrom(req_.value());
 }


### PR DESCRIPTION
Title.

This involved creating a new function for (Multi)SetValue toMulti() which converts a SingleSetValuePayload to a multi one.

One thing to note is that I reused field numbers. However, as far as I know we are still in dev and everything will be rebuilt anyways so it should be fine.