### PR TITLE
DeviceRequest bug fixes

### DIFF
--- a/sdks/cpp/common/include/Device.h
+++ b/sdks/cpp/common/include/Device.h
@@ -353,36 +353,28 @@ class Device : public IDevice {
          */
         catena::DeviceComponent getNext() override;
     };
-
     /**
      * @brief get a serializer for the device
-     * @param authz the authorizer object containing the scopes of the client
-     * @param shallow if true, the device will be returned in parts, otherwise
-     * the whole device will be returned in one message
-     * @return a DeviceSerializer object
-     */
-    std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, bool shallow = false) const override;
-    /**
-     * @brief get a serializer for the device
-     * @param clientScopes the scopes of the client
-     * @param shallow if true, the device will be returned in parts, otherwise
-     * the whole device will be returned in one message
+     * @param authz The authorizer object containing the scopes of the client
+     * @param dl The detail level to retrieve information in.
      * @param subscribed_oids the oids of the subscribed parameters
+     * @param shallow if true, the device will be returned in parts, otherwise
+     * the whole device will be returned in one message
      * @return a DeviceSerializer object
      */
-    std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, bool shallow = false) const override;
+    std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow = false) const override;
     /**
      * @brief This is a helper function for the shared IDevice function
      * getComponentSerializer to return a DeviceSerializer object. It can be
      * used on its own if calling from a Device object.
      * 
-     * @param clientScopes the scopes of the client
+     * @param authz The authorizer object containing the scopes of the client
      * @param subscribed_oids the oids of the subscribed parameters
+     * @param dl The detail level to retrieve information in.
      * @param shallow if true, the device will be returned in parts, otherwise
      * the whole device will be returned in one message
-     * @param subscribed_oids the oids of the subscribed parameters
      */
-    DeviceSerializer getDeviceSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, bool shallow = false) const;
+    DeviceSerializer getDeviceSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow = false) const;
     /**
      * @brief add an item to one of the collections owned by the device.
      * Overload for parameters and commands.

--- a/sdks/cpp/common/include/Device.h
+++ b/sdks/cpp/common/include/Device.h
@@ -357,24 +357,24 @@ class Device : public IDevice {
      * @brief get a serializer for the device
      * @param authz The authorizer object containing the scopes of the client
      * @param dl The detail level to retrieve information in.
-     * @param subscribed_oids the oids of the subscribed parameters
+     * @param subscribedOids the oids of the subscribed parameters
      * @param shallow if true, the device will be returned in parts, otherwise
      * the whole device will be returned in one message
      * @return a DeviceSerializer object
      */
-    std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow = false) const override;
+    std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribedOids, catena::Device_DetailLevel dl, bool shallow = false) const override;
     /**
      * @brief This is a helper function for the shared IDevice function
      * getComponentSerializer to return a DeviceSerializer object. It can be
      * used on its own if calling from a Device object.
      * 
      * @param authz The authorizer object containing the scopes of the client
-     * @param subscribed_oids the oids of the subscribed parameters
+     * @param subscribedOids the oids of the subscribed parameters
      * @param dl The detail level to retrieve information in.
      * @param shallow if true, the device will be returned in parts, otherwise
      * the whole device will be returned in one message
      */
-    DeviceSerializer getDeviceSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow = false) const;
+    DeviceSerializer getDeviceSerializer(Authorizer& authz, const std::set<std::string>& subscribedOids, catena::Device_DetailLevel dl, bool shallow = false) const;
     /**
      * @brief add an item to one of the collections owned by the device.
      * Overload for parameters and commands.

--- a/sdks/cpp/common/include/IDevice.h
+++ b/sdks/cpp/common/include/IDevice.h
@@ -225,22 +225,14 @@ class IDevice {
 
     /**
      * @brief get a serializer for the device
-     * @param authz the authorizer object containing the scopes of the client
-     * @param shallow if true, the device will be returned in parts, otherwise
-     * the whole device will be returned in one message
-     * @return a DeviceSerializer object
-     */
-    virtual std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, bool shallow = false) const = 0;
-
-    /**
-     * @brief get a serializer for the device
-     * @param authz the authorizer object containing the scopes of the client
+     * @param authz The authorizer object containing the scopes of the client
+     * @param dl The detail level to retrieve information in.
      * @param subscribed_oids the oids of the subscribed parameters
      * @param shallow if true, the device will be returned in parts, otherwise
      * the whole device will be returned in one message
      * @return a DeviceSerializer object
      */
-    virtual std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, bool shallow = false) const = 0;
+    virtual std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow = false) const = 0;
 
     /**
      * @brief add an item to one of the collections owned by the device.

--- a/sdks/cpp/common/include/IDevice.h
+++ b/sdks/cpp/common/include/IDevice.h
@@ -227,12 +227,12 @@ class IDevice {
      * @brief get a serializer for the device
      * @param authz The authorizer object containing the scopes of the client
      * @param dl The detail level to retrieve information in.
-     * @param subscribed_oids the oids of the subscribed parameters
+     * @param subscribedOids the oids of the subscribed parameters
      * @param shallow if true, the device will be returned in parts, otherwise
      * the whole device will be returned in one message
      * @return a DeviceSerializer object
      */
-    virtual std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow = false) const = 0;
+    virtual std::unique_ptr<IDeviceSerializer> getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribedOids, catena::Device_DetailLevel dl, bool shallow = false) const = 0;
 
     /**
      * @brief add an item to one of the collections owned by the device.

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -392,19 +392,18 @@ catena::DeviceComponent Device::DeviceSerializer::getNext() {
     return std::move(handle_.promise().deviceMessage); 
 }
 
-std::unique_ptr<Device::IDeviceSerializer> Device::getComponentSerializer(Authorizer& authz, bool shallow) const {
-    // Call the overloaded version with an explicitly constructed empty vector
-    static const std::set<std::string> empty_set;
-    return std::make_unique<Device::DeviceSerializer>(getDeviceSerializer(authz, empty_set, shallow));
+std::unique_ptr<Device::IDeviceSerializer> Device::getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow) const {
+    return std::make_unique<Device::DeviceSerializer>(getDeviceSerializer(authz, subscribed_oids, dl, shallow));
 }
 
-std::unique_ptr<Device::IDeviceSerializer> Device::getComponentSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, bool shallow) const {
-    return std::make_unique<Device::DeviceSerializer>(getDeviceSerializer(authz, subscribed_oids, shallow));
-}
-
-Device::DeviceSerializer Device::getDeviceSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, bool shallow) const {
-    catena::DeviceComponent component{};
+Device::DeviceSerializer Device::getDeviceSerializer(Authorizer& authz, const std::set<std::string>& subscribed_oids, catena::Device_DetailLevel dl, bool shallow) const {
+    // Sanitizing if trying to use SUBSCRIPTIONS mode with subscriptions disabled
+    if (dl == catena::Device_DetailLevel_SUBSCRIPTIONS && !subscriptions_) {
+        throw catena::exception_with_status("Subscriptions are not enabled for this device", catena::StatusCode::INVALID_ARGUMENT);
+    }
     
+    catena::DeviceComponent component{};
+
     // Send basic device information first
     catena::Device* dst = component.mutable_device();
     dst->set_slot(slot_);
@@ -416,135 +415,97 @@ Device::DeviceSerializer Device::getDeviceSerializer(Authorizer& authz, const st
         dst->add_access_scopes(scope);
     }
 
-    // If detail level is NONE, only send device info
-    if (detail_level_ == catena::Device_DetailLevel_NONE) {
-        co_return component;
-    }
-
-    // Error if trying to use SUBSCRIPTIONS mode with subscriptions disabled
-    // Note: If subscriptions are added through an RPC anyway, this error will not be thrown.
-    if (detail_level_ == catena::Device_DetailLevel_SUBSCRIPTIONS && !subscriptions_ && subscribed_oids.empty()) {
-        throw catena::exception_with_status("Subscriptions are not enabled for this device", catena::StatusCode::INVALID_ARGUMENT);
-    }
-
-    // Check if we have any minimal set parameters
-    bool has_minimal_set = false;
-    for (const auto& [name, param] : params_) {
-        if (param->getDescriptor().minimalSet()) {
-            has_minimal_set = true;
-            break;
-        }
-    }
-
-    // If we're in SUBSCRIPTIONS mode with no subscriptions and no minimal set params, only send device info
-    if (detail_level_ == catena::Device_DetailLevel_SUBSCRIPTIONS && 
-        subscribed_oids.empty() && 
-        !has_minimal_set) {
-        co_return component;
-    }
-
-    // Helper function to check if an OID is subscribed
-    auto is_subscribed = [&subscribed_oids, this](const std::string& param_name) {
-        // If subscriptions are disabled or we're not in SUBSCRIPTIONS mode, everything is subscribed
-        if (!subscriptions_ || (subscribed_oids.empty() && detail_level_ != catena::Device_DetailLevel_SUBSCRIPTIONS)) {
-            return true;
-        }
-        
-        // If we're in SUBSCRIPTIONS mode but have no subscriptions, nothing is subscribed
-        if (detail_level_ == catena::Device_DetailLevel_SUBSCRIPTIONS && subscribed_oids.empty()) {
+    if (dl != catena::Device_DetailLevel_NONE) {
+        // // Helper function to check if an OID is subscribed
+        auto is_subscribed = [&subscribed_oids, dl, this](const std::string& param_name) {
+            if (dl != catena::Device_DetailLevel_SUBSCRIPTIONS) {
+                return true;
+            } else {
+                // Check each subscription for exact or wildcard matches
+                for (const auto& subscription_oid : subscribed_oids) {
+                    // Remove leading slash
+                    std::string oid = subscription_oid.substr(1);
+                    // Check for exact match.
+                    if (param_name == oid) {
+                        return true;
+                    }
+                    // Check for wildcard match (ends with *)
+                    if (!oid.empty() && oid.back() == '*' && param_name.find(oid.substr(0, oid.size() - 1)) == 0) {
+                        return true;
+                    }
+                }
+            }
             return false;
-        }
-        
-        // Check each subscription for exact or wildcard matches
-        for (const auto& subscription_oid : subscribed_oids) {
-            std::string oid = subscription_oid.substr(1);  // Remove leading slash
-            if (param_name == oid) {
-                return true;
-            }
+        };
+
+        // // Only send non-minimal items in FULL mode or if explicitly subscribed in SUBSCRIPTION mode
+        if (dl == catena::Device_DetailLevel_FULL || 
+            dl == catena::Device_DetailLevel_SUBSCRIPTIONS) {
             
-            // Check for wildcard match (ends with *)
-            if (!oid.empty() && oid.back() == '*' && param_name.find(oid.substr(0, oid.size() - 1)) == 0) {
-                return true;
+            // Send menus
+            for (const auto& [group_name, menu_group] : menu_groups_) {
+                for (const auto& [name, menu] : *menu_group->menus()) {
+                    std::string oid = group_name + "/" + name;
+                    if (is_subscribed(oid)) {
+                        co_yield component;
+                        component.Clear();
+                        ::catena::Menu* dstMenu = component.mutable_menu()->mutable_menu();
+                        menu.toProto(*dstMenu);
+                        component.mutable_menu()->set_oid(oid);
+                    }
+                }
             }
-        }
-        
-        return false;
-    };
 
-    // Helper function to check if an item should be sent based on detail level and subscription
-    auto shouldSendItem = [&](const std::string& oid) {
-        // For non-IParam types, just check subscription status
-        return detail_level_ == catena::Device_DetailLevel_FULL || 
-               (detail_level_ == catena::Device_DetailLevel_SUBSCRIPTIONS && is_subscribed(oid));
-    };
-
-    // Only send non-minimal items in FULL mode or if explicitly subscribed in SUBSCRIPTION mode
-    if (detail_level_ == catena::Device_DetailLevel_FULL || 
-        (detail_level_ == catena::Device_DetailLevel_SUBSCRIPTIONS && !subscribed_oids.empty())) {
-        
-        // Send menus
-        for (const auto& [group_name, menu_group] : menu_groups_) {
-            for (const auto& [name, menu] : *menu_group->menus()) {
-                std::string oid = group_name + "/" + name;
-                if (shouldSendItem(oid)) {
+            // Send language packs
+            for (const auto& [language, language_pack] : language_packs_) {
+                if (is_subscribed(language)) {
                     co_yield component;
                     component.Clear();
-                    ::catena::Menu* dstMenu = component.mutable_menu()->mutable_menu();
-                    menu.toProto(*dstMenu);
-                    component.mutable_menu()->set_oid(oid);
+                    ::catena::LanguagePack* dstPack = component.mutable_language_pack()->mutable_language_pack();
+                    language_pack->toProto(*dstPack);
+                    component.mutable_language_pack()->set_language(language);
+                }
+            }
+
+            // Send constraints
+            for (const auto& [name, constraint] : constraints_) {
+                if (is_subscribed(name)) {
+                    co_yield component;
+                    component.Clear();
+                    ::catena::Constraint* dstConstraint = component.mutable_shared_constraint()->mutable_constraint();
+                    constraint->toProto(*dstConstraint);
+                    component.mutable_shared_constraint()->set_oid(name);
                 }
             }
         }
 
-        // Send language packs
-        for (const auto& [language, language_pack] : language_packs_) {
-            if (shouldSendItem(language)) {
-                co_yield component;
-                component.Clear();
-                ::catena::LanguagePack* dstPack = component.mutable_language_pack()->mutable_language_pack();
-                language_pack->toProto(*dstPack);
-                component.mutable_language_pack()->set_language(language);
+        // Send parameters if authorized, and either in the minimal set or if subscribed to
+        if (dl != catena::Device_DetailLevel_COMMANDS) {
+            for (const auto& [name, param] : params_) {
+                if (authz.readAuthz(*param) &&
+                    ((dl == catena::Device_DetailLevel_FULL) ||
+                     (param->getDescriptor().minimalSet()) ||
+                     (dl == catena::Device_DetailLevel_SUBSCRIPTIONS && is_subscribed(name)))) {
+                    co_yield component;
+                    component.Clear();
+                    ::catena::Param* dstParam = component.mutable_param()->mutable_param();
+                    param->toProto(*dstParam, authz);
+                    component.mutable_param()->set_oid(name);
+                }
             }
-        }
-
-        // Send constraints
-        for (const auto& [name, constraint] : constraints_) {
-            if (shouldSendItem(name)) {
-                co_yield component;
-                component.Clear();
-                ::catena::Constraint* dstConstraint = component.mutable_shared_constraint()->mutable_constraint();
-                constraint->toProto(*dstConstraint);
-                component.mutable_shared_constraint()->set_oid(name);
-            }
-        }
-    }
-
-    // Send parameters if authorized, and either in the minimal set or if subscribed to
-    if (detail_level_ != catena::Device_DetailLevel_COMMANDS) {
-        for (const auto& [name, param] : params_) {
-            if (this->shouldSendParam(*param, is_subscribed(name), authz)) {
-                co_yield component;
-                component.Clear();
-                ::catena::Param* dstParam = component.mutable_param()->mutable_param();
-                param->toProto(*dstParam, authz);
-                component.mutable_param()->set_oid(name);
+        // Send commands if authorized and in COMMANDS mode
+        } else {
+            for (const auto& [name, param] : commands_) {
+                if (authz.readAuthz(*param)) {
+                    co_yield component;
+                    component.Clear();
+                    ::catena::Param* dstParam = component.mutable_command()->mutable_param();
+                    param->toProto(*dstParam, authz);
+                    component.mutable_command()->set_oid(name);
+                }
             }
         }
     }
-
-    // Send commands if authorized and in COMMANDS mode
-    if (detail_level_ == catena::Device_DetailLevel_COMMANDS) {
-        for (const auto& [name, param] : commands_) {
-            if (this->shouldSendParam(*param, is_subscribed(name), authz)) {
-                co_yield component;
-                component.Clear();
-                ::catena::Param* dstParam = component.mutable_command()->mutable_param();
-                param->toProto(*dstParam, authz);
-                component.mutable_command()->set_oid(name);
-            }
-        }
-    }
-    
     // return the last component
     co_return component;
 }

--- a/sdks/cpp/connections/gRPC/include/DeviceRequest.h
+++ b/sdks/cpp/connections/gRPC/include/DeviceRequest.h
@@ -70,14 +70,6 @@ class CatenaServiceImpl::DeviceRequest : public CallData {
          */
         CatenaServiceImpl *service_;
         /**
-         * @brief A list of scopes that the client has access to
-         */
-        std::vector<std::string> clientScopes_;
-        /**
-         * @brief Unique pointer to the Authorizer object
-         */
-        std::unique_ptr<catena::common::Authorizer> authz_ = nullptr;
-        /**
          * @brief Request payload for device
          */
         catena::DeviceRequestPayload req_;
@@ -100,6 +92,21 @@ class CatenaServiceImpl::DeviceRequest : public CallData {
          */
         IDevice& dm_;
         /**
+         * @brief Shared ptr to the authorizer object so that we can maintain
+         * ownership of raw ptr throughout call lifetime without use of "new"
+         * keyword. 
+         */
+        std::shared_ptr<catena::common::Authorizer> sharedAuthz_;
+        /**
+         * @brief Ptr to the authorizer object. Raw as to not attempt to delete in
+         * case of kAuthzDisabled.
+         */
+        catena::common::Authorizer* authz_;
+        /**
+         * @brief The set of subscribed OIDs.
+         */
+        std::set<std::string> subscribedOids_;
+        /**
          * @brief Unique identifier for device request object
          */
         int objectId_;
@@ -107,18 +114,4 @@ class CatenaServiceImpl::DeviceRequest : public CallData {
          * @brief Counter to generate unique object IDs for each new object
          */
         static int objectCounter_;
-        /**
-         * @brief Unique identifier for the shutdown signal
-         */
-        unsigned int shutdownSignalId_;
-        /**
-         * @brief The set of subscribed OIDs.
-         */
-        std::set<std::string> subscribed_oids_;
-
-        /**
-         * @brief The set of RPC-specific subscriptions to track what this RPC has added.
-         */
-        std::set<std::string> rpc_subscriptions_;
-
 };

--- a/sdks/cpp/connections/gRPC/src/DeviceRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/DeviceRequest.cpp
@@ -67,8 +67,8 @@ CatenaServiceImpl::DeviceRequest::DeviceRequest(CatenaServiceImpl *service, IDev
  */
 void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool ok) {
     std::cout << "DeviceRequest proceed[" << objectId_ << "]: " << timeNow()
-                << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-                << std::endl;
+              << " status: " << static_cast<int>(status_) << ", ok: "
+              << std::boolalpha << ok << std::endl;
     
     // If the process is cancelled, finish the process
     if(!ok){
@@ -80,8 +80,7 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
     switch (status_) {
         case CallStatus::kCreate:
             status_ = CallStatus::kProcess;
-            service_->RequestDeviceRequest(&context_, &req_, &writer_, service_->cq_, service_->cq_,
-                                            this);
+            service_->RequestDeviceRequest(&context_, &req_, &writer_, service_->cq_, service_->cq_, this);
             break;
 
         /**
@@ -91,51 +90,36 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
         case CallStatus::kProcess:
             new DeviceRequest(service_, dm_, ok);  // to serve other clients
             context_.AsyncNotifyWhenDone(this);
-            // shutdownSignalId_ = shutdownSignal.connect([this](){
-            //     context_.TryCancel();
-            //     std::cout << "DeviceRequest[" << objectId_ << "] cancelled\n";
-            // });
-            {
             try {
                 bool shallowCopy = true; // controls whether shallow copy or deep copy is used
-                dm_.detail_level(req_.detail_level());
+                catena::exception_with_status rc{"", catena::StatusCode::OK};
                 
-                // Get service subscriptions from the manager
-                subscribed_oids_ = service_->getSubscriptionManager().getAllSubscribedOids(dm_);
-                
-                // If this request has subscriptions, add them
-                if (!req_.subscribed_oids().empty()) {
-                    // Add new subscriptions to both the manager and our tracking list
-                    for (const auto& oid : req_.subscribed_oids()) {
-                        catena::exception_with_status rc{"", catena::StatusCode::OK};
-                        if (!service_->getSubscriptionManager().addSubscription(oid, dm_, rc)) {
-                            throw catena::exception_with_status(std::string("Failed to add subscription: ") + rc.what(), rc.status);
-                        } else {
-                            rpc_subscriptions_.insert(oid);
-                        }
-                    }
-                }
-                
-                // Get final list of subscriptions for this response
-                subscribed_oids_ = service_->getSubscriptionManager().getAllSubscribedOids(dm_);
-                
-                //Handle authorization
-                std::shared_ptr<catena::common::Authorizer> sharedAuthz;
-                catena::common::Authorizer* authz;
+                // Setting up authorizer object.
                 if (service_->authorizationEnabled()) {
-                    sharedAuthz = std::make_shared<catena::common::Authorizer>(getJWSToken_());
-                    authz = sharedAuthz.get();
+                    // Authorizer throws an error if invalid jws token so no need to handle rc.
+                    sharedAuthz_ = std::make_shared<catena::common::Authorizer>(getJWSToken_());
+                    authz_ = sharedAuthz_.get();
                 } else {
-                    authz = &catena::common::Authorizer::kAuthzDisabled;
+                    authz_ = &catena::common::Authorizer::kAuthzDisabled;
                 }
 
-                // If we're in SUBSCRIPTIONS mode and have no subscriptions, we'll still send minimal set
-                if (dm_.subscriptions() && subscribed_oids_.empty() && 
-                    req_.detail_level() == catena::Device_DetailLevel_SUBSCRIPTIONS) {
-                    serializer_ = dm_.getComponentSerializer(*authz, shallowCopy);
-                } else {
-                    serializer_ = dm_.getComponentSerializer(*authz, subscribed_oids_, shallowCopy);
+                // req_.detail_level defaults to FULL
+                catena::Device_DetailLevel dl = req_.detail_level();
+
+                // Getting subscribed oids if dl == SUBSCRIPTIONS.
+                if (dl == catena::Device_DetailLevel_SUBSCRIPTIONS) {
+                    // Add new subscriptions to both the manager and our tracking list
+                    for (const auto& oid : req_.subscribed_oids()) {
+                        if (!service_->getSubscriptionManager().addSubscription(oid, dm_, rc)) {
+                            throw catena::exception_with_status(std::string("Failed to add subscription: ") + rc.what(), rc.status);
+                        }
+                    }
+                    // Get service subscriptions from the manager
+                    subscribedOids_ = service_->getSubscriptionManager().getAllSubscribedOids(dm_);
                 }
+
+                // Getting the serializer object.
+                serializer_ = dm_.getComponentSerializer(*authz_, subscribedOids_, dl, shallowCopy);
 
             // Likely authentication error, end process.
             } catch (catena::exception_with_status& err) {
@@ -143,7 +127,11 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
                 grpc::Status errorStatus(static_cast<grpc::StatusCode>(err.status), err.what());
                 writer_.Finish(errorStatus, this);
                 break;
-            }
+            } catch (...) {
+                status_ = CallStatus::kFinish;
+                grpc::Status errorStatus(grpc::StatusCode::UNKNOWN, "unknown error");
+                writer_.Finish(errorStatus, this);
+                break;
             }
             status_ = CallStatus::kWrite;
             // fall thru to start writing
@@ -194,8 +182,7 @@ void CatenaServiceImpl::DeviceRequest::proceed(CatenaServiceImpl *service, bool 
          */
         case CallStatus::kFinish:
             std::cout << "DeviceRequest[" << objectId_ << "] finished\n";
-            //shutdownSignal.disconnect(shutdownSignalId_);
-            service->deregisterItem(this);
+            service_->deregisterItem(this);
             break;
 
         // Throws an error if the state is not recognized


### PR DESCRIPTION
Changelog:
- Fixed bug with authorizer going out of scope in DeviceRequest gRPC resulting in segfault when run with detail_level FULL and authz enabled.
- Made detail_level an input variable into getDeviceSerializer instead of setting the device's detail level. This change fixes race condition where the detail level can change while getting device components.
- Cleaned up/streamlined DeviceRequest.
- Cleaned up/streamlined getDeviceSerializer.