### PR TITLE
Fix REST BPIR no-response bug + additional error handling

### DIFF
--- a/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/BasicParamInfoRequest.h
@@ -175,17 +175,7 @@ class BasicParamInfoRequest : public ICallData {
      * @brief The vector of BasicParamInfoResponse objects.
      */
     std::vector<catena::BasicParamInfoResponse> responses_;
-    
-    /**
-     * @brief Mutex for thread safety when writing responses.
-     */
-    std::mutex mtx_;
-    
-    /**
-     * @brief Lock for the writer to prevent concurrent access.
-     */
-    std::unique_lock<std::mutex> writer_lock_{mtx_, std::defer_lock};
-
+        
     /**
      * @brief Visitor class for collecting parameter info
      */


### PR DESCRIPTION
The main fix was in finish() where I added the following:

``` c++
    if (responses_.empty()) {
        // If no responses, send at least one response with the error status
        writer_.sendResponse(rc_);
    }
```

Before, if responses didn't even exist because of some error, it would just not send anything at all (not even a response code, which broke unit testing)

Additionally, I went in and added extra error handling. 