### PR TITLE
The ExecuteCommand Update

### DIFF
--- a/sdks/cpp/common/include/IParam.h
+++ b/sdks/cpp/common/include/IParam.h
@@ -39,7 +39,6 @@ namespace catena {
 namespace common { 
 
   class Authorizer;
-  // class IParamDescriptor;  
 
 /**
  * @brief IParam is the interface for business logic and connection logic to interact with parameters
@@ -174,14 +173,12 @@ class IParam {
     /**
      * @brief define a command for the parameter
      */
-    virtual void defineCommand(std::function<catena::CommandResponse(catena::Value)> command) = 0;
-    virtual void defineCommandNew(std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl) = 0;
+    virtual void defineCommand(std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl) = 0;
 
     /**
      * @brief execute the command for the parameter
      */
-    virtual catena::CommandResponse executeCommand(const catena::Value&  value) const = 0;
-    virtual std::unique_ptr<IParamDescriptor::ICommandResponder> executeCommandNew(const catena::Value&  value) const = 0;
+    virtual std::unique_ptr<IParamDescriptor::ICommandResponder> executeCommand(const catena::Value&  value) const = 0;
 
     /**
      * @brief get the descriptor of the parameter

--- a/sdks/cpp/common/include/IParam.h
+++ b/sdks/cpp/common/include/IParam.h
@@ -28,6 +28,7 @@
 //common 
 #include <Enums.h>
 #include <IConstraint.h>
+#include <IParamDescriptor.h>
 #include <Path.h>
 #include <Status.h>
 
@@ -38,7 +39,7 @@ namespace catena {
 namespace common { 
 
   class Authorizer;
-  class IParamDescriptor;  
+  // class IParamDescriptor;  
 
 /**
  * @brief IParam is the interface for business logic and connection logic to interact with parameters
@@ -174,11 +175,13 @@ class IParam {
      * @brief define a command for the parameter
      */
     virtual void defineCommand(std::function<catena::CommandResponse(catena::Value)> command) = 0;
+    virtual void defineCommandNew(std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl) = 0;
 
     /**
      * @brief execute the command for the parameter
      */
     virtual catena::CommandResponse executeCommand(const catena::Value&  value) const = 0;
+    virtual std::unique_ptr<IParamDescriptor::ICommandResponder> executeCommandNew(const catena::Value&  value) const = 0;
 
     /**
      * @brief get the descriptor of the parameter

--- a/sdks/cpp/common/include/IParamDescriptor.h
+++ b/sdks/cpp/common/include/IParamDescriptor.h
@@ -40,7 +40,7 @@
 
 //common
 #include <Tags.h>
-#include <IParam.h>
+// #include <IParam.h>
 #include <PolyglotText.h>
 
 namespace catena {
@@ -211,6 +211,20 @@ class IParamDescriptor {
      */
     virtual const catena::common::IConstraint* getConstraint() const = 0;
 
+    class ICommandResponder {
+      public:
+        ICommandResponder() = default;
+
+        ICommandResponder(const ICommandResponder&) = delete;
+        ICommandResponder& operator=(const ICommandResponder&) = delete;
+        
+        virtual ~ICommandResponder() = default;
+
+        virtual inline bool hasMore() const = 0;
+
+        virtual catena::CommandResponse getNext() = 0;
+    };
+
     /**
      * @brief define the command implementation
      * @param commandImpl a function that takes a Value and returns a CommandResponse
@@ -219,6 +233,7 @@ class IParamDescriptor {
      * If this is not a command parameter, an exception will be thrown.
      */
     virtual void defineCommand(std::function<catena::CommandResponse(catena::Value)> commandImpl) = 0;
+    virtual void defineCommandNew(std::function<std::unique_ptr<ICommandResponder>(catena::Value)> commandImpl) = 0;
 
     /**
      * @brief execute the command
@@ -229,6 +244,7 @@ class IParamDescriptor {
      * command response will be an exception with type UNIMPLEMENTED
      */
     virtual catena::CommandResponse executeCommand(catena::Value value) = 0;
+    virtual std::unique_ptr<ICommandResponder> executeCommandNew(catena::Value value) = 0;
 
     /**
      * @brief return true if this is a command parameter

--- a/sdks/cpp/common/include/IParamDescriptor.h
+++ b/sdks/cpp/common/include/IParamDescriptor.h
@@ -211,17 +211,24 @@ class IParamDescriptor {
      */
     virtual const catena::common::IConstraint* getConstraint() const = 0;
 
+    /**
+     * @brief CommandResponder is a coroutine that allows commands to return
+     * multiple responses throughout its execution's lifetime.
+     */
     class ICommandResponder {
       public:
         ICommandResponder() = default;
-
         ICommandResponder(const ICommandResponder&) = delete;
         ICommandResponder& operator=(const ICommandResponder&) = delete;
-        
         virtual ~ICommandResponder() = default;
 
+        /**
+         * @brief Returns true if the coroutine has not finished execution.
+         */
         virtual inline bool hasMore() const = 0;
-
+        /**
+         * @brief Resumes the coroutine and returns a CommandResponse object.
+         */
         virtual catena::CommandResponse getNext() = 0;
     };
 
@@ -232,8 +239,7 @@ class IParamDescriptor {
      * The passed function will be executed when executeCommand is called on this param object.
      * If this is not a command parameter, an exception will be thrown.
      */
-    virtual void defineCommand(std::function<catena::CommandResponse(catena::Value)> commandImpl) = 0;
-    virtual void defineCommandNew(std::function<std::unique_ptr<ICommandResponder>(catena::Value)> commandImpl) = 0;
+    virtual void defineCommand(std::function<std::unique_ptr<ICommandResponder>(catena::Value)> commandImpl) = 0;
 
     /**
      * @brief execute the command
@@ -243,8 +249,7 @@ class IParamDescriptor {
      * if executeCommand is called for a command that has not been defined, then the returned
      * command response will be an exception with type UNIMPLEMENTED
      */
-    virtual catena::CommandResponse executeCommand(catena::Value value) = 0;
-    virtual std::unique_ptr<ICommandResponder> executeCommandNew(catena::Value value) = 0;
+    virtual std::unique_ptr<ICommandResponder> executeCommand(catena::Value value) = 0;
 
     /**
      * @brief return true if this is a command parameter

--- a/sdks/cpp/common/include/ParamDescriptor.h
+++ b/sdks/cpp/common/include/ParamDescriptor.h
@@ -278,8 +278,6 @@ class ParamDescriptor : public IParamDescriptor {
     /**
      * @brief CommandResponder is a coroutine that allows commands to return
      * multiple responses throughout its execution's lifetime.
-     * This struct manages the state and lifetime of the coroutine. It also
-     * provides the interface for resuming the coroutine.
      */
     class CommandResponder : public ICommandResponder {
       public:

--- a/sdks/cpp/common/include/ParamWithValue.h
+++ b/sdks/cpp/common/include/ParamWithValue.h
@@ -285,23 +285,20 @@ class ParamWithValue : public catena::common::IParam {
     }
 
     /**
-     * @brief define a command for the parameter
-     */
-    void defineCommand(std::function<catena::CommandResponse(catena::Value)> command) override {
-        descriptor_.defineCommand(command);
-    }
-    void defineCommandNew(std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl) {
-        descriptor_.defineCommandNew(commandImpl);
+     * @brief define the command implementation
+     * @param commandImpl a function that takes a Value and returns a CommandResponder
+     */ 
+    void defineCommand(std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl) {
+        descriptor_.defineCommand(commandImpl);
     }
 
     /**
      * @brief execute the command for the parameter
+     * @param value the value to pass to the command implementation
+     * @return the responser from the command implementation
      */
-    catena::CommandResponse executeCommand(const catena::Value& value) const override {
+    std::unique_ptr<IParamDescriptor::ICommandResponder> executeCommand(const catena::Value& value) const override {
         return descriptor_.executeCommand(value);
-    }
-    std::unique_ptr<IParamDescriptor::ICommandResponder> executeCommandNew(const catena::Value& value) const override {
-        return descriptor_.executeCommandNew(value);
     }
 
     /**

--- a/sdks/cpp/common/include/ParamWithValue.h
+++ b/sdks/cpp/common/include/ParamWithValue.h
@@ -290,12 +290,18 @@ class ParamWithValue : public catena::common::IParam {
     void defineCommand(std::function<catena::CommandResponse(catena::Value)> command) override {
         descriptor_.defineCommand(command);
     }
+    void defineCommandNew(std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl) {
+        descriptor_.defineCommandNew(commandImpl);
+    }
 
     /**
      * @brief execute the command for the parameter
      */
     catena::CommandResponse executeCommand(const catena::Value& value) const override {
         return descriptor_.executeCommand(value);
+    }
+    std::unique_ptr<IParamDescriptor::ICommandResponder> executeCommandNew(const catena::Value& value) const override {
+        return descriptor_.executeCommandNew(value);
     }
 
     /**

--- a/sdks/cpp/common/tests/CommonMockClasses.h
+++ b/sdks/cpp/common/tests/CommonMockClasses.h
@@ -118,10 +118,8 @@ public:
     MOCK_METHOD(catena::exception_with_status, popBack, (Authorizer& authz), (override));
     MOCK_METHOD(const IConstraint*, getConstraint, (), (const, override));
     MOCK_METHOD(const std::string&, getScope, (), (const, override));
-    MOCK_METHOD(void, defineCommand, (std::function<catena::CommandResponse(catena::Value)> command), (override));
-    MOCK_METHOD(void, defineCommandNew, (std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl), (override));
-    MOCK_METHOD(catena::CommandResponse, executeCommand, (const catena::Value& value), (const, override));
-    MOCK_METHOD(std::unique_ptr<IParamDescriptor::ICommandResponder>, executeCommandNew, (const catena::Value& value), (const, override));
+    MOCK_METHOD(void, defineCommand, (std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl), (override));
+    MOCK_METHOD(std::unique_ptr<IParamDescriptor::ICommandResponder>, executeCommand, (const catena::Value& value), (const, override));
     MOCK_METHOD(const IParamDescriptor&, getDescriptor, (), (const, override));
     MOCK_METHOD(bool, isArrayType, (), (const, override));
     MOCK_METHOD(bool, validateSetValue, (const catena::Value& value, Path::Index index, Authorizer& authz, catena::exception_with_status& ans), (override));
@@ -157,10 +155,8 @@ class MockParamDescriptor : public IParamDescriptor {
         MOCK_METHOD(bool, hasMore, (), (const, override));
         MOCK_METHOD(catena::CommandResponse, getNext, (), (override));
     };
-    MOCK_METHOD(void, defineCommand, (std::function<catena::CommandResponse(catena::Value)> commandImpl), (override));
-    MOCK_METHOD(void, defineCommandNew, (std::function<std::unique_ptr<ICommandResponder>(catena::Value)> commandImpl), (override));
-    MOCK_METHOD(catena::CommandResponse, executeCommand, (catena::Value value), (override));
-    MOCK_METHOD(std::unique_ptr<ICommandResponder>, executeCommandNew, (catena::Value value), (override));
+    MOCK_METHOD(void, defineCommand, (std::function<std::unique_ptr<ICommandResponder>(catena::Value)> commandImpl), (override));
+    MOCK_METHOD(std::unique_ptr<ICommandResponder>, executeCommand, (catena::Value value), (override));
     MOCK_METHOD(bool, isCommand, (), (const, override));
 };
 

--- a/sdks/cpp/common/tests/CommonMockClasses.h
+++ b/sdks/cpp/common/tests/CommonMockClasses.h
@@ -119,7 +119,9 @@ public:
     MOCK_METHOD(const IConstraint*, getConstraint, (), (const, override));
     MOCK_METHOD(const std::string&, getScope, (), (const, override));
     MOCK_METHOD(void, defineCommand, (std::function<catena::CommandResponse(catena::Value)> command), (override));
+    MOCK_METHOD(void, defineCommandNew, (std::function<std::unique_ptr<IParamDescriptor::ICommandResponder>(catena::Value)> commandImpl), (override));
     MOCK_METHOD(catena::CommandResponse, executeCommand, (const catena::Value& value), (const, override));
+    MOCK_METHOD(std::unique_ptr<IParamDescriptor::ICommandResponder>, executeCommandNew, (const catena::Value& value), (const, override));
     MOCK_METHOD(const IParamDescriptor&, getDescriptor, (), (const, override));
     MOCK_METHOD(bool, isArrayType, (), (const, override));
     MOCK_METHOD(bool, validateSetValue, (const catena::Value& value, Path::Index index, Authorizer& authz, catena::exception_with_status& ans), (override));
@@ -150,8 +152,15 @@ class MockParamDescriptor : public IParamDescriptor {
     MOCK_METHOD(IParamDescriptor&, getSubParam, (const std::string& oid), (const, override));
     MOCK_METHOD((const std::unordered_map<std::string, IParamDescriptor*>&), getAllSubParams, (), (const, override));
     MOCK_METHOD(const catena::common::IConstraint*, getConstraint, (), (const, override));
+    class MockCommandResponder : public ICommandResponder {
+      public:
+        MOCK_METHOD(bool, hasMore, (), (const, override));
+        MOCK_METHOD(catena::CommandResponse, getNext, (), (override));
+    };
     MOCK_METHOD(void, defineCommand, (std::function<catena::CommandResponse(catena::Value)> commandImpl), (override));
+    MOCK_METHOD(void, defineCommandNew, (std::function<std::unique_ptr<ICommandResponder>(catena::Value)> commandImpl), (override));
     MOCK_METHOD(catena::CommandResponse, executeCommand, (catena::Value value), (override));
+    MOCK_METHOD(std::unique_ptr<ICommandResponder>, executeCommandNew, (catena::Value value), (override));
     MOCK_METHOD(bool, isCommand, (), (const, override));
 };
 

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/device.one_of_everything.yaml
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/device.one_of_everything.yaml
@@ -94,3 +94,5 @@ commands:
     type: INT32
   randomize:
     type: EMPTY
+  tape_bot:
+    type: EMPTY

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/one_of_everything_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/one_of_everything_REST.cpp
@@ -102,7 +102,7 @@ void defineCommands() {
      * Starts a thread which updates the number_example parameter with the next
      * number of the Fibonacci sequence every second.
      */
-    fibStart->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    fibStart->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -148,7 +148,7 @@ void defineCommands() {
     // This stops the looping thread in the fib_start command above.
     std::unique_ptr<IParam> fibStop = dm.getCommand("/fib_stop", err);
     assert(fibStop != nullptr);
-    fibStop->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    fibStop->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -167,7 +167,7 @@ void defineCommands() {
     // This sets the value of number_example.
     std::unique_ptr<IParam> fibSet = dm.getCommand("/fib_set", err);
     assert(fibSet != nullptr);
-    fibSet->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    fibSet->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -188,7 +188,7 @@ void defineCommands() {
     // This fills float_array with 128 random floats rounded to 3 decimal places.
     std::unique_ptr<IParam> randomize = dm.getCommand("/randomize", err);
     assert(randomize != nullptr);
-    randomize->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    randomize->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -217,7 +217,7 @@ void defineCommands() {
     // This simulates a tape bot and returns a stream of responses.
     std::unique_ptr<IParam> tapeBot = dm.getCommand("/tape_bot", err);
     assert(tapeBot != nullptr);
-    tapeBot->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    tapeBot->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;

--- a/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
@@ -129,7 +129,7 @@ void defineCommands() {
 
     // Define a lambda function to be executed when the command is called
     // The lambda function must take a catena::Value as an argument and return a catena::CommandResponse
-    playCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    playCommand->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -155,7 +155,7 @@ void defineCommands() {
 
     std::unique_ptr<IParam> pauseCommand = dm.getCommand("/pause", err);
     assert(pauseCommand != nullptr);
-    pauseCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    pauseCommand->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;

--- a/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
@@ -43,6 +43,7 @@
 #include <utils.h>
 #include <Device.h>
 #include <ParamWithValue.h>
+#include <ParamDescriptor.h>
 
 // REST
 #include <ServiceImpl.h>
@@ -128,53 +129,54 @@ void defineCommands() {
 
     // Define a lambda function to be executed when the command is called
     // The lambda function must take a catena::Value as an argument and return a catena::CommandResponse
-    playCommand->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
-        
-        // If the state parameter does not exist, return an exception
-        if (stateParam == nullptr) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details(err.what());
-            return response;
-        }
-
-        std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
-        {
-            std::lock_guard lg(dm.mutex());
-            state = "playing";
-            dm.valueSetByServer.emit("/state", stateParam.get(), 0);
-        }
-        
-        std::cout << "video is " << state << "\n";
-        response.mutable_no_response();
-        return response;
+    playCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
+            
+            // If the state parameter does not exist, return an exception
+            if (stateParam == nullptr) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details(err.what());
+            } else {
+                std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
+                {
+                    std::lock_guard lg(dm.mutex());
+                    state = "playing";
+                    dm.valueSetByServer.emit("/state", stateParam.get(), 0);
+                }
+                std::cout << "video is " << state << "\n";
+                response.mutable_no_response();
+            }
+            co_return response;
+        }());
     });
 
     std::unique_ptr<IParam> pauseCommand = dm.getCommand("/pause", err);
     assert(pauseCommand != nullptr);
-    pauseCommand->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
-
-        if (stateParam == nullptr) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details(err.what());
-            return response;
-        }
-
-        std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
-        {
-            std::lock_guard lg(dm.mutex());
-            state = "paused";
-            dm.valueSetByServer.emit("/state", stateParam.get(), 0);
-        }
-
-        std::cout << "video is " << state << "\n";
-        response.mutable_no_response();
-        return response;
+    pauseCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
+            
+            // If the state parameter does not exist, return an exception
+            if (stateParam == nullptr) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details(err.what());
+            } else {
+                std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
+                {
+                    std::lock_guard lg(dm.mutex());
+                    state = "paused";
+                    dm.valueSetByServer.emit("/state", stateParam.get(), 0);
+                }
+                std::cout << "video is " << state << "\n";
+                response.mutable_no_response();
+            }
+            co_return response;
+        }());
     });
 }
 

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -125,7 +125,7 @@ class ExecuteCommand : public ICallData {
     /**
      * @brief The SocketWriter object for writing to socket_.
      */
-    SocketWriter writer_;
+    SSEWriter writer_;
     /**
      * @brief The ISocketReader object.
      */
@@ -134,14 +134,6 @@ class ExecuteCommand : public ICallData {
      * @brief The device to connect to.
      */
     IDevice& dm_;
-    /**
-     * @brief The payload of the request.
-     */
-    catena::ExecuteCommandPayload req_;
-    /**
-     * @brief The OID of the parameter to connect to.
-     */
-    std::string oid_;
 };
 
 } // namespace REST

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -15,58 +15,49 @@ ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, IDev
     socket_{socket}, writer_{socket, context.origin()}, context_{context}, dm_{dm} {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
-    
-    try {
-        // Initialize the request
-        req_.set_slot(context_.slot());
-        req_.set_oid(context_.fqoid());
-        req_.set_respond(context_.hasField("respond"));
-        req_.set_proceed(context_.hasField("proceed"));
-
-        // Parse JSON body if present
-        if (!context_.jsonBody().empty()) {
-            catena::ExecuteCommandPayload json_payload;
-            auto status = google::protobuf::util::JsonStringToMessage(
-                absl::string_view(context_.jsonBody()), 
-                &json_payload
-            );
-            if (status.ok() && json_payload.has_value()) {
-                *req_.mutable_value() = json_payload.value();
-            } else {
-                throw catena::exception_with_status("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
-            }
-        }
-    } catch (...) {
-        catena::exception_with_status err("Failed to parse fields", catena::StatusCode::INVALID_ARGUMENT);
-        writer_.sendResponse(err);
-    }
 }
 
 void ExecuteCommand::proceed() {
     writeConsole_(CallStatus::kProcess, socket_.is_open());
-    { // rc scope
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    try {
-        // Get the command and execute it
-        std::unique_ptr<IParam> command = nullptr;
-        
-        if (context_.authorizationEnabled()) {
-            catena::common::Authorizer authz{context_.jwsToken()};
-            command = dm_.getCommand(req_.oid(), rc, authz);
-        } else {
-            command = dm_.getCommand(req_.oid(), rc, catena::common::Authorizer::kAuthzDisabled);
-        }
 
-        // If the command is not found, return an error
-        if (command != nullptr) {
-            // Execute the command and write response if respond = true.
-            std::unique_ptr<IParamDescriptor::ICommandResponder> responder = command->executeCommandNew(req_.value());
-            while (responder->hasMore()) {
-                writeConsole_(CallStatus::kWrite, socket_.is_open());
-                catena::CommandResponse res = responder->getNext();
-                if (req_.respond()) {
-                    writer_.sendResponse(rc, res);
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    bool respond = context_.hasField("respond");
+    bool proceed = context_.hasField("proceed");
+
+    try {
+        // Parse JSON body if not empty.
+        catena::Value val;
+        if (!context_.jsonBody().empty()) {
+            auto status = google::protobuf::util::JsonStringToMessage(absl::string_view(context_.jsonBody()), &val);
+            if (!status.ok()) {
+                rc = catena::exception_with_status("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
+            }
+        }
+        
+        // Continue if the jsonBody was successfully parsed.
+        if (rc.status == catena::StatusCode::OK) {
+            // Get the command.
+            std::unique_ptr<IParam> command = nullptr;
+            if (context_.authorizationEnabled()) {
+                catena::common::Authorizer authz{context_.jwsToken()};
+                command = dm_.getCommand(context_.fqoid(), rc, authz);
+            } else {
+                command = dm_.getCommand(context_.fqoid(), rc, catena::common::Authorizer::kAuthzDisabled);
+            }
+
+            // If the command is not found, return an error
+            if (command != nullptr) {
+                // Execute the command and write response if respond = true.
+                std::unique_ptr<IParamDescriptor::ICommandResponder> responder = command->executeCommandNew(val);
+                while (responder->hasMore()) {
+                    writeConsole_(CallStatus::kWrite, socket_.is_open());
+                    catena::CommandResponse res = responder->getNext();
+                    if (respond) {
+                        writer_.sendResponse(rc, res);
+                    }
                 }
+            } else {
+                rc = catena::exception_with_status("Command not found", catena::StatusCode::NOT_FOUND);
             }
         }
     } catch (catena::exception_with_status& err) {
@@ -75,9 +66,8 @@ void ExecuteCommand::proceed() {
         rc = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
     }
     // Writing final code if respond = false or an error occured.
-    if (rc.status != catena::StatusCode::OK || !req_.respond()) {
+    if (rc.status != catena::StatusCode::OK || !respond) {
         writer_.sendResponse(rc);
-    }
     }
 }
 

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -48,7 +48,7 @@ void ExecuteCommand::proceed() {
             // If the command is not found, return an error
             if (command != nullptr) {
                 // Execute the command and write response if respond = true.
-                std::unique_ptr<IParamDescriptor::ICommandResponder> responder = command->executeCommandNew(val);
+                std::unique_ptr<IParamDescriptor::ICommandResponder> responder = command->executeCommand(val);
                 while (responder->hasMore()) {
                     writeConsole_(CallStatus::kWrite, socket_.is_open());
                     catena::CommandResponse res = responder->getNext();

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -49,15 +49,17 @@ void ExecuteCommand::proceed() {
             if (command != nullptr) {
                 // Execute the command and write response if respond = true.
                 std::unique_ptr<IParamDescriptor::ICommandResponder> responder = command->executeCommand(val);
-                while (responder->hasMore()) {
-                    writeConsole_(CallStatus::kWrite, socket_.is_open());
-                    catena::CommandResponse res = responder->getNext();
-                    if (respond) {
-                        writer_.sendResponse(rc, res);
+                if (!responder) {
+                    rc = catena::exception_with_status("Illegal state", catena::StatusCode::INTERNAL);
+                } else {
+                    while (responder->hasMore()) {
+                        writeConsole_(CallStatus::kWrite, socket_.is_open());
+                        catena::CommandResponse res = responder->getNext();
+                        if (respond) {
+                            writer_.sendResponse(rc, res);
+                        }
                     }
                 }
-            } else {
-                rc = catena::exception_with_status("Command not found", catena::StatusCode::NOT_FOUND);
             }
         }
     } catch (catena::exception_with_status& err) {

--- a/sdks/cpp/connections/REST/tests/CMakeLists.txt
+++ b/sdks/cpp/connections/REST/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     SetValue_test.cpp
     GetParam_test.cpp
     BasicParamInfoRequest_test.cpp
+    ExecuteCommand_test.cpp
 
     ../src/SocketReader.cpp
     ../src/SocketWriter.cpp
@@ -33,6 +34,7 @@ set(SOURCES
     ../src/controllers/SetValue.cpp
     ../src/controllers/GetParam.cpp
     ../src/controllers/BasicParamInfoRequest.cpp
+    ../src/controllers/ExecuteCommand.cpp
 )	
 
 add_executable(${This} ${SOURCES})	

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/device.one_of_everything.yaml
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/device.one_of_everything.yaml
@@ -94,3 +94,5 @@ commands:
     type: INT32
   randomize:
     type: EMPTY
+  tape_bot:
+    type: EMPTY

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
@@ -108,7 +108,7 @@ void defineCommands() {
      * Starts a thread which updates the number_example parameter with the next
      * number of the Fibonacci sequence every second.
      */
-    fibStart->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    fibStart->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -154,7 +154,7 @@ void defineCommands() {
     // This stops the looping thread in the fib_start command above.
     std::unique_ptr<IParam> fibStop = dm.getCommand("/fib_stop", err);
     assert(fibStop != nullptr);
-    fibStop->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    fibStop->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -173,7 +173,7 @@ void defineCommands() {
     // This sets the value of number_example.
     std::unique_ptr<IParam> fibSet = dm.getCommand("/fib_set", err);
     assert(fibSet != nullptr);
-    fibSet->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    fibSet->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -194,7 +194,7 @@ void defineCommands() {
     // This fills float_array with 128 random floats rounded to 3 decimal places.
     std::unique_ptr<IParam> randomize = dm.getCommand("/randomize", err);
     assert(randomize != nullptr);
-    randomize->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    randomize->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -223,7 +223,7 @@ void defineCommands() {
     // This simulates a tape bot and returns a stream of responses.
     std::unique_ptr<IParam> tapeBot = dm.getCommand("/tape_bot", err);
     assert(tapeBot != nullptr);
-    tapeBot->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    tapeBot->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
@@ -42,6 +42,7 @@
 #include <utils.h>
 #include <Device.h>
 #include <ParamWithValue.h>
+#include <ParamDescriptor.h>
 
 // connections/gRPC
 #include <ServiceImpl.h>
@@ -107,108 +108,154 @@ void defineCommands() {
      * Starts a thread which updates the number_example parameter with the next
      * number of the Fibonacci sequence every second.
      */
-    fibStart->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> intParam = dm.getParam("/number_example", err);
-        
-        // If the loop is already running, return an exception.
-        if (fibLoop) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details("Already running");
-        // If the state parameter does not exist, return an exception.
-        } else if (!intParam) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details(err.what());
-        } else {
-            fibLoop = true;
-            // Detaching thread to update number_example with next number of
-            // the Fibonacci sequence every second.
-            std::thread figSeqThread([intParam = std::move(intParam)]() {
-                auto& fibParam = *dynamic_cast<ParamWithValue<int32_t>*>(intParam.get());
-                uint32_t prev = 0;
-                uint32_t curr = 1;
-                while (fibLoop) {
-                    std::this_thread::sleep_for(std::chrono::seconds(1));
-                    uint32_t next = prev + curr;
-                    prev = curr;
-                    curr = next;
-                    {
-                    std::lock_guard lg(dm.mutex());
-                    fibParam.get() = next;
-                    dm.valueSetByServer.emit("/number_example", &fibParam, 0);
+    fibStart->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> intParam = dm.getParam("/number_example", err);
+            
+            // If the loop is already running, return an exception.
+            if (fibLoop) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details("Already running");
+            // If the state parameter does not exist, return an exception.
+            } else if (!intParam) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details(err.what());
+            } else {
+                fibLoop = true;
+                // Detaching thread to update number_example with next number of
+                // the Fibonacci sequence every second.
+                std::thread figSeqThread([intParam = std::move(intParam)]() {
+                    auto& fibParam = *dynamic_cast<ParamWithValue<int32_t>*>(intParam.get());
+                    uint32_t prev = 0;
+                    uint32_t curr = 1;
+                    while (fibLoop) {
+                        std::this_thread::sleep_for(std::chrono::seconds(1));
+                        uint32_t next = prev + curr;
+                        prev = curr;
+                        curr = next;
+                        {
+                        std::lock_guard lg(dm.mutex());
+                        fibParam.get() = next;
+                        dm.valueSetByServer.emit("/number_example", &fibParam, 0);
+                        }
                     }
-                }
-            });
-            figSeqThread.detach();
+                });
+                figSeqThread.detach();
 
-            std::cout << "Fibonacci sequence start" << std::endl;;
-            response.mutable_no_response();
-        }
-        return response;
+                std::cout << "Fibonacci sequence start" << std::endl;;
+                response.mutable_no_response();
+            }
+            co_return response;
+        }());
     });
 
     // This stops the looping thread in the fib_start command above.
     std::unique_ptr<IParam> fibStop = dm.getCommand("/fib_stop", err);
     assert(fibStop != nullptr);
-    fibStop->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        if (fibLoop) {
-            fibLoop = false;
-            std::cout << "Fibonacci sequence stop" << std::endl;
-            response.mutable_no_response();
-        } else {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details("Already stopped");
-        }
-        return response;
+    fibStop->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            if (fibLoop) {
+                fibLoop = false;
+                std::cout << "Fibonacci sequence stop" << std::endl;
+                response.mutable_no_response();
+            } else {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details("Already stopped");
+            }
+            co_return response;
+        }());
     });
 
     // This sets the value of number_example.
     std::unique_ptr<IParam> fibSet = dm.getCommand("/fib_set", err);
     assert(fibSet != nullptr);
-    fibSet->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> intParam = dm.getParam("/number_example", err);
-        if (intParam) {
-            auto& fibParam = *dynamic_cast<ParamWithValue<int32_t>*>(intParam.get());
-            fibParam.get() = value.int32_value();
-            dm.valueSetByServer.emit("/number_example", &fibParam, 0);
-            response.mutable_no_response();
-        } else {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details("/number_example not found");
-        }
-        return response;
+    fibSet->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> intParam = dm.getParam("/number_example", err);
+            if (intParam) {
+                auto& fibParam = *dynamic_cast<ParamWithValue<int32_t>*>(intParam.get());
+                fibParam.get() = value.int32_value();
+                dm.valueSetByServer.emit("/number_example", &fibParam, 0);
+                response.mutable_no_response();
+            } else {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details("/number_example not found");
+            }
+            co_return response;
+        }());
     });
 
     // This fills float_array with 128 random floats rounded to 3 decimal places.
     std::unique_ptr<IParam> randomize = dm.getCommand("/randomize", err);
     assert(randomize != nullptr);
-    randomize->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> floatArray = dm.getParam("/float_array", err);
-        if (!floatArray) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details(err.what());
-        } else {
-            auto& floatArrayR = *dynamic_cast<ParamWithValue<std::vector<float>>*>(floatArray.get());
-            std::vector<float>& randomArray = floatArrayR.get();
-            randomArray.clear();
-            // Generates random floats between 0 and 80 and rounds to 3 decimal places.
-            for (int i = 0; i < floatArrayR.getDescriptor().max_length(); i++) {
-                float randomNum = static_cast<float>(rand()) / static_cast<float>(RAND_MAX / 80);
-                randomNum = std::round(randomNum * 1000) / 1000;
-                randomArray.push_back(randomNum);
+    randomize->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> floatArray = dm.getParam("/float_array", err);
+            if (!floatArray) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details(err.what());
+            } else {
+                auto& floatArrayR = *dynamic_cast<ParamWithValue<std::vector<float>>*>(floatArray.get());
+                std::vector<float>& randomArray = floatArrayR.get();
+                randomArray.clear();
+                // Generates random floats between 0 and 80 and rounds to 3 decimal places.
+                for (int i = 0; i < floatArrayR.getDescriptor().max_length(); i++) {
+                    float randomNum = static_cast<float>(rand()) / static_cast<float>(RAND_MAX / 80);
+                    randomNum = std::round(randomNum * 1000) / 1000;
+                    randomArray.push_back(randomNum);
+                }
+                std::cout << "Randomized float array" << std::endl;
+                response.mutable_no_response();
             }
-            std::cout << "Randomized float array" << std::endl;
-            response.mutable_no_response();
-        }
-        
-        return response;
+            
+            co_return response;
+        }());
+    });
+
+    // This simulates a tape bot and returns a stream of responses.
+    std::unique_ptr<IParam> tapeBot = dm.getCommand("/tape_bot", err);
+    assert(tapeBot != nullptr);
+    tapeBot->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            // Locating
+            std::cout << "Locating tape..." << std::endl;
+            response.mutable_response()->set_string_value("Locating tape...");
+            co_yield response;
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            // Loading
+            std::cout << "Tape found, loading..." << std::endl;
+            response.Clear();
+            response.mutable_response()->set_string_value("Tape found, loading...");
+            co_yield response;
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            // Seeking
+            std::cout << "Tape loaded, seeking..." << std::endl;
+            response.Clear();
+            response.mutable_response()->set_string_value("Tape loaded, seeking...");
+            co_yield response;
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            // Reading
+            std::cout << "File loaded, reading..." << std::endl;
+            response.Clear();
+            response.mutable_response()->set_string_value("File loaded, reading...");
+            co_yield response;
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            // Done
+            std::cout << "File loaded." << std::endl;
+            response.Clear();
+            response.mutable_response()->set_string_value("File loaded.");
+            co_return response;
+        }());
     });
 }
 

--- a/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
@@ -148,7 +148,7 @@ void defineCommands() {
 
     // Define a lambda function to be executed when the command is called
     // The lambda function must take a catena::Value as an argument and return a catena::CommandResponse
-    playCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    playCommand->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;
@@ -174,7 +174,7 @@ void defineCommands() {
 
     std::unique_ptr<IParam> pauseCommand = dm.getCommand("/pause", err);
     assert(pauseCommand != nullptr);
-    pauseCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+    pauseCommand->defineCommand([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
         return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
             catena::exception_with_status err{"", catena::StatusCode::OK};
             catena::CommandResponse response;

--- a/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
@@ -28,6 +28,7 @@
 #include <utils.h>
 #include <Device.h>
 #include <ParamWithValue.h>
+#include <ParamDescriptor.h>
 
 // connections/gRPC
 #include <ServiceImpl.h>
@@ -147,54 +148,54 @@ void defineCommands() {
 
     // Define a lambda function to be executed when the command is called
     // The lambda function must take a catena::Value as an argument and return a catena::CommandResponse
-    playCommand->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
-        
-        // If the state parameter does not exist, return an exception
-        if (stateParam == nullptr) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response.mutable_exception()->set_details(err.what());
-            return response;
-        }
-
-        std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
-        {
-            std::lock_guard lg(dm.mutex());
-            state = "playing";
-            dm.valueSetByServer.emit("/state", stateParam.get(), 0);
-        }
-        
-
-        std::cout << "video is " << state << "\n";
-        response.mutable_no_response();
-        return response;
+    playCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
+            
+            // If the state parameter does not exist, return an exception
+            if (stateParam == nullptr) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details(err.what());
+            } else {
+                std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
+                {
+                    std::lock_guard lg(dm.mutex());
+                    state = "playing";
+                    dm.valueSetByServer.emit("/state", stateParam.get(), 0);
+                }
+                std::cout << "video is " << state << "\n";
+                response.mutable_no_response();
+            }
+            co_return response;
+        }());
     });
 
     std::unique_ptr<IParam> pauseCommand = dm.getCommand("/pause", err);
     assert(pauseCommand != nullptr);
-    pauseCommand->defineCommand([](catena::Value value) {
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-        catena::CommandResponse response;
-        std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
-
-        if (stateParam == nullptr) {
-            response.mutable_exception()->set_type("Invalid Command");
-            response. mutable_exception()->set_details(err.what());
-            return response;
-        }
-
-        std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
-        {
-            std::lock_guard lg(dm.mutex());
-            state = "paused";
-            dm.valueSetByServer.emit("/state", stateParam.get(), 0);
-        }
-
-        std::cout << "video is " << state << "\n";
-        response.mutable_no_response();
-        return response;
+    pauseCommand->defineCommandNew([](catena::Value value) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([value]() -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            catena::CommandResponse response;
+            std::unique_ptr<IParam> stateParam = dm.getParam("/state", err);
+            
+            // If the state parameter does not exist, return an exception
+            if (stateParam == nullptr) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details(err.what());
+            } else {
+                std::string& state = dynamic_cast<ParamWithValue<std::string>*>(stateParam.get())->get();
+                {
+                    std::lock_guard lg(dm.mutex());
+                    state = "paused";
+                    dm.valueSetByServer.emit("/state", stateParam.get(), 0);
+                }
+                std::cout << "video is " << state << "\n";
+                response.mutable_no_response();
+            }
+            co_return response;
+        }());
     });
 }
 

--- a/sdks/cpp/connections/gRPC/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/ExecuteCommand.h
@@ -73,9 +73,9 @@ class ExecuteCommand : public CallData {
      */
     catena::ExecuteCommandPayload req_;
     /**
-     * @brief Response payload for command
+     * @brief Response coroutine for command
      */
-    catena::CommandResponse res_;
+    std::unique_ptr<IParamDescriptor::ICommandResponder> responder_;
     /**
      * @brief gRPC async response writer.
      */

--- a/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
@@ -135,7 +135,7 @@ void ExecuteCommand::proceed(bool ok) {
                     }
                 }
             // Looping required if we aren't writing to the client.
-            } while (!req_.respond() && status_ == CallStatus::kWrite);
+            } while (!req_.respond() && rc.status == catena::StatusCode::OK && status_ == CallStatus::kWrite);
             // Writing to the client.
             if (rc.status == catena::StatusCode::OK) {
                 if (req_.respond()) {

--- a/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
@@ -93,7 +93,7 @@ void ExecuteCommand::proceed(bool ok) {
                 // Executing the command if found.
                 if (command != nullptr) {
                     // res_ = command->executeCommand(req_.value());
-                    responder_ = command->executeCommandNew(req_.value());
+                    responder_ = command->executeCommand(req_.value());
                     status_ = CallStatus::kWrite; 
                 }
             // ERROR

--- a/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
@@ -92,7 +92,6 @@ void ExecuteCommand::proceed(bool ok) {
                 }
                 // Executing the command if found.
                 if (command != nullptr) {
-                    // res_ = command->executeCommand(req_.value());
                     responder_ = command->executeCommand(req_.value());
                     status_ = CallStatus::kWrite; 
                 }
@@ -100,7 +99,7 @@ void ExecuteCommand::proceed(bool ok) {
             } catch (catena::exception_with_status& err) {
                 rc = catena::exception_with_status(err.what(), err.status);
             } catch (...) {
-                rc = catena::exception_with_status("unknown error", catena::StatusCode::INTERNAL);
+                rc = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
             }
             // Ending process if an error occured, falling through otherwise.
             if (rc.status != catena::StatusCode::OK) {
@@ -165,10 +164,14 @@ void ExecuteCommand::proceed(bool ok) {
             service_->deregisterItem(this);
             break;
 
-        // Throws an error if the state is not recognized
-        default:
+        /*
+         * default: Error, end process.
+         * This should be impossible to reach.
+         */
+        default: // GCOVR_EXCL_START
             status_ = CallStatus::kFinish;
             grpc::Status errorStatus(grpc::StatusCode::INTERNAL, "illegal state");
             writer_.Finish(errorStatus, this);
+            // GCOVR_EXCL_STOP
     }
 }

--- a/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
@@ -92,7 +92,8 @@ void ExecuteCommand::proceed(bool ok) {
                 }
                 // Executing the command if found.
                 if (command != nullptr) {
-                    res_ = command->executeCommand(req_.value());
+                    // res_ = command->executeCommand(req_.value());
+                    responder_ = command->executeCommandNew(req_.value());
                     status_ = CallStatus::kWrite; 
                 }
             // ERROR
@@ -114,13 +115,40 @@ void ExecuteCommand::proceed(bool ok) {
          * then continues to kPostWrite or kFinish
          */
         case CallStatus::kWrite:
-            /*
-             * Currently only sends on response to the client. Add stream
-             * ability later.
-             */
-            writer_.Write(res_, this);
-            status_ = CallStatus::kPostWrite;
-            break;
+            { // rc scope
+            catena::exception_with_status rc{"", catena::StatusCode::OK};
+            catena::CommandResponse res{};
+            do {
+                if (!responder_) {
+                    // It should not be possible to get here
+                    rc = catena::exception_with_status{"Illegal state", catena::StatusCode::INTERNAL};
+                } else {
+                    // Getting the next component.
+                    try {     
+                        res = responder_->getNext();
+                        status_ = responder_->hasMore() ? CallStatus::kWrite : CallStatus::kPostWrite;
+                    // ERROR
+                    } catch (catena::exception_with_status &err) {
+                        rc = catena::exception_with_status{err.what(), err.status};
+                    } catch (...) {
+                        rc = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
+                    }
+                }
+            // Looping required if we aren't writing to the client.
+            } while (!req_.respond() && status_ == CallStatus::kWrite);
+            // Writing to the client.
+            if (rc.status == catena::StatusCode::OK) {
+                if (req_.respond()) {
+                    writer_.Write(res, this);
+                    break;
+                }
+            } else {
+                status_ = CallStatus::kFinish;
+                writer_.Finish(Status(static_cast<grpc::StatusCode>(rc.status), rc.what()), this);
+                break;
+            }
+            // Fall through of OK and respond = false;
+            }
 
         // Status after finishing writing the response, transitions to kFinish
         case CallStatus::kPostWrite:

--- a/sdks/cpp/connections/gRPC/tests/CMakeLists.txt
+++ b/sdks/cpp/connections/gRPC/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     ListLanguages_test.cpp
     LanguagePackRequest_test.cpp
     AddLanguage_test.cpp
+    ExecuteCommand_test.cpp
 )	
 
 add_executable(${This} ${SOURCES})	

--- a/sdks/cpp/connections/gRPC/tests/ExecuteCommand_test.cpp
+++ b/sdks/cpp/connections/gRPC/tests/ExecuteCommand_test.cpp
@@ -1,0 +1,606 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief This file is for testing the ExecuteCommand.cpp file.
+ * @author benjamin.whitten@rossvideo.com
+ * @date 25/06/03
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+// gtest
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// std
+#include <string>
+
+// protobuf
+#include <interface/device.pb.h>
+#include <google/protobuf/util/json_util.h>
+
+// Test helpers
+#include "gRPCMockClasses.h"
+
+// gRPC
+#include "controllers/ExecuteCommand.h"
+
+using namespace catena::common;
+using namespace catena::gRPC;
+
+// Fixture
+class gRPCExecuteCommandTests : public ::testing::Test {
+  protected:
+    /*
+     * Called at the start of all tests.
+     * Starts the mockServer and initializes the static inVal.
+     */
+    static void SetUpTestSuite() {
+        mockServer.start();
+    }
+
+    /*
+     * Sets up expectations for the creation of a new CallData obj.
+     */
+    void SetUp() override {
+        // Redirecting cout to a stringstream for testing.
+        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+        // We can always assume that a new CallData obj is created.
+        // Either from initialization or kProceed.
+        mockServer.expNew();
+    }
+
+    /*
+     * This is a test class which makes an async RPC to the MockServer on
+     * construction and compares the streamed-back response.
+     */
+    class TestRPC : public grpc::ClientReadReactor<catena::CommandResponse> {
+        public:
+            /*
+             * Adds a response to the expected values.
+             */
+            void expResponse(const std::string& stringVal) {
+                catena::CommandResponse res;
+                res.mutable_response()->set_string_value(stringVal);
+                expVals.push_back(res);
+            }
+            /* 
+             * Adds an exception to the expected values.
+             */
+            void expException(const std::string& type, const std::string& details) {
+                catena::CommandResponse res;
+                res.mutable_exception()->set_type(type);
+                res.mutable_exception()->set_details(details);
+                expVals.push_back(res);
+            }
+            /*
+             * Adds a no_response to the expected values.
+             */
+            void expNoResponse() {
+                catena::CommandResponse res;
+                res.mutable_no_response();
+                expVals.push_back(res);
+            }
+            /*
+             * This function makes an async RPC to the MockServer.
+             */
+            void TestCall(catena::CatenaService::Stub* client, const catena::exception_with_status& expRc, const catena::ExecuteCommandPayload& inVal, uint32_t expRead = 0) {
+                client->async()->ExecuteCommand(&clientContext, &inVal, this);
+                StartRead(&outVal);
+                StartCall();
+
+                // Waiting for the RPC to finish.
+                cv.wait(lock, [this] { return done; });
+                // Comparing the results.
+                EXPECT_EQ(outRc.error_code(), static_cast<grpc::StatusCode>(expRc.status));
+                EXPECT_EQ(outRc.error_message(), expRc.what());
+                EXPECT_EQ(read, expRead);
+            }
+            /*
+             * This function triggers when a read is done and compares the
+             * returned outVal with the expected response.
+             */
+            void OnReadDone(bool ok) override {
+                if (ok) {
+                    // Test value.
+                    EXPECT_EQ(outVal.SerializeAsString(), expVals[read].SerializeAsString());
+                    read += 1;
+                    StartRead(&outVal);
+                }
+            }
+            /*
+             * This function triggers when the RPC is finished and notifies
+             * Await().
+             */
+            void OnDone(const grpc::Status& status) override {
+                outRc = status;
+                done = true;
+                cv.notify_one();
+            }
+
+            grpc::ClientContext clientContext;
+            std::vector<catena::CommandResponse> expVals;
+            catena::CommandResponse outVal;
+            grpc::Status outRc;
+            uint32_t read = 0;
+
+            bool done = false;
+            std::condition_variable cv;
+            std::mutex cv_mtx;
+            std::unique_lock<std::mutex> lock{cv_mtx};
+    };
+
+    /*
+     * Streamlines creates of executeCommandPayloads. 
+     */
+    catena::ExecuteCommandPayload createPayload(const std::string& oid, const std::string& value, bool respond = true, bool proceed = true) {
+        catena::ExecuteCommandPayload inVal;
+        inVal.set_oid(oid);
+        inVal.mutable_value()->set_string_value(value);
+        inVal.set_respond(respond);
+        inVal.set_proceed(proceed);
+        return inVal;
+    }
+
+    /*
+     * Restores cout after each test.
+     */
+    void TearDown() override {
+        std::cout.rdbuf(oldCout);
+    }
+
+    /*
+     * Called at the end of all tests, shuts down the server and cleans up.
+     */
+    static void TearDownTestSuite() {
+        // Redirecting cout to a stringstream for testing.
+        std::stringstream MockConsole;
+        std::streambuf* oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+        // Destroying the server.
+        EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+            delete mockServer.testCall;
+            mockServer.testCall = nullptr;
+        }));
+        mockServer.shutdown();
+        // Restoring cout
+        std::cout.rdbuf(oldCout);
+    }
+
+    // Console variables
+    std::stringstream MockConsole;
+    std::streambuf* oldCout;
+
+    TestRPC testRPC;
+
+    static MockServer mockServer;
+
+    std::unique_ptr<MockParam> mockCommand = std::make_unique<MockParam>();
+    std::unique_ptr<MockParamDescriptor::MockCommandResponder> mockResponder = std::make_unique<MockParamDescriptor::MockCommandResponder>();
+};
+
+MockServer gRPCExecuteCommandTests::mockServer;
+
+/*
+ * ============================================================================
+ *                               ExecuteCommand tests
+ * ============================================================================
+ * 
+ * TEST 1 - Creating a ExecuteCommand object.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_create) {
+    // Creating deviceRequest object.
+    new ExecuteCommand(mockServer.service, *mockServer.dm, true);
+    EXPECT_FALSE(mockServer.testCall);
+    EXPECT_TRUE(mockServer.asyncCall);
+}
+
+/*
+ * TEST 2 - ExecuteCommand returns three CommandResponse responses.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_NormalResponse) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    testRPC.expResponse("test_response_1");
+    testRPC.expResponse("test_response_2");
+    testRPC.expResponse("test_response_3");
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", true, true);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(&authz, &Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(rc.what(), rc.status);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder);
+        }));
+    // Mocking kWrite functions
+    EXPECT_CALL(*mockResponder, getNext()).Times(3)
+        .WillOnce(::testing::Return(testRPC.expVals[0]))
+        .WillOnce(::testing::Return(testRPC.expVals[1]))
+        .WillOnce(::testing::Return(testRPC.expVals[2]));
+    EXPECT_CALL(*mockResponder, hasMore()).Times(3)
+        .WillOnce(::testing::Return(true))
+        .WillOnce(::testing::Return(true))
+        .WillOnce(::testing::Return(false));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal, 3);
+}
+
+/*
+ * TEST 3 - ExecuteCommand returns a CommandResponse no response.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_NormalNoResponse) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    testRPC.expNoResponse();
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", true, true);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(&authz, &Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(rc.what(), rc.status);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder);
+        }));
+    // Mocking kWrite functions
+    EXPECT_CALL(*mockResponder, getNext()).Times(1).WillOnce(::testing::Return(testRPC.expVals[0]));
+    EXPECT_CALL(*mockResponder, hasMore()).Times(1).WillOnce(::testing::Return(false));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal, 1);
+}
+
+/*
+ * TEST 4 - ExecuteCommand returns a CommandResponse exception.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_NormalException) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    testRPC.expException("test_exception_type", "test_exception_details");
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", true, true);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(&authz, &Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(rc.what(), rc.status);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder);
+        }));
+    // Mocking kWrite functions
+    EXPECT_CALL(*mockResponder, getNext()).Times(1).WillOnce(::testing::Return(testRPC.expVals[0]));
+    EXPECT_CALL(*mockResponder, hasMore()).Times(1).WillOnce(::testing::Return(false));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal, 1);
+}
+
+/*
+ * TEST 5 - ExecuteCommand returns no response (respond = false).
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_RespondFalse) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    // We should not read these in the asyncReader.
+    testRPC.expResponse("test_response_1");
+    testRPC.expResponse("test_response_2");
+    testRPC.expResponse("test_response_3");
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", false, true);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status(rc.what(), rc.status);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            return std::move(mockResponder);
+        }));
+    // Mocking kWrite functions
+    EXPECT_CALL(*mockResponder, getNext()).Times(3)
+        .WillOnce(::testing::Return(testRPC.expVals[0]))
+        .WillOnce(::testing::Return(testRPC.expVals[1]))
+        .WillOnce(::testing::Return(testRPC.expVals[2]));
+    EXPECT_CALL(*mockResponder, hasMore()).Times(3)
+        .WillOnce(::testing::Return(true))
+        .WillOnce(::testing::Return(true))
+        .WillOnce(::testing::Return(false));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal);
+}
+
+/*
+ * TEST 6 - ExecuteCommand returns a CommandResponse no response with authz
+ *          enabled.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_AuthzValid) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+    testRPC.expNoResponse();
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", true, true);
+    // Adding authorization mockToken metadata. This it a random RSA token.
+    std::string mockToken = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
+                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
+                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
+                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
+                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
+                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
+                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
+                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
+                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
+                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
+                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
+                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz(&testRPC.clientContext, mockToken);
+    EXPECT_CALL(*mockServer.dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_FALSE(&authz == &Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(rc.what(), rc.status);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder);
+        }));
+    // Mocking kWrite functions
+    EXPECT_CALL(*mockResponder, getNext()).Times(1).WillOnce(::testing::Return(testRPC.expVals[0]));
+    EXPECT_CALL(*mockResponder, hasMore()).Times(1).WillOnce(::testing::Return(false));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal, 1);
+}
+
+/*
+ * TEST 7 - ExecuteCommand fails from invalid JWS token.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_AuthzInvalid) { 
+    catena::exception_with_status rc("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
+
+    mockServer.expectAuthz(&testRPC.clientContext, "Bearer THIS SHOULD NOT PARSE");
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 8 - ExecuteCommand fails from JWS token not being found.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_AuthzJWSNotFound) {
+    catena::exception_with_status rc("JWS bearer token not found", catena::StatusCode::UNAUTHENTICATED);
+
+    mockServer.expectAuthz(&testRPC.clientContext, "NOT A BEARER TOKEN");
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 9 - getCommand does not find a command.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
+    catena::exception_with_status rc("Command not found", catena::StatusCode::INVALID_ARGUMENT);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([&rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status(rc.what(), rc.status);
+            return nullptr;
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 10 - getCommand throws a catena::exception_with_status.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
+    catena::exception_with_status rc("Threw error", catena::StatusCode::INVALID_ARGUMENT);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([&rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            throw catena::exception_with_status(rc.what(), rc.status);
+            return nullptr;
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 11 - getCommand throws an std::runtime error.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
+    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([&rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            throw std::runtime_error(rc.what());
+            return nullptr;
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 12 - executeCommand returns a nullptr.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
+    catena::exception_with_status rc("Illegal state", catena::StatusCode::INTERNAL);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([](const catena::Value& value) {
+            return nullptr;
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 13 - executeCommand throws a catena::exception_with_status.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
+    catena::exception_with_status rc("Threw error", catena::StatusCode::INVALID_ARGUMENT);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([&rc](const catena::Value& value) {
+            throw catena::exception_with_status(rc.what(), rc.status);
+            return nullptr;
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 14 - executeCommand returns an std::runtime_error.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
+    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([&rc](const catena::Value& value) {
+            throw std::runtime_error(rc.what());
+            return nullptr;
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, catena::ExecuteCommandPayload());
+}
+
+/*
+ * TEST 15 - getNext throws a catena::exception_with_status.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
+    catena::exception_with_status rc("Threw error", catena::StatusCode::INVALID_ARGUMENT);
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", false, true);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            return std::move(mockResponder);
+        }));
+    EXPECT_CALL(*mockResponder, getNext()).Times(1)
+        .WillOnce(::testing::Invoke([&rc]() {
+            throw catena::exception_with_status(rc.what(), rc.status);
+            return catena::CommandResponse();
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal);
+}
+
+/*
+ * TEST 16 - getNext throws a std::runtime_error.
+ */
+TEST_F(gRPCExecuteCommandTests, ExecuteCommand_GetNextThrowUnknown) {
+    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
+    catena::ExecuteCommandPayload inVal = createPayload("test_command", "test_value", false, true);
+
+    // Mocking kProcess functions
+    mockServer.expectAuthz();
+    EXPECT_CALL(*mockServer.dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(mockCommand);
+        }));
+    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            return std::move(mockResponder);
+        }));
+    EXPECT_CALL(*mockResponder, getNext()).Times(1)
+        .WillOnce(::testing::Invoke([&rc]() {
+            throw std::runtime_error(rc.what());
+            return catena::CommandResponse();
+        }));
+    mockServer.expectkFinish();
+
+    testRPC.TestCall(mockServer.client.get(), rc, inVal);
+}

--- a/sdks/cpp/connections/gRPC/tests/gRPCMockClasses.h
+++ b/sdks/cpp/connections/gRPC/tests/gRPCMockClasses.h
@@ -112,6 +112,25 @@ class MockServer {
         EXPECT_CALL(*service, cq()).Times(2).WillRepeatedly(::testing::Return(cq.get()));
     }
 
+    void expectAuthz(grpc::ClientContext* clientContext = nullptr, const std::string& mockToken = "") {
+        // Authorization is enabled
+        if (clientContext) {
+            clientContext->AddMetadata("authorization", mockToken);
+            EXPECT_CALL(*service, authorizationEnabled()).Times(2).WillRepeatedly(::testing::Return(true));
+        // Authorization is disabled
+        } else {
+            EXPECT_CALL(*service, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
+        }
+    }
+
+    void expectkFinish() {
+        // kFinish
+        EXPECT_CALL(*service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
+            delete testCall;
+            testCall = nullptr;
+        }));
+    }
+
     /*
      * Shuts down the gRPC server and client.
      */


### PR DESCRIPTION
For a long time now the functionality of our ExecuteCommand API calls has been half-finished. Nether has had the ability to return a stream of multiple responses nor the ability to suppress the response. This PR looks to implement the other half of these calls, meaning changes to both the API call as well as commands in general. In addition to these, this PR also contains unit tests providing 100% coverage for the two finished API calls.

Before merging I suggest we go over these changes to make sure everyone is on board.

Changelog:
- Implemented a coroutine CommandResponder to the ParamDescriptor class as well as ICommandResponder to the IParamDescriptor interface class.
- Updated ParamDescirptor commandImpl_ as well as all associated functions to instead define a function that returns a CommandResponder rather than a single CommandResponse.
    - The overall idea for this is that it would allow the business logic to take advantage of co_yield to return a response while in the middle of the function rather than just at the end. For a good example of this in action see the example device one_of_everything's new tape_robot command.
    - The downside to this is that the act of defining commands has become clunkier, however with the provided examples it shouldn't be more than a copy-paste job for clients.
- Updated the gRPC and REST implementations of executeCommand to use the new CommandResponder to write CommandResponse to the client.
    - Additional note is that implementing the stream toggle to REST executeComamnd should be exceptionally easy with how the current implementation is designed.
- Added response = false functionality to both implementations of executeCommand.
- Designed unit tests for both implementations of executeCommand which each provide 100% coverage.