### PR TITLE
Fixed front end and assets endpoints

### DIFF
--- a/interface/openapi/openapi.yaml
+++ b/interface/openapi/openapi.yaml
@@ -39,8 +39,8 @@ info:
   title: Catena API
   version: '1.0'
 servers:
-  - url: https://device.catenamedia.tv:443/api/v1
-  - url: http://localhost:443/api/v1
+  - url: https://device.catenamedia.tv:443/v1
+  - url: http://localhost:443/v1
 
 # default endpoint security is that at least one read scope is required.
 # the permissions in the security array are ORed together.
@@ -59,46 +59,46 @@ paths:
   /devices:
     $ref: './paths/Devices.yaml'
 
-  /device/{slot}:
+  /{slot}:
     $ref: './paths/Device.yaml'
 
-  /device/{slot}/stream:
+  /{slot}/stream:
     $ref: './paths/DeviceStream.yaml'
 
-  /device/{slot}/command/{fqoid}:
+  /{slot}/command/{fqoid}:
     $ref: './paths/Command.yaml'
 
-  /device/{slot}/asset/{fqoid}:
+  /{slot}/asset/{fqoid}:
     $ref: './paths/Asset.yaml'
 
-  /device/{slot}/asset/{fqoid}/stream:
+  /{slot}/asset/{fqoid}/stream:
     $ref: './paths/AssetStream.yaml'
 
-  /device/{slot}/basic-param/stream/{fqoid}/stream:
+  /{slot}/basic-param/{fqoid}/stream:
     $ref: './paths/BasicParamStream.yaml'
 
-  /device/{slot}/basic-param/{fqoid}:
+  /{slot}/basic-param/{fqoid}:
     $ref: './paths/BasicParam.yaml'
 
-  /device/{slot}/value/{fqoid}:
+  /{slot}/value/{fqoid}:
     $ref: './paths/Value.yaml'
 
-  /device/{slot}/values:
+  /{slot}/values:
     $ref: './paths/Values.yaml'
 
-  /device/{slot}/subscriptions:
+  /{slot}/subscriptions:
     $ref: './paths/Subscriptions.yaml'
 
-  /device/{slot}/param/{fqoid}:
+  /{slot}/param/{fqoid}:
     $ref: './paths/Param.yaml'
 
-  /device/{slot}/connect:
+  /{slot}/connect:
     $ref: './paths/Connect.yaml'
 
-  /device/{slot}/language-pack/{language-code}:
+  /{slot}/language-pack/{language-code}:
     $ref: './paths/LanguagePack.yaml'
 
-  /device/{slot}/languages:
+  /{slot}/languages:
     $ref: './paths/Languages.yaml'
 
 components:

--- a/schema/catena.device_schema.json
+++ b/schema/catena.device_schema.json
@@ -25,10 +25,20 @@
       "$ref": "#/$defs/constraint_map"
     },
     "params": {
-      "$ref": "catena.param_schema.json#/$defs/param_map"
+      "type": "object",
+      "patternProperties": {
+        "^((?![\\w.]*\\.\\d+$)[a-zA-Z][\\w.]{0,62}|\\d+|-)(\\/((?![\\w.]*\\.\\d+$)[a-zA-Z][\\w.]{0,62}|\\d+|-)){0,31}$": {
+          "$ref": "catena.param_schema.json#"
+        }
+      }
     },
     "commands": {
-      "$ref": "catena.param_schema.json#/$defs/param_map"
+      "type": "object",
+      "patternProperties": {
+        "^((?![\\w.]*\\.\\d+$)[a-zA-Z][\\w.]{0,62}|\\d+|-)(\\/((?![\\w.]*\\.\\d+$)[a-zA-Z][\\w.]{0,62}|\\d+|-)){0,31}$": {
+          "$ref": "catena.param_schema.json#"
+        }
+      }
     },
     "access_scopes": {
       "title": "Access Scopes",

--- a/schema/catena.param_schema.json
+++ b/schema/catena.param_schema.json
@@ -1116,7 +1116,8 @@
       "description": "The fully qualified object ID of a parameter, command, or external object.",
       "$comment": "The pattern is a series of segments starting with a solidus / and containing a valid oid, an array index or the one-past-the-end index.",
       "type": "string",
-      "pattern": "^((?![\\w.]*\\.\\d+$)[a-zA-Z][\\w.]{0,62}|\\d+|-)(\\/((?![\\w.]*\\.\\d+$)[a-zA-Z][\\w.]{0,62}|\\d+|-)){0,31}$"
+      "pattern": "^([\\w]+([\\.]{1}[A-Za-z]+)?)$",
+      "format": "json-pointer"
     },
     "float32": {
       "type": "number",

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,7 +1,33 @@
 #!/bin/bash
 
+check_coverage_sync() {
+    local build_dir="$1"
+    local out_of_sync=false
+    
+    # Find all .gcda files and check their timestamps against corresponding .gcno files
+    while IFS= read -r gcda_file; do
+        gcno_file="${gcda_file%.gcda}.gcno"
+        if [ -f "$gcno_file" ]; then
+            if [ "$gcno_file" -nt "$gcda_file" ]; then
+                echo "Coverage data out of sync: $gcda_file is older than $gcno_file"
+                out_of_sync=true
+            fi
+        fi
+    done < <(find "$build_dir" -name "*.gcda")
+    
+    return $([ "$out_of_sync" = true ])
+}
 
 cd ~/Catena/sdks/cpp/build
+
+# Check if coverage data is out of sync
+if check_coverage_sync ~/Catena/sdks/cpp/build; then
+    echo "Coverage data is out of sync. Cleaning and rebuilding..."
+    find ~/Catena/sdks/cpp/build -name "*.gcda" -delete    
+    ninja clean
+else
+    echo "Coverage data is in sync. Proceeding with tests..."
+fi
 ninja
 # Check for -V argument
 verbose=false
@@ -18,8 +44,6 @@ if [ "$verbose" = true ]; then
 else
   ctest
 fi
-
-
 
 cd ~/Catena/
 

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -68,6 +68,8 @@ using catena::REST::SocketReader;
 using catena::REST::SocketWriter;
 using catena::REST::SSEWriter;
 
+const std::string V1 = "v1";
+
 namespace catena {
 /**
  * @brief Namespace for classes relating to handling REST API requests.

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -93,6 +93,10 @@ class SocketReader : public ISocketReader {
      */
     uint32_t slot() const override { return slot_; };
     /**
+     * @brief Returns the fqoid of the asset to make the API call on.
+     */
+    const std::string& fqoid() const override { return fqoid_; };
+    /**
      * @brief Returns true if the field exists in the URL, regardless of its value.
      * 
      * @param key The name of the field to check.
@@ -161,6 +165,10 @@ class SocketReader : public ISocketReader {
      * @brief The slot of the device to make the API call on.
      */
     uint32_t slot_ = 0;
+    /**
+     * @brief The fqoid of the asset to make the API call on.
+     */
+    std::string fqoid_ = "";
     /**
      * @brief The client's jws token (empty if authorization is disabled).
      */

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -87,6 +87,10 @@ class ISocketReader {
      */
     virtual uint32_t slot() const = 0;
     /**
+     * @brief Returns the fqoid of the asset to make the API call on.
+     */
+    virtual const std::string& fqoid() const = 0;
+    /**
      * @brief Returns true if the field exists in the URL, regardless of its value.
      * 
      * @param key The name of the field to check.

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -53,7 +53,7 @@ CatenaServiceImpl::CatenaServiceImpl(IDevice& dm, std::string& EOPath, bool auth
     router_.addProduct("GET/v1/connect",                    Connect::makeOne);
     router_.addProduct("GET/v1/device-request",             DeviceRequest::makeOne);
     router_.addProduct("PUT/v1/execute-command",            ExecuteCommand::makeOne);
-    router_.addProduct("GET/v1/asset-request",              AssetRequest::makeOne);
+    router_.addProduct("GET/v1/asset",                      AssetRequest::makeOne);
     router_.addProduct("GET/v1/get-populated-slots",        GetPopulatedSlots::makeOne);
     router_.addProduct("GET/v1/get-value",                  GetValue::makeOne);
     router_.addProduct("PUT/v1/multi-set-value",            MultiSetValue::makeOne);
@@ -89,7 +89,8 @@ void CatenaServiceImpl::run() {
                     // Reading from the socket.
                     SocketReader context(*subscriptionManager_, EOPath_);
                     context.read(socket, authorizationEnabled_);
-                    std::string requestKey = context.method() + context.endpoint();
+                    //TODO: remove v1 from the request key when the router options are updated
+                    std::string requestKey = context.method() + "/v1" + context.endpoint();
                     // Returning empty response with options to the client if required.
                     if (context.method() == "OPTIONS") {
                         // Set to 204 No Content if in OPTIONS.

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -36,23 +36,18 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
     // Slot is not needed for GetPopulatedSlots and Connect.
     std::string path = u.path();
     try {
-        if (path.find("connect") != std::string::npos ||
-            path.find("get-populated-slots") != std::string::npos) {
-            endpoint_ = path;
-        } else {
-            std::vector<std::string> parts;
-            catena::split(parts, path, "/");
-            slot_ = std::stoi(parts[2]);
-            endpoint_ = "/" + parts[3];
+        std::vector<std::string> parts;
+        catena::split(parts, path, "/");
+        slot_ = std::stoi(parts.at(2));
+        endpoint_ = "/" + parts.at(3);
 
-            //parse fqoid
-            if (parts.back() == "stream") {
-                parts.pop_back();
-            }
-            
-            for (int i = 4; i < parts.size(); i++) {
-                fqoid_ += "/" + parts[i];
-            }
+        //parse fqoid
+        if (parts.back() == "stream") {
+            parts.pop_back();
+        }
+        
+        for (int i = 4; i < parts.size(); i++) {
+            fqoid_ += "/" + parts.at(i);
         }
     } catch (...) {
         throw catena::exception_with_status("Invalid URL", catena::StatusCode::INVALID_ARGUMENT);

--- a/sdks/cpp/connections/REST/src/SocketReader.cpp
+++ b/sdks/cpp/connections/REST/src/SocketReader.cpp
@@ -13,6 +13,7 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
     // Resetting variables.
     method_ = "";
     endpoint_ = "";
+    fqoid_ = "";
     jwsToken_ = "";
     origin_ = "";
     jsonBody_ = "";
@@ -39,9 +40,19 @@ void SocketReader::read(tcp::socket& socket, bool authz) {
             path.find("get-populated-slots") != std::string::npos) {
             endpoint_ = path;
         } else {
-            std::size_t pos = path.find_last_of('/');
-            endpoint_ = path.substr(0, pos);
-            slot_ = std::stoi(path.substr(pos + 1));
+            std::vector<std::string> parts;
+            catena::split(parts, path, "/");
+            slot_ = std::stoi(parts[2]);
+            endpoint_ = "/" + parts[3];
+
+            //parse fqoid
+            if (parts.back() == "stream") {
+                parts.pop_back();
+            }
+            
+            for (int i = 4; i < parts.size(); i++) {
+                fqoid_ += "/" + parts[i];
+            }
         }
     } catch (...) {
         throw catena::exception_with_status("Invalid URL", catena::StatusCode::INVALID_ARGUMENT);

--- a/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
@@ -32,13 +32,13 @@ void AssetRequest::proceed() {
             authz = &catena::common::Authorizer::kAuthzDisabled;
         }
         // Locking device and parsing object data.
-        std::cout << "sending asset: " << context_.fields("oid") <<"\n";
+        std::cout << "sending asset: " << context_.fqoid() <<"\n";
         std::string path = context_.EOPath();
-        path.append("/" + context_.fields("oid"));
+        path.append(context_.fqoid());
 
         // Check if the file exists
         if (!std::filesystem::exists(path)) {
-            std::string notFound = "AssetRequest[" + std::to_string(objectId_) + "] for file: " + context_.fields("oid") + " not found\n";
+            std::string notFound = "AssetRequest[" + std::to_string(objectId_) + "] for file: " + context_.fqoid() + " not found\n";
             std::cout << notFound;
             throw catena::exception_with_status(notFound, catena::StatusCode::NOT_FOUND);
         }
@@ -63,5 +63,5 @@ void AssetRequest::proceed() {
 
 void AssetRequest::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
-    std::cout << "AssetRequest[" + std::to_string(objectId_) + "] for file: " + context_.fields("oid") +" finished\n";
+    std::cout << "AssetRequest[" + std::to_string(objectId_) + "] for file: " + context_.fqoid() +" finished\n";
 }

--- a/sdks/cpp/connections/REST/tests/RESTMockClasses.h
+++ b/sdks/cpp/connections/REST/tests/RESTMockClasses.h
@@ -52,6 +52,7 @@ class MockSocketReader : public ISocketReader {
     MOCK_METHOD(const std::string&, method, (), (const, override));
     MOCK_METHOD(const std::string&, endpoint, (), (const, override));
     MOCK_METHOD(uint32_t, slot, (), (const, override));
+    MOCK_METHOD(const std::string&, fqoid, (), (const, override));
     MOCK_METHOD(bool, hasField, (const std::string& key), (const, override));
     MOCK_METHOD(const std::string&, fields, (const std::string& key), (const, override));
     MOCK_METHOD(const std::string&, jwsToken, (), (const, override));

--- a/sdks/cpp/connections/REST/tests/SocketHelper.h
+++ b/sdks/cpp/connections/REST/tests/SocketHelper.h
@@ -82,13 +82,9 @@ class SocketHelper {
                 fieldsStr += "&" + fName + "=" + fValue;
             }
         }
-        // Adding / to slot if not empty.
-        std::string slotStr = "";
-        if (!slot == 0) {
-            slotStr = "/" + std::to_string(slot);
-        }
+
         // Writing request to server.
-        std::string request = method + " " + endpoint + slotStr + fieldsStr + " HTTP/1.1\n"
+        std::string request = method + " /v1/" + std::to_string(slot) + endpoint + fieldsStr + " HTTP/1.1\n"
                               "Origin: " + origin + "\n"
                               "User-Agent: test_agent\n"
                               "Authorization: Bearer " + jwsToken + " \n"
@@ -97,6 +93,7 @@ class SocketHelper {
                               "Content-Length: " + std::to_string(jsonBody.length()) + "\r\n\r\n"
                               + jsonBody + "\n"
                               "\r\n\r\n";
+                              std::cout << request << std::endl;
         boost::asio::write(*writeSocket, boost::asio::buffer(request));
     }
 

--- a/sdks/cpp/connections/REST/tests/SocketReader_test.cpp
+++ b/sdks/cpp/connections/REST/tests/SocketReader_test.cpp
@@ -95,7 +95,7 @@ class RESTSocketReaderTests : public ::testing::Test, public SocketHelper {
     SocketReader socketReader{sm, EOPath};
     // Test request data
     std::string method = "PUT";
-    std::string endpoint = "/v1/test-call";
+    std::string endpoint = "/test-call";
     uint32_t slot = 1;
     std::unordered_map<std::string, std::string> fields = {
         {"testField1", "1"},
@@ -148,7 +148,7 @@ TEST_F(RESTSocketReaderTests, SocketReader_AuthzCase) {
  */
 TEST_F(RESTSocketReaderTests, SocketReader_NoSlotConnect) {
     // Connect does not require a slot specified.
-    endpoint = "/v1/connect";
+    endpoint = "/connect";
     slot = 0;
     writeRequest(method, endpoint, slot, fields,
                  jwsToken, jsonBody, dl, language);
@@ -161,7 +161,7 @@ TEST_F(RESTSocketReaderTests, SocketReader_NoSlotConnect) {
  */
 TEST_F(RESTSocketReaderTests, SocketReader_NoSlotGetPopulatedSlots) {
     // GetPopulatedSlots does not require a slot specified.
-    endpoint = "/v1/get-populated-slots";
+    endpoint = "/get-populated-slots";
     slot = 0;
     writeRequest(method, endpoint, slot, fields,
                  jwsToken, jsonBody, dl, language);
@@ -170,11 +170,11 @@ TEST_F(RESTSocketReaderTests, SocketReader_NoSlotGetPopulatedSlots) {
 }
 
 /* 
- * TEST 6 - Reading request from socket with no slot specified (Error).
+ * TEST 6 - add /// to url to break the url parsing and throw an exception
  */
-TEST_F(RESTSocketReaderTests, SocketReader_NoSlotError) {
-    // All other calls require a slot specified.
-    slot = 0;
+TEST_F(RESTSocketReaderTests, SocketReader_MalformedRequest) {
+    endpoint = "";
+
     writeRequest(method, endpoint, slot, fields,
                  jwsToken, jsonBody, dl, language);
     ASSERT_THROW(socketReader.read(serverSocket, authz), catena::exception_with_status);


### PR DESCRIPTION
Issue #673

Removed /device prefix from yaml
Fixed fqoid regex checking
Fixed params and comamnds definition in device_schema SocketReader now correctly handles args in request url ServiceImpl asset request matches schema
fqoid variable and getter added to SocketReader