### PR TITLE
Simplified ExecuteCommand gRPC

### DIFF
--- a/docs/gRPC/ExecuteCommand.md
+++ b/docs/gRPC/ExecuteCommand.md
@@ -18,7 +18,7 @@ message ExecuteCommandPayload {
 ```
 
 ### OUT
-Either a value, exception, boolean, or nothing.
+A stream of values, exceptions, or nothing.
 ```
 /* When streamed, only the response field will be used after the first message. */
 message CommandResponse {
@@ -28,7 +28,6 @@ message CommandResponse {
     Value response = 2;
     Exception exception = 3;  /* This is for Server/Device error executing the
                                * command. */
-    bool proceed = 4;         // Used to short circuit sending payloads 
   }
 }
 

--- a/interface/openapi/paths/ExecuteCommand.yaml
+++ b/interface/openapi/paths/ExecuteCommand.yaml
@@ -97,8 +97,4 @@ put:
               
               - $ref: "./Messages.yaml#/$defs/exception"
 
-              - title: Proceed
-                description: Used to short circuit sending payloads
-                type: boolean
-
           example: {boolean_value: true}

--- a/interface/param.proto
+++ b/interface/param.proto
@@ -327,6 +327,5 @@ message CommandResponse {
     Empty no_response = 1; // Server/Device does not have a response for the command.
     Value response = 2;
     Exception exception = 3;  // This is for Server/Device error executing the command.
-    bool proceed = 4; // Used to short circuit sending payloads 
   }
 }

--- a/interface/service.proto
+++ b/interface/service.proto
@@ -37,7 +37,7 @@ service CatenaService {
 
   rpc GetPopulatedSlots(catena.Empty) returns (SlotList);
 
-  rpc ExecuteCommand(stream ExecuteCommandPayload) returns (stream CommandResponse);
+  rpc ExecuteCommand(ExecuteCommandPayload) returns (stream CommandResponse);
 
   rpc ExternalObjectRequest(ExternalObjectRequestPayload) returns (stream ExternalObjectPayload);
 

--- a/sdks/cpp/connections/gRPC/include/ExecuteCommand.h
+++ b/sdks/cpp/connections/gRPC/include/ExecuteCommand.h
@@ -78,9 +78,9 @@ class CatenaServiceImpl::ExecuteCommand : public CallData {
          */
         catena::CommandResponse res_;
         /**
-         * @brief Stream for reading and writing gRPC messages
+         * @brief gRPC async response writer.
          */
-        grpc::ServerAsyncReaderWriter<catena::CommandResponse, catena::ExecuteCommandPayload> stream_;
+        ServerAsyncWriter<catena::CommandResponse> writer_;
         /**
          * @brief Represents the current status of the command execution
          * (kCreate, kProcess, kFinish, etc.)

--- a/sdks/cpp/connections/gRPC/src/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/ExecuteCommand.cpp
@@ -108,12 +108,6 @@ void CatenaServiceImpl::ExecuteCommand::proceed(CatenaServiceImpl *service, bool
                     res_ = command->executeCommand(req_.value());
                     status_ = CallStatus::kWrite; 
                 }
-                // If the command is not found, return an error
-                if (command == nullptr) {
-                    status_ = CallStatus::kFinish;
-                    writer_.Finish(Status(static_cast<grpc::StatusCode>(rc.status), rc.what()), this);
-                    break;
-                }
             // ERROR
             } catch (catena::exception_with_status& err) {
                 rc = catena::exception_with_status(err.what(), err.status);

--- a/sdks/cpp/connections/gRPC/src/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/ExecuteCommand.cpp
@@ -53,7 +53,7 @@ int CatenaServiceImpl::ExecuteCommand::objectCounter_ = 0;
  * object, then starts the process
  */
 CatenaServiceImpl::ExecuteCommand::ExecuteCommand(CatenaServiceImpl *service, IDevice& dm, bool ok)
-    : service_{service}, dm_{dm}, stream_(&context_),
+    : service_{service}, dm_{dm}, writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service->registerItem(this);
     objectId_ = objectCounter_++;
@@ -83,78 +83,68 @@ void CatenaServiceImpl::ExecuteCommand::proceed(CatenaServiceImpl *service, bool
          */
         case CallStatus::kCreate:
             status_ = CallStatus::kProcess;
-            service_->RequestExecuteCommand(&context_, &stream_, service_->cq_, service_->cq_, this);
+            service_->RequestExecuteCommand(&context_, &req_, &writer_, service_->cq_, service_->cq_, this);
             break;
-
         /**
          * Processes the command by reading the initial request from the client
          * and transitioning to kRead
          */
         case CallStatus::kProcess:
-            new ExecuteCommand(service_, dm_, ok);
-            /** 
-             * ExecuteCommand RPC always begins with reading initial request
-             * from client
-             */
-            status_ = CallStatus::kRead;
-            stream_.Read(&req_, this);
-            break;
-
-        /** 
-         * Reads the command request from the client and transitions to kRead.
-         * Should always tranistion to this state after calling stream_.Read()
-         */
-        case CallStatus::kRead:
-        {
+            new ExecuteCommand(service_, dm_, ok); // to serve other clients
+            context_.AsyncNotifyWhenDone(this);
+            { // rc scope
             catena::exception_with_status rc{"", catena::StatusCode::OK};
-            std::unique_ptr<IParam> command = nullptr;
-            // Check if authorization is enabled
             try {
+                std::unique_ptr<IParam> command = nullptr;
+                // Getting the command.
                 if (service_->authorizationEnabled()) {
                     catena::common::Authorizer authz{getJWSToken_()};
                     command = dm_.getCommand(req_.oid(), rc, authz);
                 } else {
                     command = dm_.getCommand(req_.oid(), rc, catena::common::Authorizer::kAuthzDisabled);
                 }
-            // Likely authentication error, end process.
+                // Executing the command if found.
+                if (command != nullptr) {
+                    res_ = command->executeCommand(req_.value());
+                    status_ = CallStatus::kWrite; 
+                }
+                // If the command is not found, return an error
+                if (command == nullptr) {
+                    status_ = CallStatus::kFinish;
+                    writer_.Finish(Status(static_cast<grpc::StatusCode>(rc.status), rc.what()), this);
+                    break;
+                }
+            // ERROR
             } catch (catena::exception_with_status& err) {
+                rc = catena::exception_with_status(err.what(), err.status);
+            } catch (...) {
+                rc = catena::exception_with_status("unknown error", catena::StatusCode::INTERNAL);
+            }
+            // Ending process if an error occured, falling through otherwise.
+            if (rc.status != catena::StatusCode::OK) {
                 status_ = CallStatus::kFinish;
-                grpc::Status errorStatus(static_cast<grpc::StatusCode>(err.status), err.what());
-                stream_.Finish(errorStatus, this);
+                writer_.Finish(Status(static_cast<grpc::StatusCode>(rc.status), rc.what()), this);
                 break;
             }
-
-            // If the command is not found, return an error
-            if (command == nullptr) {
-                status_ = CallStatus::kFinish;
-                stream_.Finish(Status(static_cast<grpc::StatusCode>(rc.status), rc.what()), this);
-                break;
-            }
-            // Execute the command
-            res_ = command->executeCommand(req_.value());
-            /**
-             * @todo: Implement streaming response
-             * For now we are not streaming the response so we can finish the
-             * call
-             */
-            status_ = CallStatus::kPostWrite; 
-            stream_.Write(res_, this);
-            break;
-        }
+            } // rc scope
 
         /**
-         * Status after reading the request, which transitions to kRead to
-         * handle subsequent requests
+         * Writes the response to the client by sending the external object and
+         * then continues to kPostWrite or kFinish
          */
         case CallStatus::kWrite:
-            status_ = CallStatus::kRead;
-            stream_.Read(&req_, this);
+            /*
+             * Currently only sends on response to the client. Add stream
+             * ability later.
+             */
+            writer_.Write(res_, this);
+            status_ = CallStatus::kPostWrite;
             break;
 
         // Status after finishing writing the response, transitions to kFinish
         case CallStatus::kPostWrite:
             status_ = CallStatus::kFinish;
-            stream_.Finish(Status::OK, this);
+            writer_.Finish(Status::OK, this);
             break;
 
         /**
@@ -170,6 +160,6 @@ void CatenaServiceImpl::ExecuteCommand::proceed(CatenaServiceImpl *service, bool
         default:
             status_ = CallStatus::kFinish;
             grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
-            stream_.Finish(errorStatus, this);
+            writer_.Finish(errorStatus, this);
     }
 }


### PR DESCRIPTION
Changed the .proto definition for the ExecuteCommand gRPC to take in a unary request rather than a stream.

Also took the chance to redo the flow of ExecuteCommand to better match best practice.

Streaming responses is not actually currently implemented in ExecuteCommand. Making that a separate issue as it also involved the REST implementation (would require changing the definition of IParam::ExecuteCommand()).