### PR TITLE
Fixed doxygen REST docs

### DIFF
--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -48,7 +48,7 @@ namespace catena {
 namespace common {
  
 /**
- * @brief Interface class for Connect.h
+ * @brief Interface class for Connect RPCs
  */
 class IConnect {
   protected:

--- a/sdks/cpp/common/include/rpc/TimeNow.h
+++ b/sdks/cpp/common/include/rpc/TimeNow.h
@@ -29,62 +29,35 @@
  */
 
 /**
- * @file ICallData.h
- * @brief Interface class for REST RPCs.
- * @author benjamin.whitten@rossvideo.com
+ * @file TimeNow.h
+ * @brief Contains a function which returns the current time as a string.
+ * @author Unknown See grpc::ServiceImpl.h.
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
-// common
-#include <Enums.h>
-#include <patterns/EnumDecorator.h>
-#include <Device.h>
-
-using DetailLevel = catena::patterns::EnumDecorator<catena::Device_DetailLevel>;
-
-// boost
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-using boost::asio::ip::tcp;
-
-// REST
-#include "SocketReader.h"
-#include "SocketWriter.h"
+// std
+#include <string>
+#include <iostream>
 
 namespace catena {
-namespace REST {
+namespace common {
 
 /**
- * @brief CallData states for status messages.
+ * @brief Returns the current time as a string including microseconds.
  */
-enum class CallStatus { kCreate, kProcess, kRead, kWrite, kPostWrite, kFinish };
+inline std::string timeNow() {
+    std::stringstream ss;
+    auto now = std::chrono::system_clock::now();
+    auto now_micros = std::chrono::time_point_cast<std::chrono::microseconds>(now);
+    auto epoch = now_micros.time_since_epoch();
+    auto micros = std::chrono::duration_cast<std::chrono::microseconds>(epoch);
+    auto now_c = std::chrono::system_clock::to_time_t(now);
+    ss << std::put_time(std::localtime(&now_c), "%F %T") << '.' << std::setw(6) << std::setfill('0')
+       << micros.count() % 1000000;
+    return ss.str();
+}
 
-/**
- * @brief Interface class for the REST API RPCs.
- */
-class ICallData {
-	public:
-		virtual ~ICallData() = default;
-		/**
-		 * @brief The RPC's main process.
-		 */
-		virtual void proceed() = 0;
-		/**
-		 * @brief Finishes the RPC.
-		 */
-		virtual void finish() = 0;
-
-	protected:
-		/**
-		 * @brief Helper function to write status messages to the API console.
-		 * 
-		 * @param status The current state of the RPC (kCreate, kFinish, etc.)
-		 * @param ok The status of the RPC (open or closed).
-		 */
-		virtual inline void writeConsole(CallStatus status, bool ok) const = 0;
-};
-
-};
-};
+} // namespace common
+} // namespace catena

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -67,10 +67,13 @@ using catena::REST::SocketWriter;
 using catena::REST::ChunkedWriter;
 
 namespace catena {
+/**
+ * @brief Namespace for classes relating to handling REST API requests.
+ */
 namespace REST {
 
 /**
- * @brief REST API
+ * @brief Implements Catena REST API request handlers.
  */
 class CatenaServiceImpl : public catena::REST::IServiceImpl {
 
@@ -114,10 +117,6 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
      * Currently unused.
      */
     bool is_port_in_use_() const override;
-    /**
-     * @brief Returns the current time as a string including microseconds.
-     */
-    static std::string timeNow();
 
     /**
      * @brief Provides io functionality for tcp::sockets used in RPCs.
@@ -160,14 +159,6 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
      * @brief Mutex for activeRpcs_ counter to avoid collisions.
      */
     std::mutex activeRpcMutex_;
-
-    // Forward declarations of CallData classes for their respective RPC.
-    class Connect;
-    class MultiSetValue;
-    class SetValue;
-    class DeviceRequest;
-    class GetValue;
-    class GetPopulatedSlots;
 
     using Router = catena::patterns::GenericFactory<catena::REST::ICallData,
                                                     std::string,

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -43,21 +43,31 @@
 
 // common
 #include <rpc/Connect.h>
+#include <rpc/TimeNow.h>
+#include <Status.h>
+#include <IParam.h>
+#include <Device.h>
 #include <utils.h>
+#include <Authorization.h>
+#include <Enums.h>
 
 // Connections/REST
-#include "ServiceImpl.h"
 #include "SocketReader.h"
 #include "SocketWriter.h"
 #include "interface/ICallData.h"
-using catena::REST::CatenaServiceImpl;
-using catena::REST::CallStatus;
+
+namespace catena {
+namespace REST {
 
 /**
- * @brief The Connect REST RPC.
+ * @brief ICallData class for the Connect REST RPC.
  */
-class CatenaServiceImpl::Connect : public catena::REST::ICallData, public catena::common::Connect {
+class Connect : public ICallData, public catena::common::Connect {
   public:
+    // Specifying which Device and IParam to use (defaults to catena::...)
+    using Device = catena::common::Device;
+    using IParam = catena::common::IParam;
+
     /**
      * @brief Constructor for the Connect RPC. Calls proceed() once
      * initialized.
@@ -100,8 +110,9 @@ class CatenaServiceImpl::Connect : public catena::REST::ICallData, public catena
      */
     inline void writeConsole(CallStatus status, bool ok) const override {
       std::cout << "Connect::proceed[" << objectId_ << "]: "
-                << timeNow() << " status: "<< static_cast<int>(status)
-                <<", ok: "<< std::boolalpha << ok << std::endl;
+                << catena::common::timeNow() << " status: "
+                << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
+                << std::endl;
     }
     /**
      * @brief Returns true if the RPC was cancelled.
@@ -154,3 +165,6 @@ class CatenaServiceImpl::Connect : public catena::REST::ICallData, public catena
      */
     static int objectCounter_;
 };
+
+}; // namespace REST
+}; // namespace catena

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -42,21 +42,31 @@
 #include <google/protobuf/util/json_util.h>
 
 // common
+#include <rpc/TimeNow.h>
+#include <Status.h>
+#include <IParam.h>
+#include <Device.h>
 #include <utils.h>
+#include <Authorization.h>
+#include <Enums.h>
 
 // Connections/REST
-#include "ServiceImpl.h"
 #include "SocketReader.h"
 #include "SocketWriter.h"
 #include "interface/ICallData.h"
-using catena::REST::CatenaServiceImpl;
-using catena::REST::CallStatus;
+
+namespace catena {
+namespace REST {
 
 /**
- * @brief CallData class for the DeviceRequest REST RPC.
+ * @brief ICallData class for the DeviceRequest REST RPC.
  */
-class CatenaServiceImpl::DeviceRequest : public catena::REST::ICallData {
+class DeviceRequest : public ICallData {
   public:
+    // Specifying which Device and IParam to use (defaults to catena::...)
+    using Device = catena::common::Device;
+    using IParam = catena::common::IParam;
+
     /**
      * @brief Constructor for the DeviceRequest RPC. Calls proceed() once
      * initialized.
@@ -93,8 +103,9 @@ class CatenaServiceImpl::DeviceRequest : public catena::REST::ICallData {
      */
     inline void writeConsole(CallStatus status, bool ok) const override {
       std::cout << "DeviceRequest::proceed[" << objectId_ << "]: "
-                << timeNow() << " status: "<< static_cast<int>(status)
-                <<", ok: "<< std::boolalpha << ok << std::endl;
+                << catena::common::timeNow() << " status: "
+                << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
+                << std::endl;
     }
     
     /**
@@ -144,3 +155,6 @@ class CatenaServiceImpl::DeviceRequest : public catena::REST::ICallData {
      */
     static int objectCounter_;
 };
+
+}; // namespace REST
+}; // namespace catena

--- a/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
@@ -41,19 +41,32 @@
 #include <interface/device.pb.h>
 #include <google/protobuf/util/json_util.h>
   
+// common
+#include <rpc/TimeNow.h>
+#include <Status.h>
+#include <IParam.h>
+#include <Device.h>
+#include <utils.h>
+#include <Authorization.h>
+#include <Enums.h>
+
 // Connections/REST
-#include "ServiceImpl.h"
 #include "SocketReader.h"
 #include "SocketWriter.h"
 #include "interface/ICallData.h"
-using catena::REST::CatenaServiceImpl;
-using catena::REST::CallStatus;
  
+namespace catena {
+namespace REST {
+
 /**
- * @brief CallData class for the GetPopulatedSlots REST RPC.
+ * @brief ICallData class for the GetPopulatedSlots REST RPC.
  */
-class CatenaServiceImpl::GetPopulatedSlots : public catena::REST::ICallData {
+class GetPopulatedSlots : public ICallData {
   public:
+    // Specifying which Device and IParam to use (defaults to catena::...)
+    using Device = catena::common::Device;
+    using IParam = catena::common::IParam;
+
     /**
      * @brief Constructor for the GetPopulatedSlots RPC. Calls proceed() once
      * initialized.
@@ -90,8 +103,9 @@ class CatenaServiceImpl::GetPopulatedSlots : public catena::REST::ICallData {
      */
     inline void writeConsole(CallStatus status, bool ok) const override {
       std::cout << "Connect::proceed[" << objectId_ << "]: "
-                << timeNow() << " status: "<< static_cast<int>(status)
-                <<", ok: "<< std::boolalpha << ok << std::endl;
+                << catena::common::timeNow() << " status: "
+                << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
+                << std::endl;
     }
  
     /**
@@ -116,4 +130,6 @@ class CatenaServiceImpl::GetPopulatedSlots : public catena::REST::ICallData {
      */
     static int objectCounter_;
 };
- 
+
+}; // namespace REST
+}; // namespace catena

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -41,19 +41,32 @@
 #include <interface/device.pb.h>
 #include <google/protobuf/util/json_util.h>
  
+// common
+#include <rpc/TimeNow.h>
+#include <Status.h>
+#include <IParam.h>
+#include <Device.h>
+#include <utils.h>
+#include <Authorization.h>
+#include <Enums.h>
+
 // Connections/REST
-#include "ServiceImpl.h"
 #include "SocketReader.h"
 #include "SocketWriter.h"
 #include "interface/ICallData.h"
-using catena::REST::CatenaServiceImpl;
-using catena::REST::CallStatus;
+
+namespace catena {
+namespace REST {
 
 /**
- * @brief CallData class for the GetValue REST RPC.
+ * @brief ICallData class for the GetValue REST RPC.
  */
-class CatenaServiceImpl::GetValue : public catena::REST::ICallData {
+class GetValue : public ICallData {
   public:
+    // Specifying which Device and IParam to use (defaults to catena::...)
+    using Device = catena::common::Device;
+    using IParam = catena::common::IParam;
+
     /**
      * @brief Constructor for the GetValue RPC. Calls proceed() once
      * initialized.
@@ -90,8 +103,9 @@ class CatenaServiceImpl::GetValue : public catena::REST::ICallData {
      */
     inline void writeConsole(CallStatus status, bool ok) const override {
       std::cout << "GetValue::proceed[" << objectId_ << "]: "
-                << timeNow() << " status: "<< static_cast<int>(status)
-                <<", ok: "<< std::boolalpha << ok << std::endl;
+                << catena::common::timeNow() << " status: "
+                << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
+                << std::endl;
     }
 
     /**
@@ -133,3 +147,6 @@ class CatenaServiceImpl::GetValue : public catena::REST::ICallData {
      */
     static int objectCounter_;
 };
+
+}; // namespace REST
+}; // namespace catena

--- a/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
@@ -41,19 +41,32 @@
 #include <interface/device.pb.h>
 #include <google/protobuf/util/json_util.h>
 
+// common
+#include <rpc/TimeNow.h>
+#include <Status.h>
+#include <IParam.h>
+#include <Device.h>
+#include <utils.h>
+#include <Authorization.h>
+#include <Enums.h>
+
 // Connections/REST
-#include "ServiceImpl.h"
 #include "SocketReader.h"
 #include "SocketWriter.h"
 #include "interface/ICallData.h"
-using catena::REST::CatenaServiceImpl;
-using catena::REST::CallStatus;
+
+namespace catena {
+namespace REST {
 
 /**
- * @brief Generic CallData class for the SetValue and MultiSetValue REST RPCs.
+ * @brief Generic ICallData class for the SetValue and MultiSetValue REST RPCs.
  */
-class CatenaServiceImpl::MultiSetValue : public catena::REST::ICallData {
+class MultiSetValue : public ICallData {
   public:
+    // Specifying which Device and IParam to use (defaults to catena::...)
+    using Device = catena::common::Device;
+    using IParam = catena::common::IParam;
+
     /**
      * @brief Constructor for the MultiSetValue RPC. Calls proceed() once
      * initialized.
@@ -103,8 +116,9 @@ class CatenaServiceImpl::MultiSetValue : public catena::REST::ICallData {
      */
     inline void writeConsole(CallStatus status, bool ok) const override {
       std::cout << typeName_ << "SetValue::proceed[" << objectId_ << "]: "
-                << timeNow() << " status: "<< static_cast<int>(status)
-                <<", ok: "<< std::boolalpha << ok << std::endl;
+                << catena::common::timeNow() << " status: "
+                << static_cast<int>(status) << ", ok: " << std::boolalpha << ok
+                << std::endl;
     }
 
     /**
@@ -142,3 +156,6 @@ class CatenaServiceImpl::MultiSetValue : public catena::REST::ICallData {
      */
     static int objectCounter_;
 };
+
+}; // namespace REST
+}; // namespace catena

--- a/sdks/cpp/connections/REST/include/controllers/SetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/SetValue.h
@@ -39,12 +39,18 @@
 
 // Connections/REST
 #include "MultiSetValue.h"
-using catena::REST::CatenaServiceImpl;
+
+namespace catena {
+namespace REST {
 
 /**
- * @brief The SetValue REST RPC.
+ * @brief ICallData class for the SetValue REST RPC.
  */
-class CatenaServiceImpl::SetValue : public MultiSetValue {
+class SetValue : public MultiSetValue {
+  // Specifying which Device and IParam to use (defaults to catena::...)
+  using Device = catena::common::Device;
+  using IParam = catena::common::IParam;
+
   public:
     /**
      * @brief Constructor for the SetValue RPC. Calls proceed() once
@@ -77,3 +83,6 @@ class CatenaServiceImpl::SetValue : public MultiSetValue {
      */
     static int objectCounter_;
 };
+
+}; // namespace REST
+}; // namespace catena

--- a/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
@@ -57,7 +57,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief Interface class for REST ServiceImpl
+ * @brief Interface for the REST::CatenaServiceImpl class
  */
 class IServiceImpl {
 
@@ -94,8 +94,6 @@ class IServiceImpl {
   private:
     /**
      * @brief Returns true if port_ is already in use.
-     * 
-     * Currently unused.
      */
     virtual bool is_port_in_use_() const = 0;
 };

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -10,6 +10,7 @@ using catena::REST::CatenaServiceImpl;
 #include <controllers/DeviceRequest.h>
 #include <controllers/GetValue.h>
 #include <controllers/GetPopulatedSlots.h>
+using catena::REST::Connect;
 
 #include "absl/flags/flag.h"
 
@@ -47,7 +48,7 @@ CatenaServiceImpl::CatenaServiceImpl(Device &dm, std::string& EOPath, bool authz
 }
 
 // Initializing the shutdown signal for all open connections.
-vdk::signal<void()> CatenaServiceImpl::Connect::shutdownSignal_;
+vdk::signal<void()> Connect::shutdownSignal_;
 
 void CatenaServiceImpl::run() {
     // TLS handled by Envoyproxy
@@ -116,18 +117,6 @@ void CatenaServiceImpl::Shutdown() {
     tcp::socket dummySocket(io_context_);
     dummySocket.connect(tcp::endpoint(tcp::v4(), port_));
 };
-
-std::string CatenaServiceImpl::timeNow() {
-    std::stringstream ss;
-    auto now = std::chrono::system_clock::now();
-    auto now_micros = std::chrono::time_point_cast<std::chrono::microseconds>(now);
-    auto epoch = now_micros.time_since_epoch();
-    auto micros = std::chrono::duration_cast<std::chrono::microseconds>(epoch);
-    auto now_c = std::chrono::system_clock::to_time_t(now);
-    ss << std::put_time(std::localtime(&now_c), "%F %T") << '.' << std::setw(6) << std::setfill('0')
-       << micros.count() % 1000000;
-    return ss.str();
-}
 
 bool CatenaServiceImpl::is_port_in_use_() const {
     try {

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -1,11 +1,12 @@
 
 // connections/REST
 #include <controllers/Connect.h>
+using catena::REST::Connect;
 
 // Initializes the object counter for Connect to 0.
-int CatenaServiceImpl::Connect::objectCounter_ = 0;
+int Connect::objectCounter_ = 0;
 
-CatenaServiceImpl::Connect::Connect(tcp::socket& socket, SocketReader& context, Device& dm) :
+Connect::Connect(tcp::socket& socket, SocketReader& context, Device& dm) :
     socket_{socket}, writer_{socket}, ok_{true}, catena::common::Connect(dm, context.authorizationEnabled(), context.jwsToken()) {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
@@ -35,7 +36,7 @@ CatenaServiceImpl::Connect::Connect(tcp::socket& socket, SocketReader& context, 
     }
 }
 
-void CatenaServiceImpl::Connect::proceed() {
+void Connect::proceed() {
     if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
     // Cancels all open connections if shutdown signal is sent.
@@ -81,7 +82,7 @@ void CatenaServiceImpl::Connect::proceed() {
     }
 }
 
-void CatenaServiceImpl::Connect::finish() {
+void Connect::finish() {
     writeConsole(CallStatus::kFinish, !socket_.is_open());
     try {
         shutdownSignal_.disconnect(shutdownSignalId_);

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -1,11 +1,12 @@
 
 // connections/REST
 #include <controllers/DeviceRequest.h>
+using catena::REST::DeviceRequest;
 
 // Initializes the object counter for Connect to 0.
-int CatenaServiceImpl::DeviceRequest::objectCounter_ = 0;
+int DeviceRequest::objectCounter_ = 0;
 
-CatenaServiceImpl::DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReader& context, Device& dm) :
+DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReader& context, Device& dm) :
     socket_{socket}, writer_{socket}, context_{context}, dm_{dm}, ok_{true} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
@@ -35,7 +36,7 @@ CatenaServiceImpl::DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReade
     }
 }
 
-void CatenaServiceImpl::DeviceRequest::proceed() {
+void DeviceRequest::proceed() {
     if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
     try {
@@ -70,7 +71,7 @@ void CatenaServiceImpl::DeviceRequest::proceed() {
     }
 }
 
-void CatenaServiceImpl::DeviceRequest::finish() {
+void DeviceRequest::finish() {
     writeConsole(CallStatus::kFinish, socket_.is_open());
     writer_.finish();
     std::cout << "DeviceRequest[" << objectId_ << "] finished\n";

--- a/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
@@ -1,17 +1,18 @@
 
 // connections/REST
 #include <controllers/GetPopulatedSlots.h>
+using catena::REST::GetPopulatedSlots;
 
 // Initializes the object counter for GetPopulatedSlots to 0.
-int CatenaServiceImpl::GetPopulatedSlots::objectCounter_ = 0;
+int GetPopulatedSlots::objectCounter_ = 0;
 
-CatenaServiceImpl::GetPopulatedSlots::GetPopulatedSlots(tcp::socket& socket, SocketReader& context, Device& dm) :
+GetPopulatedSlots::GetPopulatedSlots(tcp::socket& socket, SocketReader& context, Device& dm) :
     socket_{socket}, writer_{socket}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
 }
 
-void CatenaServiceImpl::GetPopulatedSlots::proceed() {
+void GetPopulatedSlots::proceed() {
     writeConsole(CallStatus::kProcess, socket_.is_open());
     try {
         // Getting slot from dm_.
@@ -25,7 +26,7 @@ void CatenaServiceImpl::GetPopulatedSlots::proceed() {
     }
 }
 
-void CatenaServiceImpl::GetPopulatedSlots::finish() {
+void GetPopulatedSlots::finish() {
     writeConsole(CallStatus::kFinish, socket_.is_open());
     std::cout << "GetPopulatedSlots[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -1,11 +1,12 @@
 
 // connections/REST
 #include <controllers/GetValue.h>
+using catena::REST::GetValue;
 
 // Initializes the object counter for GetValue to 0.
-int CatenaServiceImpl::GetValue::objectCounter_ = 0;
+int GetValue::objectCounter_ = 0;
 
-CatenaServiceImpl::GetValue::GetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
+GetValue::GetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
     socket_{socket}, writer_{socket}, context_{context}, dm_{dm}, ok_{true} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
@@ -26,7 +27,7 @@ CatenaServiceImpl::GetValue::GetValue(tcp::socket& socket, SocketReader& context
     }
 }
 
-void CatenaServiceImpl::GetValue::proceed() {
+void GetValue::proceed() {
     if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
     catena::Value ans;
@@ -53,7 +54,7 @@ void CatenaServiceImpl::GetValue::proceed() {
     }
 }
 
-void CatenaServiceImpl::GetValue::finish() {
+void GetValue::finish() {
     writeConsole(CallStatus::kFinish, socket_.is_open());
     std::cout << "GetValue[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -1,25 +1,26 @@
 
 // connections/REST
 #include <controllers/MultiSetValue.h>
+using catena::REST::MultiSetValue;
 
 // Initializes the object counter for MultiSetValue to 0.
-int CatenaServiceImpl::MultiSetValue::objectCounter_ = 0;
+int MultiSetValue::objectCounter_ = 0;
 
-CatenaServiceImpl::MultiSetValue::MultiSetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
+MultiSetValue::MultiSetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
     MultiSetValue(socket, context, dm, objectCounter_++) {
     typeName_ = "Multi";
     writeConsole(CallStatus::kCreate, socket_.is_open());
 }
 
-CatenaServiceImpl::MultiSetValue::MultiSetValue(tcp::socket& socket, SocketReader& context, Device& dm, int objectId) :
+MultiSetValue::MultiSetValue(tcp::socket& socket, SocketReader& context, Device& dm, int objectId) :
     socket_{socket}, writer_{socket}, context_{context}, dm_{dm}, objectId_{objectId} {}
 
-bool CatenaServiceImpl::MultiSetValue::toMulti() {
+bool MultiSetValue::toMulti() {
     absl::Status status = google::protobuf::util::JsonStringToMessage(absl::string_view(context_.jsonBody()), &reqs_);
     return status.ok();
 }
 
-void CatenaServiceImpl::MultiSetValue::proceed() {
+void MultiSetValue::proceed() {
     writeConsole(CallStatus::kProcess, socket_.is_open());
 
     catena::exception_with_status rc{"", catena::StatusCode::OK};
@@ -60,7 +61,7 @@ void CatenaServiceImpl::MultiSetValue::proceed() {
     }
 }
 
-void CatenaServiceImpl::MultiSetValue::finish() {
+void MultiSetValue::finish() {
     writeConsole(CallStatus::kFinish, socket_.is_open());
     std::cout << typeName_ << "SetValue[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/SetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/SetValue.cpp
@@ -1,16 +1,17 @@
 
 // connections/REST
 #include <controllers/SetValue.h>
+using catena::REST::SetValue;
 
 // Initializes the object counter for SetValue to 0.
-int CatenaServiceImpl::SetValue::objectCounter_ = 0;
+int SetValue::objectCounter_ = 0;
 
-CatenaServiceImpl::SetValue::SetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
+SetValue::SetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
     MultiSetValue(socket, context, dm, objectCounter_++) {
     writeConsole(CallStatus::kCreate, socket_.is_open());
 }
 
-bool CatenaServiceImpl::SetValue::toMulti() {
+bool SetValue::toMulti() {
     catena::SingleSetValuePayload payload;
     absl::Status status = google::protobuf::util::JsonStringToMessage(absl::string_view(context_.jsonBody()), &payload);
     if (status.ok()) {


### PR DESCRIPTION
Title. Doxygen doesn't like >1 namespaces so this was accomplished by moving the requests handlers outside of ServiceImpl and into the REST namespace. Additionally, this push fixes adds and fixes a few briefs and moves TimeNow() to catena::common. This function should be reused in the gRPC implementation (see issues).