### PR TITLE
SocketReader URL update

### DIFF
--- a/interface/openapi/catena.openapi.yaml
+++ b/interface/openapi/catena.openapi.yaml
@@ -42,7 +42,7 @@ servers:
   - url: https://device.catenamedia.tv/v1
   - url: http://localhost:443/v1
 paths:
-  /DeviceRequest/slot/{slot}/language/{language}/detail_level/{detail_level}/subscribed_oids/{subscribed_oids}:
+  /DeviceRequest/{slot}:
     $ref: './paths/DeviceRequest.yaml'
   /GetPopulatedSlots:
     $ref: './paths/GetPopulatedSlots.yaml'
@@ -52,7 +52,7 @@ paths:
     $ref: './paths/ExternalObjectRequest.yaml'
   /BasicParamInfoRequest/slot/{slot}/oid_prefix/{oid_prefix}/recursive/{recursive}:
     $ref: './paths/BasicParamInfoRequest.yaml'
-  /GetValue/slot/{slot}/oid/{oid}:
+  /GetValue/{slot}:
     $ref: './paths/GetValue.yaml'
   /SetValue:
     $ref: './paths/SetValue.yaml'

--- a/interface/openapi/catena.openapi.yaml
+++ b/interface/openapi/catena.openapi.yaml
@@ -46,27 +46,27 @@ paths:
     $ref: './paths/DeviceRequest.yaml'
   /GetPopulatedSlots:
     $ref: './paths/GetPopulatedSlots.yaml'
-  /ExecuteCommand/slot/{slot}/oid/{oid}/response/{respond}/proceed/{proceed}:
+  /ExecuteCommand/{slot}:
     $ref: "./paths/ExecuteCommand.yaml"
-  /ExternalObjectRequest/slot/{slot}/oid/{oid}:
+  /ExternalObjectRequest/{slot}:
     $ref: './paths/ExternalObjectRequest.yaml'
-  /BasicParamInfoRequest/slot/{slot}/oid_prefix/{oid_prefix}/recursive/{recursive}:
+  /BasicParamInfoRequest/{slot}:
     $ref: './paths/BasicParamInfoRequest.yaml'
   /GetValue/{slot}:
     $ref: './paths/GetValue.yaml'
-  /SetValue:
+  /SetValue/{slot}:
     $ref: './paths/SetValue.yaml'
-  /MultiSetValue:
+  /MultiSetValue/{slot}:
     $ref: './paths/MultiSetValue.yaml'
-  /UpdateSubscriptions/slot/{slot}:
+  /UpdateSubscriptions/{slot}:
     $ref: './paths/UpdateSubscriptions.yaml'
-  /GetParam/slot/{slot}/oid/{oid}:
+  /GetParam/{slot}:
     $ref: './paths/GetParam.yaml'
-  /Connect/language/{language}/detail_level/{detail_level}/user_agent/{user_agent}/force_connection/{force_connection}:
+  /Connect:
     $ref : './paths/Connect.yaml'
-  /AddLanguage/slot/{slot}/id/{id}:
+  /AddLanguage/{slot}:
     $ref: './paths/AddLanguage.yaml'
-  /LanguagePackRequest/slot/{slot}/language/{language}:
+  /LanguagePackRequest/{slot}:
     $ref: './paths/LanguagePackRequest.yaml'
-  /ListLanguages/slot/{slot}:
+  /ListLanguages/{slot}:
     $ref: './paths/ListLanguages.yaml'

--- a/interface/openapi/paths/AddLanguage.yaml
+++ b/interface/openapi/paths/AddLanguage.yaml
@@ -47,7 +47,7 @@ put:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
     
     - name: id
-      in: path
+      in: query
       required: true
       description: The id of the language pack to add to the device model
       schema:

--- a/interface/openapi/paths/BasicParamInfoRequest.yaml
+++ b/interface/openapi/paths/BasicParamInfoRequest.yaml
@@ -35,7 +35,8 @@
 #
 
 get:
-  summary: Gets a parameter's basic information from the device model plugged into the specified slot
+  summary: Gets a parameter's basic information from the device model plugged
+    into the specified slot
   operationId: BasicParamInfoRequest
 
   parameters:
@@ -47,17 +48,19 @@ get:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid_prefix
-      in: path
+      in: query
       required: false
-      description: Uniquely identifies the starting parameter relative to device.params. Specifying "" selects all top-level parameters
+      description: Uniquely identifies the starting parameter relative to
+        device.params. Specifying "" selects all top-level parameters
       schema:
         type: string
       default: ""
     
     - name: recursive
-      in: path
+      in: query
       required: false
-      description: Optional flag to indicate whether to include all child parameters or not.
+      description: Optional flag to indicate whether to include all child 
+        parameters or not.
       schema:
         type: boolean
       default: false
@@ -79,7 +82,8 @@ get:
                     $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
                   name:
                     title: PolyGlot Text
-                    description: Text that a client can display in one of multiple languages
+                    description: Text that a client can display in one of 
+                      multiple languages
                     type: object
                   type:
                     $ref: "../../../schema/catena.param_schema.json#/$defs/param_type"

--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -39,23 +39,24 @@ get:
   operationId: Connect
 
   parameters:
-    - name: language
-      in: path
+    - name: Language
+      in: header
       required: false
-      description: The langauge code specifiying what language to recieve updates in
+      description: The langauge code specifiying what language to recieve 
+        updates in
       schema:
         type: string
       default: en
 
-    - name: detail_level
-      in: path
+    - name: Detail-Level
+      in: header
       required: false
       description: The level of detail to connect in
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/detail_level"
 
     - name: user_agent
-      in: path
+      in: query
       required: false
       description: The user agent of the client connecting to the service
       schema:
@@ -63,7 +64,7 @@ get:
       default: ""
 
     - name: force_connection
-      in: path
+      in: query
       required: false
       description: Optional flag to force a connection
       schema:
@@ -72,7 +73,10 @@ get:
 
   responses:
     "200":
-      description: A stream of push updates from the server
+      description: A stream of push updates from the server. These updates are
+        sent as server-sent events and have stringified JSON in their data
+        field. This JSON contains a slot number and the data associated with
+        that slot.
       content:
         text/event-stream:
           schema:
@@ -153,3 +157,6 @@ get:
 
               slots_removed:
                 $ref: "../../../schema/catena.device_schema.json#/$defs/slot_list"
+          example:
+            'data: { "slot": 1} data: { "slot": 1, "value": {  "oid": 
+            "/counter",  "value": {   "int32Value": 2  } }}'

--- a/interface/openapi/paths/DeviceRequest.yaml
+++ b/interface/openapi/paths/DeviceRequest.yaml
@@ -46,30 +46,30 @@ get:
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
-    - name: language
-      in: path
+    - name: Language
+      in: header
       required: false
       description: The langauge code specifiying what language to return device components in
       schema:
         type: string
       default: en
   
-    - name: detail_level
-      in: path
+    - name: Detail-Level
+      in: header
       required: false
       description: The level of detail to request the device in
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/detail_level"
 
-    - name: subscribed_oids
-      in: path
-      required: false
-      description: A list of device component oids. Only these components will be returns if detail_level = SUBSCRIPTIONS
-      schema:
-        type: array
-        items:
-          $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
-      default: []
+    # - name: subscribed_oids
+    #   in: path
+    #   required: false
+    #   description: A list of device component oids. Only these components will be returns if detail_level = SUBSCRIPTIONS
+    #   schema:
+    #     type: array
+    #     items:
+    #       $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
+    #   default: []
 
   responses:
     "200":

--- a/interface/openapi/paths/DeviceRequest.yaml
+++ b/interface/openapi/paths/DeviceRequest.yaml
@@ -35,7 +35,8 @@
 #
 
 get:
-  summary: Gets the components of the device model plugged into the specified slot
+  summary: Gets the components of the device model plugged into the specified 
+    slot
   operationId: DeviceRequest
 
   parameters:
@@ -49,7 +50,8 @@ get:
     - name: Language
       in: header
       required: false
-      description: The langauge code specifiying what language to return device components in
+      description: The langauge code specifiying what language to return device
+        components in
       schema:
         type: string
       default: en
@@ -64,7 +66,8 @@ get:
     # - name: subscribed_oids
     #   in: path
     #   required: false
-    #   description: A list of device component oids. Only these components will be returns if detail_level = SUBSCRIPTIONS
+    #   description: A list of device component oids. Only these components 
+    #     will be returns if detail_level = SUBSCRIPTIONS
     #   schema:
     #     type: array
     #     items:
@@ -73,70 +76,16 @@ get:
 
   responses:
     "200":
-      description: A stream of components from the specified device manager
+      description: A stream of device components from the device in the
+        specified slot. These updates are sent as server-sent events and
+        have stringified JSON in their data field.
       content:
         text/event-stream:
           schema:
             $ref: "./Messages.yaml#/$defs/device_component"
   
-          example:
-            - {
-                "device": {
-                  "slot": 1,
-                  "multiSetEnabled": true,
-                  "subscriptions": true,
-                  "accessScopes": [
-                    "st2138:mon",
-                    "st2138:op",
-                    "st2138:cfg",
-                    "st2138:adm"
-                  ],
-                  "defaultScope": "st2138:op"
-                }
-              }
-            - {
-                "languagePack": {
-                  "language": "en",
-                  "languagePack": {
-                    "name": "English",
-                    "words": {
-                      "greeting": "Hello",
-                      "parting": "Goodbye"
-                    }
-                  }
-                }
-              }
-            - {
-                "sharedConstraint": {
-                  "oid": "basic_slider",
-                  "constraint": {
-                    "type": "INT_RANGE",
-                    "int32Range": {
-                      "minValue": -10,
-                      "maxValue": 10,
-                      "step": 1,
-                      "displayMin": -10,
-                      "displayMax": 10
-                    }
-                  }
-                }
-              }
-            - {
-                "param": {
-                  "oid": "text_box",
-                  "param": {
-                    "name": {
-                      "displayStrings": {
-                        "es": "Caja de Texto",
-                        "fr": "Boîte de Texte",
-                        "en": "Text Box"
-                      }
-                    },
-                    "type": "STRING",
-                    "value": {
-                      "stringValue": "Hello, World!"
-                    }
-                  }
-                }
-              }
+          example: 'data: { "device": {  "slot": 1,  "multiSetEnabled": true,
+            "subscriptions": true,  "accessScopes": [   "st2138:mon",   
+            "st2138:op",   "st2138:cfg",   "st2138:adm"  ],  "defaultScope": 
+            "st2138:op" }}'
   

--- a/interface/openapi/paths/ExecuteCommand.yaml
+++ b/interface/openapi/paths/ExecuteCommand.yaml
@@ -47,7 +47,7 @@ put:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid
-      in: path
+      in: query
       required: true
       description: The oid of the command to execute
       schema:
@@ -55,7 +55,7 @@ put:
       default: "pause"
     
     - name: respond
-      in: path
+      in: query
       required: false
       description: Optional flag to supress the server's response
       schema:
@@ -63,9 +63,10 @@ put:
       default: true
     
     - name: proceed
-      in: path
+      in: query
       required: false
-      description: Optional flag indicate whether to send the response instead as the 'DataPayload' variant of the 'Value' message
+      description: Optional flag indicate whether to send the response instead
+         as the 'DataPayload' variant of the 'Value' message
       schema:
         type: boolean
       default: false
@@ -82,13 +83,15 @@ put:
     
   responses:
     "200":
-      description: The server's response will either be a 'Value' or nothing if respond is false
+      description: The server's response will either be a 'Value' or nothing if 
+        'respond' is false
       content:
         application/json:
           schema:
             oneOf:
               - title: No Response
-                description: respond is false or server does not have a response for the command
+                description: respond is false or server does not have a 
+                  response for the command
 
               - $ref: "../../../schema/catena.param_schema.json#/$defs/value"
               

--- a/interface/openapi/paths/ExternalObjectRequest.yaml
+++ b/interface/openapi/paths/ExternalObjectRequest.yaml
@@ -47,7 +47,7 @@ get:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid
-      in: path
+      in: query
       required: true
       description: The path to the object to request from the device model
       schema:
@@ -56,7 +56,8 @@ get:
 
   responses:
     "200":
-      description: A 'DataPayload' variant of the 'Value' message and a flag indicating whether the object is cachable or not
+      description: A 'DataPayload' variant of the 'Value' message and a flag 
+        indicating whether the object is cachable or not
       content:
         application/json:
           schema:

--- a/interface/openapi/paths/GetParam.yaml
+++ b/interface/openapi/paths/GetParam.yaml
@@ -42,12 +42,13 @@ get:
     - name: slot
       in: path
       required: true
-      description: The slot of the device model containing the parameters to add/remove from client's subscriptions
+      description: The slot of the device model containing the parameters to 
+        add/remove from client's subscriptions
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid
-      in: path
+      in: query
       required: true
       description: The path to the parameter within the device model to get
       schema:

--- a/interface/openapi/paths/GetPopulatedSlots.yaml
+++ b/interface/openapi/paths/GetPopulatedSlots.yaml
@@ -45,4 +45,4 @@ get:
         application/json:
           schema:
             $ref: "../../../schema/catena.device_schema.json#/$defs/slot_list"
-          example: [1, 2, 3]
+          example: {"slots": [1, 2, 3]}

--- a/interface/openapi/paths/GetValue.yaml
+++ b/interface/openapi/paths/GetValue.yaml
@@ -42,21 +42,25 @@ get:
     - name: slot
       in: path
       required: true
-      description: The slot of the device model containing the parameter to get the value from
+      description: The slot of the device model containing the parameter to get
+        the value from
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid
       in: query
       required: true
-      description: The path to the parameter within the device model to get the value from. For array parameters, suffix with a valid index to only get the value at that index
+      description: The path to the parameter within the device model to get the
+        value from. For array parameters, suffix with a valid index to only get
+        the value at that index
       schema:
         $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
       default: "text_box"
 
   responses:
     "200":
-      description: The value of the parameter specified by oid within the device model
+      description: The value of the parameter specified by oid within the
+        device model
       content:
         application/json:
           schema:

--- a/interface/openapi/paths/GetValue.yaml
+++ b/interface/openapi/paths/GetValue.yaml
@@ -47,7 +47,7 @@ get:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid
-      in: path
+      in: query
       required: true
       description: The path to the parameter within the device model to get the value from. For array parameters, suffix with a valid index to only get the value at that index
       schema:

--- a/interface/openapi/paths/LanguagePackRequest.yaml
+++ b/interface/openapi/paths/LanguagePackRequest.yaml
@@ -46,7 +46,7 @@ get:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: language
-      in: path
+      in: query
       required: true
       description: The id of the language pack to get from the device model
       schema:

--- a/interface/openapi/paths/ListLanguages.yaml
+++ b/interface/openapi/paths/ListLanguages.yaml
@@ -58,4 +58,4 @@ get:
               lanugages:
                 title: String_Array
                 type: string_array
-          example: ["en", "fr", "es"]
+          example: {"languages": ["en", "fr", "es"]}

--- a/interface/openapi/paths/MultiSetValue.yaml
+++ b/interface/openapi/paths/MultiSetValue.yaml
@@ -38,9 +38,19 @@ put:
   summary: Set the value of multiple parameters within a device model
   operationId: MultiSetValue
 
+  parameters:
+    - name: slot
+      in: path
+      required: true
+      description: The slot of the device model containing the parameters to
+        set the values of
+      schema:
+        $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
+
   requestBody:
     required: true
-    description: A device's slot and a collection of parameter oids and values to set them to
+    description: A device's slot and a collection of parameter oids and values
+      to set them to
     content:
       application/json:
         type: object

--- a/interface/openapi/paths/MultiSetValue.yaml
+++ b/interface/openapi/paths/MultiSetValue.yaml
@@ -49,8 +49,7 @@ put:
 
   requestBody:
     required: true
-    description: A device's slot and a collection of parameter oids and values
-      to set them to
+    description: A collection of parameter oids and the values to set them to
     content:
       application/json:
         type: object
@@ -62,32 +61,11 @@ put:
             items:
               $ref: "./Messages.yaml#/$defs/set_value_payload"
         example: {
-            "slot": 1,
             "values": [
               {"oid": "/text_box", "value": {"string_value": "Goodbye, world!"}},
               {"oid": "/counter", "value": {"int32_value": 0}}
             ]
           }
-
-  # Commented out for now, at least while we still use json body and until URL
-  # format is finalized.
-  # parameters:
-  #   - name: slot
-  #     in: path
-  #     required: true
-  #     description: The slot of the device model containing the parameter to set the value of
-  #     schema:
-  #       $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
-
-  #   - name: values
-  #     in: requestBody
-  #     required: true
-  #     description: A collection of parameter oids and values to set them to
-  #     schema:
-  #       type: array
-  #       items:
-  #         $ref: "./Messages.yaml#/$defs/set_value_payload"
-  #     example: [{"oid": "/text_box", "value": {"string_value": "Goodbye, world!"}}]
       
   responses:
     "200":

--- a/interface/openapi/paths/SetValue.yaml
+++ b/interface/openapi/paths/SetValue.yaml
@@ -49,7 +49,7 @@ put:
 
   requestBody:
     required: true
-    description: A device's slot, a parameter's oid, and a value to set it to
+    description: A parameter's oid and the value to set it to
     content:
       application/json:
         type: object
@@ -58,33 +58,7 @@ put:
             $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
           value:
             $ref: "./Messages.yaml#/$defs/set_value_payload"
-        example: {"slot": 1, "value": {"oid": "/text_box", "value":{"string_value": "Goodbye, world!"}}}
-
-  # Commented out for now, at least while we still use json body and until URL
-  # format is finalized.
-  # parameters:
-    # - name: slot
-    #   in: path
-    #   required: true
-    #   description: The slot of the device model containing the parameter to set the value of
-    #   schema:
-    #     $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
-
-    # - name: oid
-    #   in: path
-    #   required: true
-    #   description: The path to the parameter within the device model to set the value of. For array parameters, suffix with a valid index to only set the value at that index, or with '-' to append to the end
-    #   schema:
-    #     $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
-    #   example: "text_box"
-
-    # - name: value
-    #   in: path
-    #   required: true
-    #   description: The value to set the parameter specified by oid to
-    #   schema:
-    #     $ref: "../../../schema/catena.param_schema.json#/$defs/value"
-    #   example: {string_value: "Goodbye, world!"}
+        example: {"oid": "/text_box", "value":{"string_value": "Goodbye, world!"}}
 
   responses:
     "200":

--- a/interface/openapi/paths/SetValue.yaml
+++ b/interface/openapi/paths/SetValue.yaml
@@ -38,6 +38,15 @@ put:
   summary: Set the value of a parameter within a device model
   operationId: SetValue
 
+  parameters:
+    - name: slot
+      in: path
+      required: true
+      description: The slot of the device model containing the parameter to set
+        the value of
+      schema:
+        $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
+
   requestBody:
     required: true
     description: A device's slot, a parameter's oid, and a value to set it to

--- a/interface/openapi/paths/UpdateSubscriptions.yaml
+++ b/interface/openapi/paths/UpdateSubscriptions.yaml
@@ -35,14 +35,16 @@
 #
 
 put:
-  summary: Updates a client's subscriptions, affecting the output of the Connect and DeviceRequest RPCs on detail_level SUBSCRIPTIONS.
+  summary: Updates a client's subscriptions, affecting the output of the
+    Connect and DeviceRequest RPCs on detail_level SUBSCRIPTIONS.
   operationId: UpdateSubscriptions
 
   parameters:
     - name: slot
       in: path
       required: true
-      description: The slot of the device model containing the parameters to add/remove from client's subscriptions
+      description: The slot of the device model containing the parameters to
+        add/remove from client's subscriptions
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
@@ -74,7 +76,8 @@ put:
         application/json:
           schema:
             title: Component Param
-            description: A parameter and the slot of the device manager it was recieved from
+            description: A parameter and the slot of the device manager it was
+              recieved from
             type: object
             properties:
               slot:
@@ -82,7 +85,8 @@ put:
               # Problems linking param
               param:
                 title: Parameter
-                description: Defines the type, value, constraints, UI, access modes and configuration options of a parameter.
+                description: Defines the type, value, constraints, UI, access
+                  modes and configuration options of a parameter.
                 type: object
 
           example:

--- a/sdks/cpp/connections/REST/CMakeLists.txt
+++ b/sdks/cpp/connections/REST/CMakeLists.txt
@@ -28,7 +28,7 @@ endif(APPLE)
 set(target catena_connections_REST)
 set(REST_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-find_package(Boost 1.64 REQUIRED COMPONENTS system date_time)
+find_package(Boost 1.81 REQUIRED COMPONENTS system date_time url)
 
 set(sources
     "src/ServiceImpl.cpp"
@@ -68,6 +68,7 @@ target_link_libraries(${target}
     PUBLIC
         proto_interface
         Boost::system
+        Boost::url
         jwt-cpp::jwt-cpp
         catena_proto_common
         absl::flags_parse

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -39,6 +39,7 @@
 
 // common
 #include <Status.h>
+#include <Enums.h>
 
 // connections/REST
 #include "interface/ISocketReader.h"
@@ -75,18 +76,16 @@ class SocketReader : public ISocketReader {
     /**
      * @brief Returns the rpc of the request.
      */
-    const std::string& rpc() const override { return rpc_; }
+    const std::string& service() const override { return service_; }
     /**
-     * @brief Parsed req_ for fields.
+     * @brief Returns the slot of the device to make the API call on.
+     */
+    uint32_t slot() const override { return slot_; };
+    /**
+     * @brief Returns the field "key" queried from the URL, or an empty sting
+     * if it does not exist.
      * 
-     * @param fields A map continaing the fields to parse and an empty
-     * string to place the parsed field in.
-     * fields is order dependent. The keys must be placed in the same order
-     * in which they appear in the URL. Additionally, the last field is
-     * assumed to be until the end of the request unless specified
-     * otherwise.
-     * 
-     * @todo Update once URL format is finalized.
+     * @param key The name of the field to retrieve.
      */
     const std::string& fields(const std::string& key) const override {
       if (fields_.find(key) != fields_.end()) {
@@ -100,14 +99,21 @@ class SocketReader : public ISocketReader {
      */
     const std::string& jwsToken() const override { return jwsToken_; }
     /**
-     * @brief Returns the json body of the request, which may be empty.
-     */
-    const std::string& jsonBody() const override { return jsonBody_; }
-    /**
      * @brief Returns the origin of the request.
      */
     const std::string& origin() const override { return origin_; }
-    uint32_t slot() const override { return slot_; };
+    /**
+     * @brief Returns the language to return the resposne in.
+     */
+    const std::string& language() const override { return language_; };
+    /**
+     * @brief Returns the detail level to return the response in.
+     */
+    int detailLevel() const override { return detailLevel_; };
+    /**
+     * @brief Returns the json body of the request, which may be empty.
+     */
+    const std::string& jsonBody() const override { return jsonBody_; }
 
     /**
      * @brief Returns true if authorization is enabled.
@@ -122,11 +128,11 @@ class SocketReader : public ISocketReader {
     /**
      * @brief The rpc of the request (/v1/GetValue, etc.)
      */
-    std::string rpc_ = "";
+    std::string service_ = "";
     /**
-     * @brief The request string (bit after "method .../rpc_").
+     * @brief The slot of the device to make the API call on.
      */
-    std::string req_ = "";
+    uint32_t slot_;
     /**
      * @brief The client's jws token (empty if authorization is disabled).
      */
@@ -139,14 +145,23 @@ class SocketReader : public ISocketReader {
      * @brief The origin of the request. Required for CORS headers.
      */
     std::string origin_ = "";
-
     /**
-     * @brief 
+     * @brief The language to return the response in.
      */
-    uint32_t slot_;
-    std::string fieldNotFound = "";
-
+    std::string language_ = "";
+    /**
+     * @brief The detail level to return the response in.
+     */
+    int detailLevel_ = -1;
+    /**
+     * @brief A map of fields queried from the URL.
+     */
     std::unordered_map<std::string, std::string> fields_;
+    /**
+     * @brief An empty string var to return if the field is not found.
+     * Exists to avoid scope issues.
+     */
+    std::string fieldNotFound = "";
     /**
      * @brief True if authorization is enabled.
      */

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -46,7 +46,9 @@
 // boost
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/url.hpp>
 using boost::asio::ip::tcp;
+using namespace boost::urls;
 
 #include <string>
 #include <iostream>
@@ -86,7 +88,13 @@ class SocketReader : public ISocketReader {
      * 
      * @todo Update once URL format is finalized.
      */
-    void fields(std::unordered_map<std::string, std::string>& fieldMap) const override;
+    const std::string& fields(const std::string& key) const override {
+      if (fields_.find(key) != fields_.end()) {
+        return fields_.at(key);
+      } else {
+        return fieldNotFound;
+      }
+    }
     /**
      * @brief Returns the client's jws token.
      */
@@ -103,6 +111,7 @@ class SocketReader : public ISocketReader {
      * @brief Returns the agent used to send the request.
      */
     const std::string& userAgent() const override { return userAgent_; }
+    uint32_t slot() const override { return slot_; };
 
     /**
      * @brief Returns true if authorization is enabled.
@@ -138,6 +147,13 @@ class SocketReader : public ISocketReader {
      * @brief The agent the request was sent from.
      */
     std::string userAgent_ = "";
+    /**
+     * @brief 
+     */
+    uint32_t slot_;
+    std::string fieldNotFound = "";
+
+    std::unordered_map<std::string, std::string> fields_;
     /**
      * @brief True if authorization is enabled.
      */

--- a/sdks/cpp/connections/REST/include/controllers/AddLanguage.h
+++ b/sdks/cpp/connections/REST/include/controllers/AddLanguage.h
@@ -122,19 +122,6 @@ class AddLanguage : public ICallData {
      * @brief The device to add the language pack to.
      */
     Device& dm_;
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
-
-    /**
-     * @brief The slot of the device to add the language pack to.
-     */
-    int slot_;
-    /**
-     * @brief The language id of the added language (en, fr, etc.).
-     */
-    std::string id_;
 
     /**
      * @brief ID of the AddLanguage object

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -49,7 +49,6 @@
 #include <Device.h>
 #include <utils.h>
 #include <Authorization.h>
-#include <Enums.h>
 
 // Connections/REST
 #include "SocketReader.h"
@@ -130,10 +129,6 @@ class Connect : public ICallData, public catena::common::Connect {
      * @brief The mutex to for locking the object while writing
      */
     std::mutex mtx_;
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
 
     /**
      * @brief Id of operation waiting for valueSetByClient to be emitted.

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -48,7 +48,6 @@
 #include <Device.h>
 #include <utils.h>
 #include <Authorization.h>
-#include <Enums.h>
 
 // Connections/REST
 #include "SocketReader.h"
@@ -123,15 +122,7 @@ class DeviceRequest : public ICallData {
      * @brief The device to get components from.
      */
     Device& dm_;
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
 
-    /**
-     * @brief The detail level to return the stream in.
-     */
-    int detailLevel_;
     /**
      * @brief A list of the subscribed oids to return.
      */

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -129,14 +129,6 @@ class DeviceRequest : public ICallData {
     bool ok_;
 
     /**
-     * @brief The slot of the device to get the components from.
-     */
-    uint32_t slot_;
-    /**
-     * @brief The language to return the stream in.
-     */
-    std::string language_;
-    /**
      * @brief The detail level to return the stream in.
      */
     int detailLevel_;

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -123,19 +123,6 @@ class GetValue : public ICallData {
      * @brief The device to set values of.
      */
     Device& dm_;
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
-
-    /**
-     * @brief The slot of the device to get the value from.
-     */
-    int slot_;
-    /**
-     * @brief The oid of the param to get the value from.
-     */
-    std::string oid_;
 
     /**
      * @brief ID of the GetValue object

--- a/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
@@ -111,6 +111,10 @@ class LanguagePackRequest : public ICallData {
      */
     tcp::socket& socket_;
     /**
+     * @brief The SocketReader object.
+     */
+    SocketReader& context_;
+    /**
      * @brief The SocketWriter object for writing to socket_.
      */
     SocketWriter writer_;
@@ -118,19 +122,6 @@ class LanguagePackRequest : public ICallData {
      * @brief The device to set values of.
      */
     Device& dm_;
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
-
-    /**
-     * @brief The slot of the device to get the value from.
-     */
-    int slot_;
-    /**
-     * @brief The oid of the param to get the value from.
-     */
-    std::string language_;
 
     /**
      * @brief ID of the LanguagePackRequest object

--- a/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
+++ b/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
@@ -111,6 +111,10 @@ class ListLanguages : public ICallData {
      */
     tcp::socket& socket_;
     /**
+     * @brief The SocketReader object.
+     */
+    SocketReader& context_;
+    /**
      * @brief The SocketWriter object for writing to socket_.
      */
     SocketWriter writer_;
@@ -118,15 +122,6 @@ class ListLanguages : public ICallData {
      * @brief The device to list languges of.
      */
     Device& dm_;
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
-
-    /**
-     * @brief The slot of the device to get the value from.
-     */
-    int slot_;
 
     /**
      * @brief ID of the ListLanguages object

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -77,16 +77,16 @@ class ISocketReader {
     /**
      * @brief Returns the rpc of the request.
      */
-    virtual const std::string& rpc() const = 0;
+    virtual const std::string& service() const = 0;
     /**
-     * @brief Parsed req_ for fields.
+     * @brief Returns the slot of the device to make the API call on.
+     */
+    virtual uint32_t slot() const = 0;
+    /**
+     * @brief Returns the field "key" queried from the URL, or an empty sting
+     * if it does not exist.
      * 
-     * @param fields A map continaing the fields to parse and an empty
-     * string to place the parsed field in.
-     * fields is order dependent. The keys must be placed in the same order
-     * in which they appear in the URL. Additionally, the last field is
-     * assumed to be until the end of the request unless specified
-     * otherwise.
+     * @param key The name of the field to retrieve.
      */
     virtual const std::string& fields(const std::string& key) const = 0;
     /**
@@ -94,14 +94,21 @@ class ISocketReader {
      */
     virtual const std::string& jwsToken() const = 0;
     /**
-     * @brief Returns the json body of the request, which may be empty.
-     */
-    virtual const std::string& jsonBody() const = 0;
-    /**
      * @brief Returns the origin of the request.
      */
     virtual const std::string& origin() const = 0;
-    virtual uint32_t slot() const = 0;
+    /**
+     * @brief Returns the language to return the resposne in.
+     */
+    virtual const std::string& language() const = 0;
+    /**
+     * @brief Returns the detail level to return the response in.
+     */
+    virtual int detailLevel() const = 0;
+    /**
+     * @brief Returns the json body of the request, which may be empty.
+     */
+    virtual const std::string& jsonBody() const = 0;
 
     /**
      * @brief Returns true if authorization is enabled.

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -88,7 +88,7 @@ class ISocketReader {
      * assumed to be until the end of the request unless specified
      * otherwise.
      */
-    virtual void fields(std::unordered_map<std::string, std::string>& fieldMap) const = 0;
+    virtual const std::string& fields(const std::string& key) const = 0;
     /**
      * @brief Returns the client's jws token.
      */
@@ -105,6 +105,7 @@ class ISocketReader {
      * @brief Returns the agent used to send the request.
      */
     virtual const std::string& userAgent() const = 0;
+    virtual uint32_t slot() const = 0;
 
     /**
      * @brief Returns true if authorization is enabled.

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -90,7 +90,7 @@ void CatenaServiceImpl::run() {
                     // Reading from the socket.
                     SocketReader context;
                     context.read(socket, authorizationEnabled_);
-                    std::string rpcKey = context.method() + context.rpc();
+                    std::string rpcKey = context.method() + context.service();
                     // Returning options to the client if required.
                     if (context.method() == "OPTIONS") {
                         writeOptions(socket, context.origin());

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -63,8 +63,8 @@ void CatenaServiceImpl::writeOptions(tcp::socket& socket, const std::string& ori
     std::string headers = "HTTP/1.1 204 No Content\r\n"
                           "Access-Control-Allow-Origin: " + origin + "\r\n"
                           "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
-                          "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With\r\n"
-                          "Access-Control-Allow-Credentials: true\r\n";
+                          "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With, Language, Detail-Level\r\n"
+                          "Access-Control-Allow-Credentials: true\r\n"
                           "Content-Length: 0\r\n\r\n";
     boost::asio::write(socket, boost::asio::buffer(headers));
     return;

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -26,12 +26,16 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
 
     // Extracting service_ and slot_ from the url (ex: v1/GetValue/{slot}).
     std::string path = u.path();
-    std::size_t pos = path.find_last_of('/');
-    service_ = path.substr(0, pos);
-    try {
-        slot_ = std::stoi(path.substr(pos + 1));
-    } catch (...) {
-        throw catena::exception_with_status("Invalid slot", catena::StatusCode::INVALID_ARGUMENT);
+    if (u.segments().size() <= 2) {
+        service_ = path;
+    } else {
+        std::size_t pos = path.find_last_of('/');
+        service_ = path.substr(0, pos);
+        try {
+            slot_ = std::stoi(path.substr(pos + 1));
+        } catch (...) {
+            throw catena::exception_with_status("Invalid slot", catena::StatusCode::INVALID_ARGUMENT);
+        }
     }
 
     // Parsing query parameters.

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -25,17 +25,19 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
     url_view u(url);
 
     // Extracting service_ and slot_ from the url (ex: v1/GetValue/{slot}).
+    // Slot is not needed for GetPopulatedSlots and Connect.
     std::string path = u.path();
-    if (u.segments().size() <= 2) {
-        service_ = path;
-    } else {
-        std::size_t pos = path.find_last_of('/');
-        service_ = path.substr(0, pos);
-        try {
+    try {
+        if (path.find("Connect") != std::string::npos ||
+            path.find("GetPopulatedSlots") != std::string::npos) {
+            service_ = path;
+        } else {
+            std::size_t pos = path.find_last_of('/');
+            service_ = path.substr(0, pos);
             slot_ = std::stoi(path.substr(pos + 1));
-        } catch (...) {
-            throw catena::exception_with_status("Invalid slot", catena::StatusCode::INVALID_ARGUMENT);
         }
+    } catch (...) {
+        throw catena::exception_with_status("Invalid URL", catena::StatusCode::INVALID_ARGUMENT);
     }
 
     // Parsing query parameters.

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -12,22 +12,15 @@ Connect::Connect(tcp::socket& socket, SocketReader& context, Device& dm) :
     writeConsole(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.
     try {
-        std::unordered_map<std::string, std::string> fields = {
-            {"force_connection", ""},
-            {"user_agent", ""},
-            {"detail_level", ""},
-            {"language", ""}
-        };
-        context.fields(fields);
-        language_ = fields.at("language");
+        language_ = context.fields("language");
         auto& dlMap = DetailLevel().getReverseMap(); // Reverse detail level map.
-        if (dlMap.find(fields.at("detail_level")) != dlMap.end()) {
-            detailLevel_ = dlMap.at(fields.at("detail_level"));
+        if (dlMap.find(context.fields("detail_level")) != dlMap.end()) {
+            detailLevel_ = dlMap.at(context.fields("detail_level"));
         } else {
             detailLevel_ = catena::Device_DetailLevel_NONE;
         }
-        userAgent_ = fields.at("user_agent");
-        forceConnection_ = fields.at("force_connection") == "true";
+        userAgent_ = context.fields("user_agent");
+        forceConnection_ = context.fields("force_connection") == "true";
     // Parse error
     } catch (...) {
         catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -7,27 +7,12 @@ using catena::REST::DeviceRequest;
 int DeviceRequest::objectCounter_ = 0;
 
 DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReader& context, Device& dm) :
-    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm}, ok_{true} {
+    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
-    // Parsing fields and assigning to respective variables.
-    try {
-        auto& dlMap = DetailLevel().getReverseMap(); // Reverse detail level map.
-        if (dlMap.find(context_.fields("detail_level")) != dlMap.end()) {
-            detailLevel_ = dlMap.at(context_.fields("detail_level"));
-        } else {
-            detailLevel_ = catena::Device_DetailLevel_NONE;
-        }
-    // Parse error
-    } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
-        ok_ = false;
-    }
 }
 
 void DeviceRequest::proceed() {
-    if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
     try {
         // controls whether shallow copy or deep copy is used

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -12,22 +12,12 @@ DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReader& context, Device&
     writeConsole(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.
     try {
-        std::unordered_map<std::string, std::string> fields = {
-            {"subscribed_oids", ""},
-            {"detail_level", ""},
-            {"language", ""},
-            {"slot", ""}
-        };
-        context_.fields(fields);
-        slot_ = fields.at("slot") != "" ? std::stoi(fields.at("slot")) : 0;
-        language_ = fields.at("language");
         auto& dlMap = DetailLevel().getReverseMap(); // Reverse detail level map.
-        if (dlMap.find(fields.at("detail_level")) != dlMap.end()) {
-            detailLevel_ = dlMap.at(fields.at("detail_level"));
+        if (dlMap.find(context_.fields("detail_level")) != dlMap.end()) {
+            detailLevel_ = dlMap.at(context_.fields("detail_level"));
         } else {
             detailLevel_ = catena::Device_DetailLevel_NONE;
         }
-        catena::split(subscribedOids_, fields.at("subscribed_oids"), ",");
     // Parse error
     } catch (...) {
         catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -7,28 +7,12 @@ using catena::REST::GetValue;
 int GetValue::objectCounter_ = 0;
 
 GetValue::GetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
-    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm}, ok_{true} {
+    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
-    // Parsing fields and assigning to respective variables.
-    try {
-        std::unordered_map<std::string, std::string> fields = {
-            {"oid", ""},
-            {"slot", ""}
-        };
-        context_.fields(fields);
-        slot_ = fields.at("slot") != "" ? std::stoi(fields.at("slot")) : 0;
-        oid_ = "/" + fields.at("oid");
-    // Parse error
-    } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
-        ok_ = false;
-    }
 }
 
 void GetValue::proceed() {
-    if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
     catena::Value ans;
     catena::exception_with_status rc("", catena::StatusCode::OK);
@@ -36,9 +20,9 @@ void GetValue::proceed() {
         // Getting value at oid from device.
         if (context_.authorizationEnabled()) {
             catena::common::Authorizer authz(context_.jwsToken());
-            rc = dm_.getValue(oid_, ans, authz);
+            rc = dm_.getValue(context_.fields("oid"), ans, authz);
         } else {
-            rc = dm_.getValue(oid_, ans, catena::common::Authorizer::kAuthzDisabled);
+            rc = dm_.getValue(context_.fields("oid"), ans, catena::common::Authorizer::kAuthzDisabled);
         }
 
     // ERROR

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -20,9 +20,9 @@ void GetValue::proceed() {
         // Getting value at oid from device.
         if (context_.authorizationEnabled()) {
             catena::common::Authorizer authz(context_.jwsToken());
-            rc = dm_.getValue(context_.fields("oid"), ans, authz);
+            rc = dm_.getValue("/" + context_.fields("oid"), ans, authz);
         } else {
-            rc = dm_.getValue(context_.fields("oid"), ans, catena::common::Authorizer::kAuthzDisabled);
+            rc = dm_.getValue("/" + context_.fields("oid"), ans, catena::common::Authorizer::kAuthzDisabled);
         }
 
     // ERROR

--- a/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
@@ -7,28 +7,12 @@ using catena::REST::LanguagePackRequest;
 int LanguagePackRequest::objectCounter_ = 0;
 
 LanguagePackRequest::LanguagePackRequest(tcp::socket& socket, SocketReader& context, Device& dm) :
-    socket_{socket}, writer_{socket, context.origin()}, dm_{dm}, ok_{true} {
+    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
-    // Parsing fields and assigning to respective variables.
-    try {
-        std::unordered_map<std::string, std::string> fields = {
-            {"language", ""},
-            {"slot", ""}
-        };
-        context.fields(fields);
-        slot_ = fields.at("slot") != "" ? std::stoi(fields.at("slot")) : 0;
-        language_ = fields.at("language");
-    // Parse error
-    } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
-        ok_ = false;
-    }
 }
 
 void LanguagePackRequest::proceed() {
-    if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
 
     // Getting the requested language pack.
@@ -36,7 +20,7 @@ void LanguagePackRequest::proceed() {
     catena::exception_with_status rc("", catena::StatusCode::OK);
     try {
         Device::LockGuard lg(dm_);
-        rc = dm_.getLanguagePack(language_, ans);
+        rc = dm_.getLanguagePack(context_.fields("language"), ans);
     // ERROR
     } catch (...) {
         rc = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);

--- a/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
@@ -7,26 +7,12 @@ using catena::REST::ListLanguages;
 int ListLanguages::objectCounter_ = 0;
 
 ListLanguages::ListLanguages(tcp::socket& socket, SocketReader& context, Device& dm) :
-    socket_{socket}, writer_{socket}, dm_{dm}, ok_{true} {
+    socket_{socket}, writer_{socket}, context_{context}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
-    // Parsing fields and assigning to respective variables.
-    try {
-        std::unordered_map<std::string, std::string> fields = {
-            {"slot", ""}
-        };
-        context.fields(fields);
-        slot_ = fields.at("slot") != "" ? std::stoi(fields.at("slot")) : 0;
-    // Parse error
-    } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
-        ok_ = false;
-    }
 }
 
 void ListLanguages::proceed() {
-    if (!ok_) { return; }
     writeConsole(CallStatus::kProcess, socket_.is_open());
 
     // Getting language list from the device.

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -17,6 +17,7 @@ MultiSetValue::MultiSetValue(tcp::socket& socket, SocketReader& context, Device&
 
 bool MultiSetValue::toMulti() {
     absl::Status status = google::protobuf::util::JsonStringToMessage(absl::string_view(context_.jsonBody()), &reqs_);
+    reqs_.set_slot(context_.slot());
     return status.ok();
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/SetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/SetValue.cpp
@@ -12,11 +12,7 @@ SetValue::SetValue(tcp::socket& socket, SocketReader& context, Device& dm) :
 }
 
 bool SetValue::toMulti() {
-    catena::SingleSetValuePayload payload;
-    absl::Status status = google::protobuf::util::JsonStringToMessage(absl::string_view(context_.jsonBody()), &payload);
-    if (status.ok()) {
-        reqs_.set_slot(payload.slot());
-        reqs_.add_values()->CopyFrom(payload.value());
-    }
+    reqs_.set_slot(context_.slot());
+    absl::Status status = google::protobuf::util::JsonStringToMessage(absl::string_view(context_.jsonBody()), reqs_.add_values());
     return status.ok();
 }


### PR DESCRIPTION
Changelog:
- Updated url to resemble the following: ```.../v1/{service}/{slot}?{param1=val1}&{param2=val2}&...&{paramN=valN}```.
- Updated sockerReader::read() to use boost::url for parsing.
- Updated socketReader::fields() to instead return field at inputted field..
- Added headers Language and Detail-Level to requests.
- Updated OpenAPI to reflect changes.
- Reflected REST API calls to reflect changes.