### PR TITLE
Change to pass the subscription manager directly into the socket

### DIFF
--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -110,11 +110,6 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
      */
     bool authorizationEnabled() override { return authorizationEnabled_; };
 
-    /**
-     * @brief Returns a reference to the subscription manager
-     */
-    catena::common::SubscriptionManager& getSubscriptionManager() { return subscriptionManager_; }
-    
   private:
     /**
      * @brief The subscription manager for handling parameter subscriptions

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -69,9 +69,9 @@ class SocketReader : public ISocketReader {
   public:
     /**
      * @brief Constructor for the SocketReader class.
-     * @param service The CatenaServiceImpl object.
+     * @param subscriptionManager The subscription manager to use.
      */
-    SocketReader(CatenaServiceImpl& service);
+    SocketReader(catena::common::SubscriptionManager& subscriptionManager);
     /**
      * @brief Populates variables using information read from the inputted
      * socket.
@@ -184,10 +184,6 @@ class SocketReader : public ISocketReader {
      * @brief True if authorization is enabled.
      */
     bool authorizationEnabled_ = false;
-    /**
-     * @brief The CatenaServiceImpl object.
-     */
-    CatenaServiceImpl* service_ = nullptr;
 };
 
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -37,7 +37,8 @@ CatenaServiceImpl::CatenaServiceImpl(IDevice& dm, std::string& EOPath, bool auth
       port_{port},
       authorizationEnabled_{authz},
       acceptor_{io_context_, tcp::endpoint(tcp::v4(), port)},
-      router_{Router::getInstance()} {
+      router_{Router::getInstance()},
+      subscriptionManager_{} {
     if (authorizationEnabled_) {
         std::cout<<"Authorization enabled."<<std::endl;
     }
@@ -77,7 +78,7 @@ void CatenaServiceImpl::run() {
             if (!shutdown_) {
                 try {
                     // Reading from the socket.
-                    SocketReader context(*this);
+                    SocketReader context(subscriptionManager_);
                     context.read(socket, authorizationEnabled_);
                     std::string rpcKey = context.method() + context.service();
                     // Returning empty response with options to the client if required.

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -6,9 +6,8 @@ using catena::REST::SocketReader;
 namespace catena {
 namespace REST {
 
-SocketReader::SocketReader(CatenaServiceImpl& service) 
-    : subscriptionManager_(service.getSubscriptionManager()),
-      service_(&service) {}
+SocketReader::SocketReader(catena::common::SubscriptionManager& subscriptionManager) 
+    : subscriptionManager_(subscriptionManager) {}
 
 void SocketReader::read(tcp::socket& socket, bool authz) {
     // Resetting variables.


### PR DESCRIPTION
As the title says - thanks Ben for pointing this out. I believe I had initially passed service in as I thought there was more use for it, but I guess that isn't needed.