### PR TITLE
Fixed REST multisetValue router and openAPI example

### DIFF
--- a/interface/openapi/paths/Values.yaml
+++ b/interface/openapi/paths/Values.yaml
@@ -66,35 +66,45 @@ put:
     content:
       application/json:
         schema:
-          type: array
-          items:
-            type: object
-            properties:
-              fqoid:
-                type: string
-                description: Fully qualified OID of the parameter to get info for
-                schema: 
-                  $ref: "../../../schema/catena.param_schema.json#/$defs/fqoid"
-              value:
-                type: object
-                schema:
-                  $ref: "../../../schema/catena.param_schema.json#/$defs/value"
-        example:
-          - oid: "/ipv4"
-            value:
-              string_value: "192.168.1.1"
-          - oid: "/gateway"
-            value:
-              string_value: "192.168.1.254"
-          - oid: "/subnet"
-            value:
-              string_value: "255.255.255.0"
-          - oid: "/dns"
-            value:
-              string_value: "8.8.8.8"
-          - oid: "/dns_alt"
-            value:
-              string_value: "8.8.4.4"
+          values:
+            type: array
+            items:
+              type: object
+              properties:
+                fqoid:
+                  type: string
+                  description: Fully qualified OID of the parameter to get info for
+                  schema: 
+                    $ref: "../../../schema/catena.param_schema.json#/$defs/fqoid"
+                value:
+                  type: object
+                  schema:
+                    $ref: "../../../schema/catena.param_schema.json#/$defs/value"
+        example: 
+          {
+            "values": [
+              {
+                oid: "/ipv4",
+                value: { string_value: "192.168.1.1" }
+              },
+              {
+                oid: "/gateway",
+                value: { string_value: "192.168.1.254" }
+              },
+              {
+                oid: "/subnet",
+                value: { string_value: "255.255.255.0" }
+              },
+              {
+                oid: "/dns",
+                value: { string_value: "8.8.8.8" }
+              },
+              {
+                oid: "/dns_alt",
+                value: { string_value: "8.8.4.4" }
+              }
+            ]
+          }
 
   responses:
     "204":

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -56,7 +56,7 @@ CatenaServiceImpl::CatenaServiceImpl(IDevice& dm, std::string& EOPath, bool auth
     router_.addProduct("GET/asset",           AssetRequest::makeOne);
     router_.addProduct("GET/devices",         GetPopulatedSlots::makeOne);
     router_.addProduct("GET/value",           GetValue::makeOne);
-    router_.addProduct("PUT/multi-set-value", MultiSetValue::makeOne);
+    router_.addProduct("PUT/values",          MultiSetValue::makeOne);
     router_.addProduct("PUT/value",           SetValue::makeOne);
     router_.addProduct("GET/param",           GetParam::makeOne);
     router_.addProduct("GET/language-pack",   LanguagePackRequest::makeOne);


### PR DESCRIPTION
**Changelog**:
- Fixed router to REST multisetValue (previously multi-set-value, now values)
- Corrected openAPI example