### PR TITLE
Replaced ChunkedWriter with SSEWriter

### DIFF
--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -74,7 +74,7 @@ get:
     "200":
       description: A stream of push updates from the server
       content:
-        application/json:
+        text/event-stream:
           schema:
             title: PushUpdates
             description: An update from the server

--- a/interface/openapi/paths/DeviceRequest.yaml
+++ b/interface/openapi/paths/DeviceRequest.yaml
@@ -75,7 +75,7 @@ get:
     "200":
       description: A stream of components from the specified device manager
       content:
-        application/json:
+        text/event-stream:
           schema:
             $ref: "./Messages.yaml#/$defs/device_component"
   

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -64,7 +64,7 @@ using boost::asio::ip::tcp;
 
 using catena::REST::SocketReader;
 using catena::REST::SocketWriter;
-using catena::REST::ChunkedWriter;
+using catena::REST::SSEWriter;
 
 namespace catena {
 /**
@@ -111,6 +111,10 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
     bool authorizationEnabled() override { return authorizationEnabled_; };
     
   private:
+    /**
+     * @brief Writes a client's options to the socket.
+     */
+    void writeOptions(tcp::socket& socket, const std::string& origin);
     /**
      * @brief Returns true if port_ is already in use.
      * 

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -99,10 +99,6 @@ class SocketReader : public ISocketReader {
      * @brief Returns the origin of the request.
      */
     const std::string& origin() const override { return origin_; }
-    /**
-     * @brief Returns the agent used to send the request.
-     */
-    const std::string& userAgent() const override { return userAgent_; }
 
     /**
      * @brief Returns true if authorization is enabled.
@@ -134,10 +130,6 @@ class SocketReader : public ISocketReader {
      * @brief The origin of the request. Required for CORS headers.
      */
     std::string origin_ = "";
-    /**
-     * @brief The agent the request was sent from.
-     */
-    std::string userAgent_ = "";
     /**
      * @brief True if authorization is enabled.
      */

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -51,6 +51,7 @@ using boost::asio::ip::tcp;
 
 // common
 #include <Status.h>
+#include <utils.h>
 
 namespace catena {
 namespace REST {
@@ -72,7 +73,6 @@ class SocketWriter : public ISocketWriter {
               "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
               "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With\r\n"
               "Access-Control-Allow-Credentials: true\r\n";
-      response_ = "";
     }
     /**
      * @brief Adds the protobuf message to the end of response in JSON format.
@@ -97,21 +97,12 @@ class SocketWriter : public ISocketWriter {
      * finish().
      */
     void finish(google::protobuf::Message& msg);
-    /**
-     * @brief Writes a response to the client detaining their options.
-     * Used when method = OPTIONS.
-     */
-    void writeOptions() override;
 
-  protected:
+  private:
     /**
      * @brief The socket to write to.
      */
     tcp::socket& socket_;
-    /**
-     * @brief The response to write to the socket.
-     */
-    std::string response_;
     /**
      * @brief CORS headers used for all responses.
      * Access-Control-Allow-Origin,
@@ -121,76 +112,74 @@ class SocketWriter : public ISocketWriter {
      */
     std::string CORS_;
     /**
+     * @brief The response to write to the socket.
+     */
+    std::string response_ = "";
+    /**
      * @brief Flag indicating whether the response is a multi-part response.
      * 
      * Used to determine formatting when finish() is called.
      */
     bool multi_ = false;
-    /**
-     * @brief Maps catena::StatusCode to HTTP status codes.
-     */
-    const std::map<catena::StatusCode, int> codeMap_ {
-    {catena::StatusCode::OK,                  200},
-    {catena::StatusCode::CANCELLED,           410},
-    {catena::StatusCode::UNKNOWN,             404},
-    {catena::StatusCode::INVALID_ARGUMENT,    406},
-    {catena::StatusCode::DEADLINE_EXCEEDED,   408},
-    {catena::StatusCode::NOT_FOUND,           410},
-    {catena::StatusCode::ALREADY_EXISTS,      409},
-    {catena::StatusCode::PERMISSION_DENIED,   401},
-    {catena::StatusCode::UNAUTHENTICATED,     407},
-    {catena::StatusCode::RESOURCE_EXHAUSTED,  8},   // TODO
-    {catena::StatusCode::FAILED_PRECONDITION, 412},
-    {catena::StatusCode::ABORTED,             10},  // TODO
-    {catena::StatusCode::OUT_OF_RANGE,        416},
-    {catena::StatusCode::UNIMPLEMENTED,       501},
-    {catena::StatusCode::INTERNAL,            500},
-    {catena::StatusCode::UNAVAILABLE,         503},
-    {catena::StatusCode::DATA_LOSS,           15},  // TODO
-    {catena::StatusCode::DO_NOT_USE,          -1},  // TODO
-    };
 };
 
 /**
- * @brief Helper class used to write to a socket using boost.
- * 
- * Subclass for chunked encoding (Stream response).
+ * @brief Helper class to write Server Sent Events to a socket using boost.
  */
-class ChunkedWriter : public SocketWriter {
+class SSEWriter : public ISocketWriter {
   public:
-    // Using parent constructor
-    using SocketWriter::SocketWriter;
-    ChunkedWriter(tcp::socket& socket, const std::string& origin = "*", const std::string& userAgent = "")
-      : SocketWriter{socket, origin}, userAgent_{userAgent} {}
     /**
-     * @brief Writes a protobuf message to socket in JSON format.
+     * @brief Constructor for SSEWriter.
+     * @param socket The socket to write to.
+     * @param origin The origin of the request.
+     */
+    SSEWriter(tcp::socket& socket, const std::string& origin = "*");
+    /**
+     * @brief Writes a protobuf message to the socket as an SSE.
      * @param msg The protobuf message to write as JSON.
      */
     void write(google::protobuf::Message& msg) override;
     /**
-     * @brief Writes an error message to the socket.
+     * @brief Writes an error message to the socket as an SSE.
      * @param err The catena::exception_with_status.
      */
     void write(catena::exception_with_status& err) override;
     /**
-     * @brief Finishes the chunked writing process.
+     * @brief Finishes the writing process.
+     * 
+     * Does nothing in SSE.
      */
-    void finish() override;
+    void finish() override {}
 
   private:
     /**
-     * @brief Writes headers to the socket in chuncked encoding format.
-     * @param status The catena::exception_with_status of the operation.
+     * @brief The socket to write to.
      */
-    void writeHeaders(catena::exception_with_status& status);
-    /**
-     * @brief Indicates whether the writer has written headers or not. 
-     */
-    bool hasHeaders_ = false;
-    /**
-     * @brief The agent the request was sent from.
-     */
-    std::string userAgent_ = "";
+    tcp::socket& socket_;
+};
+
+/**
+ * @brief Maps catena::StatusCode to HTTP status codes.
+ */
+const std::map<catena::StatusCode, int> codeMap_ {
+  {catena::StatusCode::OK,                  200},
+  {catena::StatusCode::CANCELLED,           410},
+  {catena::StatusCode::UNKNOWN,             404},
+  {catena::StatusCode::INVALID_ARGUMENT,    406},
+  {catena::StatusCode::DEADLINE_EXCEEDED,   408},
+  {catena::StatusCode::NOT_FOUND,           410},
+  {catena::StatusCode::ALREADY_EXISTS,      409},
+  {catena::StatusCode::PERMISSION_DENIED,   401},
+  {catena::StatusCode::UNAUTHENTICATED,     407},
+  {catena::StatusCode::RESOURCE_EXHAUSTED,  8},   // TODO
+  {catena::StatusCode::FAILED_PRECONDITION, 412},
+  {catena::StatusCode::ABORTED,             10},  // TODO
+  {catena::StatusCode::OUT_OF_RANGE,        416},
+  {catena::StatusCode::UNIMPLEMENTED,       501},
+  {catena::StatusCode::INTERNAL,            500},
+  {catena::StatusCode::UNAVAILABLE,         503},
+  {catena::StatusCode::DATA_LOSS,           15},  // TODO
+  {catena::StatusCode::DO_NOT_USE,          -1},  // TODO
 };
 
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -125,7 +125,7 @@ class Connect : public ICallData, public catena::common::Connect {
     /**
      * @brief The SocketWriter object for writing to socket_.
      */
-    ChunkedWriter writer_;
+    SSEWriter writer_;
     /**
      * @brief The mutex to for locking the object while writing
      */

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -118,7 +118,7 @@ class DeviceRequest : public ICallData {
     /**
      * @brief The SocketWriter object for writing to socket_.
      */
-    ChunkedWriter writer_;
+    SSEWriter writer_;
     /**
      * @brief The device to get components from.
      */

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -102,11 +102,6 @@ class ISocketReader {
      */
     virtual const std::string& origin() const = 0;
     /**
-     * @brief Returns the agent used to send the request.
-     */
-    virtual const std::string& userAgent() const = 0;
-
-    /**
      * @brief Returns true if authorization is enabled.
      */
     virtual bool authorizationEnabled() const = 0;

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -78,11 +78,6 @@ class ISocketWriter {
      */
     virtual void write(catena::exception_with_status& err) = 0;
     /**
-     * @brief Writes a response to the client detaining their options.
-     * Used when method = OPTIONS.
-     */
-    virtual void writeOptions() = 0;
-    /**
      * @brief Finishes writing process.
      */
     virtual void finish() = 0;

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -58,6 +58,18 @@ CatenaServiceImpl::CatenaServiceImpl(Device &dm, std::string& EOPath, bool authz
 // Initializing the shutdown signal for all open connections.
 vdk::signal<void()> Connect::shutdownSignal_;
 
+void CatenaServiceImpl::writeOptions(tcp::socket& socket, const std::string& origin) {
+    // Writes a response to the client detailing their options for PUT methods.
+    std::string headers = "HTTP/1.1 204 No Content\r\n"
+                          "Access-Control-Allow-Origin: " + origin + "\r\n"
+                          "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
+                          "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With\r\n"
+                          "Access-Control-Allow-Credentials: true\r\n";
+                          "Content-Length: 0\r\n\r\n";
+    boost::asio::write(socket, boost::asio::buffer(headers));
+    return;
+}
+
 void CatenaServiceImpl::run() {
     // TLS handled by Envoyproxy
     shutdown_ = false;
@@ -81,8 +93,7 @@ void CatenaServiceImpl::run() {
                     std::string rpcKey = context.method() + context.rpc();
                     // Returning options to the client if required.
                     if (context.method() == "OPTIONS") {
-                        SocketWriter writer(socket);
-                        writer.writeOptions();
+                        writeOptions(socket, context.origin());
                     // Otherwise routing to rpc.
                     } else if (router_.canMake(rpcKey)) {
                         std::unique_ptr<ICallData> rpc = router_.makeProduct(rpcKey, socket, context, dm_);

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -8,6 +8,7 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
     rpc_ = "";
     req_ = "";
     jwsToken_ = "";
+    origin_ = "";
     jsonBody_ = "";
     authorizationEnabled_ = authz;
 
@@ -58,22 +59,18 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
     std::size_t contentLength = 0;
     while(std::getline(header_stream, header) && header != "\r") {
         // authz=false once found to avoid further str comparisons.
-        if (authz && header.starts_with("Authorization: Bearer ")) {
+        if (authz && jwsToken_.empty() && header.starts_with("Authorization: Bearer ")) {
             jwsToken_ = header.substr(std::string("Authorization: Bearer ").length());
             // Removing newline.
             jwsToken_.erase(jwsToken_.length() - 1);
             authz = false;
         }
         // Getting origin
-        else if (header.starts_with("Origin: ")) {
+        else if (origin_.empty() && header.starts_with("Origin: ")) {
             origin_ = header.substr(std::string("Origin: ").length());
         }
-        // Getting user-agent
-        else if (header.starts_with("User-Agent: ")) {
-            userAgent_ = header.substr(std::string("User-Agent: ").length());
-        }
         // Getting body content-Length
-        else if (header.starts_with("Content-Length: ")) {
+        else if (contentLength == 0 && header.starts_with("Content-Length: ")) {
             contentLength = stoi(header.substr(std::string("Content-Length: ").length()));
         }
     }

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -7,7 +7,7 @@ using catena::REST::Connect;
 int Connect::objectCounter_ = 0;
 
 Connect::Connect(tcp::socket& socket, SocketReader& context, Device& dm) :
-    socket_{socket}, writer_{socket, context.origin(), context.userAgent()}, ok_{true}, shutdown_{false}, catena::common::Connect(dm, context.authorizationEnabled(), context.jwsToken()) {
+    socket_{socket}, writer_{socket, context.origin()}, ok_{true}, shutdown_{false}, catena::common::Connect(dm, context.authorizationEnabled(), context.jwsToken()) {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -7,7 +7,7 @@ using catena::REST::DeviceRequest;
 int DeviceRequest::objectCounter_ = 0;
 
 DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReader& context, Device& dm) :
-    socket_{socket}, writer_{socket, context.origin(), context.userAgent()}, context_{context}, dm_{dm}, ok_{true} {
+    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm}, ok_{true} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.


### PR DESCRIPTION
Changelog:
- ChunkedWriter has been replaced with SSEWriter, which writes Server Sent Events to the client rather than Chunked encoded responses.
- SSEWriter is no longer a subclass of SocketWriter and is now its own class inheriting ISocketWriter
- WriteOptions moved from SocketWriter to ServiceImpl.
- userAgent removed from SocketReader as the switch to Server Sent Events rendered it useless (Postman supports SSEs)
- Updated openAPI docs for Connect and DeviceRequest. OpenAPI buffers SSEs, but it also bufefd chunked encoding so there is nothing new there.
- moved codeMap_ from SocketWriter to catena::REST. 
- Made many of SocketWriter's variables private since it is no longer inherited.

**Note:** John wants a demo of this working, so maybe hold off on merging until then. This works SO much better than Chunked Encoding ever did. It is also like half the size of ChunkedWriter as the response formatting is a lot simpler.