### PR TITLE
Subscription Manager Basic Unit Testing

### DIFF
--- a/sdks/cpp/common/tests/CMakeLists.txt
+++ b/sdks/cpp/common/tests/CMakeLists.txt
@@ -31,8 +31,6 @@ target_link_libraries(${This} PUBLIC
     gmock
     gmock_main
     ${common_lib}
-    GTest::gmock
-    GTest::gmock_main
 )
 
 add_test(

--- a/sdks/cpp/common/tests/CMakeLists.txt
+++ b/sdks/cpp/common/tests/CMakeLists.txt
@@ -25,11 +25,11 @@ set(SOURCES
 
 add_executable(${This} ${SOURCES})
 
-target_link_libraries(${This} PUBLIC
-    ${GTEST_BOTH_LIBRARIES}	
-    GTest::GTest	
-    GTest::Main	
-    GTest::gmock	
+target_link_libraries(${This} PRIVATE
+    ${GTEST_BOTH_LIBRARIES}
+    GTest::GTest
+    GTest::Main
+    GTest::gmock
     GTest::gmock_main
     ${common_lib}
 )

--- a/sdks/cpp/common/tests/CMakeLists.txt
+++ b/sdks/cpp/common/tests/CMakeLists.txt
@@ -26,10 +26,11 @@ set(SOURCES
 add_executable(${This} ${SOURCES})
 
 target_link_libraries(${This} PUBLIC
-    ${GTEST_LIBRARIES}
-    ${GTEST_MAIN_LIBRARIES}
-    gmock
-    gmock_main
+    ${GTEST_BOTH_LIBRARIES}	
+    GTest::GTest	
+    GTest::Main	
+    GTest::gmock	
+    GTest::gmock_main
     ${common_lib}
 )
 

--- a/sdks/cpp/common/tests/CMakeLists.txt
+++ b/sdks/cpp/common/tests/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 set(This common_unit_tests)
 
 find_package(GTest REQUIRED)
-include_directories(../src)
-include_directories(../include)
+include_directories(../src ../include)
 include_directories(${GTEST_INCLUDE_DIRS})
 
 # set up link libs, prefer gRPC if enabled
@@ -21,6 +20,7 @@ endif(gRPC_enabled)
 
 set(SOURCES 
     utils_test.cpp
+    subscription_manager_test.cpp
 )
 
 add_executable(${This} ${SOURCES})
@@ -28,6 +28,8 @@ add_executable(${This} ${SOURCES})
 target_link_libraries(${This} PUBLIC
     ${GTEST_LIBRARIES}
     ${GTEST_MAIN_LIBRARIES}
+    gmock
+    gmock_main
     ${common_lib}
     GTest::gmock
     GTest::gmock_main

--- a/sdks/cpp/common/tests/CommonMockClasses.h
+++ b/sdks/cpp/common/tests/CommonMockClasses.h
@@ -38,13 +38,15 @@
 
 #pragma once
 
+#include <gmock/gmock.h>
 #include <IDevice.h>
 #include <IParam.h>
 #include <Status.h>
 #include <Authorization.h>
-#include <gmock/gmock.h>
+#include <ISubscriptionManager.h>
 
-using namespace catena::common;
+namespace catena {
+namespace common {
 
 // Mock IDevice for testing
 class MockDevice : public IDevice {
@@ -52,36 +54,48 @@ class MockDevice : public IDevice {
     MOCK_METHOD(void, slot, (const uint32_t slot), (override));
     MOCK_METHOD(uint32_t, slot, (), (const, override));
     MOCK_METHOD(std::mutex&, mutex, (), (override));
-    MOCK_METHOD(void, detail_level, (const catena::Device_DetailLevel detail_level), (override));
-    MOCK_METHOD(catena::Device_DetailLevel, detail_level, (), (const, override));
+    MOCK_METHOD(void, detail_level, (const Device_DetailLevel detail_level), (override));
+    MOCK_METHOD(Device_DetailLevel, detail_level, (), (const, override));
     MOCK_METHOD(const std::string&, getDefaultScope, (), (const, override));
     MOCK_METHOD(bool, subscriptions, (), (const, override));
     MOCK_METHOD(uint32_t, default_max_length, (), (const, override));
     MOCK_METHOD(uint32_t, default_total_length, (), (const, override));
     MOCK_METHOD(void, set_default_max_length, (const uint32_t default_max_length), (override));
     MOCK_METHOD(void, set_default_total_length, (const uint32_t default_total_length), (override));
-    MOCK_METHOD(void, toProto, (catena::Device& dst, Authorizer& authz, bool shallow), (const, override));
-    MOCK_METHOD(void, toProto, (catena::LanguagePacks& packs), (const, override));
-    MOCK_METHOD(void, toProto, (catena::LanguageList& list), (const, override));
-    MOCK_METHOD(catena::exception_with_status, addLanguage, (catena::AddLanguagePayload& language, Authorizer& authz), (override));
-    MOCK_METHOD(catena::exception_with_status, getLanguagePack, (const std::string& languageId, ComponentLanguagePack& pack), (const, override));
+    MOCK_METHOD(void, toProto, (Device& dst, Authorizer& authz, bool shallow), (const, override));
+    MOCK_METHOD(void, toProto, (LanguagePacks& packs), (const, override));
+    MOCK_METHOD(void, toProto, (LanguageList& list), (const, override));
+    MOCK_METHOD(exception_with_status, addLanguage, (AddLanguagePayload& language, Authorizer& authz), (override));
+    MOCK_METHOD(exception_with_status, getLanguagePack, (const std::string& languageId, ComponentLanguagePack& pack), (const, override));
     class MockDeviceSerializer : public IDeviceSerializer {
       public:
         MOCK_METHOD(bool, hasMore, (), (const, override));
-        MOCK_METHOD(catena::DeviceComponent, getNext, (), (override));
+        MOCK_METHOD(DeviceComponent, getNext, (), (override));
     };
-    MOCK_METHOD(std::unique_ptr<IDeviceSerializer>, getComponentSerializer, (Authorizer& authz, const std::set<std::string>& subscribedOids, catena::Device_DetailLevel dl, bool shallow), (const, override));
+    MOCK_METHOD(std::unique_ptr<IDeviceSerializer>, getComponentSerializer, (Authorizer& authz, const std::set<std::string>& subscribedOids, Device_DetailLevel dl, bool shallow), (const, override));
     MOCK_METHOD(void, addItem, (const std::string& key, IParam* item), (override));
     MOCK_METHOD(void, addItem, (const std::string& key, IConstraint* item), (override));
     MOCK_METHOD(void, addItem, (const std::string& key, IMenuGroup* item), (override));
     MOCK_METHOD(void, addItem, (const std::string& key, ILanguagePack* item), (override));
-    MOCK_METHOD(std::unique_ptr<IParam>, getParam, (const std::string& fqoid, catena::exception_with_status& status, Authorizer& authz), (const, override));
-    MOCK_METHOD(std::unique_ptr<IParam>, getParam, (Path& path, catena::exception_with_status& status, Authorizer& authz), (const, override));
-    MOCK_METHOD(std::vector<std::unique_ptr<IParam>>, getTopLevelParams, (catena::exception_with_status& status, Authorizer& authz), (const, override));
-    MOCK_METHOD(std::unique_ptr<IParam>, getCommand, (const std::string& fqoid, catena::exception_with_status& status, Authorizer& authz), (const, override));
-    MOCK_METHOD(bool, tryMultiSetValue, (catena::MultiSetValuePayload src, catena::exception_with_status& ans, Authorizer& authz), (override));
-    MOCK_METHOD(catena::exception_with_status, commitMultiSetValue, (catena::MultiSetValuePayload src, Authorizer& authz), (override));
-    MOCK_METHOD(catena::exception_with_status, setValue, (const std::string& jptr, catena::Value& src, Authorizer& authz), (override));
-    MOCK_METHOD(catena::exception_with_status, getValue, (const std::string& jptr, catena::Value& value, Authorizer& authz), (const, override));
+    MOCK_METHOD(std::unique_ptr<IParam>, getParam, (const std::string& fqoid, exception_with_status& status, Authorizer& authz), (const, override));
+    MOCK_METHOD(std::unique_ptr<IParam>, getParam, (Path& path, exception_with_status& status, Authorizer& authz), (const, override));
+    MOCK_METHOD(std::vector<std::unique_ptr<IParam>>, getTopLevelParams, (exception_with_status& status, Authorizer& authz), (const, override));
+    MOCK_METHOD(std::unique_ptr<IParam>, getCommand, (const std::string& fqoid, exception_with_status& status, Authorizer& authz), (const, override));
+    MOCK_METHOD(bool, tryMultiSetValue, (MultiSetValuePayload src, exception_with_status& ans, Authorizer& authz), (override));
+    MOCK_METHOD(exception_with_status, commitMultiSetValue, (MultiSetValuePayload src, Authorizer& authz), (override));
+    MOCK_METHOD(exception_with_status, setValue, (const std::string& jptr, Value& src, Authorizer& authz), (override));
+    MOCK_METHOD(exception_with_status, getValue, (const std::string& jptr, Value& value, Authorizer& authz), (const, override));
     MOCK_METHOD(bool, shouldSendParam, (const IParam& param, bool is_subscribed, Authorizer& authz), (const, override));
 };
+
+// Mock SubscriptionManager for testing
+class MockSubscriptionManager : public ISubscriptionManager {
+public:
+    MOCK_METHOD(bool, addSubscription, (const std::string& oid, IDevice& dm, exception_with_status& rc), (override));
+    MOCK_METHOD(bool, removeSubscription, (const std::string& oid, IDevice& dm, exception_with_status& rc), (override));
+    MOCK_METHOD(const std::set<std::string>&, getAllSubscribedOids, (IDevice& dm), (override));
+    MOCK_METHOD(bool, isWildcard, (const std::string& oid), (override)); //Currently untested
+};
+
+} // namespace common
+} // namespace catena

--- a/sdks/cpp/common/tests/subscription_manager_test.cpp
+++ b/sdks/cpp/common/tests/subscription_manager_test.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief This file is for testing the SubscriptionManager.cpp file.
+ * @author zuhayr.sarker@rossvideo.com
+ * @date 25/05/13
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+
+#include <gtest/gtest.h>
+#include "CommonMockClasses.h"
+#include <IDevice.h>
+#include <IParam.h>
+#include <Status.h>
+#include <Authorization.h>
+
+using namespace catena::common;
+
+class SubscriptionManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        manager = std::make_unique<MockSubscriptionManager>();
+        device = std::make_unique<MockDevice>();
+        
+        // Set up default mock behavior for device
+        ON_CALL(*device, getValue(::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Invoke([](const std::string& jptr, catena::Value& value, Authorizer& authz) -> catena::exception_with_status {
+                return catena::exception_with_status("", catena::StatusCode::OK);
+            }));
+
+        // Set up default mock behavior for subscription manager
+        ON_CALL(*manager, addSubscription(::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+                rc = catena::exception_with_status("", catena::StatusCode::OK);
+                return true;
+            }));
+        ON_CALL(*manager, removeSubscription(::testing::_, ::testing::_, ::testing::_))
+            .WillByDefault(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+                rc = catena::exception_with_status("", catena::StatusCode::OK);
+                return true;
+            }));
+        static std::set<std::string> empty_set;
+        ON_CALL(*manager, getAllSubscribedOids(::testing::_))
+            .WillByDefault(::testing::ReturnRef(empty_set));
+    }
+
+    std::unique_ptr<MockSubscriptionManager> manager;
+    std::unique_ptr<MockDevice> device;
+};
+
+// Test adding a new subscription
+TEST_F(SubscriptionManagerTest, AddNewSubscription) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    
+    // Set up expectations
+    EXPECT_CALL(*manager, addSubscription("/test/param", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::OK);
+            return true;
+        }));
+    
+    // Test adding a new subscription
+    EXPECT_TRUE(manager->addSubscription("/test/param", *device, rc));
+    EXPECT_EQ(rc.status, catena::StatusCode::OK);
+}
+
+// Test adding a duplicate subscription
+TEST_F(SubscriptionManagerTest, AddDuplicateSubscription) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    
+    // Set up expectations
+    EXPECT_CALL(*manager, addSubscription("/test/param", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::OK);
+            return true;
+        }))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::ALREADY_EXISTS);
+            return false;
+        }));
+    
+    // Add initial subscription
+    manager->addSubscription("/test/param", *device, rc);
+    
+    // Try to add the same subscription again
+    EXPECT_FALSE(manager->addSubscription("/test/param", *device, rc));
+    EXPECT_EQ(rc.status, catena::StatusCode::ALREADY_EXISTS);
+}
+
+// Test removing an existing subscription
+TEST_F(SubscriptionManagerTest, RemoveExistingSubscription) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    
+    // Set up expectations
+    EXPECT_CALL(*manager, addSubscription("/test/param", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::OK);
+            return true;
+        }));
+    EXPECT_CALL(*manager, removeSubscription("/test/param", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::OK);
+            return true;
+        }));
+    
+    // Add a subscription first
+    manager->addSubscription("/test/param", *device, rc);
+    
+    // Remove the subscription
+    EXPECT_TRUE(manager->removeSubscription("/test/param", *device, rc));
+    EXPECT_EQ(rc.status, catena::StatusCode::OK);
+}
+
+// Test removing a non-existent subscription
+TEST_F(SubscriptionManagerTest, RemoveNonExistentSubscription) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    
+    // Set up expectations
+    EXPECT_CALL(*manager, removeSubscription("/test/param", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::NOT_FOUND);
+            return false;
+        }));
+    
+    // Try to remove a subscription that doesn't exist
+    EXPECT_FALSE(manager->removeSubscription("/test/param", *device, rc));
+    EXPECT_EQ(rc.status, catena::StatusCode::NOT_FOUND);
+}
+
+// Test getting all subscribed OIDs
+TEST_F(SubscriptionManagerTest, GetAllSubscribedOids) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    
+    // Set up expectations
+    EXPECT_CALL(*manager, addSubscription("/test/param1", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::OK);
+            return true;
+        }));
+    EXPECT_CALL(*manager, addSubscription("/test/param2", ::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([](const std::string& oid, IDevice& dm, catena::exception_with_status& rc) -> bool {
+            rc = catena::exception_with_status("", catena::StatusCode::OK);
+            return true;
+        }));
+    
+    static std::set<std::string> expected_oids = {"/test/param1", "/test/param2"};
+    EXPECT_CALL(*manager, getAllSubscribedOids(::testing::_))
+        .WillOnce(::testing::ReturnRef(expected_oids));
+    
+    // Add some subscriptions
+    manager->addSubscription("/test/param1", *device, rc);
+    manager->addSubscription("/test/param2", *device, rc);
+    
+    const auto& oids = manager->getAllSubscribedOids(*device);
+    EXPECT_EQ(oids.size(), 2);
+    EXPECT_TRUE(oids.find("/test/param1") != oids.end());
+    EXPECT_TRUE(oids.find("/test/param2") != oids.end());
+}


### PR DESCRIPTION
I will be testing other edge cases and stuff in future issues/PRs. I'm assuming the new AI we added will add a summary anyway, so, I'll let it do that.

This was supposed to be numbered #631, not #627 (which is the parent issue). In any case, I linked it.


<!--start_gitstream_placeholder-->
### ✨ PR Description
The purpose and impact of these changes is to implement and test a SubscriptionManager class for managing device parameter subscriptions.

Main changes in this PR:
- Added MockSubscriptionManager class in CommonMockClasses.h
- Created new file subscription_manager_test.cpp with unit tests for SubscriptionManager
- Updated namespaces and includes in CommonMockClasses.h for consistency

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
