### PR TITLE
Changes to Connect to support LOD/subscriptions + gRPC/REST refactoring

### DIFF
--- a/.devcontainer/toolchain-cpp.dockerfile
+++ b/.devcontainer/toolchain-cpp.dockerfile
@@ -63,3 +63,4 @@ RUN . /root/toolchain.env \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && sudo apt-get update \
     && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    

--- a/.devcontainer/toolchain-cpp.dockerfile
+++ b/.devcontainer/toolchain-cpp.dockerfile
@@ -63,4 +63,3 @@ RUN . /root/toolchain.env \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && sudo apt-get update \
     && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-    

--- a/.devcontainer/toolchain-cpp.dockerfile
+++ b/.devcontainer/toolchain-cpp.dockerfile
@@ -53,3 +53,13 @@ RUN cd /usr/src/gtest \
     && sudo cmake -DCMAKE_INSTALL_PREFIX=/usr/local/.local CMakeLists.txt \
     && sudo make && sudo cp lib/*.a /usr/lib
 
+# Install Docker & Docker Compose
+RUN . /root/toolchain.env \
+    && sudo apt-get update \
+    && sudo apt-get install ca-certificates curl \
+    && sudo install -m 0755 -d /etc/apt/keyrings \
+    && sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && sudo chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && sudo apt-get update \
+    && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/.devcontainer/toolchain-cpp.dockerfile
+++ b/.devcontainer/toolchain-cpp.dockerfile
@@ -53,13 +53,3 @@ RUN cd /usr/src/gtest \
     && sudo cmake -DCMAKE_INSTALL_PREFIX=/usr/local/.local CMakeLists.txt \
     && sudo make && sudo cp lib/*.a /usr/lib
 
-# Install Docker & Docker Compose
-RUN . /root/toolchain.env \
-    && sudo apt-get update \
-    && sudo apt-get install ca-certificates curl \
-    && sudo install -m 0755 -d /etc/apt/keyrings \
-    && sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
-    && sudo chmod a+r /etc/apt/keyrings/docker.asc \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
-    && sudo apt-get update \
-    && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -45,6 +45,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <Authorization.h>
+#include <SubscriptionManager.h>
 #include "IConnect.h"
 
 #include <interface/device.pb.h>
@@ -73,8 +74,9 @@ class Connect : public IConnect {
      * @param dm The device manager.
      * @param authz true if authorization is enabled, false otherwise.
      * @param jwsToken The client's JWS token.
+     * @param subscriptionManager The subscription manager.
      */
-    Connect(IDevice& dm, bool authz, const std::string& jwsToken) : dm_{dm} {
+    Connect(IDevice& dm, bool authz, const std::string& jwsToken, SubscriptionManager& subscriptionManager) : dm_{dm}, subscriptionManager_{subscriptionManager} {
         if (authz) {
             sharedAuthz_ = std::make_shared<catena::common::Authorizer>(jwsToken);
             authz_ = sharedAuthz_.get();
@@ -115,53 +117,54 @@ class Connect : public IConnect {
                 this->cv_.notify_one();
                 return;
             }
-            
+
+            if (this->authz_ != &catena::common::Authorizer::kAuthzDisabled && !this->authz_->readAuthz(*p)) {
+                return;
+            }
+
+            // Get all subscribed OIDs
+            auto subscribedOids = this->subscriptionManager_.getAllSubscribedOids(this->dm_);
+
             // Check if we should process this update based on detail level
             bool should_update = false;
-            switch (this->detailLevel_) {
-                case catena::Device_DetailLevel_FULL:
+            
+            // Map of detail levels to their update logic
+            const std::unordered_map<int, std::function<bool()>> detailLevelMap {
+                {catena::Device_DetailLevel_FULL, [&]() {
                     // Always update for FULL detail level
-                    should_update = true;
-                    break;
-                    
-                // case catena::Device_DetailLevel_SUBSCRIPTIONS:
-                //     // Update if OID is subscribed or in minimal set
-                //     {
-                //         auto subscribedOids = service_->subscriptionManager_.getAllSubscribedOids(dm_);
-                //         should_update = p->getDescriptor().minimalSet() || 
-                //                       (std::find(subscribedOids.begin(), subscribedOids.end(), oid) != subscribedOids.end());
-                //     }
-                //     break;
-                    
-                case catena::Device_DetailLevel_MINIMAL:
+                    return true;
+                }},
+                {catena::Device_DetailLevel_MINIMAL, [&]() {
                     // For MINIMAL, only update if it's in the minimal set
-                    should_update = p->getDescriptor().minimalSet();
-                    break;
-                    
-                case catena::Device_DetailLevel_COMMANDS:
+                    return p->getDescriptor().minimalSet();
+                }},
+                {catena::Device_DetailLevel_SUBSCRIPTIONS, [&]() {
+                    // Update if OID is subscribed or in minimal set
+                    return p->getDescriptor().minimalSet() || 
+                           (std::find(subscribedOids.begin(), subscribedOids.end(), oid) != subscribedOids.end());
+                }},
+                {catena::Device_DetailLevel_COMMANDS, [&]() {
                     // For COMMANDS, only update command parameters
-                    should_update = p->getDescriptor().isCommand();
-                    break;
-                    
-                case catena::Device_DetailLevel_NONE:
+                    return p->getDescriptor().isCommand();
+                }},
+                {catena::Device_DetailLevel_NONE, [&]() {
                     // Don't send any updates
-                    should_update = false;
-                    break;
-                    
-                default:
-                    std::cout << "Unknown detail level: " << detailLevel_ << std::endl;
-                    // Don't send any updates
-                    should_update = false;
-                    break;
+                    return false;
+                }}
+            };
+
+            auto it = detailLevelMap.find(this->detailLevel_);
+            if (it != detailLevelMap.end()) {
+                should_update = it->second();
+            } else {
+                std::cout << "Unknown detail level: " << detailLevel_ << std::endl;
+                should_update = false;
             }
     
             if (!should_update) {
                 return;
             }
     
-            if (this->authz_ != &catena::common::Authorizer::kAuthzDisabled && !this->authz_->readAuthz(*p)) {
-                return;
-            }
     
             this->res_.mutable_value()->set_oid(oid);
             this->res_.mutable_value()->set_element_index(idx);
@@ -242,6 +245,10 @@ class Connect : public IConnect {
      * @brief The detail level of the response.
      */
     int detailLevel_;
+    /**
+     * @brief The subscription manager.
+     */
+    SubscriptionManager& subscriptionManager_;
     /**
      * @brief The user agent of the client.
      * 

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -76,7 +76,10 @@ class Connect : public IConnect {
      * @param jwsToken The client's JWS token.
      * @param subscriptionManager The subscription manager.
      */
-    Connect(IDevice& dm, bool authz, const std::string& jwsToken, SubscriptionManager& subscriptionManager) : dm_{dm}, subscriptionManager_{subscriptionManager} {
+    Connect(IDevice& dm, bool authz, const std::string& jwsToken, SubscriptionManager& subscriptionManager) : 
+        dm_{dm}, 
+        subscriptionManager_{subscriptionManager},
+        detailLevel_{catena::Device_DetailLevel_UNSET} {
         if (authz) {
             sharedAuthz_ = std::make_shared<catena::common::Authorizer>(jwsToken);
             authz_ = sharedAuthz_.get();
@@ -129,7 +132,7 @@ class Connect : public IConnect {
             bool should_update = false;
             
             // Map of detail levels to their update logic
-            const std::unordered_map<int, std::function<bool()>> detailLevelMap {
+            const std::unordered_map<catena::Device_DetailLevel, std::function<bool()>> detailLevelMap {
                 {catena::Device_DetailLevel_FULL, [&]() {
                     // Always update for FULL detail level
                     return true;
@@ -244,7 +247,7 @@ class Connect : public IConnect {
     /**
      * @brief The detail level of the response.
      */
-    int detailLevel_;
+    catena::Device_DetailLevel detailLevel_;
     /**
      * @brief The subscription manager.
      */

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -49,6 +49,7 @@
 #include <IDevice.h>
 #include <utils.h>
 #include <Authorization.h>
+#include <SubscriptionManager.h>
 
 // Connections/REST
 #include "SocketReader.h"

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -7,7 +7,8 @@ using catena::REST::Connect;
 int Connect::objectCounter_ = 0;
 
 Connect::Connect(tcp::socket& socket, SocketReader& context, IDevice& dm) :
-    socket_{socket}, writer_{socket, context.origin()}, shutdown_{false}, catena::common::Connect(dm, context.authorizationEnabled(), context.jwsToken()) {
+    socket_{socket}, writer_{socket, context.origin()}, shutdown_{false}, 
+    catena::common::Connect(dm, context.authorizationEnabled(), context.jwsToken(), context.getSubscriptionManager()) {
     objectId_ = objectCounter_++;
     writeConsole(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.

--- a/sdks/cpp/connections/gRPC/include/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/Connect.h
@@ -43,11 +43,12 @@
 // connections/gRPC
 #include <ServiceImpl.h>
 #include <SubscriptionManager.h>
+#include <rpc/Connect.h>
 
 /**
 * @brief CallData class for the Connect RPC
 */
-class CatenaServiceImpl::Connect : public CallData {
+class CatenaServiceImpl::Connect : public CallData, public catena::common::Connect {
     public:
         /**
          * @brief Constructor for the CallData class of the Connect gRPC.
@@ -67,6 +68,13 @@ class CatenaServiceImpl::Connect : public CallData {
          * @param ok - Flag to check if the command was successfully executed.
          */
         void proceed(CatenaServiceImpl *service, bool ok) override;
+
+        /**
+         * @brief Returns true if the connection has been cancelled.
+         * 
+         * @return true if the connection has been cancelled, false otherwise.
+         */
+        bool isCancelled() override;
 
     private:
         /**
@@ -143,14 +151,4 @@ class CatenaServiceImpl::Connect : public CallData {
          * @brief ID of the shutdown signal for the Connect object
         */
         unsigned int shutdownSignalId_;
-
-        /**
-         * @brief Updates the response message with parameter values and handles 
-         * authorization checks.
-         * 
-         * @param oid - The OID of the value to update
-         * @param idx - The index of the value to update
-         * @param p - The parameter to update
-         */
-        void updateResponse(const std::string& oid, size_t idx, const IParam* p);
 };

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -105,11 +105,6 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
      */
     enum class CallStatus { kCreate, kProcess, kRead, kWrite, kPostWrite, kFinish };
 
-    /**
-     * @brief The subscription manager for handling parameter subscriptions
-     */
-    catena::common::SubscriptionManager subscriptionManager_;
-
   /*
    * Protected so doxygen picks it up. Essentially private as CatenaServiceImpl
    * cannot be inherited.
@@ -174,6 +169,10 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
      */
     bool authorizationEnabled_;
     /**
+     * @brief The subscription manager for handling parameter subscriptions
+     */
+    catena::common::SubscriptionManager subscriptionManager_;
+    /**
      * @brief Returns the current time as a string including microseconds.
      */
     static std::string timeNow();
@@ -193,6 +192,11 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
      * @brief Flag to set authorization as enabled or disabled
      */
     inline bool authorizationEnabled() const { return authorizationEnabled_; }
+    /**
+     * @brief Get the subscription manager
+     * @return Reference to the subscription manager
+     */
+    inline catena::common::SubscriptionManager& getSubscriptionManager() { return subscriptionManager_; }
 
     //Forward declarations of CallData classes for their respective RPC
     class GetPopulatedSlots;

--- a/sdks/cpp/connections/gRPC/src/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/Connect.cpp
@@ -118,7 +118,7 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
 
             // Waiting for a language to be added to execute code.
             languageAddedId_ = dm_.languageAddedPushUpdate.connect([this](const IDevice::ComponentLanguagePack& l) {
-                updateResponse(l);
+                updateResponse_(l);
             });
 
             // send client a empty update with slot of the device

--- a/sdks/cpp/connections/gRPC/src/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/Connect.cpp
@@ -57,7 +57,8 @@ int CatenaServiceImpl::Connect::objectCounter_ = 0;
  */
 CatenaServiceImpl::Connect::Connect(CatenaServiceImpl *service, IDevice& dm, bool ok)
     : service_{service}, dm_{dm}, writer_(&context_),
-        status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
+        status_{ok ? CallStatus::kCreate : CallStatus::kFinish}, 
+        catena::common::Connect(dm, service->authorizationEnabled(), "", service_->getSubscriptionManager()) {
             std::cout << "Calling registerItem with: " << this << std::endl;
     service->registerItem(this);
     objectId_ = objectCounter_++;
@@ -117,29 +118,7 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
 
             // Waiting for a language to be added to execute code.
             languageAddedId_ = dm_.languageAddedPushUpdate.connect([this](const IDevice::ComponentLanguagePack& l) {
-                try {
-                    // If Connect was cancelled, notify client and end process.
-                    if (this->context_.IsCancelled()){
-                        this->hasUpdate_ = true;
-                        this->cv_.notify_one();
-                        return;
-                    }
-                    // Returning if authorization is enabled and the client does not have monitor scope.
-                    if (service_->authorizationEnabled()) {
-                        catena::common::Authorizer authz{getJWSToken()};
-                        if (!authz.hasAuthz(Scopes().getForwardMap().at(Scopes_e::kMonitor))) {
-                            return;
-                        }
-                    }
-                    // Updating res_'s device_component and pushing update.
-                    auto pack = this->res_.mutable_device_component()->mutable_language_pack();
-                    pack->set_language(l.language());
-                    pack->mutable_language_pack()->CopyFrom(l.language_pack());
-                    this->hasUpdate_ = true;
-                    this->cv_.notify_one();
-                } catch(catena::exception_with_status& why){
-                    // if an error is thrown, no update is pushed to the client
-                }
+                updateResponse(l);
             });
 
             // send client a empty update with slot of the device
@@ -191,99 +170,7 @@ void CatenaServiceImpl::Connect::proceed(CatenaServiceImpl *service, bool ok) {
     }
 }
 
-/**
- * Updates the response message with parameter values and handles authorization checks.
- */
-void CatenaServiceImpl::Connect::updateResponse(const std::string& oid, size_t idx, const IParam* p) {
-    try {
-        // If Connect was cancelled, notify client and end process
-        if (this->context_.IsCancelled()) {
-            this->hasUpdate_ = true;
-            this->cv_.notify_one();
-            return;
-        }
-        
-        // Check if we should process this update based on detail level
-        bool should_update = false;
-        switch (req_.detail_level()) {
-            case catena::Device_DetailLevel_FULL:
-                // Always update for FULL detail level
-                should_update = true;
-                break;
-                
-            case catena::Device_DetailLevel_SUBSCRIPTIONS:
-                // Update if OID is subscribed or in minimal set
-                {
-                    auto subscribedOids = service_->subscriptionManager_.getAllSubscribedOids(dm_);
-                    should_update = p->getDescriptor().minimalSet();
-                    
-                    // Check for exact match or wildcard match
-                    for (const auto& subscribedOid : subscribedOids) {
-                        if (subscribedOid == oid) {
-                            should_update = true;
-                            break;
-                        }
-                        // Check for wildcard match (ends with /*)
-                        if (subscribedOid.length() >= 2 && 
-                            subscribedOid.substr(subscribedOid.length() - 2) == "/*" &&
-                            oid.find(subscribedOid.substr(0, subscribedOid.length() - 2)) == 0) {
-                            should_update = true;
-                            break;
-                        }
-                    }
-                }
-                break;
-                
-            case catena::Device_DetailLevel_MINIMAL:
-                // For MINIMAL, only update if it's in the minimal set
-                should_update = p->getDescriptor().minimalSet();
-                break;
-                
-            case catena::Device_DetailLevel_COMMANDS:
-                // For COMMANDS, only update command parameters
-                should_update = p->getDescriptor().isCommand();
-                break;
-                
-            case catena::Device_DetailLevel_NONE:
-                // Don't send any updates
-                should_update = false;
-                break;
-                
-            default:
-                std::cout << "Unknown detail level: " << req_.detail_level() << std::endl;
-                return;
-        }
-
-        if (!should_update) {
-            return;
-        }
-
-        std::shared_ptr<catena::common::Authorizer> sharedAuthz;
-        catena::common::Authorizer* authz;
-        if (service_->authorizationEnabled()) {
-            sharedAuthz = std::make_shared<catena::common::Authorizer>(getJWSToken());
-            authz = sharedAuthz.get();
-        } else {
-            authz = &catena::common::Authorizer::kAuthzDisabled;
-        }
-
-        if (service_->authorizationEnabled() && !authz->readAuthz(*p)) {
-            return;
-        }
-
-        this->res_.mutable_value()->set_oid(oid);
-        this->res_.mutable_value()->set_element_index(idx);
-        
-        catena::Value* value = this->res_.mutable_value()->mutable_value();
-
-        catena::exception_with_status rc{"", catena::StatusCode::OK};
-        rc = p->toProto(*value, *authz);
-        //If the param conversion was successful, send the update
-        if (rc.status == catena::StatusCode::OK) {
-            this->hasUpdate_ = true;
-            this->cv_.notify_one();
-        }
-    } catch(catena::exception_with_status& why) {
-        // if an error is thrown, no update is pushed to the client
-    }
+// Returns true if the connection has been cancelled.
+bool CatenaServiceImpl::Connect::isCancelled() {
+    return context_.IsCancelled();
 }

--- a/sdks/cpp/connections/gRPC/src/DeviceRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/DeviceRequest.cpp
@@ -100,14 +100,14 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
                 dm_.detail_level(req_.detail_level());
                 
                 // Get service subscriptions from the manager
-                subscribed_oids_ = service_->subscriptionManager_.getAllSubscribedOids(dm_);
+                subscribed_oids_ = service_->getSubscriptionManager().getAllSubscribedOids(dm_);
                 
                 // If this request has subscriptions, add them
                 if (!req_.subscribed_oids().empty()) {
                     // Add new subscriptions to both the manager and our tracking list
                     for (const auto& oid : req_.subscribed_oids()) {
                         catena::exception_with_status rc{"", catena::StatusCode::OK};
-                        if (!service_->subscriptionManager_.addSubscription(oid, dm_, rc)) {
+                        if (!service_->getSubscriptionManager().addSubscription(oid, dm_, rc)) {
                             throw catena::exception_with_status(std::string("Failed to add subscription: ") + rc.what(), rc.status);
                         } else {
                             rpc_subscriptions_.push_back(oid);
@@ -116,7 +116,7 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
                 }
                 
                 // Get final list of subscriptions for this response
-                subscribed_oids_ = service_->subscriptionManager_.getAllSubscribedOids(dm_);
+                subscribed_oids_ = service_->getSubscriptionManager().getAllSubscribedOids(dm_);
                 
                 //Handle authorization
                 std::shared_ptr<catena::common::Authorizer> sharedAuthz;

--- a/sdks/cpp/connections/gRPC/src/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/gRPC/src/UpdateSubscriptions.cpp
@@ -102,7 +102,7 @@ void CatenaServiceImpl::UpdateSubscriptions::proceed(CatenaServiceImpl *service,
                 // Process removed OIDs
                 for (const auto& oid : req_.removed_oids()) {     
                     catena::exception_with_status rc{"", catena::StatusCode::OK};
-                    if (!service_->subscriptionManager_.removeSubscription(oid, dm_, rc)) {
+                    if (!service_->getSubscriptionManager().removeSubscription(oid, dm_, rc)) {
                         throw catena::exception_with_status(std::string("Failed to remove subscription: ") + rc.what(), rc.status);
                     }
                 }
@@ -112,7 +112,7 @@ void CatenaServiceImpl::UpdateSubscriptions::proceed(CatenaServiceImpl *service,
                     std::cout << "Adding subscription for OID: " << oid << std::endl;
                     
                     catena::exception_with_status rc{"", catena::StatusCode::OK};
-                    if (!service_->subscriptionManager_.addSubscription(oid, dm_, rc)) {
+                    if (!service_->getSubscriptionManager().addSubscription(oid, dm_, rc)) {
                         throw catena::exception_with_status(std::string("Failed to add subscription: ") + rc.what(), rc.status);
                     }
                     
@@ -196,7 +196,7 @@ void CatenaServiceImpl::UpdateSubscriptions::sendSubscribedParameters(catena::co
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     
     // Get all subscribed OIDs from the manager
-    const auto& subscribedOids = service_->subscriptionManager_.getAllSubscribedOids(dm_);
+    const auto& subscribedOids = service_->getSubscriptionManager().getAllSubscribedOids(dm_);
     std::cout << "Got " << subscribedOids.size() << " subscribed OIDs" << std::endl;
     
     // Process each subscribed OID


### PR DESCRIPTION
### LOD/Subscription Support
- Subscription Manager is passed in to **Connect** constructor
  - Consequently, there is a subscription manager member variable 
- Implemented subscriptions detail level in **Connect**

### General refactoring
- For some reason, the subscription manager was public on the gRPC implementation, so I made it private with a getter (and refactored the related files)
- REST's **ServiceImpl** does not need a getter for SubManager anymore as it is passed into the socket (from PR #559)
- Removed _updateResponse_ from **gRPC Connect** since it can just use the one under common's Connect

### Other enhancements/improvements
- **Connect** uses a map instead of switch statements now for updating based on different detail levels