### PR TITLE
Refactor gRPC/REST to use Subscription Manager interface

### DIFF
--- a/sdks/cpp/common/include/ISubscriptionManager.h
+++ b/sdks/cpp/common/include/ISubscriptionManager.h
@@ -1,0 +1,100 @@
+#pragma once
+
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file ISubscriptionManager.h
+ * @brief Interface for managing parameter subscriptions in Catena
+ * @author zuhayr.sarker@rossvideo.com
+ * @date 2025-04-24
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+#include <set>
+#include <string>
+#include <vector>
+#include <memory>
+#include <IDevice.h>
+#include <IParam.h>
+
+namespace catena {
+namespace common {
+
+using catena::common::IDevice;
+using catena::common::IParam;
+
+/**
+ * @brief Interface for managing parameter subscriptions in Catena
+ */
+class ISubscriptionManager {
+public:
+    virtual ~ISubscriptionManager() = default;
+
+    /**
+     * @brief Add an OID subscription
+     * @param oid The OID to subscribe to (can be either a unique OID like "/param" or a wildcard like "/param/*")
+     * @param dm The device model to use 
+     * @param rc The status code to return if the operation fails
+     * @return true if the subscription was added, false if it already existed
+     */
+    virtual bool addSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc) = 0;
+
+    /**
+     * @brief Remove an OID subscription
+     * @param oid The OID to unsubscribe from (can be either a unique OID or a wildcard like "/param/*")
+     * @param dm The device model to use
+     * @param rc The status code to return if the operation fails
+     * @return true if the subscription was removed, false if it didn't exist
+     */
+    virtual bool removeSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc) = 0;
+
+    /**
+     * @brief Get all subscribed OIDs, including expanding wildcard subscriptions
+     * @param dm The device model to use 
+     * @return Reference to the vector of all subscribed OIDs
+     */
+    virtual const std::vector<std::string>& getAllSubscribedOids(IDevice& dm) = 0;
+
+    /**
+     * @brief Get all unique subscriptions
+     * @return Reference to the set of unique subscriptions
+     */
+    virtual const std::set<std::string>& getUniqueSubscriptions() = 0;
+
+    /**
+     * @brief Get all wildcard subscriptions
+     * @return Reference to the set of wildcard subscriptions (OIDs ending with "/*")
+     */
+    virtual const std::set<std::string>& getWildcardSubscriptions() = 0;
+};
+
+} // namespace common
+} // namespace catena 

--- a/sdks/cpp/common/include/ISubscriptionManager.h
+++ b/sdks/cpp/common/include/ISubscriptionManager.h
@@ -94,6 +94,13 @@ public:
      * @return Reference to the set of wildcard subscriptions (OIDs ending with "/*")
      */
     virtual const std::set<std::string>& getWildcardSubscriptions() = 0;
+
+    /**
+     * @brief Check if an OID is a wildcard subscription
+     * @param oid The OID to check
+     * @return true if the OID is greater than or equal to 2 characters and ends with "/*"
+     */
+    virtual bool isWildcard(const std::string& oid) = 0;
 };
 
 } // namespace common

--- a/sdks/cpp/common/include/SubscriptionManager.h
+++ b/sdks/cpp/common/include/SubscriptionManager.h
@@ -105,7 +105,7 @@ public:
      * @param oid The OID to check
      * @return true if the OID is greater than or equal to 2 characters and ends with "/*"
      */
-    static bool isWildcard(const std::string& oid);
+    bool isWildcard(const std::string& oid) override;
 
 private:
     /**

--- a/sdks/cpp/common/include/SubscriptionManager.h
+++ b/sdks/cpp/common/include/SubscriptionManager.h
@@ -45,6 +45,7 @@
 #include <IDevice.h>
 #include <IParam.h>
 #include <ParamVisitor.h>
+#include <ISubscriptionManager.h>
 
 namespace catena {
 namespace common {
@@ -55,7 +56,7 @@ using catena::common::IParam;
 /**
  * @brief Class for managing parameter subscriptions in Catena
  */
-class SubscriptionManager {
+class SubscriptionManager : public ISubscriptionManager {
 public:
     /**
      * @brief Constructor
@@ -69,7 +70,7 @@ public:
      * @param rc The status code to return if the operation fails
      * @return true if the subscription was added, false if it already existed
      */
-    bool addSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc);
+    bool addSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc) override;
 
     /**
      * @brief Remove an OID subscription
@@ -78,26 +79,26 @@ public:
      * @param rc The status code to return if the operation fails
      * @return true if the subscription was removed, false if it didn't exist
      */
-    bool removeSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc);
+    bool removeSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc) override;
 
     /**
      * @brief Get all subscribed OIDs, including expanding wildcard subscriptions
      * @param dm The device model to use 
      * @return Reference to the vector of all subscribed OIDs
      */
-    const std::vector<std::string>& getAllSubscribedOids(IDevice& dm);
+    const std::vector<std::string>& getAllSubscribedOids(IDevice& dm) override;
 
     /**
      * @brief Get all unique subscriptions
      * @return Reference to the set of unique subscriptions
      */
-    const std::set<std::string>& getUniqueSubscriptions();
+    const std::set<std::string>& getUniqueSubscriptions() override;
 
     /**
      * @brief Get all wildcard subscriptions
      * @return Reference to the set of wildcard subscriptions (OIDs ending with "/*")
      */
-    const std::set<std::string>& getWildcardSubscriptions();
+    const std::set<std::string>& getWildcardSubscriptions() override;
 
     /**
      * @brief Check if an OID is a wildcard subscription
@@ -155,7 +156,7 @@ private:
 
     /**
      * @brief Set of unique subscriptions
-         */
+     */
     std::set<std::string> uniqueSubscriptions_; 
 
     /**

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -45,7 +45,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <Authorization.h>
-#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 #include "IConnect.h"
 
 #include <interface/device.pb.h>
@@ -76,7 +76,7 @@ class Connect : public IConnect {
      * @param jwsToken The client's JWS token.
      * @param subscriptionManager The subscription manager.
      */
-    Connect(IDevice& dm, bool authz, const std::string& jwsToken, SubscriptionManager& subscriptionManager) : 
+    Connect(IDevice& dm, bool authz, const std::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
         dm_{dm}, 
         subscriptionManager_{subscriptionManager},
         detailLevel_{catena::Device_DetailLevel_UNSET} {
@@ -251,7 +251,7 @@ class Connect : public IConnect {
     /**
      * @brief The subscription manager.
      */
-    SubscriptionManager& subscriptionManager_;
+    ISubscriptionManager& subscriptionManager_;
     /**
      * @brief The user agent of the client.
      * 

--- a/sdks/cpp/common/src/SubscriptionManager.cpp
+++ b/sdks/cpp/common/src/SubscriptionManager.cpp
@@ -42,11 +42,6 @@ using catena::common::ParamVisitor;
 namespace catena {
 namespace common {
 
-// Returns true if the OID ends with "/*", indicating it's a wildcard subscription
-bool SubscriptionManager::isWildcard(const std::string& oid) {
-    return oid.length() >= 2 && oid.substr(oid.length() - 2) == "/*";
-}
-
 // Add a subscription (either unique or wildcard). Returns true if added, false if already exists
 bool SubscriptionManager::addSubscription(const std::string& oid, IDevice& dm, exception_with_status& rc) {
     subscriptionLock_.lock();
@@ -225,6 +220,11 @@ const std::set<std::string>& SubscriptionManager::getWildcardSubscriptions() {
     auto& result = wildcardSubscriptions_;
     subscriptionLock_.unlock();
     return result;
+}
+
+// Returns true if the OID ends with "/*", indicating it's a wildcard subscription
+bool SubscriptionManager::isWildcard(const std::string& oid) {
+    return oid.length() >= 2 && oid.substr(oid.length() - 2) == "/*";
 }
 
 } // namespace common

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -45,7 +45,7 @@
 #include <IParam.h>
 #include <Authorization.h>
 #include <Enums.h>
-#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 // REST
 #include <interface/IServiceImpl.h>
 #include <interface/ICallData.h>
@@ -114,7 +114,7 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
     /**
      * @brief The subscription manager for handling parameter subscriptions
      */
-    catena::common::SubscriptionManager subscriptionManager_;
+    std::unique_ptr<catena::common::ISubscriptionManager> subscriptionManager_;
 
     /**
      * @brief Returns true if port_ is already in use.

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -41,7 +41,7 @@
 // common
 #include <Status.h>
 #include <Enums.h>
-#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 
 // connections/REST
 #include "interface/ISocketReader.h"
@@ -71,7 +71,7 @@ class SocketReader : public ISocketReader {
      * @brief Constructor for the SocketReader class.
      * @param subscriptionManager The subscription manager to use.
      */
-    SocketReader(catena::common::SubscriptionManager& subscriptionManager);
+    SocketReader(catena::common::ISubscriptionManager& subscriptionManager);
     /**
      * @brief Populates variables using information read from the inputted
      * socket.
@@ -127,7 +127,7 @@ class SocketReader : public ISocketReader {
     /**
      * @brief Returns a reference to the subscription manager
      */
-    catena::common::SubscriptionManager& getSubscriptionManager() override { return subscriptionManager_; }
+    catena::common::ISubscriptionManager& getSubscriptionManager() override { return subscriptionManager_; }
 
     /**
      * @brief Returns true if authorization is enabled.
@@ -166,7 +166,7 @@ class SocketReader : public ISocketReader {
     /**
      * @brief The subscription manager for handling parameter subscriptions
      */
-    catena::common::SubscriptionManager& subscriptionManager_;
+    catena::common::ISubscriptionManager& subscriptionManager_;
     /**
      * @brief The detail level to return the response in.
      */

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -44,6 +44,7 @@ using boost::asio::ip::tcp;
 
 //common
 #include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 
 #include <string>
 #include <unordered_map>
@@ -121,7 +122,7 @@ class ISocketReader {
     /**
      * @brief Returns a reference to the subscription manager
      */
-    virtual catena::common::SubscriptionManager& getSubscriptionManager() = 0;
+    virtual catena::common::ISubscriptionManager& getSubscriptionManager() = 0;
 };
  
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -80,7 +80,7 @@ void CatenaServiceImpl::run() {
             if (!shutdown_) {
                 try {
                     // Reading from the socket.
-                    SocketReader context(subscriptionManager_);
+                    SocketReader context(*subscriptionManager_);
                     context.read(socket, authorizationEnabled_);
                     std::string rpcKey = context.method() + context.service();
                     // Returning empty response with options to the client if required.

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -39,7 +39,7 @@ CatenaServiceImpl::CatenaServiceImpl(IDevice& dm, std::string& EOPath, bool auth
       authorizationEnabled_{authz},
       acceptor_{io_context_, tcp::endpoint(tcp::v4(), port)},
       router_{Router::getInstance()},
-      subscriptionManager_{} {
+      subscriptionManager_{std::make_unique<catena::common::SubscriptionManager>()} {
     if (authorizationEnabled_) {
         std::cout<<"Authorization enabled."<<std::endl;
     }

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -6,7 +6,7 @@ using catena::REST::SocketReader;
 namespace catena {
 namespace REST {
 
-SocketReader::SocketReader(catena::common::SubscriptionManager& subscriptionManager) 
+SocketReader::SocketReader(catena::common::ISubscriptionManager& subscriptionManager) 
     : subscriptionManager_(subscriptionManager) {}
 
 void SocketReader::read(tcp::socket& socket, bool authz) {

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -1,5 +1,6 @@
 // connections/REST
 #include <controllers/DeviceRequest.h>
+#include <ISubscriptionManager.h>
 using catena::REST::DeviceRequest;
 
 // Initializes the object counter for Connect to 0.
@@ -27,7 +28,7 @@ void DeviceRequest::proceed() {
             authz = &catena::common::Authorizer::kAuthzDisabled;
         }
                
-        auto& subscriptionManager = context_.getSubscriptionManager(); 
+        auto& subscriptionManager = context_.getSubscriptionManager();
         subscribedOids_ = subscriptionManager.getAllSubscribedOids(dm_);
 
         // Set the detail level on the device

--- a/sdks/cpp/connections/gRPC/include/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/Connect.h
@@ -42,7 +42,7 @@
 
 // connections/gRPC
 #include <ServiceImpl.h>
-#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 #include <rpc/Connect.h>
 
 /**

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -50,6 +50,7 @@
 // gRPC interface
 #include <interface/service.grpc.pb.h>
 #include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 
 #include <grpcpp/grpcpp.h>
 #include <jwt-cpp/jwt.h>
@@ -104,6 +105,11 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
      * @brief CallData states.
      */
     enum class CallStatus { kCreate, kProcess, kRead, kWrite, kPostWrite, kFinish };
+
+    /**
+     * @brief The subscription manager for handling parameter subscriptions
+     */
+    std::unique_ptr<catena::common::ISubscriptionManager> subscriptionManager_;
 
   /*
    * Protected so doxygen picks it up. Essentially private as CatenaServiceImpl

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -106,11 +106,6 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
      */
     enum class CallStatus { kCreate, kProcess, kRead, kWrite, kPostWrite, kFinish };
 
-    /**
-     * @brief The subscription manager for handling parameter subscriptions
-     */
-    std::unique_ptr<catena::common::ISubscriptionManager> subscriptionManager_;
-
   /*
    * Protected so doxygen picks it up. Essentially private as CatenaServiceImpl
    * cannot be inherited.
@@ -177,7 +172,7 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
     /**
      * @brief The subscription manager for handling parameter subscriptions
      */
-    catena::common::SubscriptionManager subscriptionManager_;
+    std::unique_ptr<catena::common::ISubscriptionManager> subscriptionManager_;
     /**
      * @brief Returns the current time as a string including microseconds.
      */
@@ -202,7 +197,7 @@ class CatenaServiceImpl : public catena::CatenaService::AsyncService {
      * @brief Get the subscription manager
      * @return Reference to the subscription manager
      */
-    inline catena::common::SubscriptionManager& getSubscriptionManager() { return subscriptionManager_; }
+    inline catena::common::ISubscriptionManager& getSubscriptionManager() { return *subscriptionManager_; }
 
     //Forward declarations of CallData classes for their respective RPC
     class GetPopulatedSlots;

--- a/sdks/cpp/connections/gRPC/include/UpdateSubscriptions.h
+++ b/sdks/cpp/connections/gRPC/include/UpdateSubscriptions.h
@@ -43,7 +43,7 @@
 #include <ServiceImpl.h>
 #include <atomic>
 #include <mutex>
-#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 
 /**
  * @brief CallData class for the UpdateSubscriptions RPC

--- a/sdks/cpp/connections/gRPC/src/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/Connect.cpp
@@ -31,8 +31,6 @@
 // common
 #include <Tags.h>
 #include <Enums.h>
-#include <SubscriptionManager.h>
-#include <ISubscriptionManager.h>
 
 // connections/gRPC
 #include <Connect.h>

--- a/sdks/cpp/connections/gRPC/src/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/Connect.cpp
@@ -61,7 +61,7 @@ int CatenaServiceImpl::Connect::objectCounter_ = 0;
 CatenaServiceImpl::Connect::Connect(CatenaServiceImpl *service, IDevice& dm, bool ok)
     : service_{service}, dm_{dm}, writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish}, 
-        catena::common::Connect(dm, service->authorizationEnabled(), "", service_->getSubscriptionManager()) {
+        catena::common::Connect(dm, service->authorizationEnabled(), "", service->getSubscriptionManager()) {
             std::cout << "Calling registerItem with: " << this << std::endl;
     service->registerItem(this);
     objectId_ = objectCounter_++;

--- a/sdks/cpp/connections/gRPC/src/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/Connect.cpp
@@ -31,9 +31,12 @@
 // common
 #include <Tags.h>
 #include <Enums.h>
+#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 
 // connections/gRPC
 #include <Connect.h>
+
 
 // type aliases
 using catena::common::ParamTag;

--- a/sdks/cpp/connections/gRPC/src/DeviceRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/DeviceRequest.cpp
@@ -33,6 +33,7 @@
 
 // connections/gRPC
 #include <DeviceRequest.h>
+#include <ISubscriptionManager.h>
 
 // type aliases
 using catena::common::ParamTag;

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -105,7 +105,7 @@ CatenaServiceImpl::CatenaServiceImpl(ServerCompletionQueue *cq, IDevice& dm, std
           dm_{dm}, 
           EOPath_{EOPath}, 
           authorizationEnabled_{authz},
-          subscriptionManager_{} {}
+          subscriptionManager_{std::make_unique<catena::common::SubscriptionManager>()} {}
 
 /**
  * Creates the CallData objects for each gRPC command.

--- a/sdks/cpp/connections/gRPC/src/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/gRPC/src/UpdateSubscriptions.cpp
@@ -33,7 +33,7 @@
 
 // connections/gRPC
 #include <UpdateSubscriptions.h>
-#include <SubscriptionManager.h>
+#include <ISubscriptionManager.h>
 
 // type aliases
 using catena::common::ParamTag;

--- a/sdks/cpp/connections/gRPC/src/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/gRPC/src/UpdateSubscriptions.cpp
@@ -33,7 +33,6 @@
 
 // connections/gRPC
 #include <UpdateSubscriptions.h>
-#include <ISubscriptionManager.h>
 
 // type aliases
 using catena::common::ParamTag;


### PR DESCRIPTION
I realize this will probably (definitely) have merge conflicts. That's fine, I will deal with them before this is finally merged in - so **PLEASE** wait to merge this in LAST after all other current PRs.

Aside from refactoring files in the codebase to use ISubscriptionManager now (a new interface definition), I also made the manager a unique pointer for intelligent memory management (also because it's consistent with other things in the codebase such as the serializer). 