### PR TITLE
Update SocketWriter to allow multiple calls write()

### DIFF
--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -82,6 +82,7 @@ class ISocketWriter {
      * Used when method = OPTIONS.
      */
     virtual void writeOptions() = 0;
+    virtual void finish() = 0;
 };
  
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -82,6 +82,9 @@ class ISocketWriter {
      * Used when method = OPTIONS.
      */
     virtual void writeOptions() = 0;
+    /**
+     * @brief Finishes writing process.
+     */
     virtual void finish() = 0;
 };
  

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -96,11 +96,16 @@ void CatenaServiceImpl::run() {
                 } catch (...) {
                     rc = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
                 }
+            } else {
+                rc = catena::exception_with_status{"Service shutdown", catena::StatusCode::CANCELLED};
             }
             // Writing to socket if there was an error.
             if (rc.status != catena::StatusCode::OK) {
-                SocketWriter writer(socket);
-                writer.write(rc);
+                // Try ensures that we don't fail to decrement active RPCs.
+                try {
+                    SocketWriter writer(socket);
+                    writer.write(rc);
+                } catch (...) {}
             }
             // rpc completed. Decrementing activeRPCs.
             {

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -96,8 +96,6 @@ void CatenaServiceImpl::run() {
                 } catch (...) {
                     rc = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
                 }
-            } else {
-                rc = catena::exception_with_status{"Service shutdown", catena::StatusCode::CANCELLED};
             }
             // Writing to socket if there was an error.
             if (rc.status != catena::StatusCode::OK) {

--- a/sdks/cpp/connections/REST/src/SocketWriter.cpp
+++ b/sdks/cpp/connections/REST/src/SocketWriter.cpp
@@ -3,22 +3,23 @@
 using catena::REST::SocketWriter;
 using catena::REST::ChunkedWriter;
 
-// SocketWriter
 void SocketWriter::write(google::protobuf::Message& msg) {
+    // Adds a JSON message to the end of the response.
     // Converting the value to JSON.
     std::string jsonOutput;
     google::protobuf::util::JsonPrintOptions options;
     options.add_whitespace = true;
     auto status = MessageToJsonString(msg, &jsonOutput, options);
-
-    // Writing headers and JSON obj if conversion was successful.
+    // Adding JSON obj to response_ if conversion was successful.
     if (status.ok()) {
-        std::string headers = "HTTP/1.1 200 OK\r\n"
-                              "Content-Type: application/json\r\n"
-                              "Content-Length: " + std::to_string(jsonOutput.size()) + "\r\n" +
-                              CORS_ +
-                              "Connection: close\r\n\r\n";
-        boost::asio::write(socket_, boost::asio::buffer(headers + jsonOutput));
+        if (response_.empty()) {
+            response_ = jsonOutput;
+        } else {
+            // Delete newline and add comma
+            response_.erase(response_.length() - 1);
+            response_ += ",\n" + jsonOutput;
+            multi_ = true;
+        }
     // Error
     } else {
         catena::exception_with_status err("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT);
@@ -27,6 +28,9 @@ void SocketWriter::write(google::protobuf::Message& msg) {
 }
 
 void SocketWriter::write(catena::exception_with_status& err) {
+    // Writes an error message to the socket.
+    // Clearing response_ and sending error.
+    response_ = "";
     std::string errMsg = err.what();
     std::string headers = "HTTP/1.1 " + std::to_string(codeMap_.at(err.status)) + " " + err.what() + "\r\n"
                           "Content-Type: text/plain\r\n"
@@ -37,6 +41,7 @@ void SocketWriter::write(catena::exception_with_status& err) {
 }
 
 void SocketWriter::writeOptions() {
+    // Writes a response to the client detailing their options for PUT methods.
     std::string headers = "HTTP/1.1 204 No Content\r\n" +
                           CORS_ +
                           "Content-Length: 0\r\n\r\n";
@@ -44,7 +49,31 @@ void SocketWriter::writeOptions() {
     return;
 }
 
-// Chunked Writer
+void SocketWriter::finish() {
+    // Finishes the writing process by writing response to socket.
+    if (!response_.empty()) {
+        // Format in a list if this is a multi-part response.
+        if (multi_) {
+            response_ = "{\n\"response\": [\n" + response_ + "]\n}";
+        }
+        // Set headers and write the response.
+        std::string headers = "HTTP/1.1 200 OK\r\n"
+                              "Content-Type: application/json\r\n"
+                              "Content-Length: " + std::to_string(response_.size()) + "\r\n" +
+                              CORS_ +
+                              "Connection: close\r\n\r\n";
+        boost::asio::write(socket_, boost::asio::buffer(headers + response_));
+    }
+}
+
+void SocketWriter::finish(google::protobuf::Message& msg) {
+    // Finishes the writing process by writing a message to the socket.
+    write(msg);
+    finish();
+}
+
+
+
 void ChunkedWriter::writeHeaders(catena::exception_with_status& status) {
     // Setting type depending on if we are writing an error or not.
     std::string type;

--- a/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
@@ -61,7 +61,7 @@ void AddLanguage::proceed() {
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
         catena::Empty ans = catena::Empty();
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.write(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
@@ -19,7 +19,7 @@ void GetPopulatedSlots::proceed() {
         SlotList slotList;
         slotList.add_slots(dm_.slot());
         // Writing response.
-        writer_.write(slotList);
+        writer_.finish(slotList);
     } catch (...) {
         catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
         writer_.write(rc);

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -48,7 +48,7 @@ void GetValue::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.write(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
@@ -44,7 +44,7 @@ void LanguagePackRequest::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.write(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
@@ -41,7 +41,7 @@ void ListLanguages::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.write(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -55,7 +55,7 @@ void MultiSetValue::proceed() {
     // Writing response.
     if (rc.status == catena::StatusCode::OK) {
         catena::Empty ans = catena::Empty();
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.write(rc);
     }


### PR DESCRIPTION
Updated socketWriter to allow multiple calls to write() until finish() is called. It essentially just buffers a response now.

Alternatively a call to finish(msg) will accomplish the what the old write(msg) did.