### PR TITLE
2/4 BPIR Unit Test: Top-Level w/Recursion + Slight Tweaks

### DIFF
--- a/sdks/cpp/connections/REST/tests/BasicParamInfoRequest_test.cpp
+++ b/sdks/cpp/connections/REST/tests/BasicParamInfoRequest_test.cpp
@@ -51,6 +51,7 @@
 #include "SocketHelper.h"
 #include "RESTMockClasses.h"
 #include "../../common/tests/CommonMockClasses.h"
+#include "../../common/tests/CommonTestHelpers.h"
 #include "RESTTestHelpers.h"
 
 // REST
@@ -67,20 +68,20 @@ protected:
 
     void SetUp() override {
         // Redirecting cout to a stringstream for testing
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+        //oldCout = std::cout.rdbuf(MockConsole.rdbuf());
 
         // Set default actions for common mock calls
-        ON_CALL(context, origin()).WillByDefault(::testing::ReturnRef(origin));
-        ON_CALL(context, hasField("recursive")).WillByDefault(::testing::Return(false));
-        ON_CALL(context, fields("oid_prefix")).WillByDefault(::testing::ReturnRef(empty_prefix));
-        ON_CALL(dm, mutex()).WillByDefault(::testing::ReturnRef(mockMtx));
+        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin));
+        EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
+        EXPECT_CALL(context, fields("oid_prefix")).WillRepeatedly(::testing::ReturnRef(empty_prefix));
+        EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
+        EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
 
         request = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
-
     }
 
     void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
+        //std::cout.rdbuf(oldCout); // Restoring cout
         // Cleanup code here
         if (request) {
             delete request;
@@ -172,6 +173,9 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_authz_valid_token) 
     };
     catena::REST::test::setupMockParam(mockParam.get(), paramInfo);
 
+    // Add isArrayType expectation
+    EXPECT_CALL(*mockParam, isArrayType()).WillRepeatedly(::testing::Return(false));
+
     // Override default behaviors for this test
     EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(true));
     EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::ReturnRef(mockToken));
@@ -222,6 +226,10 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParams) 
     };
     catena::REST::test::setupMockParam(param1.get(), param1_info);
     catena::REST::test::setupMockParam(param2.get(), param2_info);
+    
+    // Add isArrayType expectations
+    EXPECT_CALL(*param1, isArrayType()).WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*param2, isArrayType()).WillRepeatedly(::testing::Return(false));
     
     top_level_params.push_back(std::move(param1));
     top_level_params.push_back(std::move(param2));
@@ -307,6 +315,12 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
     // Set up array-specific expectations
     EXPECT_CALL(*arrayParam, isArrayType()).WillRepeatedly(::testing::Return(true));
     EXPECT_CALL(*arrayParam, size()).WillRepeatedly(::testing::Return(5));
+    EXPECT_CALL(*arrayParam, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid("array_param");
+            response.mutable_info()->set_type(catena::ParamType::STRING_ARRAY);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        })); 
     
     top_level_params.push_back(std::move(arrayParam));
 
@@ -386,11 +400,14 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsTh
     // Set up param2 to throw during processing
     EXPECT_CALL(*param2, getOid())
         .WillRepeatedly(::testing::ReturnRef(param2_info.oid));
-    EXPECT_CALL(*param2, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::_))
+    EXPECT_CALL(*param2, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
         .WillOnce(::testing::Invoke([](catena::BasicParamInfoResponse&, catena::common::Authorizer&) -> catena::exception_with_status {
             throw catena::exception_with_status("Error getting top-level parameters", catena::StatusCode::INTERNAL);
             return catena::exception_with_status("", catena::StatusCode::OK);  // This line should never be reached
         }));
+
+    // Add isArrayType expectation for param1
+    EXPECT_CALL(*param1, isArrayType()).WillRepeatedly(::testing::Return(false));
     
     top_level_params.push_back(std::move(param1));
     top_level_params.push_back(std::move(param2));
@@ -412,115 +429,552 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsTh
     EXPECT_EQ(actual, expected);
 }
 
-// The following work, but are not the focus of this branch!
+// == MODE 2 TESTS: Get all top-level parameters with recursion ==
 
-// == MODE 3 TESTS: Get a specific parameter and its children if recursive ==
+// Test 2.1: Get all top-level parameters with recursion
+TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWithRecursion) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
 
-// Test 3.1: Get specific parameter without recursion
-// TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_proceedSpecificParam) {
-//     catena::exception_with_status rc("", catena::StatusCode::OK);
+    // Setup mock parameters
+    std::vector<std::unique_ptr<IParam>> top_level_params;
+    auto parentParam = std::make_unique<MockParam>();
+    auto childParam = std::make_unique<MockParam>();
     
-//     // Setup mock parameter with our helper
-//     std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-//     catena::REST::test::ParamInfo paramInfo{
-//         .oid = mockOid,
-//         .type = catena::ParamType::STRING
-//     };
-//     catena::REST::test::setupMockParam(mockParam.get(), paramInfo);
+    // Set up mock parameters 
+    catena::REST::test::ParamInfo parent_info{
+        .oid = "parent",
+        .type = catena::ParamType::STRING
+    };
+    catena::REST::test::ParamInfo child_info{
+        .oid = "child",
+        .type = catena::ParamType::STRING
+    };
 
-//     // Setup mock expectations for mode 2 (specific parameter)
-//     EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-//     EXPECT_CALL(context, fields("oid_prefix")).WillRepeatedly(::testing::ReturnRef(mockOid));
-//     EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-//     EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
+    std::string parentOid = parent_info.oid;
+    std::string childOid = child_info.oid;
+    std::string nested_oid = "/" + parent_info.oid + "/" + child_info.oid;
+
+    // Set up parameter hierarchy using ParamHierarchyBuilder
+    auto parentDesc = ParamHierarchyBuilder::createDescriptor("/" + parent_info.oid);
+    auto nestedDesc = ParamHierarchyBuilder::createDescriptor(nested_oid);
+    ParamHierarchyBuilder::addChild(parentDesc, child_info.oid, nestedDesc);
+
+    // Set up mock parameters with their descriptors
+    setupMockParam(parentParam.get(), parent_info.oid, *parentDesc.descriptor);
+    setupMockParam(childParam.get(), nested_oid, *nestedDesc.descriptor);
+
+    // Set up mock expectations for getDescriptor
+    EXPECT_CALL(*parentParam, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*parentDesc.descriptor));
+    EXPECT_CALL(*childParam, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+
+    // Add expectations for isArrayType
+    EXPECT_CALL(*parentParam, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*childParam, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+
+    // Add expectations for toProto
+    EXPECT_CALL(*parentParam, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([parentOid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(parentOid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    EXPECT_CALL(*childParam, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([childOid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(childOid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    // Add expectation for getAllSubParams to return the child
+    std::unordered_map<std::string, IParamDescriptor*> subParams;
+    subParams[child_info.oid] = nestedDesc.descriptor.get();
+    EXPECT_CALL(*parentDesc.descriptor, getAllSubParams())
+        .WillRepeatedly(::testing::ReturnRef(subParams));
+
+    // Add expectation for getSubParam to return the child descriptor
+    EXPECT_CALL(*parentDesc.descriptor, getSubParam(childOid))
+        .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+
+    // Add expectation for getOid on parent descriptor
+    EXPECT_CALL(*parentDesc.descriptor, getOid())
+        .WillRepeatedly(::testing::ReturnRef(parentOid));
     
-//     EXPECT_CALL(dm, getParam("/" + mockOid, ::testing::_, ::testing::_))
-//         .WillOnce(::testing::Invoke(
-//             [&mockParam](const std::string&, catena::exception_with_status& status, Authorizer&) {
-//                 status = catena::exception_with_status("", catena::StatusCode::OK);
-//                 return std::move(mockParam);
-//             }
-//         ));
+    top_level_params.push_back(std::move(parentParam));
+
+    // Enable recursion
+    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
+
+    // Setup mock expectations for getTopLevelParams
+    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(top_level_params);
+        }));
+
+    // Setup mock expectations for getParam to handle child traversal
+    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([&childParam, &nestedDesc, nested_oid, childOid](const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
+            catena::common::Path path(fqoid);
+            if (path.fqoid() == nested_oid) {
+                auto param = std::make_unique<MockParam>();
+                setupMockParam(param.get(), fqoid, *nestedDesc.descriptor);
+                
+                // Set up all necessary expectations for the child parameter
+                EXPECT_CALL(*param, getDescriptor())
+                    .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+                EXPECT_CALL(*param, isArrayType())
+                    .WillRepeatedly(::testing::Return(false));
+                EXPECT_CALL(*param, getOid())
+                    .WillRepeatedly(::testing::ReturnRef(fqoid));
+                EXPECT_CALL(*param, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+                    .WillRepeatedly(::testing::Invoke([childOid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+                        response.mutable_info()->set_oid(childOid);
+                        response.mutable_info()->set_type(catena::ParamType::STRING);
+                        return catena::exception_with_status("", catena::StatusCode::OK);
+                    }));
+                
+                status = catena::exception_with_status("", catena::StatusCode::OK);
+                return param;
+            }
+            status = catena::exception_with_status("Parameter not found", catena::StatusCode::NOT_FOUND);
+            return nullptr;
+        }));
+
+    // Create a new request after setting up all expectations
+    auto topRecursionRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+
+    // Execute
+    topRecursionRequest->proceed();
+    topRecursionRequest->finish();
+
+    // Get expected and actual responses
+    std::vector<std::string> jsonBodies;
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(parent_info));
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(child_info));
+    std::string expected = expectedSSEResponse(rc, jsonBodies);
+    std::string actual = readResponse();
     
-//     // Execute
-//     request->proceed();
-//     request->finish();
+    delete topRecursionRequest;
 
-//     // Get expected and actual responses
-//     std::string jsonBody = catena::REST::test::createParamInfoJson(paramInfo);
-//     std::string expected = expectedSSEResponse(rc, {jsonBody});
-//     std::string actual = readResponse();
-//     EXPECT_EQ(actual, expected);
-// }
+    EXPECT_EQ(actual, expected);
+}
 
-// // Test 3.2: Get specific parameter with recursion
-// TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getSpecificParamWithRecursion) {
-//     catena::exception_with_status rc("", catena::StatusCode::OK);
+// Test 2.2: Get top-level parameters with recursion and array children
+TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWithRecursionAndArrays) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+
+    // Setup mock parameters
+    std::vector<std::unique_ptr<IParam>> top_level_params;
+    auto parentParam = std::make_unique<MockParam>();
+    auto arrayChild = std::make_unique<MockParam>();
     
-//     // Setup mock parameter with our helper
-//     std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-//     catena::REST::test::ParamInfo paramInfo{
-//         .oid = mockOid,
-//         .type = catena::ParamType::STRING
-//     };
-//     catena::REST::test::setupMockParam(mockParam.get(), paramInfo);
+    // Set up mock parameters 
+    catena::REST::test::ParamInfo parent_info{
+        .oid = "parent",
+        .type = catena::ParamType::STRING
+    };
+    catena::REST::test::ParamInfo arrayChild_info{
+        .oid = "array_child",
+        .type = catena::ParamType::STRING_ARRAY,
+        .array_length = 3
+    };
 
-//     // Setup mock expectations
-//     EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-//     EXPECT_CALL(context, fields("oid_prefix")).WillRepeatedly(::testing::ReturnRef(mockOid));
-//     EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-//     EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
+    std::string parentOid = parent_info.oid;
+    std::string childOid = arrayChild_info.oid;
+    std::string nested_oid = "/" + parent_info.oid + "/" + arrayChild_info.oid;
+
+    // Set up parameter hierarchy using ParamHierarchyBuilder
+    auto parentDesc = ParamHierarchyBuilder::createDescriptor("/" + parent_info.oid);
+    auto nestedDesc = ParamHierarchyBuilder::createDescriptor(nested_oid);
+    ParamHierarchyBuilder::addChild(parentDesc, arrayChild_info.oid, nestedDesc);
+
+    // Set up mock parameters with their descriptors
+    setupMockParam(parentParam.get(), parent_info.oid, *parentDesc.descriptor);
+    setupMockParam(arrayChild.get(), nested_oid, *nestedDesc.descriptor);
+
+    // Set up mock expectations for getDescriptor
+    EXPECT_CALL(*parentParam, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*parentDesc.descriptor));
+    EXPECT_CALL(*arrayChild, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+
+    // Add expectations for isArrayType
+    EXPECT_CALL(*parentParam, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*arrayChild, isArrayType())
+        .WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*arrayChild, size())
+        .WillRepeatedly(::testing::Return(arrayChild_info.array_length));
+
+    // Add expectations for toProto
+    EXPECT_CALL(*parentParam, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([parentOid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(parentOid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    EXPECT_CALL(*arrayChild, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([childOid, arrayChild_info](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(childOid);
+            response.mutable_info()->set_type(catena::ParamType::STRING_ARRAY);
+            response.set_array_length(arrayChild_info.array_length);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    // // Add expectation for updateArrayLengths_ to be called
+    // EXPECT_CALL(*arrayRequest, updateArrayLengths_(childOid, arrayChild_info.array_length))
+    //     .Times(1);
+
+    // // Add expectation for addParamToResponses_ to be called
+    // EXPECT_CALL(*arrayRequest, addParamToResponses_(::testing::_, ::testing::_))
+    //     .Times(2);
+
+    // Add expectation for getAllSubParams to return the child
+    std::unordered_map<std::string, IParamDescriptor*> subParams;
+    subParams[arrayChild_info.oid] = nestedDesc.descriptor.get();
+    EXPECT_CALL(*parentDesc.descriptor, getAllSubParams())
+        .WillRepeatedly(::testing::ReturnRef(subParams));
+
+    // Add expectation for getSubParam to return the child descriptor
+    EXPECT_CALL(*parentDesc.descriptor, getSubParam(childOid))
+        .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+
+    // Add expectation for getOid on parent descriptor
+    EXPECT_CALL(*parentDesc.descriptor, getOid())
+        .WillRepeatedly(::testing::ReturnRef(parentOid));
     
-//     EXPECT_CALL(dm, getParam("/" + mockOid, ::testing::_, ::testing::_))
-//         .WillOnce(::testing::Invoke(
-//             [&mockParam](const std::string&, catena::exception_with_status& status, Authorizer&) {
-//                 status = catena::exception_with_status("", catena::StatusCode::OK);
-//                 return std::move(mockParam);
-//             }
-//         ));
+    top_level_params.push_back(std::move(parentParam));
 
-//     // Execute
-//     request->proceed();
-//     request->finish();
+    // Enable recursion
+    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
 
-//     // Get expected and actual responses
-//     std::string jsonBody = catena::REST::test::createParamInfoJson(paramInfo);
-//     std::string expected = expectedSSEResponse(rc, {jsonBody});
-//     std::string actual = readResponse();
-//     EXPECT_EQ(actual, expected);
-// }
+    // Setup mock expectations for getTopLevelParams
+    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(top_level_params);
+        }));
 
-// // Test 3.3: Error case - invalid parameter
-// TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_invalidParam) {
-//     catena::exception_with_status rc("Invalid parameter", catena::StatusCode::NOT_FOUND);
+    // Setup mock expectations for getParam to handle child traversal
+    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([&arrayChild, &nestedDesc, nested_oid, childOid, arrayChild_info](const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
+            catena::common::Path path(fqoid);
+            if (path.fqoid() == nested_oid) {
+                auto param = std::make_unique<MockParam>();
+                setupMockParam(param.get(), fqoid, *nestedDesc.descriptor);
+                
+                // Set up all necessary expectations for the child parameter
+                EXPECT_CALL(*param, getDescriptor())
+                    .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+                EXPECT_CALL(*param, isArrayType())
+                    .WillRepeatedly(::testing::Return(true));
+                EXPECT_CALL(*param, size())
+                    .WillRepeatedly(::testing::Return(arrayChild_info.array_length));
+                EXPECT_CALL(*param, getOid())
+                    .WillRepeatedly(::testing::ReturnRef(fqoid));
+                EXPECT_CALL(*param, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+                    .WillRepeatedly(::testing::Invoke([childOid, arrayChild_info](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+                        response.mutable_info()->set_oid(childOid);
+                        response.mutable_info()->set_type(catena::ParamType::STRING_ARRAY);
+                        response.set_array_length(arrayChild_info.array_length);
+                        return catena::exception_with_status("", catena::StatusCode::OK);
+                    }));
+                
+                status = catena::exception_with_status("", catena::StatusCode::OK);
+                return param;
+            }
+            status = catena::exception_with_status("Parameter not found", catena::StatusCode::NOT_FOUND);
+            return nullptr;
+        }));
+
+    // Create a new request after setting up all expectations
+    auto arrayRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+
+    // Execute
+    arrayRequest->proceed();
+    arrayRequest->finish();
+
+    // Get expected and actual responses
+    std::vector<std::string> jsonBodies;
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(parent_info));
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(arrayChild_info));
+    std::string expected = expectedSSEResponse(rc, jsonBodies);
+    std::string actual = readResponse();
     
-//     std::string invalid_param = "invalid_param";
+    delete arrayRequest;
 
-//     // Setup mock expectations
-//     EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-//     EXPECT_CALL(context, fields("oid_prefix")).WillRepeatedly(::testing::ReturnRef(invalid_param));
-//     EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-//     EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
+    EXPECT_EQ(actual, expected);
+}
+
+// Test 2.3: Get top-level parameters with recursion and error in child processing
+TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWithRecursionError) {
+    catena::exception_with_status rc("Error processing child parameter", catena::StatusCode::INTERNAL);
+
+    // Setup mock parameters
+    std::vector<std::unique_ptr<IParam>> top_level_params;
+    auto parentParam = std::make_unique<MockParam>();
+    auto errorChild = std::make_unique<MockParam>();
     
-//     EXPECT_CALL(dm, getParam("/" + invalid_param, ::testing::_, ::testing::_))
-//         .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status& status, Authorizer&) {
-//             status = catena::exception_with_status("Invalid parameter", catena::StatusCode::NOT_FOUND);
-//             return nullptr;
-//         }));
+    // Set up mock parameters 
+    catena::REST::test::ParamInfo parent_info{
+        .oid = "parent",
+        .type = catena::ParamType::STRING
+    };
+    catena::REST::test::ParamInfo errorChild_info{
+        .oid = "error_child",
+        .type = catena::ParamType::STRING,
+        .status = catena::StatusCode::INTERNAL
+    };
 
-//     // Create a new request for this test
-//     auto invalidRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    std::string parentOid = parent_info.oid;
+    std::string childOid = errorChild_info.oid;
+    std::string nested_oid = "/" + parent_info.oid + "/" + errorChild_info.oid;
 
-//     // Execute
-//     invalidRequest->proceed();
-//     invalidRequest->finish();
+    // Set up parameter hierarchy using ParamHierarchyBuilder
+    auto parentDesc = ParamHierarchyBuilder::createDescriptor("/" + parent_info.oid);
+    auto nestedDesc = ParamHierarchyBuilder::createDescriptor(nested_oid);
+    ParamHierarchyBuilder::addChild(parentDesc, errorChild_info.oid, nestedDesc);
 
-//     // Get expected and actual responses
-//     std::string expected = expectedSSEResponse(rc);
-//     std::string actual = readResponse();
-//     EXPECT_EQ(actual, expected);
+    // Set up mock parameters with their descriptors
+    setupMockParam(parentParam.get(), parent_info.oid, *parentDesc.descriptor);
+    setupMockParam(errorChild.get(), nested_oid, *nestedDesc.descriptor);
 
-//     // Cleanup
-//     delete invalidRequest;
-// }
+    // Set up mock expectations for getDescriptor
+    EXPECT_CALL(*parentParam, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*parentDesc.descriptor));
+    EXPECT_CALL(*errorChild, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+
+    // Add expectations for isArrayType
+    EXPECT_CALL(*parentParam, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*errorChild, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+
+    // Add expectations for toProto
+    EXPECT_CALL(*parentParam, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([parentOid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(parentOid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    EXPECT_CALL(*errorChild, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillOnce(::testing::Invoke([](catena::BasicParamInfoResponse&, catena::common::Authorizer&) -> catena::exception_with_status {
+            throw catena::exception_with_status("Error processing child parameter", catena::StatusCode::INTERNAL);
+        }));
+
+    // Add expectation for getAllSubParams to return the child
+    std::unordered_map<std::string, IParamDescriptor*> subParams;
+    subParams[errorChild_info.oid] = nestedDesc.descriptor.get();
+    EXPECT_CALL(*parentDesc.descriptor, getAllSubParams())
+        .WillRepeatedly(::testing::ReturnRef(subParams));
+
+    // Add expectation for getSubParam to return the child descriptor
+    EXPECT_CALL(*parentDesc.descriptor, getSubParam(childOid))
+        .WillRepeatedly(::testing::ReturnRef(*nestedDesc.descriptor));
+
+    // Add expectation for getOid on parent descriptor
+    EXPECT_CALL(*parentDesc.descriptor, getOid())
+        .WillRepeatedly(::testing::ReturnRef(parentOid));
+    
+    top_level_params.push_back(std::move(parentParam));
+
+    // Enable recursion
+    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
+
+    // Setup mock expectations
+    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(top_level_params);
+        }));
+
+    // Setup mock expectations for getParam to handle child traversal
+    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([&errorChild, &nestedDesc, nested_oid](const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
+            catena::common::Path path(fqoid);
+            if (path.fqoid() == nested_oid) {
+                status = catena::exception_with_status("", catena::StatusCode::OK);
+                return std::move(errorChild);
+            }
+            status = catena::exception_with_status("Parameter not found", catena::StatusCode::NOT_FOUND);
+            return nullptr;
+        }));
+
+    // Create a new request after setting up all expectations
+    auto errorRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+
+    // Execute
+    errorRequest->proceed();
+    errorRequest->finish();
+
+    // Get expected and actual responses
+    std::string expected = expectedSSEResponse(rc);
+    std::string actual = readResponse();
+    
+    delete errorRequest;
+
+    EXPECT_EQ(actual, expected);
+}
+
+// Test 2.4: Get top-level parameters with recursion and deep nesting
+TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWithDeepNesting) {
+    catena::exception_with_status rc("", catena::StatusCode::OK);
+
+    // Setup mock parameters
+    std::vector<std::unique_ptr<IParam>> top_level_params;
+    auto level1 = std::make_unique<MockParam>();
+    auto level2 = std::make_unique<MockParam>();
+    auto level3 = std::make_unique<MockParam>();
+    
+    // Set up mock parameters 
+    catena::REST::test::ParamInfo level1_info{
+        .oid = "level1",
+        .type = catena::ParamType::STRING
+    };
+    catena::REST::test::ParamInfo level2_info{
+        .oid = "level2",
+        .type = catena::ParamType::STRING
+    };
+    catena::REST::test::ParamInfo level3_info{
+        .oid = "level3",
+        .type = catena::ParamType::STRING
+    };
+
+    std::string level1Oid = level1_info.oid;
+    std::string level2Oid = level2_info.oid;
+    std::string level3Oid = level3_info.oid;
+    std::string level2Path = "/" + level1Oid + "/" + level2Oid;
+    std::string level3Path = level2Path + "/" + level3Oid;
+
+    // Set up parameter hierarchy using ParamHierarchyBuilder
+    auto level1Desc = ParamHierarchyBuilder::createDescriptor("/" + level1Oid);
+    auto level2Desc = ParamHierarchyBuilder::createDescriptor(level2Path);
+    auto level3Desc = ParamHierarchyBuilder::createDescriptor(level3Path);
+    
+    ParamHierarchyBuilder::addChild(level1Desc, level2Oid, level2Desc);
+    ParamHierarchyBuilder::addChild(level2Desc, level3Oid, level3Desc);
+
+    // Set up mock parameters with their descriptors
+    setupMockParam(level1.get(), level1Oid, *level1Desc.descriptor);
+    setupMockParam(level2.get(), level2Path, *level2Desc.descriptor);
+    setupMockParam(level3.get(), level3Path, *level3Desc.descriptor);
+
+    // Set up mock expectations for getDescriptor
+    EXPECT_CALL(*level1, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*level1Desc.descriptor));
+    EXPECT_CALL(*level2, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*level2Desc.descriptor));
+    EXPECT_CALL(*level3, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(*level3Desc.descriptor));
+
+    // Add expectations for isArrayType
+    EXPECT_CALL(*level1, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*level2, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+    EXPECT_CALL(*level3, isArrayType())
+        .WillRepeatedly(::testing::Return(false));
+
+    // Add expectations for toProto
+    EXPECT_CALL(*level1, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([level1Oid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(level1Oid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    EXPECT_CALL(*level2, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([level2Oid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(level2Oid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    EXPECT_CALL(*level3, toProto(::testing::An<catena::BasicParamInfoResponse&>(), ::testing::An<catena::common::Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([level3Oid](catena::BasicParamInfoResponse& response, catena::common::Authorizer&) {
+            response.mutable_info()->set_oid(level3Oid);
+            response.mutable_info()->set_type(catena::ParamType::STRING);
+            return catena::exception_with_status("", catena::StatusCode::OK);
+        }));
+
+    // Add expectations for getAllSubParams
+    std::unordered_map<std::string, IParamDescriptor*> level1SubParams;
+    level1SubParams[level2Oid] = level2Desc.descriptor.get();
+    EXPECT_CALL(*level1Desc.descriptor, getAllSubParams())
+        .WillRepeatedly(::testing::ReturnRef(level1SubParams));
+
+    std::unordered_map<std::string, IParamDescriptor*> level2SubParams;
+    level2SubParams[level3Oid] = level3Desc.descriptor.get();
+    EXPECT_CALL(*level2Desc.descriptor, getAllSubParams())
+        .WillRepeatedly(::testing::ReturnRef(level2SubParams));
+
+    // Add expectations for getSubParam
+    EXPECT_CALL(*level1Desc.descriptor, getSubParam(level2Oid))
+        .WillRepeatedly(::testing::ReturnRef(*level2Desc.descriptor));
+    EXPECT_CALL(*level2Desc.descriptor, getSubParam(level3Oid))
+        .WillRepeatedly(::testing::ReturnRef(*level3Desc.descriptor));
+
+    // Add expectations for getOid
+    EXPECT_CALL(*level1Desc.descriptor, getOid())
+        .WillRepeatedly(::testing::ReturnRef(level1Oid));
+    EXPECT_CALL(*level2Desc.descriptor, getOid())
+        .WillRepeatedly(::testing::ReturnRef(level2Path));
+    EXPECT_CALL(*level3Desc.descriptor, getOid())
+        .WillRepeatedly(::testing::ReturnRef(level3Path));
+    
+    top_level_params.push_back(std::move(level1));
+
+    // Enable recursion
+    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
+
+    // Setup mock expectations
+    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) {
+            status = catena::exception_with_status("", catena::StatusCode::OK);
+            return std::move(top_level_params);
+        }));
+
+    // Setup mock expectations for getParam to handle child traversal
+    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+        .WillRepeatedly(::testing::Invoke([&level2, &level3, &level2Desc, &level3Desc, level2Path, level3Path]
+            (const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
+            catena::common::Path path(fqoid);
+            if (path.fqoid() == level2Path) {
+                status = catena::exception_with_status("", catena::StatusCode::OK);
+                return std::move(level2);
+            } else if (path.fqoid() == level3Path) {
+                status = catena::exception_with_status("", catena::StatusCode::OK);
+                return std::move(level3);
+            }
+            status = catena::exception_with_status("Parameter not found", catena::StatusCode::NOT_FOUND);
+            return nullptr;
+        }));
+
+    // Create a new request after setting up all expectations
+    auto deepNestingRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+
+    // Execute
+    deepNestingRequest->proceed();
+    deepNestingRequest->finish();
+
+    // Get expected and actual responses
+    std::vector<std::string> jsonBodies;
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(level1_info));
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(level2_info));
+    jsonBodies.push_back(catena::REST::test::createParamInfoJson(level3_info));
+    std::string expected = expectedSSEResponse(rc, jsonBodies);
+    std::string actual = readResponse();
+    
+    delete deepNestingRequest;
+
+    EXPECT_EQ(actual, expected);
+}
 

--- a/sdks/cpp/connections/REST/tests/BasicParamInfoRequest_test.cpp
+++ b/sdks/cpp/connections/REST/tests/BasicParamInfoRequest_test.cpp
@@ -678,7 +678,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
     EXPECT_EQ(actual, expected);
 }
 
-// Test 2.5: Get top-level parameters with error status from getTopLevelParams
+// Test 2.4: Get top-level parameters with error status from getTopLevelParams
 TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWithErrorStatus) {
     catena::exception_with_status rc("Error getting parameters", catena::StatusCode::INTERNAL);
 
@@ -706,7 +706,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
     EXPECT_EQ(actual, expected);
 }
 
-// Test 2.6: Get top-level parameters with empty list and recursion
+// Test 2.5: Get top-level parameters with empty list and recursion
 TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWithEmptyListAndRecursion) {
     catena::exception_with_status rc("No top-level parameters found", catena::StatusCode::NOT_FOUND);
 


### PR DESCRIPTION
## 📃 Intro
- I had to re-write this PR several times after constantly noticing issues (mostly redundancies), so please excuse the time it took to put it up.
  - Somehow, one of these "fixes" reduced coverage a little from one commit to another, which is a little annoying, but the code looks better so that's a future me problem.
- YES there are going to be missing mocks, YES there are going to be redundancies - that is FINE, I still have 2/4 of the PRs in this pipeline to go.
---

## ⌛ Coverage Progress


|   | Status | Exec/Total |  COVERAGE % |  |± Exec  | ± %   |
| ------------- | ------------- | ------------- | -------------| -------------| ------------- | ------------- |
| 🟨 LINES | ❗Needs Work | 122/145  | 84.1% | ⬆️ | +37 | +25.5% |
| 🟩 FUNCTIONS  | ✅ Full Coverage | 7/7 |  100% | ⬆️ |  +2 | +28.6% |
| 🟧 BRANCHES  | ❗Needs work  | 155/311  |  49.8% | ⬆️ | +54 | +17.3% |

---

### Main Focus:

![image](https://github.com/user-attachments/assets/fe526ebb-2080-4a93-abea-f469a38ddcf1)

### Additional Focus:

![image](https://github.com/user-attachments/assets/49ff9f36-5208-4f7f-8565-09718bbce345)

---

## ✨ Main Additions/Changes

### 🟡 BasicParamInfoRequest_test.h Changes
#### Fixture Changes
- Changed the ON_CALLs to be EXPECT_CALLs to avoid a warning about unimportant mocks
- Added a `createParamHierarchy`: Helps setup a parent-child parameter hierarchy with common expectations
#### Tests 0-1 Changes
- Made a few minor tweaks to pre-existing ests, mostly removing redundancies
  - I also added expectations for descriptors (modified the setupMockParam function in the helpers, though refer to below for more info)
#### 🟢(NEW) Mode 2 Tests: Testing top-level parameters with recursion
- 🟢 2.1: SUCCESS getting top-level parameters with recursion and deep nesting
  - Test three levels of nesting with recursion
- 🟢 2.2: SUCCESS getting top-level parameters with recursion and arrays
  - Only one level of nesting, but it tests both the parent and the child being an array
    - Specifying the parent as an array helps cover the first isArrayType check on line 123
  - Specifies lengths, and checks against `updateArrayLengths()` in the setupMockParam helper
- ⭕ 2.3: ERROR processing a child when doing a top-level param recursion check
  -Actual/expected response should still both be `500` 
  - The child will throw in toProto and push an `INTERNAL` status code
  - Something tells me there is some redundant checking in this test, but that's a future me problem.
- ⭕ 2.4: ERROR in getting top-level parameters, catena status code `INTERNAL`
  - Actual/expected response should still both be `500` 
- ⭕ 2.5: ERROR in getting top-level parameters when there is an empty list, catena status code `NOT_FOUND`
  - Actual/expected response should both be `404 NOT FOUND`
  
### 🟡 RESTTESTHelpers.h Changes
- Added expectations for descriptor and arrays, which just copies over from the helper in CommonTestHelpers.h
  - Bit of repetition between these two, maybe it could be remedied in @ctwarog-ross 's UT refactors.
  