### PR TITLE
Fixed gRPC Connect command update bug + refactoring .find to be .contain

### DIFF
--- a/sdks/cpp/common/include/NamedChoiceConstraint.h
+++ b/sdks/cpp/common/include/NamedChoiceConstraint.h
@@ -116,14 +116,14 @@ template <typename T> class NamedChoiceConstraint : public catena::common::ICons
     bool satisfied(const catena::Value& src) const override {
 
         if constexpr (std::is_same<T, int32_t>::value) {
-            return choices_.find(src.int32_value()) != choices_.end();
+            return choices_.contains(src.int32_value());
         }
 
         if constexpr (std::is_same<T, std::string>::value) {
             if (!strict_) {
                 return true;
             }
-            return choices_.find(src.string_value()) != choices_.end();
+            return choices_.contains(src.string_value());
         }
     }
 

--- a/sdks/cpp/common/include/patterns/EnumDecorator.h
+++ b/sdks/cpp/common/include/patterns/EnumDecorator.h
@@ -103,9 +103,8 @@ template <typename E> class EnumDecorator {
      */
     EnumDecorator(const std::string& str) : value_{static_cast<E>(0)} {
         const RevMap& revMap = getReverseMap();
-        auto it = revMap.find(str);
-        if (it != revMap.end()) {
-            value_ = it->second;
+        if (revMap.contains(str)) {
+            value_ = revMap.at(str);
         }
     }
 
@@ -141,8 +140,7 @@ template <typename E> class EnumDecorator {
      * @param value the integral value
      */
     EnumDecorator(utype value) : value_{static_cast<E>(value)} {
-        auto it = fwdMap_.find(value_);
-        if (it == fwdMap_.end()) {
+        if (!fwdMap_.contains(value_)) {
             value_ = static_cast<E>(0);
         }
     }
@@ -198,9 +196,8 @@ template <typename E> class EnumDecorator {
      * @brief cast to a string
      */
     operator std::string() const {
-        auto it = fwdMap_.find(value_);
-        if (it != fwdMap_.end()) {
-            return it->second;
+        if (fwdMap_.contains(value_)) {
+            return fwdMap_.at(value_);
         } else {
             return std::string();
         }
@@ -210,9 +207,8 @@ template <typename E> class EnumDecorator {
      * @brief get the string representation of the enum value
      */
     const std::string& toString() const {
-        auto it = fwdMap_.find(value_);
-        if (it != fwdMap_.end()) {
-            return it->second;
+        if (fwdMap_.contains(value_)) {
+            return fwdMap_.at(value_);
         } else {
             static std::string empty;
             return empty;

--- a/sdks/cpp/common/include/patterns/Functory.h
+++ b/sdks/cpp/common/include/patterns/Functory.h
@@ -148,7 +148,7 @@ public:
     */
     bool has(const K key) const {
         LockGuard lock(_mtx);
-        return _registry.find(key) != _registry.end();
+        return _registry.contains(key);
     }
 };
 }

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -76,7 +76,7 @@ class Connect : public IConnect {
      * @param jwsToken The client's JWS token.
      * @param subscriptionManager The subscription manager.
      */
-    Connect(IDevice& dm, bool authz, const sFixed gRPC connect command update bug d::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
+    Connect(IDevice& dm, bool authz, const std::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
         dm_{dm}, 
         subscriptionManager_{subscriptionManager},
         detailLevel_{catena::Device_DetailLevel_UNSET} {
@@ -173,6 +173,7 @@ class Connect : public IConnect {
                 std::cout << "Not updating due to detail level filter" << std::endl;
                 return;
             }
+    
     
             this->res_.mutable_value()->set_oid(oid);
             this->res_.mutable_value()->set_element_index(idx);

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -161,9 +161,8 @@ class Connect : public IConnect {
                 }}
             };
 
-            auto it = detailLevelMap.find(this->detailLevel_);
-            if (it != detailLevelMap.end()) {
-                it->second();
+            if (detailLevelMap.contains(this->detailLevel_)) {
+                detailLevelMap.at(this->detailLevel_)();
             } else {
                 std::cout << "Unknown detail level: " << detailLevel_ << std::endl;
                 should_update = false;

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -135,28 +135,23 @@ class Connect : public IConnect {
             const std::unordered_map<catena::Device_DetailLevel, std::function<void()>> detailLevelMap {
                 {catena::Device_DetailLevel_FULL, [&]() {
                     // Always update for FULL detail level
-                    std::cout << "Updating for FULL detail level" << std::endl;
                     should_update = true;
                 }},
                 {catena::Device_DetailLevel_MINIMAL, [&]() {
                     // For MINIMAL, only update if it's in the minimal set
-                    std::cout << "Updating for MINIMAL detail level" << std::endl;
                     should_update = p->getDescriptor().minimalSet();
                 }},
                 {catena::Device_DetailLevel_SUBSCRIPTIONS, [&]() {
                     // Update if OID is subscribed or in minimal set
-                    std::cout << "Updating for SUBSCRIPTIONS detail level" << std::endl;
                     should_update = p->getDescriptor().minimalSet() || 
                            (std::find(subscribedOids.begin(), subscribedOids.end(), oid) != subscribedOids.end());
                 }},
                 {catena::Device_DetailLevel_COMMANDS, [&]() {
                     // For COMMANDS, only update command parameters
-                    std::cout << "Updating for COMMANDS detail level" << std::endl;
                     should_update = p->getDescriptor().isCommand();
                 }},
                 {catena::Device_DetailLevel_NONE, [&]() {
                     // Don't send any updates
-                    std::cout << "Updating for NONE detail level" << std::endl;
                     should_update = false;
                 }}
             };
@@ -164,12 +159,10 @@ class Connect : public IConnect {
             if (detailLevelMap.contains(this->detailLevel_)) {
                 detailLevelMap.at(this->detailLevel_)();
             } else {
-                std::cout << "Unknown detail level: " << detailLevel_ << std::endl;
                 should_update = false;
             }
     
             if (!should_update) {
-                std::cout << "Not updating due to detail level filter" << std::endl;
                 return;
             }
     
@@ -183,7 +176,6 @@ class Connect : public IConnect {
             rc = p->toProto(*value, *authz_);
             //If the param conversion was successful, send the update
             if (rc.status == catena::StatusCode::OK) {
-                std::cout << "Update successful, notifying writer" << std::endl;
                 this->hasUpdate_ = true;
                 this->cv_.notify_one();
             } else {

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -178,8 +178,6 @@ class Connect : public IConnect {
             if (rc.status == catena::StatusCode::OK) {
                 this->hasUpdate_ = true;
                 this->cv_.notify_one();
-            } else {
-                std::cout << "Update failed with status: " << rc.status << std::endl;
             }
         } catch(catena::exception_with_status& why) {
             // if an error is thrown, no update is pushed to the client

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -79,7 +79,7 @@ class Connect : public IConnect {
     Connect(IDevice& dm, bool authz, const std::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
         dm_{dm}, 
         subscriptionManager_{subscriptionManager},
-        detailLevel_{catena::Device_DetailLevel_NONE} {
+        detailLevel_{catena::Device_DetailLevel_UNSET} {
         if (authz) {
             sharedAuthz_ = std::make_shared<catena::common::Authorizer>(jwsToken);
             authz_ = sharedAuthz_.get();

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -76,7 +76,7 @@ class Connect : public IConnect {
      * @param jwsToken The client's JWS token.
      * @param subscriptionManager The subscription manager.
      */
-    Connect(IDevice& dm, bool authz, const std::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
+    Connect(IDevice& dm, bool authz, const sFixed gRPC connect command update bug d::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
         dm_{dm}, 
         subscriptionManager_{subscriptionManager},
         detailLevel_{catena::Device_DetailLevel_UNSET} {
@@ -174,7 +174,6 @@ class Connect : public IConnect {
                 return;
             }
     
-            std::cout << "Setting up response for OID: " << oid << ", index: " << idx << std::endl;
             this->res_.mutable_value()->set_oid(oid);
             this->res_.mutable_value()->set_element_index(idx);
             

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -165,38 +165,38 @@ catena::exception_with_status Device::getValue (const std::string& jptr, catena:
 
 catena::exception_with_status Device::getLanguagePack(const std::string& languageId, ComponentLanguagePack& pack) const {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
-    auto foundPack = language_packs_.find(languageId);
-    // ERROR: Did not find the pack.
-    if (foundPack == language_packs_.end()) {
-        return catena::exception_with_status("Language pack '" + languageId + "' not found", catena::StatusCode::NOT_FOUND);
+    // Check if language pack exists.
+    if (!language_packs_.contains(languageId)) {
+        ans = catena::exception_with_status("Language pack '" + languageId + "' not found", catena::StatusCode::NOT_FOUND);
+    } else {
+        // Setting the code and transferring language pack info.
+        pack.set_language(languageId);
+        auto languagePack = pack.mutable_language_pack();
+        language_packs_.at(languageId)->toProto(*languagePack);
     }
-    // Setting the code and transfering language pack info.
-    pack.set_language(languageId);
-    auto languagePack = pack.mutable_language_pack();
-    foundPack->second->toProto(*languagePack);
-    // Returning an OK status.
-    return catena::exception_with_status("", catena::StatusCode::OK);
+    return ans;
 }
 
 catena::exception_with_status Device::addLanguage (catena::AddLanguagePayload& language, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     // Admin scope required.
     if (!authz.hasAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin) + ":w")) {
-        return catena::exception_with_status("Not authorized to add language", catena::StatusCode::PERMISSION_DENIED);
+        ans = catena::exception_with_status("Not authorized to add language", catena::StatusCode::PERMISSION_DENIED);
     } else {
         auto& name = language.language_pack().name();
         auto& id = language.id();
         // Making sure LanguagePack is properly formatted.
         if (name.empty() || id.empty()) {
-            return catena::exception_with_status("Invalid language pack", catena::StatusCode::INVALID_ARGUMENT);
+            ans = catena::exception_with_status("Invalid language pack", catena::StatusCode::INVALID_ARGUMENT);
+        } else {
+            // added_packs_ here to maintain ownership in device scope.
+            added_packs_[id] = std::make_shared<LanguagePack>(id, name, LanguagePack::ListInitializer{}, *this);
+            language_packs_[id]->fromProto(language.language_pack());      
+            // Pushing update to connect gRPC.
+            ComponentLanguagePack pack;
+            ans = getLanguagePack(id, pack);
+            languageAddedPushUpdate.emit(pack);
         }
-        // added_packs_ here to maintain ownership in device scope.
-        added_packs_[id] = std::make_shared<LanguagePack>(id, name, LanguagePack::ListInitializer{}, *this);
-        language_packs_[id]->fromProto(language.language_pack());      
-        // Pushing update to connect gRPC.
-        ComponentLanguagePack pack;
-        ans = getLanguagePack(id, pack);
-        languageAddedPushUpdate.emit(pack);
     }
     return ans;
 }

--- a/sdks/cpp/common/src/ParamDescriptor.cpp
+++ b/sdks/cpp/common/src/ParamDescriptor.cpp
@@ -89,9 +89,8 @@ void ParamDescriptor::toProto(catena::BasicParamInfo &paramInfo, Authorizer& aut
 }
 
 const std::string& ParamDescriptor::name(const std::string& language) const { 
-    auto it = name_.displayStrings().find(language);
-    if (it != name_.displayStrings().end()) {
-        return it->second;
+    if (name_.displayStrings().contains(language)) {
+        return name_.displayStrings().at(language);
     } else {
         static const std::string empty;
         return empty;

--- a/sdks/cpp/common/src/PicklistConstraint.cpp
+++ b/sdks/cpp/common/src/PicklistConstraint.cpp
@@ -57,7 +57,7 @@ bool PicklistConstraint::satisfied(const catena::Value& src) const {
         return true;
     }
 
-    return choices_.find(src.string_value()) != choices_.end();
+    return choices_.contains(src.string_value());
 }
 
 /**

--- a/sdks/cpp/common/src/SubscriptionManager.cpp
+++ b/sdks/cpp/common/src/SubscriptionManager.cpp
@@ -107,7 +107,7 @@ bool SubscriptionManager::removeSubscription(const std::string& oid, IDevice& dm
         std::string baseOid = oid.substr(0, oid.length() - 2); // Remove "/*"
         
         // Check if wildcard subscription exists
-        if (wildcardSubscriptions_.find(oid) == wildcardSubscriptions_.end()) {
+        if (!wildcardSubscriptions_.contains(oid)) {
             rc = catena::exception_with_status("Wildcard subscription not found for OID: " + oid, 
                                              catena::StatusCode::NOT_FOUND);
             subscriptionLock_.unlock();
@@ -132,7 +132,7 @@ bool SubscriptionManager::removeSubscription(const std::string& oid, IDevice& dm
         return true;
     } else {
         // Check if unique subscription exists
-        if (uniqueSubscriptions_.find(oid) == uniqueSubscriptions_.end()) {
+        if (!uniqueSubscriptions_.contains(oid)) {
             rc = catena::exception_with_status("Subscription not found for OID: " + oid, 
                                              catena::StatusCode::NOT_FOUND);
             subscriptionLock_.unlock();

--- a/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
@@ -137,7 +137,7 @@ void statusUpdateExample(){
 
         // this is the "receiving end" of the status update example
         dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
-            if (handlers.find(oid) != handlers.end()) {
+            if (handlers.contains(oid)) {
                 handlers[oid](oid, p, idx);
             }
         });

--- a/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
@@ -137,7 +137,7 @@ void statusUpdateExample(){
 
         // this is the "receiving end" of the status update example
         dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
-            if (handlers.find(oid) != handlers.end()) {
+            if (handlers.contains(oid)) {
                 handlers[oid](oid, p, idx);
             }
         });

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -98,7 +98,7 @@ class SocketReader : public ISocketReader {
      * @param key The name of the field to retrieve.
      */
     const std::string& fields(const std::string& key) const override {
-      if (fields_.find(key) != fields_.end()) {
+      if (fields_.contains(key)) {
         return fields_.at(key);
       } else {
         return fieldNotFound;

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -76,7 +76,7 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
             std::string dl = header.substr(std::string("Detail-Level: ").length());
             dl.erase(dl.length() - 1); // Removing newline.
             auto& dlMap = catena::common::DetailLevel().getReverseMap(); // Reverse detail level map.
-            if (dlMap.find(dl) != dlMap.end()) {
+            if (dlMap.contains(dl)) {
                 detailLevel_ = dlMap.at(dl);
             }
         }

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -137,7 +137,7 @@ void statusUpdateExample(){
 
         // this is the "receiving end" of the status update example
         dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
-            if (handlers.find(oid) != handlers.end()) {
+            if (handlers.contains(oid)) {
                 handlers[oid](oid, p, idx);
             }
         });

--- a/sdks/cpp/connections/gRPC/include/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/Connect.h
@@ -86,10 +86,6 @@ class CatenaServiceImpl::Connect : public CallData, public catena::common::Conne
          */
         catena::ConnectPayload req_;
         /**
-         * @brief Server response (updates).
-         */
-        catena::PushUpdates res_;
-        /**
          * @brief gRPC async writer to write updates.
          */
         ServerAsyncWriter<catena::PushUpdates> writer_;
@@ -98,22 +94,9 @@ class CatenaServiceImpl::Connect : public CallData, public catena::common::Conne
          */
         CallStatus status_;
         /**
-         * @brief The device to connect to.
-         */
-        IDevice& dm_;
-        /**
          * @brief The mutex to for locking the object while writing
          */
         std::mutex mtx_;
-        /**
-         * @brief Condition variable to notify the object when the value has
-         * been updated
-         */
-        std::condition_variable cv_;
-        /**
-         * @brief Flag to check if the value has been updated
-         */
-        bool hasUpdate_{false};
         /**
          * @brief ID of the Connect object
          */


### PR DESCRIPTION
The bug was essentially that we had duplicate update variables so they have since been removed from gRPC (and the common variables are used instead)

Also changed the map in the common connect to have a return variable instead of multiple returns

NEW: Updated a bunch of files that normally used .find to instead use .contains