### PR TITLE
Implement BasicParamInfoRequest in REST + enhancement in REST/gRPC

### DIFF
--- a/interface/openapi/paths/BasicParamInfoRequest.yaml
+++ b/interface/openapi/paths/BasicParamInfoRequest.yaml
@@ -48,7 +48,7 @@ get:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid_prefix
-      in: path
+      in: query
       required: false
       description: Uniquely identifies the starting parameter relative to device.params. Specifying "" selects all top-level parameters
       schema:
@@ -56,7 +56,7 @@ get:
       default: ""
     
     - name: recursive
-      in: path
+      in: query
       required: false
       description: Optional flag to indicate whether to include all child parameters or not.
       schema:

--- a/interface/openapi/paths/BasicParamInfoRequest.yaml
+++ b/interface/openapi/paths/BasicParamInfoRequest.yaml
@@ -15,7 +15,7 @@
 # may be used to endorse or promote products derived from this software without
 # specific prior written permission.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -29,14 +29,14 @@
 #
 
 #
-# OpenAPI documentation of the BasicParamInfoRequest RPC for the Catena REST API
+# OpenAPI documentation of the BasicParamInfoRequest Request Handler for the Catena REST API
 # Author: benjamin.whitten@rossvideo.com
-# Date: 25/04/03
+# Author: zuhayr.sarker@rossvideo.com
+# Date: 25/04/22
 #
 
 get:
-  summary: Gets a parameter's basic information from the device model plugged
-    into the specified slot
+  summary: Gets a parameter's basic information from the device model plugged into the specified slot
   operationId: BasicParamInfoRequest
 
   parameters:
@@ -48,65 +48,69 @@ get:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
     - name: oid_prefix
-      in: query
+      in: path
       required: false
-      description: Uniquely identifies the starting parameter relative to
-        device.params. Specifying "" selects all top-level parameters
+      description: Uniquely identifies the starting parameter relative to device.params. Specifying "" selects all top-level parameters
       schema:
         type: string
       default: ""
     
     - name: recursive
-      in: query
+      in: path
       required: false
-      description: Optional flag to indicate whether to include all child 
-        parameters or not.
+      description: Optional flag to indicate whether to include all child parameters or not.
       schema:
         type: boolean
       default: false
 
   responses:
     "200":
-      description: A stream of basic information from the specified parameter(s)
+      description: |
+        Returns a stream of basic information about the specified parameter(s).
+        The response is a sequence of JSON objects, each containing information about a single parameter.
+        Each object in the stream has the following structure:
       content:
         application/json:
           schema:
             title: BasicParamInfoResponse
-            type: object
-            properties:
-              info:
-                title: BasicParamInfoRequest
-                type: object
-                properties:
-                  oid:
-                    $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
-                  name:
-                    title: PolyGlot Text
-                    description: Text that a client can display in one of 
-                      multiple languages
-                    type: object
-                  type:
-                    $ref: "../../../schema/catena.param_schema.json#/$defs/param_type"
-                  template_oid:
-                    $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
-                
-              array_length:
-                title: Integer
-                type: interger
-                description: The depth of the parameter in the searched tree.
+            type: array
+            items:
+              type: object
+              properties:
+                info:
+                  title: BasicParamInfoRequest
+                  type: object
+                  properties:
+                    oid:
+                      $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
+                    name:
+                      title: PolyGlot Text
+                      description: Text that a client can display in one of multiple languages
+                      type: object
+                    type:
+                      $ref: "../../../schema/catena.param_schema.json#/$defs/param_type"
+                    template_oid:
+                      $ref: "../../../schema/catena.param_schema.json#/$defs/oid"
+                  
+                array_length:
+                  title: Integer
+                  type: integer
+                  description: The depth of the parameter in the searched tree.
           
-          example: {
-            "info": {
-              "oid": "text_box",
-              "name": {
-                "display_strings": {
-                  "en": "Text Box",
-                  "fr": "Boîte de Texte",
-                  "es": "Caja de Texto"
-                }
+          example: [
+            {
+              "info": {
+                "oid": "text_box",
+                "name": {
+                  "display_strings": {
+                    "en": "Text Box",
+                    "fr": "Boîte de Texte",
+                    "es": "Caja de Texto"
+                  }
+                },
+                "type": "STRING",
+                "template_oid": ""
               },
-              "type": "STRING",
-              "template_oid": ""
-            },
-            "array_length": 0
-          }
+              "array_length": 0
+            }
+          ]

--- a/sdks/cpp/connections/REST/CMakeLists.txt
+++ b/sdks/cpp/connections/REST/CMakeLists.txt
@@ -43,6 +43,7 @@ set(sources
     "src/controllers/AddLanguage.cpp"
     "src/controllers/LanguagePackRequest.cpp"
     "src/controllers/ListLanguages.cpp"
+    "src/controllers/BasicParamInfoRequest.cpp"
 )
 
 add_library(${target} STATIC ${sources})

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file BasicParamInfoRequest.h
+ * @brief Implements REST BasicParamInfoRequest RPC.
+ * @author zuhayr.sarker@rossvideo.com
+ * @date 2025-04-09
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+#pragma once
+
+// protobuf
+#include <interface/device.pb.h>
+#include <google/protobuf/util/json_util.h>
+ 
+// Connections/REST
+#include "ServiceImpl.h"
+#include "SocketReader.h"
+#include "SocketWriter.h"
+#include "interface/ICallData.h"
+#include <Device.h>
+
+// common
+#include <ParamVisitor.h>
+#include <rpc/TimeNow.h>
+
+using catena::REST::CatenaServiceImpl;
+using catena::REST::CallStatus;
+using catena::common::ParamTag;
+using catena::common::Path;
+using catena::common::ParamVisitor;
+using catena::common::Device;
+using catena::common::IParam;
+using catena::common::Authorizer;
+using catena::common::timeNow;
+using catena::common::IParamVisitor;
+
+namespace catena {
+namespace REST {
+
+/**
+ * @brief CallData class for the BasicParamInfoRequest REST RPC.
+ */
+class BasicParamInfoRequest : public catena::REST::ICallData {
+  public:
+    /**
+     * @brief Constructor for the BasicParamInfoRequest RPC. Calls proceed() once
+     * initialized.
+     *
+     * @param socket The socket to write the response to.
+     * @param context The SocketReader object.
+     * @param dm The device to get the parameter info from.
+     */ 
+    BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, catena::common::Device& dm);
+    
+    /**
+     * @brief BasicParamInfoRequest's main process.
+     */
+    void proceed() override;
+    
+    /**
+     * @brief Finishes the BasicParamInfoRequest process.
+     */
+    void finish() override;
+    
+    /**
+     * @brief Creates a new rpc object for use with GenericFactory.
+     * 
+     * @param socket The socket to write the response stream to.
+     * @param context The SocketReader object.
+     * @param dm The device to connect to.
+     */
+    static ICallData* makeOne(tcp::socket& socket, SocketReader& context, catena::common::Device& dm) {
+      return new BasicParamInfoRequest(socket, context, dm);
+    }
+    
+  private:
+    /**
+     * @brief Helper function to write status messages to the API console.
+     * 
+     * @param status The current state of the RPC (kCreate, kFinish, etc.)
+     * @param ok The status of the RPC (open or closed).
+     */
+    inline void writeConsole(CallStatus status, bool ok) const override {
+      std::cout << "BasicParamInfoRequest::proceed[" << objectId_ << "]: "
+                << timeNow() << " status: "<< static_cast<int>(status)
+                <<", ok: "<< std::boolalpha << ok << std::endl;
+    }
+    
+    /**
+     * @brief Helper method to add a parameter to the responses
+     * @param param The parameter to add
+     * @param authz The authorization object
+     */
+    void addParamToResponses(IParam* param, catena::common::Authorizer& authz);
+    
+    /**
+     * @brief Updates the array lengths of the responses.
+     * 
+     * @param array_name - The name of the array.
+     * @param length - The length of the array.
+     */
+    void updateArrayLengths(const std::string& array_name, uint32_t length);
+
+    /**
+     * @brief The socket to write the response to.
+     */
+    tcp::socket& socket_;
+    
+    /**
+     * @brief The SocketReader object.
+     */
+    SocketReader& context_;
+    
+    /**
+     * @brief The SSEWriter object for writing to socket_.
+     */
+    SSEWriter writer_;
+    
+    /**
+     * @brief The device to get parameter info from.
+     */
+    catena::common::Device& dm_;
+    
+    /**
+     * @brief Flag indicating if the RPC is working correctly.
+     */
+    bool ok_;
+
+    /**
+     * @brief The oid prefix to get parameter info for.
+     */
+    std::string oid_prefix_;
+    
+    /**
+     * @brief Whether to recursively get parameter info.
+     */
+    bool recursive_;
+
+    /**
+     * @brief ID of the BasicParamInfoRequest object
+     */
+    int objectId_;
+    
+    /**
+     * @brief The total # of BasicParamInfoRequest objects.
+     */
+    static int objectCounter_;
+    
+    /**
+     * @brief The vector of BasicParamInfoResponse objects.
+     */
+    std::vector<catena::BasicParamInfoResponse> responses_;
+    
+    /**
+     * @brief Mutex for thread safety when writing responses.
+     */
+    std::mutex mtx_;
+    
+    /**
+     * @brief Lock for the writer to prevent concurrent access.
+     */
+    std::unique_lock<std::mutex> writer_lock_{mtx_, std::defer_lock};
+
+    /**
+     * @brief Visitor class for collecting parameter info
+     */
+    class BasicParamInfoVisitor : public catena::common::IParamVisitor {
+        public:
+            /**
+             * @brief Constructor for the BasicParamInfoVisitor class
+             * @param device The device to visit
+             * @param authz The authorizer
+             * @param responses The vector of responses
+             * @param request The request
+             */
+            BasicParamInfoVisitor(catena::common::Device& device, catena::common::Authorizer& authz,
+                                std::vector<catena::BasicParamInfoResponse>& responses,
+                                BasicParamInfoRequest& request)
+                : device_(device), authz_(authz), responses_(responses), request_(request) {}
+
+            /**
+             * @brief Visit a parameter
+             * @param param The parameter to visit
+             * @param path The path of the parameter
+             */
+            void visit(IParam* param, const std::string& path) override;
+            
+            /**
+             * @brief Visit an array
+             * @param param The array to visit
+             * @param path The path of the array
+             * @param length The length of the array
+             */
+            void visitArray(IParam* param, const std::string& path, uint32_t length) override;
+
+        private:
+            /**
+             * @brief The device to visit within the visitor
+             */
+            catena::common::Device& device_;
+
+            /**
+             * @brief The authorizer within the visitor
+             */
+            catena::common::Authorizer& authz_;
+
+            /**
+             * @brief The vector of responses within the visitor
+             */
+            std::vector<catena::BasicParamInfoResponse>& responses_;
+
+            /**
+             * @brief The request payload within the visitor
+             */
+            BasicParamInfoRequest& request_;
+    };
+};
+
+}; // namespace REST
+}; // namespace catena 

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -30,9 +30,9 @@
 
 /**
  * @file BasicParamInfoRequest.h
- * @brief Implements REST BasicParamInfoRequest RPC.
+ * @brief Implements REST BasicParamInfoRequest controller.
  * @author zuhayr.sarker@rossvideo.com
- * @date 2025-04-09
+ * @date 2025-04-22
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -53,16 +53,10 @@
 #include <ParamVisitor.h>
 #include <rpc/TimeNow.h>
 
-using catena::REST::CatenaServiceImpl;
-using catena::REST::CallStatus;
-using catena::common::ParamTag;
-using catena::common::Path;
-using catena::common::ParamVisitor;
-using catena::common::Device;
+// Forward declarations
 using catena::common::IParam;
-using catena::common::Authorizer;
-using catena::common::timeNow;
 using catena::common::IParamVisitor;
+using catena::common::timeNow;
 
 namespace catena {
 namespace REST {

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -13,6 +13,7 @@ using catena::REST::CatenaServiceImpl;
 #include <controllers/AddLanguage.h>
 #include <controllers/LanguagePackRequest.h>
 #include <controllers/ListLanguages.h>
+#include <controllers/BasicParamInfoRequest.h>
 
 using catena::REST::Connect;
 
@@ -53,6 +54,7 @@ CatenaServiceImpl::CatenaServiceImpl(Device &dm, std::string& EOPath, bool authz
     router_.addProduct("GET/v1/LanguagePackRequest",    LanguagePackRequest::makeOne);
     router_.addProduct("GET/v1/ListLanguages",          ListLanguages::makeOne);
     router_.addProduct("PUT/v1/AddLanguage",            AddLanguage::makeOne);
+    router_.addProduct("GET/v1/BasicParamInfoRequest",  BasicParamInfoRequest::makeOne);
 }
 
 // Initializing the shutdown signal for all open connections.

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -234,7 +234,7 @@ void BasicParamInfoRequest::updateArrayLengths(const std::string& array_name, ui
 // Visits a parameter and adds it to the response vector
 void BasicParamInfoRequest::BasicParamInfoVisitor::visit(IParam* param, const std::string& path) {
     // Only add non-array parameters that aren't the top-most parameter
-    bool isTopParameter = path == request_.oid_prefix_;
+    bool isTopParameter = path == request_.oid_prefix_ || path == "/" + param->getOid();
     bool isArray = param->isArrayType();
     if (isTopParameter || isArray) {
         return;
@@ -246,7 +246,7 @@ void BasicParamInfoRequest::BasicParamInfoVisitor::visit(IParam* param, const st
 // Visits an array and updates the array length information
 void BasicParamInfoRequest::BasicParamInfoVisitor::visitArray(IParam* param, const std::string& path, uint32_t length) {
     // Only add array parameters that aren't the top-most parameter
-    bool isTopParameter = path == request_.oid_prefix_;
+    bool isTopParameter = path == request_.oid_prefix_ || path == "/" + param->getOid();
     if (isTopParameter) {
         return;
     }

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// connections/REST
+#include <controllers/BasicParamInfoRequest.h>
+using catena::REST::BasicParamInfoRequest;
+
+// common
+#include <Tags.h>
+#include <ParamVisitor.h>
+
+// type aliases
+using catena::common::ParamTag;
+using catena::common::Path;
+using catena::common::ParamVisitor;
+using catena::common::IParam;
+using catena::common::Authorizer;
+
+// Initializes the object counter for BasicParamInfoRequest to 0.
+int BasicParamInfoRequest::objectCounter_ = 0;
+
+BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, catena::common::Device& dm) :
+    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm}, ok_{true}, recursive_{false} {
+    objectId_ = objectCounter_++;
+    writeConsole(CallStatus::kCreate, socket_.is_open());
+    
+    // Parsing fields and assigning to respective variables.
+    try {
+        // Handle URL-encoded empty values
+        std::string oid_prefix_value = context.fields("oid_prefix");
+        if (oid_prefix_value == "%7B%7D" || oid_prefix_value == "%7Boid_prefix%7D" || oid_prefix_value.empty()) {
+            oid_prefix_ = "";
+        } else {
+            oid_prefix_ = "/" + oid_prefix_value;
+        }
+        recursive_ = context.fields("recursive") == "true";
+    // Parse error
+    } catch (...) {
+        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
+        writer_.write(err);
+        ok_ = false;
+    }
+}
+
+void BasicParamInfoRequest::proceed() {
+    writeConsole(CallStatus::kCreate, ok_);
+    if (!ok_) {
+        finish();
+        return;
+    }
+
+    writeConsole(CallStatus::kProcess, ok_);
+    if (!ok_) {
+        finish();
+        return;
+    }
+
+    try {
+        std::unique_ptr<IParam> param;
+        catena::exception_with_status rc{"", catena::StatusCode::OK};
+        std::shared_ptr<Authorizer> sharedAuthz;
+        Authorizer* authz;
+        if (context_.authorizationEnabled()) {
+            sharedAuthz = std::make_shared<Authorizer>(context_.jwsToken());
+            authz = sharedAuthz.get();
+        } else {
+            authz = &Authorizer::kAuthzDisabled;
+        }
+
+        // Mode 1: Get all top-level parameters
+        if (oid_prefix_.empty() && !recursive_) {
+            std::vector<std::unique_ptr<IParam>> top_level_params;
+
+            {
+                catena::common::Device::LockGuard lg(dm_);
+                top_level_params = dm_.getTopLevelParams(rc, *authz);
+            }
+
+            if (rc.status == catena::StatusCode::OK && !top_level_params.empty()) {
+                catena::common::Device::LockGuard lg(dm_);
+                responses_.clear();
+                // Process each top-level parameter
+                for (auto& top_level_param : top_level_params) {
+                    // Add the parameter to our response list
+                    addParamToResponses(top_level_param.get(), *authz);
+                    // For array types, calculate and update array length
+                    if (top_level_param->isArrayType()) {
+                        uint32_t array_length = top_level_param->size();
+                        if (array_length > 0) {
+                            updateArrayLengths(top_level_param->getOid(), array_length);
+                        }
+                    }
+                }
+                writer_lock_.lock();
+                for (auto& response : responses_) {
+                    writer_.write(dynamic_cast<google::protobuf::Message&>(response));
+                }
+                writer_lock_.unlock();
+            }
+        }
+        // Mode 2: Get a specific parameter and its children
+        else if (!oid_prefix_.empty()) { 
+            {
+                catena::common::Device::LockGuard lg(dm_);
+                param = dm_.getParam(oid_prefix_, rc, *authz);
+            }
+
+            if (rc.status == catena::StatusCode::OK && param) {
+                responses_.clear();
+                
+                // Add the main parameter first 
+                responses_.emplace_back();
+                param->toProto(responses_.back(), *authz);
+                
+                // If the parameter is an array, update the array length
+                if (param->isArrayType()) {
+                    uint32_t array_length = param->size();
+                    if (array_length > 0) {
+                        updateArrayLengths(param->getOid(), array_length);
+                    }
+                }
+                
+                // If recursive is true, collect all parameter info recursively through visitor pattern
+                if (recursive_) {
+                    BasicParamInfoVisitor visitor(dm_, *authz, responses_, *this);
+                    ParamVisitor::traverseParams(param.get(), oid_prefix_, dm_, visitor);
+                }
+
+                // Write all responses to the client
+                writer_lock_.lock();
+                for (auto& response : responses_) {
+                    writer_.write(dynamic_cast<google::protobuf::Message&>(response));
+                }
+                writer_lock_.unlock();
+            } else {
+                throw catena::exception_with_status(rc.what(), rc.status);
+            }
+        }
+    } catch (catena::exception_with_status& err) {
+        writer_.write(err);
+    } catch (...) {
+        catena::exception_with_status err("Unknown error in BasicParamInfoRequest", catena::StatusCode::UNKNOWN);
+        writer_.write(err);
+    }
+}
+
+void BasicParamInfoRequest::finish() {
+    writeConsole(CallStatus::kFinish, socket_.is_open());
+    writer_.finish();
+    std::cout << "BasicParamInfoRequest[" << objectId_ << "] finished\n";
+}
+
+// Helper method to add a parameter to the responses
+void BasicParamInfoRequest::addParamToResponses(IParam* param, catena::common::Authorizer& authz) {
+    responses_.emplace_back();
+    auto& response = responses_.back();
+    response.mutable_info();
+    param->toProto(response, authz);
+}
+
+// Updates the array_length field in the protobuf responses
+void BasicParamInfoRequest::updateArrayLengths(const std::string& array_name, uint32_t length) {
+    if (length > 0) {
+        for (auto it = responses_.rbegin(); it != responses_.rend(); ++it) {
+            // Only update if the OID exactly matches the array name
+            if (it->info().oid() == array_name) {
+                it->set_array_length(length);
+            }
+        }
+    }
+}
+
+// Visits a parameter and adds it to the response vector
+void BasicParamInfoRequest::BasicParamInfoVisitor::visit(IParam* param, const std::string& path) {
+    // Only add non-array parameters that aren't the top-most parameter
+    bool isTopParameter = path == request_.oid_prefix_;
+    bool isArray = param->isArrayType();
+    if (isTopParameter || isArray) {
+        return;
+    }
+
+    request_.addParamToResponses(param, authz_);
+}
+
+// Visits an array and updates the array length information
+void BasicParamInfoRequest::BasicParamInfoVisitor::visitArray(IParam* param, const std::string& path, uint32_t length) {
+    // Only add array parameters that aren't the top-most parameter
+    bool isTopParameter = path == request_.oid_prefix_;
+    if (isTopParameter) {
+        return;
+    }
+
+    request_.addParamToResponses(param, authz_);
+
+    // Update array length information
+    if (length > 0) {
+        request_.updateArrayLengths(param->getOid(), length);
+    }
+} 

--- a/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/BasicParamInfoRequest.cpp
@@ -170,6 +170,45 @@ void CatenaServiceImpl::BasicParamInfoRequest::proceed(CatenaServiceImpl *servic
                     } else {
                         throw catena::exception_with_status(rc.what(), rc.status);
                     }
+
+                // Mode 3: Get ALL parameters recursively
+                } else if (req_.oid_prefix().empty() && req_.recursive()) {
+                    std::vector<std::unique_ptr<IParam>> top_level_params;
+
+                    {
+                    Device::LockGuard lg(dm_);
+                    top_level_params = dm_.getTopLevelParams(rc, *authz);
+                    }
+
+                    if (rc.status == catena::StatusCode::OK && !top_level_params.empty()) {
+                        Device::LockGuard lg(dm_);                      
+                        responses_.clear();  
+                        // Process each top-level parameter recursively
+                        for (auto& top_level_param : top_level_params) {
+                            // Add the parameter to our response list
+                            addParamToResponses(top_level_param.get(), *authz);
+                            // For array types, calculate and update array length
+                            if (top_level_param->isArrayType()) {
+                                uint32_t array_length = top_level_param->size();
+                                if (array_length > 0) {
+                                    updateArrayLengths(top_level_param->getOid(), array_length);
+                                }
+                            }
+                            
+                            // Collect all parameter info recursively through visitor pattern
+                            BasicParamInfoVisitor visitor(dm_, *authz, responses_, *this);
+                            ParamVisitor::traverseParams(top_level_param.get(), "/" + top_level_param->getOid(), dm_, visitor);
+                        }
+                        
+                        // Begin writing responses back to the client
+                        writer_lock_.lock();
+                        status_ = CallStatus::kWrite;
+                        writer_.Write(responses_[0], this);  //Write the first response
+                        writer_lock_.unlock();
+                        break;  
+                    } else {
+                        throw catena::exception_with_status(rc.what(), rc.status);
+                    }
                 }
 
             } catch (catena::exception_with_status& err) {
@@ -261,7 +300,7 @@ void CatenaServiceImpl::BasicParamInfoRequest::addParamToResponses(IParam* param
 // Visits a parameter and adds it to the response vector
 void CatenaServiceImpl::BasicParamInfoRequest::BasicParamInfoVisitor::visit(IParam* param, const std::string& path) {
     // Only add non-array parameters that aren't the top-most parameter
-    bool isTopParameter = path == request_.req_.oid_prefix();
+    bool isTopParameter = path == request_.req_.oid_prefix() || path == "/" + param->getOid();
     bool isArray = param->isArrayType();
     if (isTopParameter || isArray) {
         return;
@@ -273,7 +312,7 @@ void CatenaServiceImpl::BasicParamInfoRequest::BasicParamInfoVisitor::visit(IPar
 // Visits an array and updates the array length information
 void CatenaServiceImpl::BasicParamInfoRequest::BasicParamInfoVisitor::visitArray(IParam* param, const std::string& path, uint32_t length) {
     // Only add array parameters that aren't the top-most parameter
-    bool isTopParameter = path == request_.req_.oid_prefix();
+    bool isTopParameter = path == request_.req_.oid_prefix() || path == "/" + param->getOid();
     if (isTopParameter) {
         return;
     }


### PR DESCRIPTION
This PR adds BPIR to the REST suite.

As Ben pointed out in issue #545 , we were technically missing a case, which involves recursing through every single parameter in the device (as in, recursing through each top-level parameter). This functionality has since been added to both the REST and gRPC implementations. 

Other than that, BasicParamInfoRequest is essentially nearly the exact same in REST as it is in gRPC, so there shouldn't be much to check aside from what has already been seen. 

I can demo this on Wednesday with the new mode.