### PR TITLE
Removed formatting from json output and streamlined printing options to client.

### DIFF
--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -112,10 +112,6 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
     
   private:
     /**
-     * @brief Writes a client's options to the socket.
-     */
-    void writeOptions(tcp::socket& socket, const std::string& origin);
-    /**
      * @brief Returns true if port_ is already in use.
      * 
      * Currently unused.

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -71,7 +71,7 @@ class SocketWriter : public ISocketWriter {
     SocketWriter(tcp::socket& socket, const std::string& origin = "*") : socket_{socket} {
       CORS_ = "Access-Control-Allow-Origin: " + origin + "\r\n"
               "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
-              "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With\r\n"
+              "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With, Language, Detail-Level\r\n"
               "Access-Control-Allow-Credentials: true\r\n";
     }
     /**


### PR DESCRIPTION
Changelog:
- Removed JSON formatting from output to make more machine readable.
- Updated sockerWriter's unsued bufferedWrite functionality to have no formatting.
- Removed writeOptions from service impl, now done via writing an empty status::OK error via sockerWriter.

Note* Json output can still be pretty printed by both openAPI docs and Postman.