### PR TITLE
Preliminary REST LOD support, primarily on DeviceRequest

### DIFF
--- a/interface/device.proto
+++ b/interface/device.proto
@@ -42,6 +42,7 @@ message Device {
     MINIMAL = 2;
     COMMANDS = 3;
     NONE = 4;
+    UNSET = 5;
   }
   DetailLevel detail_level = 2;
 

--- a/sdks/cpp/common/include/Enums.h
+++ b/sdks/cpp/common/include/Enums.h
@@ -65,7 +65,8 @@ inline const common::DetailLevel::FwdMap common::DetailLevel::fwdMap_ = {
   {Device_DetailLevel_SUBSCRIPTIONS, "SUBSCRIPTIONS"},
   {Device_DetailLevel_MINIMAL,       "MINIMAL"},
   {Device_DetailLevel_COMMANDS,      "COMMANDS"},
-  {Device_DetailLevel_NONE,          "NONE"}
+  {Device_DetailLevel_NONE,          "NONE"},
+  {Device_DetailLevel_UNSET,         "UNSET"}
 };
 
 }  // namespace catena

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -416,8 +416,8 @@ Device::DeviceSerializer Device::getDeviceSerializer(Authorizer& authz, const st
         dst->add_access_scopes(scope);
     }
 
-    // If detail level is NONE, only send device info
-    if (detail_level_ == catena::Device_DetailLevel_NONE) {
+    // If detail level is NONE or UNSET, only send device info
+    if (detail_level_ == catena::Device_DetailLevel_NONE || detail_level_ == catena::Device_DetailLevel_UNSET) {
         co_return component;
     }
 
@@ -560,6 +560,7 @@ bool Device::shouldSendParam(const IParam& param, bool is_subscribed, Authorizer
             
             should_send = 
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_NONE)) ||
+                (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_UNSET)) ||
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_MINIMAL) && param.getDescriptor().minimalSet()) ||
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_FULL)) ||
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_SUBSCRIPTIONS) && (param.getDescriptor().minimalSet() || is_subscribed)) ||

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -416,8 +416,8 @@ Device::DeviceSerializer Device::getDeviceSerializer(Authorizer& authz, const st
         dst->add_access_scopes(scope);
     }
 
-    // If detail level is NONE or UNSET, only send device info
-    if (detail_level_ == catena::Device_DetailLevel_NONE || detail_level_ == catena::Device_DetailLevel_UNSET) {
+    // If detail level is NONE, only send device info
+    if (detail_level_ == catena::Device_DetailLevel_NONE) {
         co_return component;
     }
 
@@ -560,7 +560,6 @@ bool Device::shouldSendParam(const IParam& param, bool is_subscribed, Authorizer
             
             should_send = 
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_NONE)) ||
-                (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_UNSET)) ||
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_MINIMAL) && param.getDescriptor().minimalSet()) ||
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_FULL)) ||
                 (casted_detail_level == static_cast<int>(catena::Device_DetailLevel_SUBSCRIPTIONS) && (param.getDescriptor().minimalSet() || is_subscribed)) ||

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -32,6 +32,7 @@
  * @file ServiceImpl
  * @brief Implements REST API
  * @author Benjamin.whitten@rossvideo.com
+ * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2024 Ross Video Ltd
  */
 
@@ -44,7 +45,7 @@
 #include <IParam.h>
 #include <Authorization.h>
 #include <Enums.h>
-
+#include <SubscriptionManager.h>
 // REST
 #include <interface/IServiceImpl.h>
 #include <interface/ICallData.h>
@@ -108,8 +109,18 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
      * @brief Returns true if authorization is enabled.
      */
     bool authorizationEnabled() override { return authorizationEnabled_; };
+
+    /**
+     * @brief Returns a reference to the subscription manager
+     */
+    catena::common::SubscriptionManager& getSubscriptionManager() { return subscriptionManager_; }
     
   private:
+    /**
+     * @brief The subscription manager for handling parameter subscriptions
+     */
+    catena::common::SubscriptionManager subscriptionManager_;
+
     /**
      * @brief Returns true if port_ is already in use.
      * 

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -32,6 +32,7 @@
  * @file SocketReader.h
  * @brief Helper class used to read from a socket using boost.
  * @author benjamin.whitten@rossvideo.com
+ * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
@@ -40,6 +41,7 @@
 // common
 #include <Status.h>
 #include <Enums.h>
+#include <SubscriptionManager.h>
 
 // connections/REST
 #include "interface/ISocketReader.h"
@@ -57,11 +59,19 @@ using namespace boost::urls;
 namespace catena {
 namespace REST {
 
+// Forward declaration
+class CatenaServiceImpl;
+
 /**
  * @brief Helper class used to read from a socket using boost.
  */
 class SocketReader : public ISocketReader {
   public:
+    /**
+     * @brief Constructor for the SocketReader class.
+     * @param service The CatenaServiceImpl object.
+     */
+    SocketReader(CatenaServiceImpl& service);
     /**
      * @brief Populates variables using information read from the inputted
      * socket.
@@ -74,9 +84,9 @@ class SocketReader : public ISocketReader {
      */
     const std::string& method() const override { return method_; }
     /**
-     * @brief Returns the rpc of the request.
+     * @brief Returns the REST endpoint of the request (/v1/GetValue, etc.)
      */
-    const std::string& service() const override { return service_; }
+    const std::string& service() const override { return endpoint_; }
     /**
      * @brief Returns the slot of the device to make the API call on.
      */
@@ -109,11 +119,15 @@ class SocketReader : public ISocketReader {
     /**
      * @brief Returns the detail level to return the response in.
      */
-    int detailLevel() const override { return detailLevel_; };
+    catena::Device_DetailLevel detailLevel() const override { return detailLevel_; };
     /**
      * @brief Returns the json body of the request, which may be empty.
      */
     const std::string& jsonBody() const override { return jsonBody_; }
+    /**
+     * @brief Returns a reference to the subscription manager
+     */
+    catena::common::SubscriptionManager& getSubscriptionManager() override { return subscriptionManager_; }
 
     /**
      * @brief Returns true if authorization is enabled.
@@ -126,9 +140,9 @@ class SocketReader : public ISocketReader {
      */
     std::string method_ = "";
     /**
-     * @brief The rpc of the request (/v1/GetValue, etc.)
+     * @brief The REST endpoint being accessed (/v1/GetValue, etc.)
      */
-    std::string service_ = "";
+    std::string endpoint_ = "";
     /**
      * @brief The slot of the device to make the API call on.
      */
@@ -150,9 +164,13 @@ class SocketReader : public ISocketReader {
      */
     std::string language_ = "";
     /**
+     * @brief The subscription manager for handling parameter subscriptions
+     */
+    catena::common::SubscriptionManager& subscriptionManager_;
+    /**
      * @brief The detail level to return the response in.
      */
-    int detailLevel_ = -1;
+    catena::Device_DetailLevel detailLevel_ = Device_DetailLevel_UNSET;
     /**
      * @brief A map of fields queried from the URL.
      */
@@ -166,6 +184,10 @@ class SocketReader : public ISocketReader {
      * @brief True if authorization is enabled.
      */
     bool authorizationEnabled_ = false;
+    /**
+     * @brief The CatenaServiceImpl object.
+     */
+    CatenaServiceImpl* service_ = nullptr;
 };
 
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -170,7 +170,7 @@ class SocketReader : public ISocketReader {
     /**
      * @brief The detail level to return the response in.
      */
-    catena::Device_DetailLevel detailLevel_ = Device_DetailLevel_UNSET;
+    catena::Device_DetailLevel detailLevel_;
     /**
      * @brief A map of fields queried from the URL.
      */

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -32,6 +32,7 @@
  * @file DeviceRequest.h
  * @brief Implements REST DeviceRequest RPC.
  * @author benjamin.whitten@rossvideo.com
+ * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
@@ -127,6 +128,16 @@ class DeviceRequest : public ICallData {
      * @brief A list of the subscribed oids to return.
      */
     std::vector<std::string> subscribedOids_;
+
+    /**
+     * @brief A list of the subscriptions from the current request.
+     */
+    std::vector<std::string> requestSubscriptions_;
+
+    /**
+     * @brief Serializer for device.
+     */
+    std::unique_ptr<IDevice::IDeviceSerializer> serializer_ = nullptr;
 
     /**
      * @brief ID of the DeviceRequest object

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -42,6 +42,9 @@
 #include <boost/asio/ssl.hpp>
 using boost::asio::ip::tcp;
 
+//common
+#include <SubscriptionManager.h>
+
 #include <string>
 #include <unordered_map>
  
@@ -104,7 +107,7 @@ class ISocketReader {
     /**
      * @brief Returns the detail level to return the response in.
      */
-    virtual int detailLevel() const = 0;
+    virtual catena::Device_DetailLevel detailLevel() const = 0;
     /**
      * @brief Returns the json body of the request, which may be empty.
      */
@@ -114,6 +117,11 @@ class ISocketReader {
      * @brief Returns true if authorization is enabled.
      */
     virtual bool authorizationEnabled() const = 0;
+
+    /**
+     * @brief Returns a reference to the subscription manager
+     */
+    virtual catena::common::SubscriptionManager& getSubscriptionManager() = 0;
 };
  
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -75,7 +75,7 @@ void CatenaServiceImpl::run() {
             if (!shutdown_) {
                 try {
                     // Reading from the socket.
-                    SocketReader context;
+                    SocketReader context(*this);
                     context.read(socket, authorizationEnabled_);
                     std::string rpcKey = context.method() + context.service();
                     // Returning empty response with options to the client if required.

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -95,9 +95,9 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
             boost::asio::read(socket, boost::asio::buffer(&jsonBody_[contentLength - remainingLength], remainingLength));
         }
     }
-    // Setting detail level to none if not set.
+    // Setting detail level to UNSET if not set.
     if (detailLevel_ == Device_DetailLevel_UNSET) {
-        detailLevel_ = catena::Device_DetailLevel_NONE;
+        detailLevel_ = catena::Device_DetailLevel_UNSET;
     }
 }
 

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -95,9 +95,9 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
             boost::asio::read(socket, boost::asio::buffer(&jsonBody_[contentLength - remainingLength], remainingLength));
         }
     }
-    // Setting detail level to UNSET if not set.
+    // Setting detail level to NONE if not set.
     if (detailLevel_ == Device_DetailLevel_UNSET) {
-        detailLevel_ = catena::Device_DetailLevel_UNSET;
+        detailLevel_ = catena::Device_DetailLevel_NONE;
     }
 }
 

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -1,15 +1,23 @@
 
 #include <SocketReader.h>
+#include "ServiceImpl.h"
 using catena::REST::SocketReader;
+
+namespace catena {
+namespace REST {
+
+SocketReader::SocketReader(CatenaServiceImpl& service) 
+    : subscriptionManager_(service.getSubscriptionManager()),
+      service_(&service) {}
 
 void SocketReader::read(tcp::socket& socket, bool authz) {
     // Resetting variables.
     method_ = "";
-    service_ = "";
+    endpoint_ = "";
     jwsToken_ = "";
     origin_ = "";
     jsonBody_ = "";
-    detailLevel_ = -1;
+    detailLevel_ = Device_DetailLevel_UNSET;
     authorizationEnabled_ = authz;
 
     // Reading the headers.
@@ -24,16 +32,16 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
     std::istringstream(header) >> method_ >> url >> httpVersion;
     url_view u(url);
 
-    // Extracting service_ and slot_ from the url (ex: v1/GetValue/{slot}).
+    // Extracting endpoint_ and slot_ from the url (ex: v1/GetValue/{slot}).
     // Slot is not needed for GetPopulatedSlots and Connect.
     std::string path = u.path();
     try {
         if (path.find("Connect") != std::string::npos ||
             path.find("GetPopulatedSlots") != std::string::npos) {
-            service_ = path;
+            endpoint_ = path;
         } else {
             std::size_t pos = path.find_last_of('/');
-            service_ = path.substr(0, pos);
+            endpoint_ = path.substr(0, pos);
             slot_ = std::stoi(path.substr(pos + 1));
         }
     } catch (...) {
@@ -65,7 +73,7 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
             language_.erase(language_.length() - 1); // Removing newline.
         }
         // Getting detail level
-        else if (detailLevel_ == -1 && header.starts_with("Detail-Level: ")) {
+        else if (detailLevel_ == Device_DetailLevel_UNSET && header.starts_with("Detail-Level: ")) {
             std::string dl = header.substr(std::string("Detail-Level: ").length());
             dl.erase(dl.length() - 1); // Removing newline.
             auto& dlMap = catena::common::DetailLevel().getReverseMap(); // Reverse detail level map.
@@ -88,7 +96,10 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
         }
     }
     // Setting detail level to none if not set.
-    if (detailLevel_ == -1) {
+    if (detailLevel_ == Device_DetailLevel_UNSET) {
         detailLevel_ = catena::Device_DetailLevel_NONE;
     }
 }
+
+}; // Namespace REST
+}; // Namespace catena

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -1,4 +1,3 @@
-
 // connections/REST
 #include <controllers/DeviceRequest.h>
 using catena::REST::DeviceRequest;
@@ -10,6 +9,29 @@ DeviceRequest::DeviceRequest(tcp::socket& socket, SocketReader& context, IDevice
     socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
+    // Parsing fields and assigning to respective variables.
+    try {
+        // Split and filter out empty values
+        std::string subscribedOids = context_.fields("subscribed_oids");
+        /** TODO:
+          * %7B%7D is the URL-encoded version of {}
+          * It is unclear whether we should proceed with just simple CSV or JSON
+          * This needs to be updated when the format is decided upon.
+          */
+        if (!subscribedOids.empty() && subscribedOids != "{}" && subscribedOids != "%7B%7D") {
+            catena::split(requestSubscriptions_, subscribedOids, ",");
+            // Add leading slash to OIDs if missing
+            for (auto& oid : requestSubscriptions_) {
+                if (!oid.empty() && oid[0] != '/') {
+                    oid = "/" + oid;
+                }
+            }
+        }
+    // Parse error
+    } catch (...) {
+        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
+        writer_.write(err);
+    }
 }
 
 void DeviceRequest::proceed() {
@@ -25,24 +47,81 @@ void DeviceRequest::proceed() {
         } else {
             authz = &catena::common::Authorizer::kAuthzDisabled;
         }
-        // Getting the component serializer.
-        std::unique_ptr<IDevice::IDeviceSerializer> serializer = dm_.getComponentSerializer(*authz, shallowCopy);
-        // Getting each component ans writing to the stream.
-        while (serializer->hasMore()) {
+
+
+        auto& subscriptionManager = context_.getSubscriptionManager();
+        subscribedOids_ = subscriptionManager.getAllSubscribedOids(dm_);
+        
+        // Track if any subscriptions throw an error
+        bool subscriptionError = false;
+        
+        // If this request has subscriptions, add them
+        if (!requestSubscriptions_.empty()) {
+            // Add new subscriptions to both the manager and our tracking list
+            for (const auto& oid : requestSubscriptions_) {
+                catena::exception_with_status rc{"", catena::StatusCode::OK};
+                if (!subscriptionManager.addSubscription(oid, dm_, rc)) {
+                    subscriptionError = true;
+                    // Build detailed error message
+                    std::string errorMsg = "Failed to add subscription for OID '" + oid + "': ";
+                    if (rc.status == catena::StatusCode::ALREADY_EXISTS) {
+                        errorMsg += "Subscription already exists";
+                    } else if (rc.status == catena::StatusCode::NOT_FOUND) {
+                        errorMsg += "OID not found";
+                    } else if (rc.status == catena::StatusCode::PERMISSION_DENIED) {
+                        errorMsg += "Permission denied";
+                    } else {
+                        errorMsg += rc.what();
+                    }
+                    catena::exception_with_status status(errorMsg, rc.status);
+                    writer_.write(status);
+                    continue; // Skip if subscription fails to add
+                }
+            }
+        }
+
+        // Get final list of subscriptions for this response
+        subscribedOids_ = subscriptionManager.getAllSubscribedOids(dm_);
+
+        // Set the detail level on the device
+        dm_.detail_level(context_.detailLevel());
+
+        // If we're in SUBSCRIPTIONS mode, we'll send minimal set if no subscriptions
+        if (context_.detailLevel() == catena::Device_DetailLevel_SUBSCRIPTIONS) {
+            if (subscribedOids_.empty()) {
+                serializer_ = dm_.getComponentSerializer(*authz, shallowCopy);
+            } else {
+                serializer_ = dm_.getComponentSerializer(*authz, subscribedOids_, shallowCopy);
+            }
+        } else {
+            serializer_ = dm_.getComponentSerializer(*authz, subscribedOids_, shallowCopy);
+        }
+
+        // Getting each component and writing to the stream.
+        while (serializer_->hasMore()) {
             writeConsole(CallStatus::kWrite, socket_.is_open());
             catena::DeviceComponent component{};
             {
             std::lock_guard lg(dm_.mutex());
-            component = serializer->getNext();
+            component = serializer_->getNext();
             }
             writer_.write(component);
+        }
+
+        // If some subscriptions failed, set status code to 202
+        if (subscriptionError) {
+            //writer_.finishWithStatus(202); // Unimplemented
+        } else {
+            writer_.finish();
         }
     // ERROR: Write to stream and end call.
     } catch (catena::exception_with_status& err) {
         writer_.write(err);
+        writer_.finish();
     } catch (...) {
-        catena::exception_with_status err{"Unknown errror", catena::StatusCode::UNKNOWN};
+        catena::exception_with_status err{"Unknown error", catena::StatusCode::UNKNOWN};
         writer_.write(err);
+        writer_.finish();
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -27,8 +27,6 @@ void DeviceRequest::proceed() {
             authz = &catena::common::Authorizer::kAuthzDisabled;
         }
                
-        // Track if any subscriptions throw an error
-        bool subscriptionError = false;
         auto& subscriptionManager = context_.getSubscriptionManager(); 
         subscribedOids_ = subscriptionManager.getAllSubscribedOids(dm_);
 
@@ -56,13 +54,8 @@ void DeviceRequest::proceed() {
             }
             writer_.write(component);
         }
-
-        // If some subscriptions failed, set status code to 202
-        if (subscriptionError) {
-            //writer_.finishWithStatus(202); // Unimplemented
-        } else {
-            writer_.finish();
-        }
+        writer_.finish();
+        
     // ERROR: Write to stream and end call.
     } catch (catena::exception_with_status& err) {
         writer_.write(err);


### PR DESCRIPTION
This is the first part of adding LOD (Level of Detail) support to REST, the second part is going to be with Connect. 

Again, it is mostly similar to the gRPC implementation aside from one MAJOR change - DeviceRequest NO LONGER supports adding/removing subscriptions in REST. This overcomplicates things as it requires an additional POST/PUT handler. This one is simply a GET method that does exactly what it says - request information on device.

It supports all the levels of detail, including subscriptions, but we can fully test subscriptions on it when I finally implement the update subscriptions handler in #532 .

Here are a list of changes:

### Enums.h / device.proto
- Added new `UNSET` detail level in order to allow openAPI to recognize when the client has set a detail level (used to be `NONE`, but the client can set that too)

### ServiceImpl
- SubscriptionManager was switched to be initialized within the service, similar to the gRPC implementation
- The ServiceImplementation now initializes a SocketReader variable with itself (the service)

### SocketReader
- SocketReader has a constructor that has the service passed into it (similarly, a service member variable is added)
  - This needed to be done because the manager needs to persist for the lifespan of the service, not for the lifespan of a SocketReader
  - This also means SocketReader has a reference to the manager  
- Default device LOD is now `UNSET` - this is the uninitialized state 

### Device
- Minor changes to add `UNSET` to the list of detail levels - again, its just a flag to check if the client explicitly set a detail level

### DeviceRequest
- The service is referenced in DeviceRequest, mainly to access the subscription manager
- Fix detail level to be `catena::Device_DetailLevel` instead of `int`
- Needed an optional serializer for DeviceRequest (again, similar to gRPC)
- Utilizes updated system to grab fields from the context
- General functionality for setting the serializer based on detail level
- No longer has update/removal functionality for subscriptions 

### General
- Renamed `service_` variable (the url) to be `endpoint_`, this is more fitting for REST -then the actual `service_` variable can be of type `CatenaServiceImpl`
 