### PR TITLE
Fixed a number of errors flagged when running examples using valgrind.

### DIFF
--- a/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
@@ -120,44 +120,41 @@ void combo_boxUpdateHandler(const std::string& oid, const IParam* p, const int32
 }
 
 void statusUpdateExample(){   
-    std::thread loop([]() {
-        std::map<std::string, std::function<void(const std::string&, const IParam*, const int32_t)>> handlers;
-        handlers["/counter"] = counterUpdateHandler;
-        handlers["/text_box"] = text_boxUpdateHandler;
-        handlers["/button"] = buttonUpdateHandler;
-        handlers["/slider"] = sliderUpdateHandler;
-        handlers["/combo_box"] = combo_boxUpdateHandler;
+    std::map<std::string, std::function<void(const std::string&, const IParam*, const int32_t)>> handlers;
+    handlers["/counter"] = counterUpdateHandler;
+    handlers["/text_box"] = text_boxUpdateHandler;
+    handlers["/button"] = buttonUpdateHandler;
+    handlers["/slider"] = sliderUpdateHandler;
+    handlers["/combo_box"] = combo_boxUpdateHandler;
 
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
-            if (handlers.contains(oid)) {
-                handlers[oid](oid, p, idx);
-            }
-        });
-
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-
-        // The rest is the "sending end" of the status update example
-        std::unique_ptr<IParam> param = dm.getParam("/counter", err);
-        if (param == nullptr) {
-            throw err;
-        }
-
-        // downcast the IParam to a ParamWithValue<int32_t>
-        auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param.get());
-
-        while (globalLoop) {
-            // update the counter once per second, and emit the event
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            {
-                std::lock_guard lg(dm.mutex());
-                counter.get()++;
-                std::cout << counter.getOid() << " set to " << counter.get() << '\n';
-                dm.valueSetByServer.emit("/counter", &counter, 0);
-            }
+    // this is the "receiving end" of the status update example
+    dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
+        if (handlers.contains(oid)) {
+            handlers[oid](oid, p, idx);
         }
     });
-    loop.detach();
+
+    catena::exception_with_status err{"", catena::StatusCode::OK};
+
+    // The rest is the "sending end" of the status update example
+    std::unique_ptr<IParam> param = dm.getParam("/counter", err);
+    if (param == nullptr) {
+        throw err;
+    }
+
+    // downcast the IParam to a ParamWithValue<int32_t>
+    auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param.get());
+
+    while (globalLoop) {
+        // update the counter once per second, and emit the event
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        {
+            std::lock_guard lg(dm.mutex());
+            counter.get()++;
+            std::cout << counter.getOid() << " set to " << counter.get() << '\n';
+            dm.valueSetByServer.emit("/counter", &counter, 0);
+        }
+    }
 }
 
 void RunRESTServer() {
@@ -178,9 +175,11 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        statusUpdateExample();
-        
+        std::thread loop(statusUpdateExample);
+
         api.run();
+
+        loop.join();
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';
     }

--- a/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
@@ -175,11 +175,11 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        std::thread loop(statusUpdateExample);
+        std::thread counterLoop(statusUpdateExample);
 
         api.run();
 
-        loop.join();
+        counterLoop.join();
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';
     }

--- a/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
@@ -120,44 +120,41 @@ void combo_boxUpdateHandler(const std::string& oid, const IParam* p, const int32
 }
 
 void statusUpdateExample(){   
-    std::thread loop([]() {
-        std::map<std::string, std::function<void(const std::string&, const IParam*, const int32_t)>> handlers;
-        handlers["/counter"] = counterUpdateHandler;
-        handlers["/text_box"] = text_boxUpdateHandler;
-        handlers["/button"] = buttonUpdateHandler;
-        handlers["/slider"] = sliderUpdateHandler;
-        handlers["/combo_box"] = combo_boxUpdateHandler;
+    std::map<std::string, std::function<void(const std::string&, const IParam*, const int32_t)>> handlers;
+    handlers["/counter"] = counterUpdateHandler;
+    handlers["/text_box"] = text_boxUpdateHandler;
+    handlers["/button"] = buttonUpdateHandler;
+    handlers["/slider"] = sliderUpdateHandler;
+    handlers["/combo_box"] = combo_boxUpdateHandler;
 
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
-            if (handlers.contains(oid)) {
-                handlers[oid](oid, p, idx);
-            }
-        });
-
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-
-        // The rest is the "sending end" of the status update example
-        std::unique_ptr<IParam> param = dm.getParam("/counter", err);
-        if (param == nullptr) {
-            throw err;
-        }
-
-        // downcast the IParam to a ParamWithValue<int32_t>
-        auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param.get());
-
-        while (globalLoop) {
-            // update the counter once per second, and emit the event
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            {
-                std::lock_guard lg(dm.mutex());
-                counter.get()++;
-                std::cout << counter.getOid() << " set to " << counter.get() << '\n';
-                dm.valueSetByServer.emit("/counter", &counter, 0);
-            }
+    // this is the "receiving end" of the status update example
+    dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
+        if (handlers.contains(oid)) {
+            handlers[oid](oid, p, idx);
         }
     });
-    loop.detach();
+
+    catena::exception_with_status err{"", catena::StatusCode::OK};
+
+    // The rest is the "sending end" of the status update example
+    std::unique_ptr<IParam> param = dm.getParam("/counter", err);
+    if (param == nullptr) {
+        throw err;
+    }
+
+    // downcast the IParam to a ParamWithValue<int32_t>
+    auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param.get());
+
+    while (globalLoop) {
+        // update the counter once per second, and emit the event
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        {
+            std::lock_guard lg(dm.mutex());
+            counter.get()++;
+            std::cout << counter.getOid() << " set to " << counter.get() << '\n';
+            dm.valueSetByServer.emit("/counter", &counter, 0);
+        }
+    }
 }
 
 void RunRESTServer() {
@@ -178,9 +175,11 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        statusUpdateExample();
-        
+        std::thread loop(statusUpdateExample);
+
         api.run();
+
+        loop.join();
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';
     }

--- a/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
@@ -175,11 +175,11 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        std::thread loop(statusUpdateExample);
+        std::thread counterLoop(statusUpdateExample);
 
         api.run();
 
-        loop.join();
+        counterLoop.join();
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';
     }

--- a/sdks/cpp/connections/REST/examples/structs_with_authz_REST/structs_with_authz_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/structs_with_authz_REST/structs_with_authz_REST.cpp
@@ -124,7 +124,9 @@ void RunRESTServer() {
             std::string front = jptr.front_as_string();
             jptr.pop();
 
-            handlers[front](jptr.toString(), p, idx);
+            if (handlers.contains(front)) {
+                handlers[front](jptr.toString(), p, idx);
+            }
         });
         
         api.run();

--- a/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
@@ -81,18 +81,6 @@ void handle_signal(int sig) {
     t.join();
 }
 
-void statusUpdate(){   
-    std::thread loop([]() {
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
-            // all we do here is print out the oid of the parameter that was changed
-            // your biz logic would do something _even_more_ interesting!
-            std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
-        });
-    });
-    loop.detach();
-}
-
 void RunRESTServer() {
     // install signal handlers
     signal(SIGINT, handle_signal);
@@ -111,9 +99,14 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        statusUpdate();
-        
+        // Notifies the console when a value is set by the client.
+        uint32_t valueSetByClientId = dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
+            std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
+        });
+
         api.run();
+        dm.valueSetByClient.disconnect(valueSetByClientId);
+
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';
     }

--- a/sdks/cpp/connections/REST/examples/use_menus_REST/use_menus_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_menus_REST/use_menus_REST.cpp
@@ -131,11 +131,11 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        std::thread loop(statusUpdateExample);
+        std::thread counterLoop(statusUpdateExample);
 
         api.run();
 
-        loop.join();
+        counterLoop.join();
 
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';

--- a/sdks/cpp/connections/REST/examples/use_menus_REST/use_menus_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_menus_REST/use_menus_REST.cpp
@@ -83,37 +83,34 @@ void handle_signal(int sig) {
 }
 
 void statusUpdateExample(){   
-    std::thread loop([]() {
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
-            // all we do here is print out the oid of the parameter that was changed
-            // your biz logic would do something _even_more_ interesting!
-            std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
-        });
-
-        // The rest is the "sending end" of the status update example
-        IParam* param = dm.getItem<ParamTag>("counter");
-        if (param == nullptr) {
-            std::stringstream why;
-            why << __PRETTY_FUNCTION__ << "\nparam 'counter' not found";
-            throw catena::exception_with_status(why.str(), catena::StatusCode::NOT_FOUND);
-        }
-
-        // downcast the IParam to a ParamWithValue<int32_t>
-        auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param);
-
-        while (globalLoop) {
-            // update the counter once per second, and emit the event
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            {
-                std::lock_guard lg(dm.mutex());
-                counter.get()++;
-                std::cout << counter.getOid() << " set to " << counter.get() << '\n';
-                dm.valueSetByServer.emit("/counter", &counter, 0);
-            }
-        }
+    // this is the "receiving end" of the status update example
+    dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
+        // all we do here is print out the oid of the parameter that was changed
+        // your biz logic would do something _even_more_ interesting!
+        std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
     });
-    loop.detach();
+
+    // The rest is the "sending end" of the status update example
+    IParam* param = dm.getItem<ParamTag>("counter");
+    if (param == nullptr) {
+        std::stringstream why;
+        why << __PRETTY_FUNCTION__ << "\nparam 'counter' not found";
+        throw catena::exception_with_status(why.str(), catena::StatusCode::NOT_FOUND);
+    }
+
+    // downcast the IParam to a ParamWithValue<int32_t>
+    auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param);
+
+    while (globalLoop) {
+        // update the counter once per second, and emit the event
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        {
+            std::lock_guard lg(dm.mutex());
+            counter.get()++;
+            std::cout << counter.getOid() << " set to " << counter.get() << '\n';
+            dm.valueSetByServer.emit("/counter", &counter, 0);
+        }
+    }
 }
 
 void RunRESTServer() {
@@ -134,9 +131,12 @@ void RunRESTServer() {
         std::cout << "API Version: " << api.version() << std::endl;
         std::cout << "REST on 0.0.0.0:" << port << std::endl;
         
-        statusUpdateExample();
-        
+        std::thread loop(statusUpdateExample);
+
         api.run();
+
+        loop.join();
+
     } catch (std::exception &why) {
         std::cerr << "Problem: " << why.what() << '\n';
     }

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -103,6 +103,7 @@ class Connect : public ICallData, public catena::common::Connect {
      * open connections to be shut down.
      */
     static vdk::signal<void()> shutdownSignal_;
+    
   private:
     /**
      * @brief Helper function to write status messages to the API console.

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -76,13 +76,11 @@ void Connect::proceed() {
 
 void Connect::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
-    try {
-        shutdownSignal_.disconnect(shutdownSignalId_);
-        dm_.valueSetByClient.disconnect(valueSetByClientId_);
-        dm_.valueSetByServer.disconnect(valueSetByServerId_);
-        dm_.languageAddedPushUpdate.disconnect(languageAddedId_);
-    // Listener not yet initialized.
-    } catch (...) {}
+    // Disconnecting all initialized listeners.
+    if (shutdownSignalId_ != 0) { shutdownSignal_.disconnect(shutdownSignalId_); }
+    if (valueSetByClientId_ != 0) { dm_.valueSetByClient.disconnect(valueSetByClientId_); }
+    if (valueSetByServerId_ != 0) { dm_.valueSetByServer.disconnect(valueSetByServerId_); }
+    if (languageAddedId_ != 0) { dm_.languageAddedPushUpdate.disconnect(languageAddedId_); }
     // Finishing and closing the socket.
     if (socket_.is_open()) {
         writer_.sendResponse(catena::exception_with_status("", catena::StatusCode::OK));

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -202,12 +202,12 @@ void RunRPCServer(std::string addr)
         service.init();
         std::thread cq_thread([&]() { service.processEvents(); });
 
-        std::thread loop(statusUpdateExample);
+        std::thread counterLoop(statusUpdateExample);
 
         // wait for the server to shutdown and tidy up
         server->Wait();
 
-        loop.join();
+        counterLoop.join();
 
         cq->Shutdown();
         cq_thread.join();

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -127,44 +127,41 @@ void combo_boxUpdateHandler(const std::string& oid, const IParam* p, const int32
 }
 
 void statusUpdateExample(){   
-    std::thread loop([]() {
-        std::map<std::string, std::function<void(const std::string&, const IParam*, const int32_t)>> handlers;
-        handlers["/counter"] = counterUpdateHandler;
-        handlers["/text_box"] = text_boxUpdateHandler;
-        handlers["/button"] = buttonUpdateHandler;
-        handlers["/slider"] = sliderUpdateHandler;
-        handlers["/combo_box"] = combo_boxUpdateHandler;
+    std::map<std::string, std::function<void(const std::string&, const IParam*, const int32_t)>> handlers;
+    handlers["/counter"] = counterUpdateHandler;
+    handlers["/text_box"] = text_boxUpdateHandler;
+    handlers["/button"] = buttonUpdateHandler;
+    handlers["/slider"] = sliderUpdateHandler;
+    handlers["/combo_box"] = combo_boxUpdateHandler;
 
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
-            if (handlers.contains(oid)) {
-                handlers[oid](oid, p, idx);
-            }
-        });
-
-        catena::exception_with_status err{"", catena::StatusCode::OK};
-
-        // The rest is the "sending end" of the status update example
-        std::unique_ptr<IParam> param = dm.getParam("/counter", err);
-        if (param == nullptr) {
-            throw err;
-        }
-
-        // downcast the IParam to a ParamWithValue<int32_t>
-        auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param.get());
-
-        while (globalLoop) {
-            // update the counter once per second, and emit the event
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            {
-                std::lock_guard lg(dm.mutex());
-                counter.get()++;
-                std::cout << counter.getOid() << " set to " << counter.get() << '\n';
-                dm.valueSetByServer.emit("/counter", &counter, 0);
-            }
+    // this is the "receiving end" of the status update example
+    dm.valueSetByClient.connect([&handlers](const std::string& oid, const IParam* p, const int32_t idx) {
+        if (handlers.contains(oid)) {
+            handlers[oid](oid, p, idx);
         }
     });
-    loop.detach();
+
+    catena::exception_with_status err{"", catena::StatusCode::OK};
+
+    // The rest is the "sending end" of the status update example
+    std::unique_ptr<IParam> param = dm.getParam("/counter", err);
+    if (param == nullptr) {
+        throw err;
+    }
+
+    // downcast the IParam to a ParamWithValue<int32_t>
+    auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param.get());
+
+    while (globalLoop) {
+        // update the counter once per second, and emit the event
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        {
+            std::lock_guard lg(dm.mutex());
+            counter.get()++;
+            std::cout << counter.getOid() << " set to " << counter.get() << '\n';
+            dm.valueSetByServer.emit("/counter", &counter, 0);
+        }
+    }
 }
 
 void RunRPCServer(std::string addr)
@@ -205,10 +202,12 @@ void RunRPCServer(std::string addr)
         service.init();
         std::thread cq_thread([&]() { service.processEvents(); });
 
-        statusUpdateExample();
+        std::thread loop(statusUpdateExample);
 
         // wait for the server to shutdown and tidy up
         server->Wait();
+
+        loop.join();
 
         cq->Shutdown();
         cq_thread.join();

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/structs_with_authz.cpp
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/structs_with_authz.cpp
@@ -139,7 +139,9 @@ void RunRPCServer(std::string addr)
             std::string front = jptr.front_as_string();
             jptr.pop();
 
-            handlers[front](jptr.toString(), p, idx);
+            if (handlers.contains(front)) {
+                handlers[front](jptr.toString(), p, idx);
+            }
         });
 
         // wait for the server to shutdown and tidy up

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/structs_with_authz_yaml.cpp
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/structs_with_authz_yaml.cpp
@@ -90,9 +90,6 @@ void audioDeckUpdateHandler(const std::string& jptr, const IParam* p, const int3
 
 }
 
-
-        
-
 void RunRPCServer(std::string addr)
 {
     // install signal handlers
@@ -139,7 +136,9 @@ void RunRPCServer(std::string addr)
             std::string front = jptr.front_as_string();
             jptr.pop();
 
-            handlers[front](jptr.toString(), p, idx);
+            if (handlers.contains(front)) {
+                handlers[front](jptr.toString(), p, idx);
+            }
         });
 
         // wait for the server to shutdown and tidy up

--- a/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
@@ -76,20 +76,6 @@ void handle_signal(int sig) {
     t.join();
 }
 
-
-
-void statusUpdate(){   
-    std::thread loop([]() {
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
-            // all we do here is print out the oid of the parameter that was changed
-            // your biz logic would do something _even_more_ interesting!
-            std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
-        });
-    });
-    loop.detach();
-}
-
 void RunRPCServer(std::string addr)
 {
     // install signal handlers
@@ -125,10 +111,14 @@ void RunRPCServer(std::string addr)
         service.init();
         std::thread cq_thread([&]() { service.processEvents(); });
 
-        statusUpdate();
+        // Notifies the console when a value is set by the client.
+        uint32_t valueSetByClientId = dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
+            std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
+        });
 
         // wait for the server to shutdown and tidy up
         server->Wait();
+        dm.valueSetByClient.disconnect(valueSetByClientId);
 
         cq->Shutdown();
         cq_thread.join();

--- a/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
@@ -139,12 +139,12 @@ void RunRPCServer(std::string addr)
         service.init();
         std::thread cq_thread([&]() { service.processEvents(); });
 
-        std::thread loop(statusUpdateExample);
+        std::thread counterLoop(statusUpdateExample);
 
         // wait for the server to shutdown and tidy up
         server->Wait();
 
-        loop.join();
+        counterLoop.join();
 
         cq->Shutdown();
         cq_thread.join();

--- a/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
@@ -80,37 +80,34 @@ void handle_signal(int sig) {
 
 
 void statusUpdateExample(){   
-    std::thread loop([]() {
-        // this is the "receiving end" of the status update example
-        dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
-            // all we do here is print out the oid of the parameter that was changed
-            // your biz logic would do something _even_more_ interesting!
-            std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
-        });
-
-        // The rest is the "sending end" of the status update example
-        IParam* param = dm.getItem<ParamTag>("counter");
-        if (param == nullptr) {
-            std::stringstream why;
-            why << __PRETTY_FUNCTION__ << "\nparam 'counter' not found";
-            throw catena::exception_with_status(why.str(), catena::StatusCode::NOT_FOUND);
-        }
-
-        // downcast the IParam to a ParamWithValue<int32_t>
-        auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param);
-
-        while (globalLoop) {
-            // update the counter once per second, and emit the event
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            {
-                std::lock_guard lg(dm.mutex());
-                counter.get()++;
-                std::cout << counter.getOid() << " set to " << counter.get() << '\n';
-                dm.valueSetByServer.emit("/counter", &counter, 0);
-            }
-        }
+    // this is the "receiving end" of the status update example
+    dm.valueSetByClient.connect([](const std::string& oid, const IParam* p, const int32_t idx) {
+        // all we do here is print out the oid of the parameter that was changed
+        // your biz logic would do something _even_more_ interesting!
+        std::cout << "*** signal received: " << oid << " has been changed by client" << '\n';
     });
-    loop.detach();
+
+    // The rest is the "sending end" of the status update example
+    IParam* param = dm.getItem<ParamTag>("counter");
+    if (param == nullptr) {
+        std::stringstream why;
+        why << __PRETTY_FUNCTION__ << "\nparam 'counter' not found";
+        throw catena::exception_with_status(why.str(), catena::StatusCode::NOT_FOUND);
+    }
+
+    // downcast the IParam to a ParamWithValue<int32_t>
+    auto& counter = *dynamic_cast<ParamWithValue<int32_t>*>(param);
+
+    while (globalLoop) {
+        // update the counter once per second, and emit the event
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        {
+            std::lock_guard lg(dm.mutex());
+            counter.get()++;
+            std::cout << counter.getOid() << " set to " << counter.get() << '\n';
+            dm.valueSetByServer.emit("/counter", &counter, 0);
+        }
+    }
 }
 
 void RunRPCServer(std::string addr)
@@ -142,10 +139,12 @@ void RunRPCServer(std::string addr)
         service.init();
         std::thread cq_thread([&]() { service.processEvents(); });
 
-        statusUpdateExample();
+        std::thread loop(statusUpdateExample);
 
         // wait for the server to shutdown and tidy up
         server->Wait();
+
+        loop.join();
 
         cq->Shutdown();
         cq_thread.join();

--- a/sdks/cpp/connections/gRPC/include/CallData.h
+++ b/sdks/cpp/connections/gRPC/include/CallData.h
@@ -109,7 +109,7 @@ class CallData : public ICallData {
     /**
      * @brief Pointer to CatenaServiceImpl
      */
-    ICatenaServiceImpl *service_;
+    ICatenaServiceImpl* service_;
 };
 
 };

--- a/sdks/cpp/connections/gRPC/include/controllers/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/Connect.h
@@ -110,25 +110,22 @@ class Connect : public CallData, public catena::common::Connect {
      * @brief The total # of Connect objects.
      */
     static int objectCounter_;
-    /**
-     * @brief Unused???
-     */
-    unsigned int pushUpdatesId_;
+
     /**
      * @brief Id of operation waiting for valueSetByClient to be emitted.
      * Used when ending the connection.
      */
-    unsigned int valueSetByClientId_;
+    unsigned int valueSetByClientId_ = 0;
     /**
      * @brief Id of operation waiting for valueSetByServer to be emitted.
      * Used when ending the connection.
      */
-    unsigned int valueSetByServerId_;
+    unsigned int valueSetByServerId_ = 0;
     /**
      * @brief Id of operation waiting for languageAddedPushUpdate to be
      * emitted. Used when ending the connection.
      */
-    unsigned int languageAddedId_;
+    unsigned int languageAddedId_ = 0;
 
     /**
      * @brief Signal emitted in the case of an error which requires the all
@@ -138,7 +135,7 @@ class Connect : public CallData, public catena::common::Connect {
     /**
      * @brief ID of the shutdown signal for the Connect object
     */
-    unsigned int shutdownSignalId_;
+    unsigned int shutdownSignalId_ = 0;
 };
 
 }; // namespace gRPC

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -78,6 +78,10 @@ void CatenaServiceImpl::processEvents() {
                 std::thread(&ICallData::proceed, static_cast<ICallData *>(tag), ok).detach();
                 break;
             case ServerCompletionQueue::SHUTDOWN:
+                // Waiting until all events are processed to exit.
+                while (registry_.size() > 0) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
                 return;
             case ServerCompletionQueue::TIMEOUT:
                 break;

--- a/sdks/cpp/connections/gRPC/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/AddLanguage.cpp
@@ -48,6 +48,7 @@ void AddLanguage::proceed(bool ok) {
               << std::boolalpha << ok << std::endl;
     
     if(!ok){
+        std::cout << "AddLanguage[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
     

--- a/sdks/cpp/connections/gRPC/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/AddLanguage.cpp
@@ -46,8 +46,9 @@ void AddLanguage::proceed(bool ok) {
     std::cout << "AddLanguage::proceed[" << objectId_ << "]: " << timeNow()
               << " status: " << static_cast<int>(status_) << ", ok: "
               << std::boolalpha << ok << std::endl;
-    
-    if(!ok){
+
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "AddLanguage[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/BasicParamInfoRequest.cpp
@@ -43,18 +43,13 @@ BasicParamInfoRequest::BasicParamInfoRequest(ICatenaServiceImpl *service, IDevic
 }
 
 void BasicParamInfoRequest::proceed(bool ok) {
-    if (!service_)
-        return;
-
     std::cout << "BasicParamInfoRequest proceed[" << objectId_ << "]: " << timeNow()
               << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
               << std::endl;
 
-    if(!ok) {
+    if(!ok){
         std::cout << "BasicParamInfoRequest[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
-        service_->deregisterItem(this);
-        return;
     }
 
     switch (status_) {

--- a/sdks/cpp/connections/gRPC/src/controllers/BasicParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/BasicParamInfoRequest.cpp
@@ -43,11 +43,12 @@ BasicParamInfoRequest::BasicParamInfoRequest(ICatenaServiceImpl *service, IDevic
 }
 
 void BasicParamInfoRequest::proceed(bool ok) {
-    std::cout << "BasicParamInfoRequest proceed[" << objectId_ << "]: " << timeNow()
-              << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-              << std::endl;
+    std::cout << "BasicParamInfoRequest::proceed[" << objectId_ << "]: "
+              << timeNow() << " status: " << static_cast<int>(status_)
+              << ", ok: " << std::boolalpha << ok << std::endl;
 
-    if(!ok){
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "BasicParamInfoRequest[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -52,14 +52,14 @@ catena::gRPC::Connect::Connect(ICatenaServiceImpl *service, IDevice& dm, bool ok
 // Manages gRPC command execution process using the state variable status.
 void catena::gRPC::Connect::proceed(bool ok) {
     std::cout << "Connect proceed[" << objectId_ << "]: " << timeNow()
-                << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-                << std::endl;
+                << " status: " << static_cast<int>(status_) << ", ok: "
+                << std::boolalpha << ok << std::endl;
 
     /**
      * The newest connect object (the one that has not yet been attached to a
      * client request) will send shutdown signal to cancel all open connections
      */
-    if(!ok){
+    if (!ok && status_ != CallStatus::kFinish) {
         std::cout << "Connect[" << objectId_ << "] cancelled\n";
         std::cout << "Cancelling all open connections" << std::endl;
         shutdownSignal_.emit();

--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -59,7 +59,7 @@ void catena::gRPC::Connect::proceed(bool ok) {
      * The newest connect object (the one that has not yet been attached to a
      * client request) will send shutdown signal to cancel all open connections
      */
-    if(!ok && status_ != CallStatus::kFinish){
+    if(!ok){
         std::cout << "Connect[" << objectId_ << "] cancelled\n";
         std::cout << "Cancelling all open connections" << std::endl;
         shutdownSignal_.emit();
@@ -151,10 +151,11 @@ void catena::gRPC::Connect::proceed(bool ok) {
          */
         case CallStatus::kFinish:
             std::cout << "Connect[" << objectId_ << "] finished\n";
-            shutdownSignal_.disconnect(shutdownSignalId_);
-            dm_.valueSetByClient.disconnect(valueSetByClientId_);
-            dm_.valueSetByServer.disconnect(valueSetByServerId_);
-            dm_.languageAddedPushUpdate.disconnect(languageAddedId_);
+            // Disconnecting all initialized listeners.
+            if (shutdownSignalId_ != 0) { shutdownSignal_.disconnect(shutdownSignalId_); }
+            if (valueSetByClientId_ != 0) { dm_.valueSetByClient.disconnect(valueSetByClientId_); }
+            if (valueSetByServerId_ != 0) { dm_.valueSetByServer.disconnect(valueSetByServerId_); }
+            if (languageAddedId_ != 0) { dm_.languageAddedPushUpdate.disconnect(languageAddedId_); }
             service_->deregisterItem(this);
             break;
         // default: Error, end process.

--- a/sdks/cpp/connections/gRPC/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/DeviceRequest.cpp
@@ -57,7 +57,7 @@ void DeviceRequest::proceed(bool ok) {
               << std::boolalpha << ok << std::endl;
     
     // If the process is cancelled, finish the process
-    if(!ok){
+    if (!ok) {
         std::cout << "DeviceRequest[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
@@ -53,11 +53,11 @@ ExecuteCommand::ExecuteCommand(ICatenaServiceImpl *service, IDevice& dm, bool ok
  */
 void ExecuteCommand::proceed(bool ok) {
     std::cout << "ExecuteCommand proceed[" << objectId_ << "]: " << timeNow()
-                << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-                << std::endl;
+              << " status: " << static_cast<int>(status_) << ", ok: "
+              << std::boolalpha << ok << std::endl;
 
     // If the process is cancelled, finish the process
-    if(!ok){
+    if (!ok) {
         std::cout << "ExecuteCommand[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
@@ -71,7 +71,7 @@ void ExternalObjectRequest::proceed(bool ok) {
                 << std::endl;
     
     // If the process is cancelled, finish the process
-    if(!ok){
+    if (!ok) {
         std::cout << "ExternalObjectRequest[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetParam.cpp
@@ -55,11 +55,9 @@ void GetParam::proceed( bool ok) {
               << " status: " << static_cast<int>(status_) << ", ok: "
               << std::boolalpha << ok << std::endl;
     
-    if(!ok) {
+    if(!ok){
         std::cout << "GetParam[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
-        service_->deregisterItem(this);
-        return;
     }
     
     switch (status_) {

--- a/sdks/cpp/connections/gRPC/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetParam.cpp
@@ -54,8 +54,9 @@ void GetParam::proceed( bool ok) {
     std::cout << "GetParam::proceed[" << objectId_ << "]: " << timeNow()
               << " status: " << static_cast<int>(status_) << ", ok: "
               << std::boolalpha << ok << std::endl;
-    
-    if(!ok){
+
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "GetParam[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetPopulatedSlots.cpp
@@ -48,11 +48,12 @@ GetPopulatedSlots::GetPopulatedSlots(ICatenaServiceImpl *service, IDevice& dm, b
 
 // Manages gRPC command execution process using the state variable status.
 void GetPopulatedSlots::proceed( bool ok) {
-    std::cout << "GetPopulatedSlots::proceed[" << objectId_ << "]: " << timeNow()
-                << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-                << std::endl;
+    std::cout << "GetPopulatedSlots::proceed[" << objectId_ << "]: "
+              << timeNow() << " status: " << static_cast<int>(status_)
+              << ", ok: " << std::boolalpha << ok << std::endl;
 
-    if(!ok){
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "GetPopulatedSlots[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetPopulatedSlots.cpp
@@ -53,6 +53,7 @@ void GetPopulatedSlots::proceed( bool ok) {
                 << std::endl;
 
     if(!ok){
+        std::cout << "GetPopulatedSlots[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
 

--- a/sdks/cpp/connections/gRPC/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetValue.cpp
@@ -49,10 +49,11 @@ GetValue::GetValue(ICatenaServiceImpl *service, IDevice& dm, bool ok) : CallData
 // Manages gRPC command execution process using the state variable status.
 void GetValue::proceed( bool ok) {
     std::cout << "GetValue::proceed[" << objectId_ << "]: " << timeNow()
-                << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-                << std::endl;
+                << " status: " << static_cast<int>(status_) << ", ok: "
+                << std::boolalpha << ok << std::endl;
 
-    if(!ok){
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "GetValue[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetValue.cpp
@@ -53,6 +53,7 @@ void GetValue::proceed( bool ok) {
                 << std::endl;
 
     if(!ok){
+        std::cout << "GetValue[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
 

--- a/sdks/cpp/connections/gRPC/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/LanguagePackRequest.cpp
@@ -43,10 +43,12 @@ LanguagePackRequest::LanguagePackRequest(ICatenaServiceImpl *service, IDevice& d
 }
 
 void LanguagePackRequest::proceed(bool ok) {
-    std::cout << "LanguagePackRequest::proceed[" << objectId_ << "]: " << timeNow()
-              << " status: " << static_cast<int>(status_) << ", ok: "
-              << std::boolalpha << ok << std::endl;
-    if(!ok){
+    std::cout << "LanguagePackRequest::proceed[" << objectId_ << "]: "
+              << timeNow() << " status: " << static_cast<int>(status_)
+              << ", ok: " << std::boolalpha << ok << std::endl;
+    
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "LanguagePackRequest[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/LanguagePackRequest.cpp
@@ -47,8 +47,10 @@ void LanguagePackRequest::proceed(bool ok) {
               << " status: " << static_cast<int>(status_) << ", ok: "
               << std::boolalpha << ok << std::endl;
     if(!ok){
+        std::cout << "LanguagePackRequest[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
+
     switch(status_){
         /** 
          * kCreate: Updates status to kProcess and requests the

--- a/sdks/cpp/connections/gRPC/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ListLanguages.cpp
@@ -47,6 +47,7 @@ void ListLanguages::proceed(bool ok) {
               << " status: " << static_cast<int>(status_) << ", ok: "
               << std::boolalpha << ok << std::endl;
     if(!ok){
+        std::cout << "ListLanguages[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
     switch(status_){

--- a/sdks/cpp/connections/gRPC/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ListLanguages.cpp
@@ -46,10 +46,13 @@ void ListLanguages::proceed(bool ok) {
     std::cout << "ListLanguages::proceed[" << objectId_ << "]: " << timeNow()
               << " status: " << static_cast<int>(status_) << ", ok: "
               << std::boolalpha << ok << std::endl;
-    if(!ok){
+    
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "ListLanguages[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
+
     switch(status_){
         /** 
          * kCreate: Updates status to kProcess and requests the ListLanguages

--- a/sdks/cpp/connections/gRPC/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/MultiSetValue.cpp
@@ -56,10 +56,11 @@ void MultiSetValue::create_(bool ok) {
 
 void MultiSetValue::proceed(bool ok) { 
     std::cout << typeName << "::proceed[" << objectId_ << "]: " << timeNow()
-                << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-                << std::endl;
-    
-    if(!ok){
+                << " status: " << static_cast<int>(status_) << ", ok: "
+                << std::boolalpha << ok << std::endl;
+
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << typeName << "[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/MultiSetValue.cpp
@@ -60,6 +60,7 @@ void MultiSetValue::proceed(bool ok) {
                 << std::endl;
     
     if(!ok){
+        std::cout << typeName << "[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }
     

--- a/sdks/cpp/connections/gRPC/src/controllers/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/UpdateSubscriptions.cpp
@@ -43,11 +43,12 @@ UpdateSubscriptions::UpdateSubscriptions(ICatenaServiceImpl *service, IDevice& d
 }
 
 void UpdateSubscriptions::proceed(bool ok) {
-    std::cout << "UpdateSubscriptions proceed[" << objectId_ << "]: " << timeNow()
-              << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
-              << std::endl;
+    std::cout << "UpdateSubscriptions proceed[" << objectId_ << "]: "
+              << timeNow() << " status: " << static_cast<int>(status_)
+              << ", ok: " << std::boolalpha << ok << std::endl;
 
-    if(!ok){
+    // If the process is cancelled, finish the process
+    if (!ok) {
         std::cout << "UpdateSubscriptions[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
     }

--- a/sdks/cpp/connections/gRPC/src/controllers/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/UpdateSubscriptions.cpp
@@ -43,18 +43,13 @@ UpdateSubscriptions::UpdateSubscriptions(ICatenaServiceImpl *service, IDevice& d
 }
 
 void UpdateSubscriptions::proceed(bool ok) {
-    if (!service_)
-        return;
-
     std::cout << "UpdateSubscriptions proceed[" << objectId_ << "]: " << timeNow()
               << " status: " << static_cast<int>(status_) << ", ok: " << std::boolalpha << ok
               << std::endl;
 
-    if(!ok) {
+    if(!ok){
         std::cout << "UpdateSubscriptions[" << objectId_ << "] cancelled\n";
         status_ = CallStatus::kFinish;
-        service_->deregisterItem(this);
-        return;
     }
 
     switch (status_) {


### PR DESCRIPTION
**Overview:**
- Brought valgrind errors when running gRPC examples down to a consistent 2 (used to be upwards of 60), which can be assumed to be issues on the side of the gRPC and protobuf libraries.
- Brought valgrind errors when running REST examples down to a consistent 4 (imagine it used to be much more), which can be assumed to be issues on the side of the boost and protobuf libraries.

**Changelog:**
- Updated detached threads in example services to instead join() after the server has shut down.
    - Before the threads would sometimes finish after global scope resulting in calls to a non existent device and service.
- Updated connect endpoints signal ids to have default values that are checked before disconnecting.
    - Namely an issue on the gRPC side resulting in the unused Connect RPC to disconnect from signals it is not connected to.
- Updated gRPC service implementation's processEvents() function to wait for all CallData objects in the registry to get deregistered before returning.
    - Similar to the thread issue listed above, the CallData objects would sometimes be destroyed after the service resulting in a call to a non-existent DeregisterItem() function.