### PR TITLE
Update tasks.json to have coverage commands

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,8 +28,21 @@
         {
             "label": "Generate Coverage",
             "type": "shell",
-            "command": "cd ${workspaceFolder} && gcovr --root . --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' --html=coverage/index.html --html-details  --lcov=coverage/coverage.info --xml=coverage/coverage.xml",
-            "group": "build",
+            "command": "cd ${workspaceFolder}/sdks/cpp/build && mkdir -p ${workspaceFolder}/coverage && gcovr --root ${workspaceFolder} --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' --html=${workspaceFolder}/coverage/index.html --html-details --lcov=${workspaceFolder}/coverage/coverage.info --xml=${workspaceFolder}/coverage/coverage.xml --gcov-ignore-errors=no_working_dir_found --object-directory=. --gcov-object-directory=.",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Clean Coverage",
+            "type": "shell",
+            "command": "cd ${workspaceFolder} && find . -name '*.gcov' -delete && find . -name '*.gcda' -delete && find . -name '*.gcno' -delete && rm -rf coverage",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": []
         },
         {
@@ -58,8 +71,9 @@
             //    - Build type from CMAKE_BUILD_TYPE env var
             //    - Connections from CONNECTIONS env var
             //    - Install prefix set to /usr/local/.local
+            //    - Coverage flags set for C++ and C
             // 6. Run ninja to build the project
-            "command": "cd ${workspaceFolder}/sdks/cpp && if [ -f build/build.ninja ]; then (cd build && ninja clean); fi && if [ ! -d build ]; then mkdir build; fi && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCONNECTIONS=$CONNECTIONS -DCMAKE_INSTALL_PREFIX=/usr/local/.local .. && ninja",
+            "command": "cd ${workspaceFolder}/sdks/cpp && if [ -f build/build.ninja ]; then (cd build && ninja clean); fi && if [ ! -d build ]; then mkdir build; fi && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCONNECTIONS=\"gRPC;REST\" -DCMAKE_CXX_FLAGS=\"--coverage\" -DCMAKE_C_FLAGS=\"--coverage\" -DCMAKE_EXE_LINKER_FLAGS=\"--coverage\" -DCMAKE_INSTALL_PREFIX=/usr/local/.local .. && ninja",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
What the title says, if the AI wants to say whatever it wants it can. I mostly used cursor to write up these commands, anyway.

- Updated the fresh build to include coverage now
- Added Generate Coverage to isDefault to get it to show up in the drop-down when doing ctrl+shift+b
- Added Clean Coverage in case it spits some garbage

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose and impact:
This PR enhances code coverage generation and build processes for a C++ project.

Main changes:
- Updated "Generate Coverage" task with more detailed gcovr command and output options
- Added new "Clean Coverage" task to remove coverage-related files
- Modified "Fresh Build" task to include coverage flags for C++ and C compilation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
