### PR TITLE
Added stream option to command in openAPI docs

### DIFF
--- a/interface/openapi/openapi.yaml
+++ b/interface/openapi/openapi.yaml
@@ -68,6 +68,9 @@ paths:
   /{slot}/command/{fqoid}:
     $ref: './paths/Command.yaml'
 
+  /{slot}/command/{fqoid}/stream:
+    $ref: './paths/CommandStream.yaml'
+
   /{slot}/asset/{fqoid}:
     $ref: './paths/Asset.yaml'
 

--- a/interface/openapi/paths/CommandStream.yaml
+++ b/interface/openapi/paths/CommandStream.yaml
@@ -31,12 +31,12 @@
 #
 # OpenAPI documentation of the ExecuteCommand RPC for the Catena REST API
 # Author: benjamin.whitten@rossvideo.com
-# Date: 25/04/03
+# Date: 25/06/06
 #
 
 post:
   summary: Execute a command on a device model
-  operationId: ExecuteCommand
+  operationId: ExecuteCommandStream
 
   # Override default security, at least one scope with write access is required.
   security:
@@ -90,28 +90,22 @@ post:
   responses:
     "200":
       description: |
-        If 'respond' is true, the server's response will one or more 'Values',
-        empty responses, or exceptions. If 'respond' is false, the server will
-        not respond with content, just the status code.
+        If 'respond' is true, the server's response will be a stream of command
+        responses. If 'respond' is false, the server will not respond with
+        content, just the status code.
+        The response is a sequence of stringified JSON objects, each containing
+        a single command response.
+        Each object in the stream has the following structure:
       content:
-        application/json:
+        text/event-stream:
           schema:
-            oneOf:
-              - title: No Response
-                description: respond is true and the server does not have a 
-                  response for the command
-
-              - title: Response
-                description: respond is true and the server has a response for
-                  the command containing a single 'Value'.
-                fields:
-                  - title: value
-                    $ref: "../../../schema/catena.param_schema.json#/$defs/value"
-              
-              - $ref: "./Messages.yaml#/$defs/exception"
-
-          example: {"data":[{"response":{"string_value":"Command executed successfully"}}]}
-
+            type: string
+          
+          example: |
+            <stringified {"no_response":{}}>
+            <stringified {"response":{"string_value":"Command executed successfully"}}>
+            <stringified {"exception":{"type":"Invalid Command","error_message":"Error message","details":"Something went wrong"}}>
+            done
 
     "500":
       $ref: '../openapi.yaml#/components/responses/InternalServerError'


### PR DESCRIPTION
Changlog:
- Added a /stream option for command in the openAPI docs.
- Updated command openAPI docs to better reflect the endpoint.