### PR TITLE
Update tasks.json for coverage

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,7 +28,7 @@
         {
             "label": "Generate Coverage",
             "type": "shell",
-            "command": "./scripts/run_coverage.sh",
+            "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -38,7 +38,7 @@
         {
             "label": "Generate Coverage with HTML",
             "type": "shell",
-            "command": "./scripts/run_coverage.sh --html",
+            "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh --html",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,22 +38,19 @@
         {
             "label": "Generate Coverage with HTML",
             "type": "shell",
-            "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh --html",
+            "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh --html && cd coverage && echo 'Starting server...' && echo 'Coverage report available at: http://0.0.0.0:8000/index.html' && echo 'Press Ctrl+C to stop the server' && python3 -m http.server 8000",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": []
-        },
-        {
-            "label": "Clean Coverage",
-            "type": "shell",
-            "command": "cd ${workspaceFolder} && find . -name '*.gcov' -delete && find . -name '*.gcda' -delete && find . -name '*.gcno' -delete && rm -rf coverage",
-            "group": {
-                "kind": "build",
-                "isDefault": true
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "echo": true,
+                "focus": true
             },
-            "problemMatcher": []
+            "isBackground": true
         },
         {
             "label": "Run Ninja",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,8 +28,31 @@
         {
             "label": "Generate Coverage",
             "type": "shell",
-            "command": "cd ${workspaceFolder} && gcovr --root . --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' --html=coverage/index.html --html-details  --lcov=coverage/coverage.info --xml=coverage/coverage.xml",
-            "group": "build",
+            "command": "./scripts/run_coverage.sh",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Generate Coverage with HTML",
+            "type": "shell",
+            "command": "./scripts/run_coverage.sh --html",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Clean Coverage",
+            "type": "shell",
+            "command": "cd ${workspaceFolder} && find . -name '*.gcov' -delete && find . -name '*.gcda' -delete && find . -name '*.gcno' -delete && rm -rf coverage",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": []
         },
         {
@@ -58,8 +81,9 @@
             //    - Build type from CMAKE_BUILD_TYPE env var
             //    - Connections from CONNECTIONS env var
             //    - Install prefix set to /usr/local/.local
+            //    - Coverage flags set for C++ and C
             // 6. Run ninja to build the project
-            "command": "cd ${workspaceFolder}/sdks/cpp && if [ -f build/build.ninja ]; then (cd build && ninja clean); fi && if [ ! -d build ]; then mkdir build; fi && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCONNECTIONS=$CONNECTIONS -DCMAKE_INSTALL_PREFIX=/usr/local/.local .. && ninja",
+            "command": "cd ${workspaceFolder}/sdks/cpp && if [ -f build/build.ninja ]; then (cd build && ninja clean); fi && if [ ! -d build ]; then mkdir build; fi && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCONNECTIONS=\"gRPC;REST\" -DCMAKE_CXX_FLAGS=\"--coverage\" -DCMAKE_C_FLAGS=\"--coverage\" -DCMAKE_EXE_LINKER_FLAGS=\"--coverage\" -DCMAKE_INSTALL_PREFIX=/usr/local/.local .. && ninja",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
Update to run script for coverage, remove remove coverage, and add python server for HTML preview

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose and impact:
This PR simplifies and enhances the code coverage generation process in VSCode tasks.

Main changes:
- Replaces complex coverage command with a call to a script (run_coverage.sh)
- Adds a new task to generate coverage with HTML and start a local server
- Removes the "Clean Coverage" task

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
