### PR TITLE
Fixed authorizer in gRPC

### DIFF
--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -76,16 +76,10 @@ class Connect : public IConnect {
      * @param jwsToken The client's JWS token.
      * @param subscriptionManager The subscription manager.
      */
-    Connect(IDevice& dm, bool authz, const std::string& jwsToken, ISubscriptionManager& subscriptionManager) : 
+    Connect(IDevice& dm, ISubscriptionManager& subscriptionManager) : 
         dm_{dm}, 
         subscriptionManager_{subscriptionManager},
         detailLevel_{catena::Device_DetailLevel_UNSET} {
-        if (authz) {
-            sharedAuthz_ = std::make_shared<catena::common::Authorizer>(jwsToken);
-            authz_ = sharedAuthz_.get();
-        } else {
-            authz_ = &catena::common::Authorizer::kAuthzDisabled;
-        }
     }
     /**
      * @brief Connect does not have copy semantics
@@ -211,6 +205,20 @@ class Connect : public IConnect {
             this->cv_.notify_one();
         } catch(catena::exception_with_status& why){
             // if an error is thrown, no update is pushed to the client
+        }
+    }
+
+    /**
+     * @brief Sets up the authorizer object with the jwsToken.
+     * @param jwsToken The jwsToken to use for authorization.
+     * @param authz true if authorization is enabled, false otherwise.
+     */
+    void initAuthz_(const std::string& jwsToken, bool authz = false) override {
+        if (authz) {
+            sharedAuthz_ = std::make_shared<catena::common::Authorizer>(jwsToken);
+            authz_ = sharedAuthz_.get();
+        } else {
+            authz_ = &catena::common::Authorizer::kAuthzDisabled;
         }
     }
 

--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -81,6 +81,13 @@ class IConnect {
      * @param l The added ComponentLanguagePack emitted by device.
      */
     virtual void updateResponse_(const catena::DeviceComponent_ComponentLanguagePack& l) = 0;
+    
+    /**
+     * @brief Sets up the authorizer object with the jwsToken.
+     * @param jwsToken The jwsToken to use for authorization.
+     * @param authz true if authorization is enabled, false otherwise.
+     */
+    virtual void initAuthz_(const std::string& jwsToken, bool authz = false) = 0;
 };
  
 }; // common

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -8,12 +8,14 @@ int Connect::objectCounter_ = 0;
 
 Connect::Connect(tcp::socket& socket, SocketReader& context, IDevice& dm) :
     socket_{socket}, writer_{socket, context.origin()}, shutdown_{false}, context_{context},
-    catena::common::Connect(dm, context.authorizationEnabled(), context.jwsToken(), context.getSubscriptionManager()) {
+    catena::common::Connect(dm, context.getSubscriptionManager()) {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.
     userAgent_ = context.fields("user_agent");
     forceConnection_ = context.fields("force_connection") == "true";
+    // Setting up the client's authorizer.
+    initAuthz_(context_.jwsToken(), context_.authorizationEnabled());
 }
 
 void Connect::proceed() {

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -14,39 +14,44 @@ Connect::Connect(tcp::socket& socket, SocketReader& context, IDevice& dm) :
     // Parsing fields and assigning to respective variables.
     userAgent_ = context.fields("user_agent");
     forceConnection_ = context.fields("force_connection") == "true";
-    // Setting up the client's authorizer.
-    initAuthz_(context_.jwsToken(), context_.authorizationEnabled());
 }
 
 void Connect::proceed() {
     writeConsole_(CallStatus::kProcess, socket_.is_open());
-    // Cancels all open connections if shutdown signal is sent.
-    shutdownSignalId_ = shutdownSignal_.connect([this](){
+
+    try {
+        // Setting up the client's authorizer.
+        initAuthz_(context_.jwsToken(), context_.authorizationEnabled());
+        // Cancels all open connections if shutdown signal is sent.
+        shutdownSignalId_ = shutdownSignal_.connect([this](){
+            shutdown_ = true;
+            this->hasUpdate_ = true;
+            this->cv_.notify_one();
+        });
+        // Waiting for a value set by server to be sent to execute code.
+        valueSetByServerId_ = dm_.valueSetByServer.connect([this](const std::string& oid, const IParam* p, const int32_t idx){
+            updateResponse_(oid, idx, p);
+        });
+        // Waiting for a value set by client to be sent to execute code.
+        valueSetByClientId_ = dm_.valueSetByClient.connect([this](const std::string& oid, const IParam* p, const int32_t idx){
+            updateResponse_(oid, idx, p);
+        });
+        // Waiting for a language to be added to execute code.
+        languageAddedId_ = dm_.languageAddedPushUpdate.connect([this](const IDevice::ComponentLanguagePack& l) {
+            updateResponse_(l);
+        });
+        // Set detail level from context
+        detailLevel_ = context_.detailLevel();
+        dm_.detail_level(detailLevel_);
+        // send client an empty update with slot of the device
+        catena::PushUpdates populatedSlots;
+        populatedSlots.set_slot(dm_.slot());
+        writer_.write(populatedSlots);
+    // Used to catch the authz error.
+    } catch (catena::exception_with_status& err) {
+        writer_.write(err);
         shutdown_ = true;
-        this->hasUpdate_ = true;
-        this->cv_.notify_one();
-    });
-
-    // Set detail level from context
-    detailLevel_ = context_.detailLevel();
-    dm_.detail_level(detailLevel_);
-
-    // Waiting for a value set by server to be sent to execute code.
-    valueSetByServerId_ = dm_.valueSetByServer.connect([this](const std::string& oid, const IParam* p, const int32_t idx){
-        updateResponse_(oid, idx, p);
-    });
-    // Waiting for a value set by client to be sent to execute code.
-    valueSetByClientId_ = dm_.valueSetByClient.connect([this](const std::string& oid, const IParam* p, const int32_t idx){
-        updateResponse_(oid, idx, p);
-    });
-    // Waiting for a language to be added to execute code.
-    languageAddedId_ = dm_.languageAddedPushUpdate.connect([this](const IDevice::ComponentLanguagePack& l) {
-        updateResponse_(l);
-    });
-    // send client an empty update with slot of the device
-    catena::PushUpdates populatedSlots;
-    populatedSlots.set_slot(dm_.slot());
-    writer_.write(populatedSlots);
+    }
 
     // kWrite: Waiting for updates to send to the client.
     std::unique_lock<std::mutex> lock{mtx_, std::defer_lock};


### PR DESCRIPTION
Fixed authorizer in gRPC and updated REST to reflect new implementation.

Changelog:
- Moved authz creation outside of connect constructor and into new function initAuthz_.
- Updated REST and gRPC implementations to call initAuthz at correct time.
- Fixed issue preventing the write of an invalid JWS token error to SSEWriter.