### PR TITLE
Fixed front end and commands endpoints

### DIFF
--- a/interface/openapi/paths/Command.yaml
+++ b/interface/openapi/paths/Command.yaml
@@ -34,7 +34,7 @@
 # Date: 25/04/03
 #
 
-put:
+post:
   summary: Execute a command on a device model
   operationId: ExecuteCommand
 
@@ -84,7 +84,7 @@ put:
       application/json:
         schema:
           $ref: "../../../schema/catena.param_schema.json#/$defs/value"
-        example: {float32_value: 0.5}
+        example: {value:{"float32_value": 0.5}}
 
     
   responses:

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -52,7 +52,7 @@ CatenaServiceImpl::CatenaServiceImpl(IDevice& dm, std::string& EOPath, bool auth
 
     router_.addProduct("GET/v1/connect",                    Connect::makeOne);
     router_.addProduct("GET/v1/device-request",             DeviceRequest::makeOne);
-    router_.addProduct("PUT/v1/execute-command",            ExecuteCommand::makeOne);
+    router_.addProduct("POST/v1/command",                   ExecuteCommand::makeOne);
     router_.addProduct("GET/v1/asset",                      AssetRequest::makeOne);
     router_.addProduct("GET/v1/get-populated-slots",        GetPopulatedSlots::makeOne);
     router_.addProduct("GET/v1/get-value",                  GetValue::makeOne);

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -18,7 +18,7 @@ ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDev
     try {
         // Initialize the request
         req_.set_slot(context_.slot());
-        req_.set_oid("/" + context_.fields("oid"));
+        req_.set_oid(context_.fqoid());
         req_.set_respond(context_.hasField("respond"));
         req_.set_proceed(context_.hasField("proceed"));
 
@@ -29,7 +29,6 @@ ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDev
                 absl::string_view(context_.jsonBody()), 
                 &json_payload
             );
-            
             if (status.ok() && json_payload.has_value()) {
                 *req_.mutable_value() = json_payload.value();
             } else {


### PR DESCRIPTION
Issue #673

Changed command message type to post in openapi yaml Fixed command value formatting in openapi yaml
Fixed command endpoint name
Command back-end processing now correctly uses fqoid