### PR TITLE
Simple Health Endpoint

### DIFF
--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -96,6 +96,10 @@ void CatenaServiceImpl::run() {
                         // Set to 204 No Content if in OPTIONS.
                         rc = catena::exception_with_status("", catena::StatusCode::NO_CONTENT);
                         SocketWriter(socket, context.origin()).sendResponse(rc);
+                    // Sending an empty 200 OK response for health check.
+                    } else if (requestKey == "GET/v1/health") {
+                        rc = catena::exception_with_status("", catena::StatusCode::OK);
+                        SocketWriter(socket, context.origin()).sendResponse(rc);
                     // Otherwise routing to request.
                     } else if (router_.canMake(requestKey)) {
                         std::unique_ptr<ICallData> request = router_.makeProduct(requestKey, socket, context, dm_);
@@ -118,7 +122,7 @@ void CatenaServiceImpl::run() {
                     rc = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
                 }
             } else {
-                rc = catena::exception_with_status{"Service shutdown", catena::StatusCode::CANCELLED};
+                rc = catena::exception_with_status{"Service unavailable", catena::StatusCode::UNAVAILABLE};
             }
             // Writing to socket if there was an error.
             if (rc.status != catena::StatusCode::OK) {

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -93,12 +93,10 @@ void CatenaServiceImpl::run() {
                     std::string requestKey = context.method() + "/v1" + context.endpoint();
                     // Returning empty response with options to the client if required.
                     if (context.method() == "OPTIONS") {
-                        // Set to 204 No Content if in OPTIONS.
                         rc = catena::exception_with_status("", catena::StatusCode::NO_CONTENT);
                         SocketWriter(socket, context.origin()).sendResponse(rc);
                     // Sending an empty 200 OK response for health check.
                     } else if (requestKey == "GET/v1/health") {
-                        rc = catena::exception_with_status("", catena::StatusCode::OK);
                         SocketWriter(socket, context.origin()).sendResponse(rc);
                     // Otherwise routing to request.
                     } else if (router_.canMake(requestKey)) {
@@ -111,7 +109,7 @@ void CatenaServiceImpl::run() {
                     }
                 // ERROR
                 } catch (const catena::exception_with_status& e) {
-                    rc = std::move(catena::exception_with_status(e.what(), e.status)); 
+                    rc = catena::exception_with_status(e.what(), e.status); 
                 } catch (const std::invalid_argument& e) {
                     rc = catena::exception_with_status(e.what(), catena::StatusCode::INVALID_ARGUMENT);
                 } catch (const std::runtime_error& e) {


### PR DESCRIPTION
This PR contains a very primitive health endpoint for the REST implementation. You can access it with the following: GET /v1/0/health (Slot will not be required in the future, SocketReader does not currently parse correctly though). 

At the moment, if it goes though it will return status code 200 with no data. If something goes wrong, which in this case should only be if 1) the service is shutdown and you somehow still got a call in or 2) you made an error in your call, it will return 503 and 400 respectively.

A more advanced health endpoint which does things like check for timed out threads would require much more work across (probably) all API calls (things like a registry similar to what's in the gRPC service impl and a timeout function would be required). This is possibly a task for the future.

_**TL:DR** Simple health endpoint which returns 200 if everything is good and anything else otherwise._