### PR TITLE
Major Refactoring of REST + Preliminary Response Code Handling

### DIFF
--- a/interface/openapi/paths/BasicParamInfoRequest.yaml
+++ b/interface/openapi/paths/BasicParamInfoRequest.yaml
@@ -36,32 +36,40 @@
 #
 
 get:
-  summary: Gets a parameter's basic information from the device model plugged into the specified slot
+  summary: Gets information about parameters within a device model
   operationId: BasicParamInfoRequest
 
   parameters:
     - name: slot
       in: path
       required: true
-      description: The slot of the device model to get the object from
+      description: The slot of the device model containing the parameters to get info for
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
 
-    - name: oid_prefix
-      in: query
-      required: false
-      description: Uniquely identifies the starting parameter relative to device.params. Specifying "" selects all top-level parameters
-      schema:
-        type: string
-      default: ""
-    
     - name: recursive
       in: query
       required: false
-      description: Optional flag to indicate whether to include all child parameters or not.
+      description: Whether to recursively get info for all children
       schema:
         type: boolean
       default: false
+
+  requestBody:
+    required: false
+    description: Optional JSON body containing the oid_prefix
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            oid_prefix:
+              type: string
+              description: The prefix of the OID to get info for
+              default: ""
+        example: {
+          "oid_prefix": "text_box"
+        }
 
   responses:
     "200":
@@ -69,6 +77,7 @@ get:
         Returns a stream of basic information about the specified parameter(s).
         The response is a sequence of JSON objects, each containing information about a single parameter.
         Each object in the stream has the following structure:
+        
       content:
         application/json:
           schema:

--- a/interface/openapi/paths/BasicParamInfoRequest.yaml
+++ b/interface/openapi/paths/BasicParamInfoRequest.yaml
@@ -50,26 +50,21 @@ get:
     - name: recursive
       in: query
       required: false
-      description: Whether to recursively get info for all children
+      description: Optional flag to recursively get info for all children. The 
+        presence of this parameter enables recursion, regardless of its value. 
+        (The value is ignored; any value such as "true" will have the same 
+        effect.)
       schema:
-        type: boolean
-      default: false
+        type: string
+        enum: ["true"]
 
-  requestBody:
-    required: false
-    description: Optional JSON body containing the oid_prefix
-    content:
-      application/json:
-        schema:
-          type: object
-          properties:
-            oid_prefix:
-              type: string
-              description: The prefix of the OID to get info for
-              default: ""
-        example: {
-          "oid_prefix": "text_box"
-        }
+    - name: oid_prefix
+      in: query
+      required: false
+      description: The prefix of the OID to get info for
+      schema:
+        type: string
+      default: ""
 
   responses:
     "200":

--- a/interface/openapi/paths/Connect.yaml
+++ b/interface/openapi/paths/Connect.yaml
@@ -15,7 +15,7 @@
 # may be used to endorse or promote products derived from this software without
 # specific prior written permission.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -66,10 +66,13 @@ get:
     - name: force_connection
       in: query
       required: false
-      description: Optional flag to force a connection
+      description: Optional flag to force a connection. The presence of this 
+        parameter forces the connection, regardless of its value. (The value 
+        is ignored; any value assigned such as "true" will have the same 
+        effect.)
       schema:
-        type: boolean
-      default: false
+        type: string
+        enum: ["true"]
 
   responses:
     "200":

--- a/interface/openapi/paths/ExecuteCommand.yaml
+++ b/interface/openapi/paths/ExecuteCommand.yaml
@@ -15,7 +15,7 @@
 # may be used to endorse or promote products derived from this software without
 # specific prior written permission.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -57,19 +57,25 @@ put:
     - name: respond
       in: query
       required: false
-      description: Optional flag to supress the server's response
+      description: Optional flag to suppress the server's response. The 
+        presence of this parameter suppresses the response, regardless of 
+        its value. (The value is ignored; any value such as "true" will 
+        have the same effect.)
       schema:
-        type: boolean
-      default: true
+        type: string
+        enum: ["true"]
     
     - name: proceed
       in: query
       required: false
-      description: Optional flag indicate whether to send the response instead
-         as the 'DataPayload' variant of the 'Value' message
+      description: Optional flag to indicate whether to send the response 
+        as the 'DataPayload' variant of the 'Value' message. The presence 
+        of this parameter enables this behavior, regardless of its value. 
+        (The value is ignored; any value such as "true" will have the same 
+        effect.)
       schema:
-        type: boolean
-      default: false
+        type: string
+        enum: ["true"]
     
   requestBody:
     required: false

--- a/sdks/cpp/common/include/Status.h
+++ b/sdks/cpp/common/include/Status.h
@@ -32,7 +32,9 @@ namespace catena {
 /**
  * @brief Status Code - reproduced from google's grpc project and extended for REST.
  * 
- * Codes 0-16 are compatible with gRPC. Codes >= 20 are REST-specific and should not be used in gRPC contexts.
+ * Codes 0-16 are compatible with gRPC. Codes mapped to HTTP status codes are 
+ * REST-specific and should not be used in gRPC contexts.
+ * 
  * The license for this code is Apache 2.0 which permits redistribution
  * and modification. The original code is available at: https://github.com/grpc/grpc
  * 

--- a/sdks/cpp/common/include/Status.h
+++ b/sdks/cpp/common/include/Status.h
@@ -30,8 +30,9 @@
 namespace catena {
 
 /**
- * @brief Status Code - reproduced from google's grpc project.
+ * @brief Status Code - reproduced from google's grpc project and extended for REST.
  * 
+ * Codes 0-16 are compatible with gRPC. Codes >= 20 are REST-specific and should not be used in gRPC contexts.
  * The license for this code is Apache 2.0 which permits redistribution
  * and modification. The original code is available at: https://github.com/grpc/grpc
  * 
@@ -156,7 +157,23 @@ enum StatusCode {
   DATA_LOSS = 15,
 
   /// Force users to include a default branch:
-  DO_NOT_USE = -1
+  DO_NOT_USE = -1,
+
+  // --- REST-specific status codes (do not use in gRPC) ---
+  /**
+   * The following codes are intended for REST/HTTP APIs only and do not map to gRPC status codes.
+   * Use these codes to represent HTTP-specific conditions.
+   */
+  CREATED               = 100, ///< HTTP 201: The request has succeeded and a new resource has been created as a result. REST only.
+  ACCEPTED              = 101, ///< HTTP 202: The request has been accepted for processing, but the processing has not been completed. REST only.
+  NO_CONTENT            = 102, ///< HTTP 204: The server successfully processed the request and is not returning any content. REST only.
+  UNPROCESSABLE_ENTITY  = 20,  ///< HTTP 422: The request was well-formed but was unable to be followed due to semantic errors. REST only.
+  METHOD_NOT_ALLOWED    = 21,  ///< HTTP 405: The method is not allowed for the requested resource. REST only.
+  CONFLICT              = 22,  ///< HTTP 409: The request could not be completed due to a conflict. REST only.
+  TOO_MANY_REQUESTS     = 23,  ///< HTTP 429: The user has sent too many requests in a given amount of time. REST only.
+  BAD_GATEWAY           = 24,  ///< HTTP 502: The server was acting as a gateway or proxy and received an invalid response. REST only.
+  SERVICE_UNAVAILABLE   = 25,  ///< HTTP 503: The server is not ready to handle the request. REST only.
+  GATEWAY_TIMEOUT       = 26,  ///< HTTP 504: The server was acting as a gateway or proxy and did not receive a timely response. REST only.
 };
 
 /**

--- a/sdks/cpp/common/include/Status.h
+++ b/sdks/cpp/common/include/Status.h
@@ -164,16 +164,16 @@ enum StatusCode {
    * The following codes are intended for REST/HTTP APIs only and do not map to gRPC status codes.
    * Use these codes to represent HTTP-specific conditions.
    */
-  CREATED               = 100, ///< HTTP 201: The request has succeeded and a new resource has been created as a result. REST only.
-  ACCEPTED              = 101, ///< HTTP 202: The request has been accepted for processing, but the processing has not been completed. REST only.
-  NO_CONTENT            = 102, ///< HTTP 204: The server successfully processed the request and is not returning any content. REST only.
-  UNPROCESSABLE_ENTITY  = 20,  ///< HTTP 422: The request was well-formed but was unable to be followed due to semantic errors. REST only.
-  METHOD_NOT_ALLOWED    = 21,  ///< HTTP 405: The method is not allowed for the requested resource. REST only.
-  CONFLICT              = 22,  ///< HTTP 409: The request could not be completed due to a conflict. REST only.
-  TOO_MANY_REQUESTS     = 23,  ///< HTTP 429: The user has sent too many requests in a given amount of time. REST only.
-  BAD_GATEWAY           = 24,  ///< HTTP 502: The server was acting as a gateway or proxy and received an invalid response. REST only.
-  SERVICE_UNAVAILABLE   = 25,  ///< HTTP 503: The server is not ready to handle the request. REST only.
-  GATEWAY_TIMEOUT       = 26,  ///< HTTP 504: The server was acting as a gateway or proxy and did not receive a timely response. REST only.
+  CREATED               = 201, ///< HTTP 201: The request has succeeded and a new resource has been created as a result. REST only.
+  ACCEPTED              = 202, ///< HTTP 202: The request has been accepted for processing, but the processing has not been completed. REST only.
+  NO_CONTENT            = 204, ///< HTTP 204: The server successfully processed the request and is not returning any content. REST only.
+  UNPROCESSABLE_ENTITY  = 422, ///< HTTP 422: The request was well-formed but was unable to be followed due to semantic errors. REST only.
+  METHOD_NOT_ALLOWED    = 405, ///< HTTP 405: The method is not allowed for the requested resource. REST only.
+  CONFLICT              = 409, ///< HTTP 409: The request could not be completed due to a conflict. REST only.
+  TOO_MANY_REQUESTS     = 429, ///< HTTP 429: The user has sent too many requests in a given amount of time. REST only.
+  BAD_GATEWAY           = 502, ///< HTTP 502: The server was acting as a gateway or proxy and received an invalid response. REST only.
+  SERVICE_UNAVAILABLE   = 503, ///< HTTP 503: The server is not ready to handle the request. REST only.
+  GATEWAY_TIMEOUT       = 504, ///< HTTP 504: The server was acting as a gateway or proxy and did not receive a timely response. REST only.
 };
 
 /**

--- a/sdks/cpp/common/include/Status.h
+++ b/sdks/cpp/common/include/Status.h
@@ -10,7 +10,7 @@
 
  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -163,19 +163,43 @@ enum StatusCode {
 
   // --- REST-specific status codes (do not use in gRPC) ---
   /**
-   * The following codes are intended for REST/HTTP APIs only and do not map to gRPC status codes.
-   * Use these codes to represent HTTP-specific conditions.
+   * The following codes are intended for REST/HTTP APIs only and do not map to 
+   * gRPC status codes. Use these codes to represent HTTP-specific conditions.
    */
-  CREATED               = 201, ///< HTTP 201: The request has succeeded and a new resource has been created as a result. REST only.
-  ACCEPTED              = 202, ///< HTTP 202: The request has been accepted for processing, but the processing has not been completed. REST only.
-  NO_CONTENT            = 204, ///< HTTP 204: The server successfully processed the request and is not returning any content. REST only.
-  UNPROCESSABLE_ENTITY  = 422, ///< HTTP 422: The request was well-formed but was unable to be followed due to semantic errors. REST only.
-  METHOD_NOT_ALLOWED    = 405, ///< HTTP 405: The method is not allowed for the requested resource. REST only.
-  CONFLICT              = 409, ///< HTTP 409: The request could not be completed due to a conflict. REST only.
-  TOO_MANY_REQUESTS     = 429, ///< HTTP 429: The user has sent too many requests in a given amount of time. REST only.
-  BAD_GATEWAY           = 502, ///< HTTP 502: The server was acting as a gateway or proxy and received an invalid response. REST only.
-  SERVICE_UNAVAILABLE   = 503, ///< HTTP 503: The server is not ready to handle the request. REST only.
-  GATEWAY_TIMEOUT       = 504, ///< HTTP 504: The server was acting as a gateway or proxy and did not receive a timely response. REST only.
+  /// The request has succeeded and a new resource has been created as a result.
+  CREATED = 201,
+
+  /// The request has been accepted for processing, but the processing has not
+  /// yet been completed.
+  ACCEPTED = 202,
+
+  /// The server successfully processed the request and is not returning any
+  /// content in the response.
+  NO_CONTENT = 204,
+
+  /// The request was well-formed but was unable to be followed due to semantic
+  /// errors in the request.
+  UNPROCESSABLE_ENTITY = 422,
+
+  /// The method is not allowed for the requested resource.
+  METHOD_NOT_ALLOWED = 405,
+
+  /// The request could not be completed due to a conflict.
+  CONFLICT = 409,
+
+  /// The user has sent too many requests in a given amount of time.
+  TOO_MANY_REQUESTS = 429,
+
+  /// The server was acting as a gateway/proxy and received an invalid response
+  /// from the upstream server.
+  BAD_GATEWAY = 502,
+
+  /// The server is not ready to handle the request.
+  SERVICE_UNAVAILABLE = 503,
+
+  /// The server was acting as a gateway/proxy and did not receive a timely
+  /// response from the upstream server.
+  GATEWAY_TIMEOUT = 504,
 };
 
 /**

--- a/sdks/cpp/common/src/SubscriptionManager.cpp
+++ b/sdks/cpp/common/src/SubscriptionManager.cpp
@@ -61,6 +61,14 @@ bool SubscriptionManager::addSubscription(const std::string& oid, IDevice& dm, e
         return false;
     }
 
+    // Check for duplicate subscription
+    if (!isWildcard(oid) && subscriptions_.find(oid) != subscriptions_.end()) {
+        rc = catena::exception_with_status("Subscription already exists for OID: " + oid,
+                                         catena::StatusCode::NO_CONTENT);
+        subscriptionLock_.unlock();
+        return false;
+    }
+
     if (isWildcard(oid)) {
         // Expand wildcard and add all matching OIDs
         std::string basePath = oid.substr(0, oid.length() - 2);

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -124,7 +124,7 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
     bool is_port_in_use_() const override;
 
     /**
-     * @brief Provides io functionality for tcp::sockets used in RPCs.
+     * @brief Provides io functionality for tcp::sockets used in requests.
      */
     boost::asio::io_context io_context_;
     /**
@@ -156,14 +156,14 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
      */
     bool shutdown_ = false;
     /**
-     * @brief Counter used to track number of active RPCs. Run() does not
-     * finish until this number is 0.
+     * @brief Counter used to track number of active requests. Run() does not
+     * return until this is 0.
      */
-    uint32_t activeRpcs_ = 0;
+    uint32_t activeRequests_ = 0;
     /**
-     * @brief Mutex for activeRpcs_ counter to avoid collisions.
+     * @brief Mutex for activeRequests_ counter to avoid collisions.
      */
-    std::mutex activeRpcMutex_;
+    std::mutex activeRequestMutex_;
 
     using Router = catena::patterns::GenericFactory<catena::REST::ICallData,
                                                     std::string,
@@ -171,7 +171,7 @@ class CatenaServiceImpl : public catena::REST::IServiceImpl {
                                                     ISocketReader&,
                                                     IDevice&>;
     /**
-     * @brief Creating an ICallData factory for handling RPC routing.
+     * @brief Creating an ICallData factory for handling request routing.
      */
     Router& router_;
 };

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -96,7 +96,7 @@ class SocketReader : public ISocketReader {
      * 
      * @param key The name of the field to check.
      */
-    bool hasField(const std::string& key) const {
+    bool hasField(const std::string& key) const override {
       return fields_.contains(key);
     }
     /**

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -92,6 +92,14 @@ class SocketReader : public ISocketReader {
      */
     uint32_t slot() const override { return slot_; };
     /**
+     * @brief Returns true if the field exists in the URL, regardless of its value.
+     * 
+     * @param key The name of the field to check.
+     */
+    bool hasField(const std::string& key) const {
+      return fields_.contains(key);
+    }
+    /**
      * @brief Returns the field "key" queried from the URL, or an empty sting
      * if it does not exist.
      * 

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -80,7 +80,7 @@ class SocketReader : public ISocketReader {
      */
     void read(tcp::socket& socket, bool authz = false) override;
     /**
-     * @brief Returns the method of the request.
+     * @brief Returns the HTTP method of the request.
      */
     const std::string& method() const override { return method_; }
     /**

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -56,11 +56,6 @@ using boost::asio::ip::tcp;
 namespace catena {
 namespace REST {
 
-struct HttpStatus {
-    int code;
-    std::string reason;
-};
-
 /**
  * @brief Helper class used to write a unary response to a socket using boost.
  * 
@@ -108,7 +103,7 @@ class SocketWriter : public ISocketWriter {
      * SocketWriter exlusive function which acts as a call to write() then
      * finish().
      */
-    void finish(const HttpStatus& status);
+    void finish(catena::StatusCode status);
 
   private:
     /**
@@ -141,12 +136,12 @@ class SocketWriter : public ISocketWriter {
 class SSEWriter : public ISocketWriter {
   public:
     /**
-     * @brief Constructor for SSEWriter with status code and reason.
+     * @brief Constructor for SSEWriter with status code.
      * @param socket The socket to write to.
      * @param origin The origin of the request.
-     * @param status The HTTP status code and reason.
+     * @param status The catena::StatusCode.
      */
-    SSEWriter(tcp::socket& socket, const std::string& origin, const HttpStatus& status = {200, "OK"});
+    SSEWriter(tcp::socket& socket, const std::string& origin = "*", catena::StatusCode status = catena::StatusCode::OK);
     /**
      * @brief Writes a protobuf message to the socket as an SSE.
      * @param msg The protobuf message to write as JSON.
@@ -172,9 +167,9 @@ class SSEWriter : public ISocketWriter {
 };
 
 /**
- * @brief Maps catena::StatusCode to HTTP status codes.
+ * @brief Maps catena::StatusCode to HTTP status codes and reasons.
  */
-const std::map<catena::StatusCode, HttpStatus> codeMap_ {
+const std::map<catena::StatusCode, std::pair<int, std::string>> codeMap_ {
   {catena::StatusCode::OK,                  {200, "OK"}},
   {catena::StatusCode::CANCELLED,           {400, "Cancelled"}},
   {catena::StatusCode::UNKNOWN,             {500, "Internal Server Error"}},

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -79,13 +79,19 @@ class SocketWriter : public ISocketWriter {
      * @brief Adds the protobuf message to the end of response in JSON format.
      * @param msg The protobuf message to add as JSON.
      */
-    virtual void write(google::protobuf::Message& msg) override;
+    void write(google::protobuf::Message& msg) override;
 
     /**
      * @brief Finishes writing the HTTP response.
      * @param err Optional error status to finish with. If not provided, finishes with OK status.
      */
-    virtual void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
+    void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
+
+    /**
+     * @brief Finishes the writing process by writing a message to the socket.
+     * SocketWriter exclusive function which acts as a call to write() then finish().
+     */
+    void finish(google::protobuf::Message& msg);
 
   private:
     /**
@@ -129,13 +135,13 @@ class SSEWriter : public ISocketWriter {
      * @brief Writes a protobuf message to the socket as an SSE.
      * @param msg The protobuf message to write as JSON.
      */
-    virtual void write(google::protobuf::Message& msg) override;
+    void write(google::protobuf::Message& msg) override;
 
     /**
      * @brief Finishes the SSE stream.
      * @param err Optional error status to finish with. If not provided, finishes with OK status.
      */
-    virtual void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
+    void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
 
   private:
     /**

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -79,19 +79,14 @@ class SocketWriter : public ISocketWriter {
      * @brief Adds the protobuf message to the end of response in JSON format.
      * @param msg The protobuf message to add as JSON.
      */
-    void write(google::protobuf::Message& msg) override;
+    void write(const google::protobuf::Message& msg) override;
 
     /**
      * @brief Finishes writing the HTTP response.
-     * @param err Optional error status to finish with. If not provided, finishes with OK status.
+     * @param msg The protobuf message to write (if status is OK)
+     * @param err The error status to finish with. If status is OK, writes the message, otherwise writes the error.
      */
-    void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
-
-    /**
-     * @brief Finishes the writing process by writing a message to the socket.
-     * SocketWriter exclusive function which acts as a call to write() then finish().
-     */
-    void finish(google::protobuf::Message& msg);
+    void finish(const google::protobuf::Message& msg = catena::Empty(), const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
 
   private:
     /**
@@ -135,13 +130,14 @@ class SSEWriter : public ISocketWriter {
      * @brief Writes a protobuf message to the socket as an SSE.
      * @param msg The protobuf message to write as JSON.
      */
-    void write(google::protobuf::Message& msg) override;
+    void write(const google::protobuf::Message& msg) override;
 
     /**
      * @brief Finishes the SSE stream.
-     * @param err Optional error status to finish with. If not provided, finishes with OK status.
+     * @param msg The protobuf message to write (if status is OK)
+     * @param err The error status to finish with. If status is OK, writes the message, otherwise writes the error.
      */
-    void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
+    void finish(const google::protobuf::Message& msg = catena::Empty(), const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
 
   private:
     /**

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -98,12 +98,13 @@ class SocketWriter : public ISocketWriter {
      */
     void finish(google::protobuf::Message& msg);
     /**
-     * @brief Finishes the writing process by writing a message to the socket.
+     * @brief Finishes the writing process by writing an error to the socket.
      * 
      * SocketWriter exlusive function which acts as a call to write() then
      * finish().
+     * @param err The catena::exception_with_status containing the error details.
      */
-    void finish(catena::StatusCode status);
+    void finish(const catena::exception_with_status& err);
 
   private:
     /**
@@ -136,12 +137,12 @@ class SocketWriter : public ISocketWriter {
 class SSEWriter : public ISocketWriter {
   public:
     /**
-     * @brief Constructor for SSEWriter with status code.
+     * @brief Constructor for SSEWriter.
      * @param socket The socket to write to.
      * @param origin The origin of the request.
-     * @param status The catena::StatusCode.
+     * @param err The catena::exception_with_status for initialization.
      */
-    SSEWriter(tcp::socket& socket, const std::string& origin = "*", catena::StatusCode status = catena::StatusCode::OK);
+    SSEWriter(tcp::socket& socket, const std::string& origin = "*", const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK));
     /**
      * @brief Writes a protobuf message to the socket as an SSE.
      * @param msg The protobuf message to write as JSON.

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -74,37 +74,18 @@ class SocketWriter : public ISocketWriter {
               "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With, Language, Detail-Level\r\n"
               "Access-Control-Allow-Credentials: true\r\n";
     }
+
     /**
      * @brief Adds the protobuf message to the end of response in JSON format.
      * @param msg The protobuf message to add as JSON.
      */
     virtual void write(google::protobuf::Message& msg) override;
+
     /**
-     * @brief Writes an error message to the socket.
-     * @param err The catena::exception_with_status.
+     * @brief Finishes writing the HTTP response.
+     * @param err Optional error status to finish with. If not provided, finishes with OK status.
      */
-    virtual void write(catena::exception_with_status& err) override;
-    /**
-     * @brief Finishes the writing process by writing response to socket.
-     * 
-     * If the response is empty, it does nothing.
-     */
-    virtual void finish() override;
-    /**
-     * @brief Finishes the writing process by writing a message to the socket.
-     * 
-     * SocketWriter exlusive function which acts as a call to write() then
-     * finish().
-     */
-    void finish(google::protobuf::Message& msg);
-    /**
-     * @brief Finishes the writing process by writing an error to the socket.
-     * 
-     * SocketWriter exlusive function which acts as a call to write() then
-     * finish().
-     * @param err The catena::exception_with_status containing the error details.
-     */
-    void finish(const catena::exception_with_status& err);
+    virtual void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
 
   private:
     /**
@@ -143,22 +124,18 @@ class SSEWriter : public ISocketWriter {
      * @param err The catena::exception_with_status for initialization.
      */
     SSEWriter(tcp::socket& socket, const std::string& origin = "*", const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK));
+
     /**
      * @brief Writes a protobuf message to the socket as an SSE.
      * @param msg The protobuf message to write as JSON.
      */
-    void write(google::protobuf::Message& msg) override;
+    virtual void write(google::protobuf::Message& msg) override;
+
     /**
-     * @brief Writes an error message to the socket as an SSE.
-     * @param err The catena::exception_with_status.
+     * @brief Finishes the SSE stream.
+     * @param err Optional error status to finish with. If not provided, finishes with OK status.
      */
-    void write(catena::exception_with_status& err) override;
-    /**
-     * @brief Finishes the writing process.
-     * 
-     * Does nothing in SSE.
-     */
-    void finish() override {}
+    virtual void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) override;
 
   private:
     /**

--- a/sdks/cpp/connections/REST/include/controllers/AddLanguage.h
+++ b/sdks/cpp/connections/REST/include/controllers/AddLanguage.h
@@ -30,7 +30,7 @@
 
 /**
  * @file AddLanguage.h
- * @brief Implements REST AddLanguage endpoint.
+ * @brief Implements REST AddLanguage controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -58,7 +58,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the AddLanguage REST endpoint.
+ * @brief ICallData class for the AddLanguage REST controller.
  */
 class AddLanguage : public ICallData {
   public:
@@ -67,7 +67,7 @@ class AddLanguage : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the AddLanguage endpoint.
+     * @brief Constructor for the AddLanguage controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -83,7 +83,7 @@ class AddLanguage : public ICallData {
      */
     void finish() override;
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/AddLanguage.h
+++ b/sdks/cpp/connections/REST/include/controllers/AddLanguage.h
@@ -30,7 +30,7 @@
 
 /**
  * @file AddLanguage.h
- * @brief Implements REST AddLanguage RPC.
+ * @brief Implements REST AddLanguage endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -58,7 +58,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the AddLanguage REST RPC.
+ * @brief ICallData class for the AddLanguage REST endpoint.
  */
 class AddLanguage : public ICallData {
   public:
@@ -67,7 +67,7 @@ class AddLanguage : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the AddLanguage RPC.
+     * @brief Constructor for the AddLanguage endpoint.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -83,7 +83,7 @@ class AddLanguage : public ICallData {
      */
     void finish() override;
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -96,8 +96,8 @@ class AddLanguage : public ICallData {
     /**
      * @brief Helper function to write status messages to the API console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "AddLanguage::proceed[" << objectId_ << "]: "

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -151,6 +151,11 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
     catena::common::IDevice& dm_;
 
     /**
+     * @brief The request payload from JSON body
+     */
+    catena::BasicParamInfoRequestPayload req_;
+    
+    /**
      * @brief The oid prefix to get parameter info for.
      */
     std::string oid_prefix_;

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -100,6 +100,8 @@ class BasicParamInfoRequest : public ICallData {
       return new BasicParamInfoRequest(socket, context, dm);
     }
     
+    
+  private:
     /**
      * @brief Writes the current state of the request to the console.
      * @param status The current state of the request (kCreate, kFinish, etc.)
@@ -110,12 +112,9 @@ class BasicParamInfoRequest : public ICallData {
                 << timeNow() << " status: "<< static_cast<int>(status)
                 <<", ok: "<< std::boolalpha << ok << std::endl;
     }
-    
-  private:
     /**
      * @brief Helper method to add a parameter to the responses
      * @param param The parameter to add
-     * @param authz The authorization object
      */
     void addParamToResponses_(IParam* param, catena::common::Authorizer& authz);
     

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -77,7 +77,7 @@ class BasicParamInfoRequest : public ICallData {
      * @param context The ISocketReader object.
      * @param dm The device to get the parameter info from.
      */ 
-    BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, IDevice& dm);
+    BasicParamInfoRequest(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     
     /**
      * @brief BasicParamInfoRequest's main process.

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -82,7 +82,7 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the BasicParamInfoRequest process.
+     * @brief Finishes the BasicParamInfoRequest process
      */
     void finish() override;
     
@@ -138,17 +138,17 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
     /**
      * @brief The SSEWriter object for writing to socket_.
      */
-    SSEWriter writer_;
+    std::unique_ptr<SSEWriter> writer_{nullptr};
     
+    /**
+     * @brief The error status
+     */
+    catena::exception_with_status rc_;
+
     /**
      * @brief The device to get parameter info from.
      */
     catena::common::IDevice& dm_;
-    
-    /**
-     * @brief Flag indicating if the RPC is working correctly.
-     */
-    bool ok_;
 
     /**
      * @brief The oid prefix to get parameter info for.

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -62,7 +62,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the BasicParamInfoRequest REST endpoint.
+ * @brief ICallData class for the BasicParamInfoRequest REST controller.
  */
 class BasicParamInfoRequest : public ICallData {
   public:
@@ -71,7 +71,7 @@ class BasicParamInfoRequest : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the BasicParamInfoRequest endpoint.
+     * @brief Constructor for the BasicParamInfoRequest controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -90,13 +90,13 @@ class BasicParamInfoRequest : public ICallData {
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
      * @param dm The device to connect to.
      */
-    static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, catena::common::IDevice& dm) {
+    static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
       return new BasicParamInfoRequest(socket, context, dm);
     }
     

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -62,19 +62,22 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the BasicParamInfoRequest REST RPC.
+ * @brief ICallData class for the BasicParamInfoRequest REST endpoint.
  */
-class BasicParamInfoRequest : public catena::REST::ICallData {
+class BasicParamInfoRequest : public ICallData {
   public:
+    // Specifying which Device and IParam to use (defaults to catena::...)
+    using IDevice = catena::common::IDevice;
+    using IParam = catena::common::IParam;
+
     /**
-     * @brief Constructor for the BasicParamInfoRequest RPC. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the BasicParamInfoRequest endpoint.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
      * @param dm The device to get the parameter info from.
      */ 
-    BasicParamInfoRequest(tcp::socket& socket, ISocketReader& context, catena::common::IDevice& dm);
+    BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, IDevice& dm);
     
     /**
      * @brief BasicParamInfoRequest's main process.
@@ -87,7 +90,7 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
     void finish() override;
     
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -97,12 +100,10 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
       return new BasicParamInfoRequest(socket, context, dm);
     }
     
-  private:
     /**
-     * @brief Helper function to write status messages to the API console.
-     * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @brief Writes the current state of the request to the console.
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "BasicParamInfoRequest::proceed[" << objectId_ << "]: "
@@ -110,6 +111,7 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
                 <<", ok: "<< std::boolalpha << ok << std::endl;
     }
     
+  private:
     /**
      * @brief Helper method to add a parameter to the responses
      * @param param The parameter to add
@@ -148,7 +150,7 @@ class BasicParamInfoRequest : public catena::REST::ICallData {
     /**
      * @brief The device to get parameter info from.
      */
-    catena::common::IDevice& dm_;
+    IDevice& dm_;
 
     /**
      * @brief The request payload from JSON body

--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -152,11 +152,6 @@ class BasicParamInfoRequest : public ICallData {
     IDevice& dm_;
 
     /**
-     * @brief The request payload from JSON body
-     */
-    catena::BasicParamInfoRequestPayload req_;
-    
-    /**
      * @brief The oid prefix to get parameter info for.
      */
     std::string oid_prefix_;

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -129,7 +129,7 @@ class Connect : public ICallData, public catena::common::Connect {
      */
     SSEWriter writer_;
     /**
-     * @brief The SocketReader object for reading the request.
+     * @brief The ISocketReader object for reading the request.
      */
     ISocketReader& context_;
     /**

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -131,7 +131,7 @@ class Connect : public ICallData, public catena::common::Connect {
     /**
      * @brief The SocketReader object for reading the request.
      */
-    SocketReader& context_;
+    ISocketReader& context_;
     /**
      * @brief The mutex to for locking the object while writing
      */

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -30,7 +30,7 @@
 
 /**
  * @file Connect.h
- * @brief Implements REST Connect endpoint.
+ * @brief Implements REST Connect controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -60,7 +60,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the Connect REST endpoint.
+ * @brief ICallData class for the Connect REST controller.
  */
 class Connect : public ICallData, public catena::common::Connect {
   public:
@@ -69,7 +69,7 @@ class Connect : public ICallData, public catena::common::Connect {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the Connect endpoint.
+     * @brief Constructor for the Connect controller.
      *
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -77,15 +77,17 @@ class Connect : public ICallData, public catena::common::Connect {
      */ 
     Connect(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
-     * Connect main process
+     * @brief Connect's main process.
      */
     void proceed() override;
+    
     /**
-     * Finishes the Connect process by disconnecting listeners.
+     * @brief Finishes the Connect process.
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -30,7 +30,7 @@
 
 /**
  * @file Connect.h
- * @brief Implements REST Connect RPC.
+ * @brief Implements REST Connect endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -60,7 +60,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the Connect REST RPC.
+ * @brief ICallData class for the Connect REST endpoint.
  */
 class Connect : public ICallData, public catena::common::Connect {
   public:
@@ -69,7 +69,7 @@ class Connect : public ICallData, public catena::common::Connect {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the Connect RPC.
+     * @brief Constructor for the Connect endpoint.
      *
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -85,7 +85,7 @@ class Connect : public ICallData, public catena::common::Connect {
      */
     void finish() override;
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -104,8 +104,8 @@ class Connect : public ICallData, public catena::common::Connect {
     /**
      * @brief Helper function to write status messages to the API console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "Connect::proceed[" << objectId_ << "]: "
@@ -114,7 +114,7 @@ class Connect : public ICallData, public catena::common::Connect {
                 << std::endl;
     }
     /**
-     * @brief Returns true if the RPC was cancelled.
+     * @brief Returns true if the request was cancelled.
      */
     inline bool isCancelled() override { return !this->socket_.is_open(); }
 
@@ -127,12 +127,9 @@ class Connect : public ICallData, public catena::common::Connect {
      */
     SSEWriter writer_;
     /**
-     * @brief The mutex to for locking the object while writing
+     * @brief The SocketReader object for reading the request.
      */
-    /**
-     * @brief The ISocketReader object for reading the request.
-     */
-    ISocketReader& context_;
+    SocketReader& context_;
     /**
      * @brief The mutex to for locking the object while writing
      */

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -30,7 +30,7 @@
 
 /**
  * @file DeviceRequest.h
- * @brief Implements REST DeviceRequest RPC.
+ * @brief Implements REST DeviceRequest endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the DeviceRequest REST RPC.
+ * @brief CallData class for the DeviceRequest REST endpoint.
  */
 class DeviceRequest : public ICallData {
   public:
@@ -68,23 +68,26 @@ class DeviceRequest : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the DeviceRequest RPC.
+     * @brief Constructor for the DeviceRequest endpoint. Calls proceed() once
+     * initialized.
      *
-     * @param socket The socket to write the response stream to.
+     * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to get components from.
+     * @param dm The device to get information from.
      */ 
     DeviceRequest(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
      * @brief DeviceRequest's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the DeviceRequest process.
+     * @brief Finishes the DeviceRequest process
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -93,12 +96,12 @@ class DeviceRequest : public ICallData {
     static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
       return new DeviceRequest(socket, context, dm);
     }
-  private:
+    
     /**
-     * @brief Helper function to write status messages to the API console.
+     * @brief Writes the current state of the request to the console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "DeviceRequest::proceed[" << objectId_ << "]: "
@@ -106,7 +109,7 @@ class DeviceRequest : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-    
+  private:
     /**
      * @brief The socket to write the response stream to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -96,6 +96,8 @@ class DeviceRequest : public ICallData {
       return new DeviceRequest(socket, context, dm);
     }
     
+
+  private:
     /**
      * @brief Writes the current state of the request to the console.
      * 
@@ -108,7 +110,6 @@ class DeviceRequest : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-  private:
     /**
      * @brief The socket to write the response stream to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -30,7 +30,7 @@
 
 /**
  * @file DeviceRequest.h
- * @brief Implements REST DeviceRequest endpoint.
+ * @brief Implements REST DeviceRequest controller.
  * @author benjamin.whitten@rossvideo.com
  * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the DeviceRequest REST endpoint.
+ * @brief ICallData class for the DeviceRequest REST controller.
  */
 class DeviceRequest : public ICallData {
   public:
@@ -68,8 +68,7 @@ class DeviceRequest : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the DeviceRequest endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the DeviceRequest controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -82,12 +81,12 @@ class DeviceRequest : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the DeviceRequest process
+     * @brief Finishes the DeviceRequest process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -30,7 +30,7 @@
 
 /**
  * @file ExecuteCommand.h
- * @brief Implements the ExecuteCommand REST API
+ * @brief Implements REST ExecuteCommand endpoint.
  * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -64,21 +64,47 @@ class ExecuteCommand : public ICallData {
     }
 
     /**
-     * @brief Constructor for the ExecuteCommand RPC.
+     * @brief Constructor for the ExecuteCommand endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The SocketReader object.
-     * @param dm The device to connect to.
-     */
+     * @param dm The device to execute the command on.
+     */ 
     ExecuteCommand(tcp::socket& socket, SocketReader& context, IDevice& dm);
+    
     /**
      * @brief ExecuteCommand's main process.
      */
     void proceed() override;
+    
     /**
      * @brief Finishes the ExecuteCommand process
      */
     void finish() override;
+    
+    /**
+     * @brief Creates a new request object for use with GenericFactory.
+     * 
+     * @param socket The socket to write the response stream to.
+     * @param context The SocketReader object.
+     * @param dm The device to connect to.
+     */
+    static ICallData* makeOne(tcp::socket& socket, SocketReader& context, IDevice& dm) {
+      return new ExecuteCommand(socket, context, dm);
+    }
+    
+    /**
+     * @brief Writes the current state of the request to the console.
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
+     */
+    inline void writeConsole_(CallStatus status, bool ok) const override {
+      std::cout << "ExecuteCommand::proceed[" << objectId_ << "]: "
+                << catena::common::timeNow() << " status: "
+                << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
+                << std::endl;
+    }
 
   private:
     /**
@@ -113,19 +139,6 @@ class ExecuteCommand : public ICallData {
      * @brief The OID of the parameter to connect to.
      */
     std::string oid_;
-
-    /**
-     * @brief Helper function to write status messages to the API console.
-     * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
-     */
-    inline void writeConsole_(CallStatus status, bool ok) const override {
-        std::cout << "ExecuteCommand::proceed[" << objectId_ << "]: "
-                  << catena::common::timeNow() << " status: "
-                  << static_cast<int>(status) << ", ok: " << std::boolalpha << ok
-                  << std::endl;
-    }
 };
 
 } // namespace REST

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -63,8 +63,21 @@ class ExecuteCommand : public ICallData {
         return new ExecuteCommand(socket, context, dm);
     }
 
-    ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDevice& dm);
+    /**
+     * @brief Constructor for the ExecuteCommand RPC.
+     *
+     * @param socket The socket to write the response to.
+     * @param context The SocketReader object.
+     * @param dm The device to connect to.
+     */
+    ExecuteCommand(tcp::socket& socket, SocketReader& context, IDevice& dm);
+    /**
+     * @brief ExecuteCommand's main process.
+     */
     void proceed() override;
+    /**
+     * @brief Finishes the ExecuteCommand process
+     */
     void finish() override;
 
   private:

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -71,10 +71,10 @@ class ExecuteCommand : public ICallData {
      * @brief Constructor for the ExecuteCommand controller.
      *
      * @param socket The socket to write the response to.
-     * @param context The SocketReader object.
+     * @param context The ISocketReader object.
      * @param dm The device to execute the command on.
      */ 
-    ExecuteCommand(tcp::socket& socket, SocketReader& context, IDevice& dm);
+    ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     
     /**
      * @brief ExecuteCommand's main process.

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -30,7 +30,7 @@
 
 /**
  * @file ExecuteCommand.h
- * @brief Implements REST ExecuteCommand endpoint.
+ * @brief Implements REST ExecuteCommand controller.
  * @author zuhayr.sarker@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -56,7 +56,11 @@ namespace REST {
 
 using catena::common::IParam;
 using catena::common::IDevice;
+using catena::common::timeNow;
 
+/**
+ * @brief Controller class for handling ExecuteCommand REST requests.
+ */
 class ExecuteCommand : public ICallData {
   public:
     static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
@@ -64,8 +68,7 @@ class ExecuteCommand : public ICallData {
     }
 
     /**
-     * @brief Constructor for the ExecuteCommand endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the ExecuteCommand controller.
      *
      * @param socket The socket to write the response to.
      * @param context The SocketReader object.
@@ -84,7 +87,7 @@ class ExecuteCommand : public ICallData {
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The SocketReader object.
@@ -101,9 +104,8 @@ class ExecuteCommand : public ICallData {
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "ExecuteCommand::proceed[" << objectId_ << "]: "
-                << catena::common::timeNow() << " status: "
-                << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
-                << std::endl;
+                << timeNow() << " status: "<< static_cast<int>(status)
+                <<", ok: "<< std::boolalpha << ok << std::endl;
     }
 
   private:

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -97,7 +97,10 @@ class ExecuteCommand : public ICallData {
       return new ExecuteCommand(socket, context, dm);
     }
     
-    /**
+
+
+  private:
+      /**
      * @brief Writes the current state of the request to the console.
      * @param status The current state of the request (kCreate, kFinish, etc.)
      * @param ok The status of the request (open or closed).
@@ -107,8 +110,6 @@ class ExecuteCommand : public ICallData {
                 << timeNow() << " status: "<< static_cast<int>(status)
                 <<", ok: "<< std::boolalpha << ok << std::endl;
     }
-
-  private:
     /**
      * @brief The number of ExecuteCommand objects created.
      */

--- a/sdks/cpp/connections/REST/include/controllers/GetParam.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetParam.h
@@ -29,8 +29,8 @@
  */
 
 /**
- * @file GetValue.h
- * @brief Implements REST GetValue RPC.
+ * @file GetParam.h
+ * @brief Implements REST GetParam controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the GetParam REST endpoint.
+ * @brief ICallData class for the GetParam REST controller.
  */
 class GetParam : public ICallData {
   public:
@@ -68,8 +68,7 @@ class GetParam : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the GetParam endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the GetParam controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -82,12 +81,12 @@ class GetParam : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the GetParam process
+     * @brief Finishes the GetParam process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/GetParam.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetParam.h
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the GetValue REST RPC.
+ * @brief CallData class for the GetParam REST endpoint.
  */
 class GetParam : public ICallData {
   public:
@@ -68,23 +68,26 @@ class GetParam : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the GetValue RPC.
+     * @brief Constructor for the GetParam endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to get the value from.
+     * @param dm The device to get the parameter from.
      */ 
     GetParam(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
-     * @brief GetValue's main process.
+     * @brief GetParam's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the GetValue process.
+     * @brief Finishes the GetParam process
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -93,12 +96,12 @@ class GetParam : public ICallData {
     static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
       return new GetParam(socket, context, dm);
     }
-  private:
+    
     /**
-     * @brief Helper function to write status messages to the API console.
+     * @brief Writes the current state of the request to the console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "GetParam::proceed[" << objectId_ << "]: "
@@ -107,6 +110,7 @@ class GetParam : public ICallData {
                 << std::endl;
     }
 
+  private:
     /**
      * @brief The socket to write the response to.
      */
@@ -125,11 +129,11 @@ class GetParam : public ICallData {
     IDevice& dm_;
 
     /**
-     * @brief ID of the GetValue object
+     * @brief ID of the GetParam object
      */
     int objectId_;
     /**
-     * @brief The total # of GetValue objects.
+     * @brief The total # of GetParam objects.
      */
     static int objectCounter_;
 };

--- a/sdks/cpp/connections/REST/include/controllers/GetParam.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetParam.h
@@ -96,6 +96,9 @@ class GetParam : public ICallData {
       return new GetParam(socket, context, dm);
     }
     
+
+
+  private:
     /**
      * @brief Writes the current state of the request to the console.
      * 
@@ -108,8 +111,6 @@ class GetParam : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-
-  private:
     /**
      * @brief The socket to write the response to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
@@ -30,7 +30,7 @@
 
 /**
  * @file GetPopulatedSlots.h
- * @brief Implements REST GetPopulatedSlots RPC.
+ * @brief Implements REST GetPopulatedSlots endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the GetPopulatedSlots REST RPC.
+ * @brief CallData class for the GetPopulatedSlots REST endpoint.
  */
 class GetPopulatedSlots : public ICallData {
   public:
@@ -68,10 +68,11 @@ class GetPopulatedSlots : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the GetPopulatedSlots RPC.
+     * @brief Constructor for the GetPopulatedSlots endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
-     * @param context The ISocketReader object. Here to maintain consistency.
+     * @param context The ISocketReader object.
      * @param dm The device to get the slot of.
      */ 
     GetPopulatedSlots(tcp::socket& socket, ISocketReader& context, IDevice& dm);
@@ -80,11 +81,11 @@ class GetPopulatedSlots : public ICallData {
      */
     void proceed() override;
     /**
-     * @brief Finishes the GetPopulatedSlots process.
+     * @brief Finishes the GetPopulatedSlots process
      */
     void finish() override;
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -95,10 +96,10 @@ class GetPopulatedSlots : public ICallData {
     }
   private:
     /**
-     * @brief Helper function to write status messages to the API console.
+     * @brief Writes the current state of the request to the console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "Connect::proceed[" << objectId_ << "]: "

--- a/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
@@ -30,7 +30,7 @@
 
 /**
  * @file GetPopulatedSlots.h
- * @brief Implements REST GetPopulatedSlots endpoint.
+ * @brief Implements REST GetPopulatedSlots controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the GetPopulatedSlots REST endpoint.
+ * @brief ICallData class for the GetPopulatedSlots REST controller.
  */
 class GetPopulatedSlots : public ICallData {
   public:
@@ -68,24 +68,25 @@ class GetPopulatedSlots : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the GetPopulatedSlots endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the GetPopulatedSlots controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to get the slot of.
+     * @param dm The device to get the populated slots of.
      */ 
     GetPopulatedSlots(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
      * @brief GetPopulatedSlots's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the GetPopulatedSlots process
+     * @brief Finishes the GetPopulatedSlots process.
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -30,7 +30,7 @@
 
 /**
  * @file GetValue.h
- * @brief Implements REST GetValue RPC.
+ * @brief Implements REST GetValue endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the GetValue REST RPC.
+ * @brief CallData class for the GetValue REST endpoint.
  */
 class GetValue : public ICallData {
   public:
@@ -68,7 +68,8 @@ class GetValue : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the GetValue RPC.
+     * @brief Constructor for the GetValue endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -79,12 +80,14 @@ class GetValue : public ICallData {
      * @brief GetValue's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the GetValue process.
+     * @brief Finishes the GetValue process
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -93,12 +96,12 @@ class GetValue : public ICallData {
     static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
       return new GetValue(socket, context, dm);
     }
-  private:
+    
     /**
-     * @brief Helper function to write status messages to the API console.
+     * @brief Writes the current state of the request to the console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "GetValue::proceed[" << objectId_ << "]: "
@@ -106,7 +109,7 @@ class GetValue : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-
+  private:
     /**
      * @brief The socket to write the response to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -96,6 +96,8 @@ class GetValue : public ICallData {
       return new GetValue(socket, context, dm);
     }
     
+    
+  private:
     /**
      * @brief Writes the current state of the request to the console.
      * 
@@ -108,7 +110,6 @@ class GetValue : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-  private:
     /**
      * @brief The socket to write the response to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -30,7 +30,7 @@
 
 /**
  * @file GetValue.h
- * @brief Implements REST GetValue endpoint.
+ * @brief Implements REST GetValue controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the GetValue REST endpoint.
+ * @brief ICallData class for the GetValue REST controller.
  */
 class GetValue : public ICallData {
   public:
@@ -68,8 +68,7 @@ class GetValue : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the GetValue endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the GetValue controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -82,12 +81,12 @@ class GetValue : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the GetValue process
+     * @brief Finishes the GetValue process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
@@ -30,7 +30,7 @@
 
 /**
  * @file LanguagePackRequest.h
- * @brief Implements REST LanguagePackRequest endpoint.
+ * @brief Implements REST LanguagePackRequest controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -58,7 +58,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the LanguagePackRequest REST endpoint.
+ * @brief ICallData class for the LanguagePackRequest REST controller.
  */
 class LanguagePackRequest : public ICallData {
   public:
@@ -67,8 +67,7 @@ class LanguagePackRequest : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the LanguagePackRequest endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the LanguagePackRequest controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -81,12 +80,12 @@ class LanguagePackRequest : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the LanguagePackRequest process
+     * @brief Finishes the LanguagePackRequest process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
@@ -95,6 +95,8 @@ class LanguagePackRequest : public ICallData {
       return new LanguagePackRequest(socket, context, dm);
     }
     
+
+  private:
     /**
      * @brief Writes the current state of the request to the console.
      * 
@@ -107,7 +109,6 @@ class LanguagePackRequest : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-  private:
     /**
      * @brief The socket to write the response to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/LanguagePackRequest.h
@@ -30,7 +30,7 @@
 
 /**
  * @file LanguagePackRequest.h
- * @brief Implements REST LanguagePackRequest RPC.
+ * @brief Implements REST LanguagePackRequest endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -58,7 +58,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the LanguagePackRequest REST RPC.
+ * @brief CallData class for the LanguagePackRequest REST endpoint.
  */
 class LanguagePackRequest : public ICallData {
   public:
@@ -67,23 +67,26 @@ class LanguagePackRequest : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the LanguagePackRequest RPC.
+     * @brief Constructor for the LanguagePackRequest endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to get the value from.
+     * @param dm The device to get the language pack from.
      */ 
     LanguagePackRequest(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
      * @brief LanguagePackRequest's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the LanguagePackRequest process.
+     * @brief Finishes the LanguagePackRequest process
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -92,12 +95,12 @@ class LanguagePackRequest : public ICallData {
     static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
       return new LanguagePackRequest(socket, context, dm);
     }
-  private:
+    
     /**
-     * @brief Helper function to write status messages to the API console.
+     * @brief Writes the current state of the request to the console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "LanguagePackRequest::proceed[" << objectId_ << "]: "
@@ -105,7 +108,7 @@ class LanguagePackRequest : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-
+  private:
     /**
      * @brief The socket to write the response to.
      */
@@ -119,7 +122,7 @@ class LanguagePackRequest : public ICallData {
      */
     SocketWriter writer_;
     /**
-     * @brief The device to set values of.
+     * @brief The device to get language pack from.
      */
     IDevice& dm_;
 

--- a/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
+++ b/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
@@ -29,8 +29,8 @@
  */
 
 /**
- * @file ListLanguagess.h
- * @brief Implements REST ListLanguages RPC.
+ * @file ListLanguages.h
+ * @brief Implements REST ListLanguages endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -58,7 +58,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the ListLanguages REST RPC.
+ * @brief CallData class for the ListLanguages REST endpoint.
  */
 class ListLanguages : public ICallData {
   public:
@@ -67,23 +67,26 @@ class ListLanguages : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the ListLanguages RPC.
+     * @brief Constructor for the ListLanguages endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to get the value from.
+     * @param dm The device to list languages from.
      */ 
     ListLanguages(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
      * @brief ListLanguages's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the ListLanguages process.
+     * @brief Finishes the ListLanguages process
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -92,12 +95,12 @@ class ListLanguages : public ICallData {
     static ICallData* makeOne(tcp::socket& socket, ISocketReader& context, IDevice& dm) {
       return new ListLanguages(socket, context, dm);
     }
-  private:
+    
     /**
-     * @brief Helper function to write status messages to the API console.
+     * @brief Writes the current state of the request to the console.
      * 
-     * @param status The current state of the RPC (kCreate, kFinish, etc.)
-     * @param ok The status of the RPC (open or closed).
+     * @param status The current state of the request (kCreate, kFinish, etc.)
+     * @param ok The status of the request (open or closed).
      */
     inline void writeConsole_(CallStatus status, bool ok) const override {
       std::cout << "ListLanguages::proceed[" << objectId_ << "]: "
@@ -105,7 +108,7 @@ class ListLanguages : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-
+  private:
     /**
      * @brief The socket to write the response to.
      */
@@ -119,7 +122,7 @@ class ListLanguages : public ICallData {
      */
     SocketWriter writer_;
     /**
-     * @brief The device to list languges of.
+     * @brief The device to list languages from.
      */
     IDevice& dm_;
 

--- a/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
+++ b/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
@@ -95,6 +95,8 @@ class ListLanguages : public ICallData {
       return new ListLanguages(socket, context, dm);
     }
     
+
+  private:
     /**
      * @brief Writes the current state of the request to the console.
      * 
@@ -107,7 +109,6 @@ class ListLanguages : public ICallData {
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok
                 << std::endl;
     }
-  private:
     /**
      * @brief The socket to write the response to.
      */

--- a/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
+++ b/sdks/cpp/connections/REST/include/controllers/ListLanguages.h
@@ -30,7 +30,7 @@
 
 /**
  * @file ListLanguages.h
- * @brief Implements REST ListLanguages endpoint.
+ * @brief Implements REST ListLanguages controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -58,7 +58,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the ListLanguages REST endpoint.
+ * @brief ICallData class for the ListLanguages REST controller.
  */
 class ListLanguages : public ICallData {
   public:
@@ -67,8 +67,7 @@ class ListLanguages : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the ListLanguages endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the ListLanguages controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -81,12 +80,12 @@ class ListLanguages : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the ListLanguages process
+     * @brief Finishes the ListLanguages process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
@@ -30,7 +30,7 @@
 
 /**
  * @file MultiSetValue.h
- * @brief Implements REST MultiSetValue endpoint.
+ * @brief Implements REST MultiSetValue controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the MultiSetValue REST endpoint.
+ * @brief ICallData class for the MultiSetValue REST controller.
  */
 class MultiSetValue : public ICallData {
   public:
@@ -68,12 +68,11 @@ class MultiSetValue : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the MultiSetValue endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the MultiSetValue controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to set the values in.
+     * @param dm The device to set values on.
      */ 
     MultiSetValue(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
@@ -82,12 +81,12 @@ class MultiSetValue : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the MultiSetValue process
+     * @brief Finishes the MultiSetValue process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
@@ -140,10 +140,6 @@ class MultiSetValue : public ICallData {
     IDevice& dm_;
 
     /**
-     * @brief The JSON payload from the request.
-     */
-    std::string jsonPayload_;
-    /**
      * @brief The MultiSetValuePayload from the request.
      */
     catena::MultiSetValuePayload reqs_;

--- a/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
@@ -30,7 +30,7 @@
 
 /**
  * @file MultiSetValue.h
- * @brief Implements REST MultiSetValue RPC.
+ * @brief Implements REST MultiSetValue endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -59,7 +59,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief Generic ICallData class for the SetValue and MultiSetValue REST RPCs.
+ * @brief CallData class for the MultiSetValue REST endpoint.
  */
 class MultiSetValue : public ICallData {
   public:
@@ -68,23 +68,26 @@ class MultiSetValue : public ICallData {
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the MultiSetValue RPC.
+     * @brief Constructor for the MultiSetValue endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to set the value(s) of.
+     * @param dm The device to set the values in.
      */ 
     MultiSetValue(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
-     * @brief MultiSetValue main process.
+     * @brief MultiSetValue's main process.
      */
     void proceed() override;
+    
     /**
-     * @brief Finishes the MultiSetValue process.
+     * @brief Finishes the MultiSetValue process
      */
     void finish() override;
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.
@@ -95,7 +98,7 @@ class MultiSetValue : public ICallData {
     }
   protected:
     /**
-     * @brief Constructor for child SetValue RPCs. Does not call proceed().
+     * @brief Constructor for child SetValue rest endpoints. Does not call proceed().
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
      * @param dm The device to set the value(s) of.
@@ -136,13 +139,18 @@ class MultiSetValue : public ICallData {
      * @brief The device to set values of.
      */
     IDevice& dm_;
+
     /**
-     * @brief The MultiSetValuePayload extracted from jsonPayload_.
+     * @brief The JSON payload from the request.
+     */
+    std::string jsonPayload_;
+    /**
+     * @brief The MultiSetValuePayload from the request.
      */
     catena::MultiSetValuePayload reqs_;
 
     /**
-     * @brief ID of the (Multi)SetValue object
+     * @brief ID of the MultiSetValue object
      */
     int objectId_;
   private:

--- a/sdks/cpp/connections/REST/include/controllers/SetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/SetValue.h
@@ -30,7 +30,7 @@
 
 /**
  * @file SetValue.h
- * @brief Implements REST SetValue endpoint.
+ * @brief Implements REST SetValue controller.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -44,7 +44,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief CallData class for the SetValue REST endpoint.
+ * @brief ICallData class for the SetValue REST controller.
  */
 class SetValue : public MultiSetValue {
   // Specifying which Device and IParam to use (defaults to catena::...)
@@ -53,8 +53,7 @@ class SetValue : public MultiSetValue {
 
   public:
     /**
-     * @brief Constructor for the SetValue endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the SetValue controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/SetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/SetValue.h
@@ -30,7 +30,7 @@
 
 /**
  * @file SetValue.h
- * @brief Implements REST SetValue RPC.
+ * @brief Implements REST SetValue endpoint.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -44,7 +44,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief ICallData class for the SetValue REST RPC.
+ * @brief CallData class for the SetValue REST endpoint.
  */
 class SetValue : public MultiSetValue {
   // Specifying which Device and IParam to use (defaults to catena::...)
@@ -53,15 +53,16 @@ class SetValue : public MultiSetValue {
 
   public:
     /**
-     * @brief Constructor for the SetValue RPC.
+     * @brief Constructor for the SetValue endpoint. Calls proceed() once
+     * initialized.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
-     * @param dm The device to set the value of.
+     * @param dm The device to set the value in.
      */ 
     SetValue(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new rest object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/UpdateSubscriptions.h
+++ b/sdks/cpp/connections/REST/include/controllers/UpdateSubscriptions.h
@@ -54,7 +54,7 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief Controller class for handling UpdateSubscriptions requests
+ * @brief ICallData class for the UpdateSubscriptions REST controller.
  */
 class UpdateSubscriptions : public ICallData {
 public:
@@ -63,8 +63,7 @@ public:
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the UpdateSubscriptions endpoint. Calls proceed() once
-     * initialized.
+     * @brief Constructor for the UpdateSubscriptions controller.
      *
      * @param socket The socket to write the response to.
      * @param context The ISocketReader object.
@@ -73,17 +72,17 @@ public:
     UpdateSubscriptions(tcp::socket& socket, ISocketReader& context, IDevice& dm);
     
     /**
-     * @brief Processes the UpdateSubscriptions request
+     * @brief UpdateSubscriptions's main process.
      */
     void proceed() override;
     
     /**
-     * @brief Finishes the UpdateSubscriptions process
+     * @brief Finishes the UpdateSubscriptions process.
      */
     void finish() override;
     
     /**
-     * @brief Creates a new request object for use with GenericFactory.
+     * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/controllers/UpdateSubscriptions.h
+++ b/sdks/cpp/connections/REST/include/controllers/UpdateSubscriptions.h
@@ -131,7 +131,7 @@ private:
     /**
      * @brief The SocketWriter object for writing to socket_.
      */
-    SSEWriter writer_;
+    std::unique_ptr<SSEWriter> writer_{nullptr};
 
     /**
      * @brief The request payload
@@ -177,6 +177,11 @@ private:
      * @brief The device model
      */
     IDevice& dm_;
+    
+    /**
+     * @brief The error status
+     */
+    catena::exception_with_status rc_;
 };
 
 } // namespace REST 

--- a/sdks/cpp/connections/REST/include/controllers/UpdateSubscriptions.h
+++ b/sdks/cpp/connections/REST/include/controllers/UpdateSubscriptions.h
@@ -63,25 +63,27 @@ public:
     using IParam = catena::common::IParam;
 
     /**
-     * @brief Constructor for the UpdateSubscriptions controller
-     * @param socket The TCP socket for the connection
-     * @param context The socket reader context
-     * @param dm The device model
-     */
+     * @brief Constructor for the UpdateSubscriptions endpoint. Calls proceed() once
+     * initialized.
+     *
+     * @param socket The socket to write the response to.
+     * @param context The ISocketReader object.
+     * @param dm The device to update subscriptions on.
+     */ 
     UpdateSubscriptions(tcp::socket& socket, ISocketReader& context, IDevice& dm);
-
+    
     /**
      * @brief Processes the UpdateSubscriptions request
      */
     void proceed() override;
-
+    
     /**
      * @brief Finishes the UpdateSubscriptions process
      */
     void finish() override;
-
+    
     /**
-     * @brief Creates a new rpc object for use with GenericFactory.
+     * @brief Creates a new request object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.
      * @param context The ISocketReader object.

--- a/sdks/cpp/connections/REST/include/interface/ICallData.h
+++ b/sdks/cpp/connections/REST/include/interface/ICallData.h
@@ -30,7 +30,7 @@
 
 /**
  * @file ICallData.h
- * @brief Interface class for REST endpoints.
+ * @brief Interface class for REST controllers.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -62,17 +62,17 @@ namespace REST {
 enum class CallStatus { kCreate, kProcess, kRead, kWrite, kPostWrite, kFinish };
 
 /**
- * @brief Interface class for the REST API endpoints.
+ * @brief Interface class for REST API controllers.
  */
 class ICallData {
 	public:
 		virtual ~ICallData() = default;
 		/**
-		 * @brief The endpoint's main process.
+		 * @brief The controller's main process.
 		 */
 		virtual void proceed() = 0;
 		/**
-		 * @brief Finishes the endpoint.
+		 * @brief Finishes the controller.
 		 */
 		virtual void finish() = 0;
 

--- a/sdks/cpp/connections/REST/include/interface/ICallData.h
+++ b/sdks/cpp/connections/REST/include/interface/ICallData.h
@@ -30,7 +30,7 @@
 
 /**
  * @file ICallData.h
- * @brief Interface class for REST RPCs.
+ * @brief Interface class for REST endpoints.
  * @author benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2025 Ross Video Ltd
  */
@@ -62,17 +62,17 @@ namespace REST {
 enum class CallStatus { kCreate, kProcess, kRead, kWrite, kPostWrite, kFinish };
 
 /**
- * @brief Interface class for the REST API RPCs.
+ * @brief Interface class for the REST API endpoints.
  */
 class ICallData {
 	public:
 		virtual ~ICallData() = default;
 		/**
-		 * @brief The RPC's main process.
+		 * @brief The endpoint's main process.
 		 */
 		virtual void proceed() = 0;
 		/**
-		 * @brief Finishes the RPC.
+		 * @brief Finishes the endpoint.
 		 */
 		virtual void finish() = 0;
 
@@ -80,8 +80,8 @@ class ICallData {
 		/**
 		 * @brief Helper function to write status messages to the API console.
 		 * 
-		 * @param status The current state of the RPC (kCreate, kFinish, etc.)
-		 * @param ok The status of the RPC (open or closed).
+		 * @param status The current state of the request (kCreate, kFinish, etc.)
+		 * @param ok The status of the request (open or closed).
 		 */
 		virtual inline void writeConsole_(CallStatus status, bool ok) const = 0;
 };

--- a/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
@@ -30,7 +30,7 @@
 
 /**
  * @file IServiceImpl.h
- * @brief Implements REST API
+ * @brief Interface for the REST API implementation
  * @author Benjamin.whitten@rossvideo.com
  * @copyright Copyright © 2024 Ross Video Ltd
  */
@@ -82,7 +82,7 @@ class IServiceImpl {
      */
     virtual void run() = 0;
     /**
-     * @brief Shuts down an running API. This should only be called sometime
+     * @brief Shuts down the running API server. This should only be called sometimes
      * after a call to run().
      */
     virtual void Shutdown() = 0;

--- a/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
@@ -82,7 +82,7 @@ class IServiceImpl {
      */
     virtual void run() = 0;
     /**
-     * @brief Shuts down the running API server. This should only be called sometimes
+     * @brief Shuts down the running API server. This should only be called some time.
      * after a call to run().
      */
     virtual void Shutdown() = 0;

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -75,11 +75,11 @@ class ISocketReader {
      */
     virtual void read(tcp::socket& socket, bool authz = false) = 0;
     /**
-     * @brief Returns the method of the request.
+     * @brief Returns the HTTP method of the request.
      */
     virtual const std::string& method() const = 0;
     /**
-     * @brief Returns the rpc of the request.
+     * @brief Returns the REST endpoint of the request.
      */
     virtual const std::string& service() const = 0;
     /**
@@ -102,7 +102,7 @@ class ISocketReader {
      */
     virtual const std::string& origin() const = 0;
     /**
-     * @brief Returns the language to return the resposne in.
+     * @brief Returns the language to return the response in.
      */
     virtual const std::string& language() const = 0;
     /**

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -87,6 +87,12 @@ class ISocketReader {
      */
     virtual uint32_t slot() const = 0;
     /**
+     * @brief Returns true if the field exists in the URL, regardless of its value.
+     * 
+     * @param key The name of the field to check.
+     */
+    virtual bool hasField(const std::string& key) const = 0;
+    /**
      * @brief Returns the field "key" queried from the URL, or an empty sting
      * if it does not exist.
      * 

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -72,15 +72,12 @@ class ISocketWriter {
      * @param msg The protobuf message to write as JSON.
      */
     virtual void write(google::protobuf::Message& msg) = 0;
-    /**
-     * @brief Writes an error message to the socket.
-     * @param err The catena::exception_with_status.
-     */
-    virtual void write(catena::exception_with_status& err) = 0;
+
     /**
      * @brief Finishes writing the HTTP response.
+     * @param err Optional error status to finish with. If not provided, finishes with OK status.
      */
-    virtual void finish() = 0;
+    virtual void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) = 0;
 };
  
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -78,7 +78,7 @@ class ISocketWriter {
      */
     virtual void write(catena::exception_with_status& err) = 0;
     /**
-     * @brief Finishes writing process.
+     * @brief Finishes writing the HTTP response.
      */
     virtual void finish() = 0;
 };

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -75,9 +75,9 @@ class ISocketWriter {
 
     /**
      * @brief Finishes writing the HTTP response.
-     * @param err Optional error status to finish with. If not provided, finishes with OK status.
+     * @param err The error status to finish with.
      */
-    virtual void finish(const catena::exception_with_status& err = catena::exception_with_status("", catena::StatusCode::OK)) = 0;
+    virtual void finish(const catena::exception_with_status& err) = 0;
 };
  
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -71,13 +71,13 @@ class ISocketWriter {
      * @brief Writes a protobuf message to socket in JSON format.
      * @param msg The protobuf message to write as JSON.
      */
-    virtual void write(google::protobuf::Message& msg) = 0;
+    virtual void write(const google::protobuf::Message& msg) = 0;
 
     /**
      * @brief Finishes writing the HTTP response.
      * @param err The error status to finish with.
      */
-    virtual void finish(const catena::exception_with_status& err) = 0;
+    virtual void finish(const google::protobuf::Message& msg, const catena::exception_with_status& err) = 0;
 };
  
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -89,7 +89,7 @@ void CatenaServiceImpl::run() {
                     std::string requestKey = context.method() + context.service();
                     // Returning empty response with options to the client if required.
                     if (context.method() == "OPTIONS") {
-                        SocketWriter(socket, context.origin()).finish(rc);
+                        SocketWriter(socket, context.origin()).finish(catena::Empty(), rc);
                     // Otherwise routing to request.
                     } else if (router_.canMake(requestKey)) {
                         std::unique_ptr<ICallData> request = router_.makeProduct(requestKey, socket, context, dm_);
@@ -119,7 +119,7 @@ void CatenaServiceImpl::run() {
                 // Try ensures that we don't fail to decrement active requests.
                 try {
                     SocketWriter writer(socket);
-                    writer.finish(rc);
+                    writer.finish(catena::Empty(), rc);
                 } catch (...) {}
             }
             // request completed. Decrementing activeRequests.

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -89,7 +89,7 @@ void CatenaServiceImpl::run() {
                     std::string requestKey = context.method() + context.service();
                     // Returning empty response with options to the client if required.
                     if (context.method() == "OPTIONS") {
-                        SocketWriter(socket, context.origin()).write(rc);
+                        SocketWriter(socket, context.origin()).finish(rc);
                     // Otherwise routing to request.
                     } else if (router_.canMake(requestKey)) {
                         std::unique_ptr<ICallData> request = router_.makeProduct(requestKey, socket, context, dm_);

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -119,7 +119,7 @@ void CatenaServiceImpl::run() {
                 // Try ensures that we don't fail to decrement active requests.
                 try {
                     SocketWriter writer(socket);
-                    writer.finish(rc.status);
+                    writer.finish(rc);
                 } catch (...) {}
             }
             // request completed. Decrementing activeRequests.

--- a/sdks/cpp/connections/REST/src/SocketWriter.cpp
+++ b/sdks/cpp/connections/REST/src/SocketWriter.cpp
@@ -47,6 +47,8 @@ void SocketWriter::finish(const google::protobuf::Message& msg, const catena::ex
     std::stringstream headers;
     headers << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
             << "Content-Type: application/json\r\n"
+            << "Content-Length: " << response_.length() << "\r\n"
+            << "Connection: close\r\n"
             << CORS_ << "\r\n"
             << response_;
 

--- a/sdks/cpp/connections/REST/src/SocketWriter.cpp
+++ b/sdks/cpp/connections/REST/src/SocketWriter.cpp
@@ -21,82 +21,51 @@ void SocketWriter::write(google::protobuf::Message& msg) {
         }
     // Error
     } else {
-        catena::exception_with_status err("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT);
-        write(err);
+        finish(catena::exception_with_status("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT));
     }
-}
-
-void SocketWriter::write(catena::exception_with_status& err) {
-    // Writes an error message to the socket.
-    // Clearing response_ and gettinge errCode.
-    int errCode;
-    if (response_.empty() && err.status == catena::StatusCode::OK) {
-        errCode = 204;
-    } else {
-        errCode = codeMap_.at(err.status).first;
-    }
-    std::string errorMessage = err.what();
-    
-    // Returning the response.
-    std::string headers = "HTTP/1.1 " + std::to_string(errCode) + " " + errorMessage + "\r\n"
-                          "Content-Type: text/plain\r\n"
-                          "Content-Length: " + std::to_string(errorMessage.size()) + "\r\n" +
-                          CORS_ +
-                          "Connection: close\r\n\r\n";
-    boost::asio::write(socket_, boost::asio::buffer(headers + errorMessage));
-}
-
-void SocketWriter::finish() {
-    // Finishes the writing process by writing response to socket.
-    if (!response_.empty()) {
-        // Format in a list if this is a multi-part response.
-        if (multi_) {
-            response_ = "{\"response\":[" + response_ + "]}";
-        }
-        // Set headers and write the response.
-        std::string headers = "HTTP/1.1 200 OK\r\n"
-                              "Content-Type: application/json\r\n"
-                              "Content-Length: " + std::to_string(response_.size()) + "\r\n" +
-                              CORS_ +
-                              "Connection: close\r\n\r\n";
-        boost::asio::write(socket_, boost::asio::buffer(headers + response_));
-    }
-}
-
-void SocketWriter::finish(google::protobuf::Message& msg) {
-    // Finishes the writing process by writing a message to the socket.
-    write(msg);
-    finish();
 }
 
 void SocketWriter::finish(const catena::exception_with_status& err) {
-    // Finishes the writing process by writing a status to the socket.
+    // Finishes the writing process with an error message.
     auto httpStatus = codeMap_.at(err.status);
-    std::stringstream ss;
-    ss << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
-       << "Content-Type: application/json\r\n"
-       << CORS_
-       << "Content-Length: " << response_.length() << "\r\n"
-       << "\r\n"
-       << response_;
+    
+    //If response is empty but status is ok, set rc to 204
+    if (response_.empty() && err.status == catena::StatusCode::OK) {
+        httpStatus = codeMap_.at(catena::StatusCode::NO_CONTENT);
+    }
 
-    boost::asio::write(socket_, boost::asio::buffer(ss.str()));
+    if (!response_.empty()) {
+        if (multi_) {
+            response_ = "{\"response\":[" + response_ + "]}";
+        } 
+    }
+
+    std::stringstream headers;
+    headers << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
+            << "Content-Type: text/plain\r\n"
+            << CORS_ << "\r\n"
+            << "Content-Length: " << response_.length() << "\r\n"
+            << "Connection: close\r\n"
+            << "\r\n"
+            << response_;
+
+    boost::asio::write(socket_, boost::asio::buffer(headers.str()));
 }
 
 SSEWriter::SSEWriter(tcp::socket& socket, const std::string& origin, const catena::exception_with_status& err) : socket_{socket} {
     auto httpStatus = codeMap_.at(err.status);
-    std::stringstream ss;
-    ss << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
-       << "Content-Type: text/event-stream\r\n"
-       << "Cache-Control: no-cache\r\n"
-       << "Connection: keep-alive\r\n"
-       << "Access-Control-Allow-Origin: " << origin << "\r\n"
-       << "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
-       << "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With, Language, Detail-Level\r\n"
-       << "Access-Control-Allow-Credentials: true\r\n"
-       << "\r\n";
+    std::stringstream headers;
+    headers << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
+            << "Content-Type: text/event-stream\r\n"
+            << "Cache-Control: no-cache\r\n"
+            << "Connection: keep-alive\r\n"
+            << "Access-Control-Allow-Origin: " << origin << "\r\n"
+            << "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
+            << "Access-Control-Allow-Headers: Content-Type, Authorization, accept, Origin, X-Requested-With, Language, Detail-Level\r\n"
+            << "Access-Control-Allow-Credentials: true\r\n"
+            << "\r\n";
 
-    boost::asio::write(socket_, boost::asio::buffer(ss.str()));
+    boost::asio::write(socket_, boost::asio::buffer(headers.str()));
 }
 
 void SSEWriter::write(google::protobuf::Message& msg) {   
@@ -110,15 +79,14 @@ void SSEWriter::write(google::protobuf::Message& msg) {
         boost::asio::write(socket_, boost::asio::buffer("data: " + jsonOutput + "\n\n"));
     // Error, writting error to the client.
     } else {
-        catena::exception_with_status err("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT);
-        write(err);
+        finish(catena::exception_with_status("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT));
     }
 }
 
-void SSEWriter::write(catena::exception_with_status& err) {
+void SSEWriter::finish(const catena::exception_with_status& err) {
     // Writing error message.
     auto httpStatus = codeMap_.at(err.status);
-    std::stringstream ss;
-    ss << "data: " << httpStatus.second << " " << err.what() << "\n\n";
-    boost::asio::write(socket_, boost::asio::buffer(ss.str()));
+    std::stringstream headers;
+    headers << "data: " << httpStatus.second << " " << err.what() << "\n\n";
+    boost::asio::write(socket_, boost::asio::buffer(headers.str()));
 }

--- a/sdks/cpp/connections/REST/src/SocketWriter.cpp
+++ b/sdks/cpp/connections/REST/src/SocketWriter.cpp
@@ -21,8 +21,7 @@ void SocketWriter::write(const google::protobuf::Message& msg) {
         }
     // Error
     } else {
-        catena::Empty empty;
-        finish(empty, catena::exception_with_status("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT));
+        finish(catena::Empty(), catena::exception_with_status("Failed to convert protobuf to JSON", catena::StatusCode::INVALID_ARGUMENT));
     }
 }
 
@@ -49,9 +48,6 @@ void SocketWriter::finish(const google::protobuf::Message& msg, const catena::ex
     headers << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
             << "Content-Type: application/json\r\n"
             << CORS_ << "\r\n"
-            << "Content-Length: " << response_.length() << "\r\n"
-            << "Connection: close\r\n"
-            << "\r\n"
             << response_;
 
     boost::asio::write(socket_, boost::asio::buffer(headers.str()));

--- a/sdks/cpp/connections/REST/src/SocketWriter.cpp
+++ b/sdks/cpp/connections/REST/src/SocketWriter.cpp
@@ -34,15 +34,13 @@ void SocketWriter::finish(const catena::exception_with_status& err) {
         httpStatus = codeMap_.at(catena::StatusCode::NO_CONTENT);
     }
 
-    if (!response_.empty()) {
-        if (multi_) {
-            response_ = "{\"response\":[" + response_ + "]}";
-        } 
+    if (!response_.empty() && multi_) {
+        response_ = "{\"response\":[" + response_ + "]}";
     }
 
     std::stringstream headers;
     headers << "HTTP/1.1 " << httpStatus.first << " " << httpStatus.second << "\r\n"
-            << "Content-Type: text/plain\r\n"
+            << "Content-Type: application/json\r\n"
             << CORS_ << "\r\n"
             << "Content-Length: " << response_.length() << "\r\n"
             << "Connection: close\r\n"
@@ -50,6 +48,12 @@ void SocketWriter::finish(const catena::exception_with_status& err) {
             << response_;
 
     boost::asio::write(socket_, boost::asio::buffer(headers.str()));
+}
+
+void SocketWriter::finish(google::protobuf::Message& msg) {
+    // Finishes the writing process by writing a message to the socket.
+    write(msg);
+    finish(catena::exception_with_status("", catena::StatusCode::OK));
 }
 
 SSEWriter::SSEWriter(tcp::socket& socket, const std::string& origin, const catena::exception_with_status& err) : socket_{socket} {

--- a/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
@@ -43,12 +43,7 @@ void AddLanguage::proceed() {
     }
 
     // Finishing by writing answer to client.
-    if (rc.status == catena::StatusCode::OK) {
-        catena::Empty ans = catena::Empty();
-        writer_.finish(ans);
-    } else {
-        writer_.finish(rc);
-    }
+    writer_.finish(catena::Empty(), rc);
 }
 
 void AddLanguage::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
@@ -45,14 +45,13 @@ void AddLanguage::proceed() {
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
         catena::Empty ans = catena::Empty();
-        writer_.finish(ans);
+        writer_.write(ans);
     } else {
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 
 void AddLanguage::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "AddLanguage[" << objectId_ << "] finished\n";
-    writer_.finish();
 }

--- a/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
@@ -45,7 +45,7 @@ void AddLanguage::proceed() {
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
         catena::Empty ans = catena::Empty();
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.finish(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AddLanguage.cpp
@@ -54,4 +54,5 @@ void AddLanguage::proceed() {
 void AddLanguage::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "AddLanguage[" << objectId_ << "] finished\n";
+    writer_.finish();
 }

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -47,7 +47,7 @@ using catena::common::IDevice;
 // Initializes the object counter for BasicParamInfoRequest to 0.
 int BasicParamInfoRequest::objectCounter_ = 0;
 
-BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, IDevice& dm) :
+BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, ISocketReader& context, IDevice& dm) :
     socket_{socket}, context_{context}, dm_{dm}, 
     rc_("", catena::StatusCode::OK), recursive_{false} {
     objectId_ = objectCounter_++;

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -56,7 +56,8 @@ BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& 
     // Parsing fields and assigning to respective variables.
     try {
         // Get recursive from query parameters - presence means true
-        recursive_ = context.fields("recursive") == "true" || context.fields("recursive").empty();
+        recursive_ = context.hasField("recursive");
+
 
         // Get oid_prefix from JSON body if present, otherwise from query parameters
         if (!context_.jsonBody().empty()) {

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -87,7 +87,6 @@ BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& 
 }
 
 void BasicParamInfoRequest::proceed() {
-    writeConsole_(CallStatus::kCreate, socket_.is_open());
     writeConsole_(CallStatus::kProcess, socket_.is_open());
 
     try {

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -50,7 +50,7 @@ int BasicParamInfoRequest::objectCounter_ = 0;
 BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, IDevice& dm) :
     socket_{socket}, context_{context}, dm_{dm}, 
     rc_("", catena::StatusCode::OK), recursive_{false},
-    writer_{std::make_unique<SSEWriter>(socket, context.origin())} {
+    writer_{std::make_unique<SSEWriter>(socket, context.origin(), rc_.status)} {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     
@@ -220,7 +220,7 @@ void BasicParamInfoRequest::finish() {
     std::cout << "BasicParamInfoRequest[" << objectId_ << "] finished\n";
     
     if (!writer_) {
-        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), catena::REST::codeMap_.at(rc_.status));
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), rc_.status);
     }
     socket_.close();
 }

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -47,8 +47,9 @@ using catena::common::IDevice;
 // Initializes the object counter for BasicParamInfoRequest to 0.
 int BasicParamInfoRequest::objectCounter_ = 0;
 
-BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, ISocketReader& context, IDevice& dm) :
-    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm}, ok_{true}, recursive_{false} {
+BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, IDevice& dm) :
+    socket_{socket}, context_{context}, dm_{dm}, 
+    rc_("", catena::StatusCode::OK), recursive_{false} {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     
@@ -64,24 +65,14 @@ BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, ISocketReader&
         recursive_ = context.fields("recursive") == "true";
     // Parse error
     } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
-        ok_ = false;
+        rc_ = catena::exception_with_status("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
+        finish();
     }
 }
 
 void BasicParamInfoRequest::proceed() {
-    writeConsole_(CallStatus::kCreate, ok_);
-    if (!ok_) {
-        finish();
-        return;
-    }
-
-    writeConsole_(CallStatus::kProcess, ok_);
-    if (!ok_) {
-        finish();
-        return;
-    }
+    writeConsole_(CallStatus::kCreate, socket_.is_open());
+    writeConsole_(CallStatus::kProcess, socket_.is_open());
 
     try {
         std::unique_ptr<IParam> param;
@@ -121,7 +112,7 @@ void BasicParamInfoRequest::proceed() {
                 }
                 writer_lock_.lock();
                 for (auto& response : responses_) {
-                    writer_.write(response);
+                    writer_->write(response);
                 }
                 writer_lock_.unlock();
             }
@@ -157,11 +148,12 @@ void BasicParamInfoRequest::proceed() {
                 // Write all responses to the client
                 writer_lock_.lock();
                 for (auto& response : responses_) {
-                    writer_.write(response);
+                    writer_->write(response);
                 }
                 writer_lock_.unlock();
             } else {
-                throw catena::exception_with_status(rc.what(), rc.status);
+                rc_ = catena::exception_with_status(rc.what(), rc.status);
+                finish();
             }
         }
         // Mode 3: Get all top-level parameters with recursion
@@ -193,23 +185,28 @@ void BasicParamInfoRequest::proceed() {
                 }
                 writer_lock_.lock();
                 for (auto& response : responses_) {
-                    writer_.write(response);
+                    writer_->write(response);
                 }
                 writer_lock_.unlock();
             }
         }
     } catch (catena::exception_with_status& err) {
-        writer_.write(err);
+        rc_ = std::move(err);
+        finish();
     } catch (...) {
-        catena::exception_with_status err("Unknown error in BasicParamInfoRequest", catena::StatusCode::UNKNOWN);
-        writer_.write(err);
+        rc_ = catena::exception_with_status("Unknown error in BasicParamInfoRequest", catena::StatusCode::UNKNOWN);
+        finish();
     }
 }
 
 void BasicParamInfoRequest::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
-    writer_.finish();
     std::cout << "BasicParamInfoRequest[" << objectId_ << "] finished\n";
+    
+    if (!writer_) {
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), catena::REST::codeMap_.at(rc_.status));
+    }
+    socket_.close();
 }
 
 // Helper method to add a parameter to the responses

--- a/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/BasicParamInfoRequest.cpp
@@ -49,8 +49,7 @@ int BasicParamInfoRequest::objectCounter_ = 0;
 
 BasicParamInfoRequest::BasicParamInfoRequest(tcp::socket& socket, SocketReader& context, IDevice& dm) :
     socket_{socket}, context_{context}, dm_{dm}, 
-    rc_("", catena::StatusCode::OK), recursive_{false},
-    writer_{std::make_unique<SSEWriter>(socket, context.origin(), rc_.status)} {
+    rc_("", catena::StatusCode::OK), recursive_{false} {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     
@@ -219,7 +218,7 @@ void BasicParamInfoRequest::finish() {
     std::cout << "BasicParamInfoRequest[" << objectId_ << "] finished\n";
     
     if (!writer_) {
-        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), rc_.status);
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), rc_);
     }
     socket_.close();
 }

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -13,7 +13,7 @@ Connect::Connect(tcp::socket& socket, ISocketReader& context, IDevice& dm) :
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.
     userAgent_ = context.fields("user_agent");
-    forceConnection_ = context.fields("force_connection") == "true" || context.fields("force_connection").empty();
+    forceConnection_ = context.hasField("force_connection");
 }
 
 void Connect::proceed() {

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -13,7 +13,7 @@ Connect::Connect(tcp::socket& socket, ISocketReader& context, IDevice& dm) :
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     // Parsing fields and assigning to respective variables.
     userAgent_ = context.fields("user_agent");
-    forceConnection_ = context.fields("force_connection") == "true";
+    forceConnection_ = context.fields("force_connection") == "true" || context.fields("force_connection").empty();
 }
 
 void Connect::proceed() {

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -49,7 +49,7 @@ void Connect::proceed() {
         writer_.write(populatedSlots);
     // Used to catch the authz error.
     } catch (catena::exception_with_status& err) {
-        writer_.finish(err);
+        writer_.finish(catena::Empty(), err);
         shutdown_ = true;
     }
 
@@ -84,7 +84,7 @@ void Connect::finish() {
     } catch (...) {}
     // Finishing and closing the socket.
     if (socket_.is_open()) {
-        writer_.finish(catena::exception_with_status("", catena::StatusCode::OK));
+        writer_.finish(catena::Empty(), catena::exception_with_status("", catena::StatusCode::OK));
         socket_.close();
     }
     std::cout << "Connect[" << objectId_ << "] finished\n";

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -49,7 +49,7 @@ void Connect::proceed() {
         writer_.write(populatedSlots);
     // Used to catch the authz error.
     } catch (catena::exception_with_status& err) {
-        writer_.write(err);
+        writer_.finish(err);
         shutdown_ = true;
     }
 
@@ -84,7 +84,7 @@ void Connect::finish() {
     } catch (...) {}
     // Finishing and closing the socket.
     if (socket_.is_open()) {
-        writer_.finish();
+        writer_.finish(catena::exception_with_status("", catena::StatusCode::OK));
         socket_.close();
     }
     std::cout << "Connect[" << objectId_ << "] finished\n";

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -55,14 +55,14 @@ void DeviceRequest::proceed() {
             }
             writer_.write(component);
         }
-        writer_.finish(catena::exception_with_status("", catena::StatusCode::OK));
+        writer_.finish(catena::Empty(), catena::exception_with_status("", catena::StatusCode::OK));
         
     // ERROR: Write to stream and end call.
     } catch (catena::exception_with_status& err) {
-        writer_.finish(err);
+        writer_.finish(catena::Empty(), err);
     } catch (...) {
         catena::exception_with_status err{"Unknown error", catena::StatusCode::UNKNOWN};
-        writer_.finish(err);
+        writer_.finish(catena::Empty(), err);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -55,21 +55,18 @@ void DeviceRequest::proceed() {
             }
             writer_.write(component);
         }
-        writer_.finish();
+        writer_.finish(catena::exception_with_status("", catena::StatusCode::OK));
         
     // ERROR: Write to stream and end call.
     } catch (catena::exception_with_status& err) {
-        writer_.write(err);
-        writer_.finish();
+        writer_.finish(err);
     } catch (...) {
         catena::exception_with_status err{"Unknown error", catena::StatusCode::UNKNOWN};
-        writer_.write(err);
-        writer_.finish();
+        writer_.finish(err);
     }
 }
 
 void DeviceRequest::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
-    writer_.finish();
     std::cout << "DeviceRequest[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -91,4 +91,5 @@ void ExecuteCommand::proceed() {
 void ExecuteCommand::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "ExecuteCommand[" << objectId_ << "] finished\n";
+    writer_.finish();
 } 

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -38,7 +38,7 @@ ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDev
         }
     } catch (...) {
         catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
+        writer_.finish(err);
     }
 }
 
@@ -60,7 +60,7 @@ void ExecuteCommand::proceed() {
         // If the command is not found, return an error
         if (command == nullptr) {
             if (req_.respond()) {
-                writer_.write(rc);
+                writer_.finish(rc);
             }
             return;
         }
@@ -71,19 +71,19 @@ void ExecuteCommand::proceed() {
         // Only write response if respond is true
         if (req_.respond()) {
             if (rc.status == catena::StatusCode::OK) {
-                writer_.finish(res);
+                writer_.write(res);
             } else {
-                writer_.write(rc);
+                writer_.finish(rc);
             }
         }
     } catch (catena::exception_with_status& err) {
         if (req_.respond()) {
-            writer_.write(err);
+            writer_.finish(err);
         }
     } catch (...) {
         if (req_.respond()) {
             catena::exception_with_status err("Unknown error", catena::StatusCode::UNKNOWN);
-            writer_.write(err);
+            writer_.finish(err);
         }
     }
 }
@@ -91,5 +91,4 @@ void ExecuteCommand::proceed() {
 void ExecuteCommand::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "ExecuteCommand[" << objectId_ << "] finished\n";
-    writer_.finish();
 } 

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -19,8 +19,8 @@ ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDev
         // Initialize the request
         req_.set_slot(context_.slot());
         req_.set_oid("/" + context_.fields("oid"));
-        req_.set_respond(context_.fields("respond") == "true");
-        req_.set_proceed(context_.fields("proceed") == "true");
+        req_.set_respond(context_.hasField("respond"));
+        req_.set_proceed(context_.hasField("proceed"));
 
         // Parse JSON body if present
         if (!context_.jsonBody().empty()) {
@@ -72,11 +72,7 @@ void ExecuteCommand::proceed() {
 
         // Only write response if respond is true
         if (req_.respond()) {
-            if (rc.status == catena::StatusCode::OK) {
-                writer_.write(res);
-            } else {
-                writer_.finish(res, rc);
-            }
+            writer_.finish(res, rc);
         }
     } catch (catena::exception_with_status& err) {
         if (req_.respond()) {

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -38,7 +38,8 @@ ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDev
         }
     } catch (...) {
         catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.finish(err);
+        catena::Empty empty;
+        writer_.finish(empty, err);
     }
 }
 
@@ -60,7 +61,8 @@ void ExecuteCommand::proceed() {
         // If the command is not found, return an error
         if (command == nullptr) {
             if (req_.respond()) {
-                writer_.finish(rc);
+                catena::Empty empty;
+                writer_.finish(empty, rc);
             }
             return;
         }
@@ -73,17 +75,17 @@ void ExecuteCommand::proceed() {
             if (rc.status == catena::StatusCode::OK) {
                 writer_.write(res);
             } else {
-                writer_.finish(rc);
+                writer_.finish(res, rc);
             }
         }
     } catch (catena::exception_with_status& err) {
         if (req_.respond()) {
-            writer_.finish(err);
+            writer_.finish(catena::Empty(), err);
         }
     } catch (...) {
         if (req_.respond()) {
             catena::exception_with_status err("Unknown error", catena::StatusCode::UNKNOWN);
-            writer_.finish(err);
+            writer_.finish(catena::Empty(), err);
         }
     }
 }

--- a/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
@@ -43,7 +43,7 @@ void GetParam::proceed() {
     }
 
     // Finishing by writing answer to client.
-    writer_.finish(catena::Empty(), rc);
+    writer_.finish(ans, rc);
 }
 
 void GetParam::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
@@ -44,7 +44,7 @@ void GetParam::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.finish(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
@@ -44,9 +44,9 @@ void GetParam::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
+        writer_.write(ans);
     } else {
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
@@ -43,11 +43,7 @@ void GetParam::proceed() {
     }
 
     // Finishing by writing answer to client.
-    if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
-    } else {
-        writer_.finish(rc);
-    }
+    writer_.finish(catena::Empty(), rc);
 }
 
 void GetParam::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
@@ -19,10 +19,10 @@ void GetPopulatedSlots::proceed() {
         SlotList slotList;
         slotList.add_slots(dm_.slot());
         // Writing response.
-        writer_.finish(slotList);
+        writer_.write(slotList);
     } catch (...) {
         catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
@@ -19,10 +19,10 @@ void GetPopulatedSlots::proceed() {
         SlotList slotList;
         slotList.add_slots(dm_.slot());
         // Writing response.
-        writer_.finish(slotList);
+        writer_.finish(catena::Empty(), catena::exception_with_status("", catena::StatusCode::OK));
     } catch (...) {
         catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-        writer_.finish(rc);
+        writer_.finish(catena::Empty(), rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
@@ -19,7 +19,7 @@ void GetPopulatedSlots::proceed() {
         SlotList slotList;
         slotList.add_slots(dm_.slot());
         // Writing response.
-        writer_.write(slotList);
+        writer_.finish(slotList);
     } catch (...) {
         catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
         writer_.finish(rc);

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -34,7 +34,7 @@ void GetValue::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.finish(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -33,11 +33,7 @@ void GetValue::proceed() {
     }
 
     // Finishing by writing answer to client.
-    if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
-    } else {
-        writer_.finish(rc);
-    }
+    writer_.finish(ans, rc);
 }
 
 void GetValue::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -34,9 +34,9 @@ void GetValue::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
+        writer_.write(ans);
     } else {
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
@@ -28,7 +28,7 @@ void LanguagePackRequest::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.finish(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
@@ -28,9 +28,9 @@ void LanguagePackRequest::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
+        writer_.write(ans);
     } else {
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/LanguagePackRequest.cpp
@@ -27,11 +27,7 @@ void LanguagePackRequest::proceed() {
     }
 
     // Finishing by writing answer to client.
-    if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
-    } else {
-        writer_.finish(rc);
-    }
+    writer_.finish(ans,rc);
 }
 
 void LanguagePackRequest::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
@@ -27,7 +27,7 @@ void ListLanguages::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.finish(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
@@ -26,11 +26,7 @@ void ListLanguages::proceed() {
     }
 
     // Finishing by writing answer to client.
-    if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
-    } else {
-        writer_.finish(rc);
-    }
+    writer_.finish(ans, rc);
 }
 
 void ListLanguages::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ListLanguages.cpp
@@ -27,9 +27,9 @@ void ListLanguages::proceed() {
 
     // Finishing by writing answer to client.
     if (rc.status == catena::StatusCode::OK) {
-        writer_.finish(ans);
+        writer_.write(ans);
     } else {
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -54,12 +54,7 @@ void MultiSetValue::proceed() {
         rc = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
     }
     // Writing response.
-    if (rc.status == catena::StatusCode::OK) {
-        catena::Empty ans = catena::Empty();
-        writer_.finish(ans);
-    } else {
-        writer_.finish(rc);
-    }
+    writer_.finish(catena::Empty(), rc);
 }
 
 void MultiSetValue::finish() {

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -56,9 +56,9 @@ void MultiSetValue::proceed() {
     // Writing response.
     if (rc.status == catena::StatusCode::OK) {
         catena::Empty ans = catena::Empty();
-        writer_.finish(ans);
+        writer_.write(ans);
     } else {
-        writer_.write(rc);
+        writer_.finish(rc);
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -56,7 +56,7 @@ void MultiSetValue::proceed() {
     // Writing response.
     if (rc.status == catena::StatusCode::OK) {
         catena::Empty ans = catena::Empty();
-        writer_.write(ans);
+        writer_.finish(ans);
     } else {
         writer_.finish(rc);
     }

--- a/sdks/cpp/connections/REST/src/controllers/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/UpdateSubscriptions.cpp
@@ -114,7 +114,7 @@ void UpdateSubscriptions::finish() {
     std::cout << "UpdateSubscriptions[" << objectId_ << "] finished\n";
     
     if (!writer_) {
-        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), rc_.status);
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), rc_);
     }
     socket_.close();
 }

--- a/sdks/cpp/connections/REST/src/controllers/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/UpdateSubscriptions.cpp
@@ -51,7 +51,7 @@ UpdateSubscriptions::UpdateSubscriptions(tcp::socket& socket, ISocketReader& con
     : socket_(socket),
       context_(context),
       dm_(dm),
-      writer_(socket, context.origin()) {
+      rc_("", catena::StatusCode::OK) {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
     try {
@@ -60,12 +60,15 @@ UpdateSubscriptions::UpdateSubscriptions(tcp::socket& socket, ISocketReader& con
             absl::Status status = google::protobuf::util::JsonStringToMessage(
                 absl::string_view(context_.jsonBody()), &req_);
             if (!status.ok()) {
-                throw catena::exception_with_status("Failed to parse UpdateSubscriptionsPayload: " + status.ToString(), catena::StatusCode::INVALID_ARGUMENT);
+                rc_ = catena::exception_with_status("Failed to parse UpdateSubscriptionsPayload: " + status.ToString(), catena::StatusCode::INVALID_ARGUMENT);
+                finish();
+                return;
             }
         }
     } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.write(err);
+        rc_ = catena::exception_with_status("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
+        finish();
+        return;
     }
 }
 
@@ -73,6 +76,7 @@ void UpdateSubscriptions::proceed() {
     writeConsole_(CallStatus::kProcess, socket_.is_open());
 
     try {
+        //I don't think authz is currently used in this controller
         catena::common::Authorizer* authz;
         std::shared_ptr<catena::common::Authorizer> sharedAuthz;
         if (context_.authorizationEnabled()) {
@@ -82,97 +86,37 @@ void UpdateSubscriptions::proceed() {
             authz = &catena::common::Authorizer::kAuthzDisabled;
         }
 
-        // Clear any existing responses
-        responses_.clear();
-        current_response_ = 0;
-
         // Process removed OIDs
         for (const auto& oid : req_.removed_oids()) {     
-            catena::exception_with_status rc{"", catena::StatusCode::OK};
-            if (!context_.getSubscriptionManager().removeSubscription(oid, dm_, rc)) {
-                throw catena::exception_with_status(std::string("Failed to remove subscription: ") + rc.what(), rc.status);
+            if (!context_.getSubscriptionManager().removeSubscription(oid, dm_, rc_)) {
+                break;
             }
         }
 
         // Process added OIDs
         for (const auto& oid : req_.added_oids()) {
-            std::cout << "Adding subscription for OID: " << oid << std::endl;
-            
-            catena::exception_with_status rc{"", catena::StatusCode::OK};
-            if (!context_.getSubscriptionManager().addSubscription(oid, dm_, rc)) {
-                throw catena::exception_with_status(std::string("Failed to add subscription: ") + rc.what(), rc.status);
+            if (!context_.getSubscriptionManager().addSubscription(oid, dm_, rc_)) {
+                break;
             }
-        }
-
-        // Now that all subscriptions are processed, send current values for all subscribed parameters
-        try {
-            sendSubscribedParameters_(*authz);
-        } catch (const catena::exception_with_status& e) {
-            std::cout << "Error getting subscribed parameters: " << e.what() << std::endl;
-            // Don't throw here - we still want to finish the request successfully
-            responses_.clear();
-        }
-
-        // If we have responses, start writing them
-        if (!responses_.empty()) {
-            writer_lock_.lock();
-            writeConsole_(CallStatus::kWrite, true);
-            for (auto& response : responses_) {
-                writer_.write(response);
-            }
-            writer_lock_.unlock();
-        } else {
-            std::cout << "No responses to send, finishing..." << std::endl;
         }
 
     } catch (const catena::exception_with_status& e) {
-        std::cout << "Error processing subscriptions: " << e.what() << std::endl;
-        finish();
+        rc_ = catena::exception_with_status(e.what(), e.status);
     } catch (const std::exception& e) {
-        std::cout << "Unknown error processing subscriptions: " << e.what() << std::endl;
-        finish();
+        rc_ = catena::exception_with_status(e.what(), catena::StatusCode::UNKNOWN);
     }
+
+    finish();
 }
 
 void UpdateSubscriptions::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
-    writer_.finish();
-    socket_.close();
-}
-
-void UpdateSubscriptions::sendSubscribedParameters_(catena::common::Authorizer& authz) {
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
+    std::cout << "UpdateSubscriptions[" << objectId_ << "] finished\n";
     
-    // Get all subscribed OIDs from the manager
-    const auto& subscribedOids = context_.getSubscriptionManager().getAllSubscribedOids(dm_);
-    std::cout << "Got " << subscribedOids.size() << " subscribed OIDs" << std::endl;
-    
-    // Process each subscribed OID
-    for (const auto& oid : subscribedOids) {
-        std::cout << "Processing subscribed OID: " << oid << std::endl;
-        std::unique_ptr<IParam> param;
-        {
-            std::lock_guard lg(dm_.mutex());
-            param = dm_.getParam(oid, rc);
-        }
-        
-        if (rc.status != catena::StatusCode::OK) {
-            std::cout << "Error getting parameter: " << rc.what() << std::endl;
-            throw catena::exception_with_status("Failed to get parameter for OID: " + oid, rc.status);
-        }
-        
-        if (!param) {
-            std::cout << "Parameter not found: " << oid << std::endl;
-            throw catena::exception_with_status("Parameter not found for OID: " + oid, 
-                                              catena::StatusCode::NOT_FOUND);
-        }
-
-        catena::DeviceComponent_ComponentParam response;
-        response.set_oid(oid);
-        param->toProto(*response.mutable_param(), authz);
-        responses_.push_back(response);
-        std::cout << "Added response for OID: " << oid << std::endl;
+    if (!writer_) {
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), catena::REST::codeMap_.at(rc_.status));
     }
+    socket_.close();
 }
 
 } // namespace catena::REST 

--- a/sdks/cpp/connections/REST/src/controllers/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/UpdateSubscriptions.cpp
@@ -114,7 +114,7 @@ void UpdateSubscriptions::finish() {
     std::cout << "UpdateSubscriptions[" << objectId_ << "] finished\n";
     
     if (!writer_) {
-        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), catena::REST::codeMap_.at(rc_.status));
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin(), rc_.status);
     }
     socket_.close();
 }


### PR DESCRIPTION
# This is a big one.

## General Naming Refactoring
- This is the biggest change, I went across all files in REST and refactored certain variables/comments such as renaming RPCs to either endpoints or controllers or whatever was deemed appropriate
  - I am not going to detail every single comment fix, just know that I went in cleaned up everything, including some spelling mistakes and things like how we called GetParam GetValue in the comments (possibly an error from copy-pasting cookie cutter code structure)

## REST Query/Param/Body Refactoring
### BasicParamInfoRequest
- ~Changed OIDs to be added in the JSON body instead of params~
  - ~Recursive still remains in the param, but you can do `../BasicParamInfoRequest/1?recursive` for the URL instead of adding the `=true`~
- ~Updated OpenAPI YAML to reflect the changes~
- This was incorrect, GET methods cannot have bodies, it has been reverted back to be a query for OID! 

## Status/Error Codes
### Status.h (Common)
- Added new status codes to the Catena `StatusCode` enum such as 201, 202, 422, etc. 
  - We might add/remove some, but these are just there for now
### SocketWriter.h
- Updated the existing codemap to integrate with these new added status codes, and also added a text to some of them
  - Ex. 404 sends a text to the client of "Not Found", this is parsed into the headers 

## Tweaks/Additions in Other Classes
### SubscriptionManager
- Was missing logic for if OIDs even exist - if they are not found, it sends `NOT_FOUND` (error 404), if it is a duplicate when adding, it forwards `NO_CONTENT` (error 204)
### UpdateSubscriptions
- Added an `rc_` member variable which tracks return code
- Removed any response writing because this is a PUT request
- Removed _sendSubscribedParameters_ function because, again, this is a PUT
  - Refactored duplicates and "not founds" to SubscriptionManager (above) which then instead get sent as response codes
### BasicParamInfoRequest
- Added an `rc_` member variable which tracks return code
  - Return codes still need to be implemented, which I will do across all classes in #580 
### Connect
- You can now just do `.../v1/Connect?force_connection` instead of setting it to `=true` in the endpoint

## Changes in Service and Socket
### ServiceImpl
- Added back in the explicit braces for locking activeRequest counting as per Ben's request 
- Added some catches to throw the correct return code
### SocketWriter
- Modified the Socket and SSE finish functions to take a catena status code and then write them to the headers in order to forward the correct response codes - they just use the modified codemap
  - Similar thing is done to the SSEWriter write, although this is more for writing to the responses for things such as GET requests

## General Changes
- Made SSEWriter a unique pointer in some classes where it is a member variable
  - This, again, might have to be updated in #580 across all classes.
- Some classes were missing a writer_.finish() in their finish functions (ex. ExecuteCommand)
