### PR TITLE
Refactor gRPC Unit Tests

### DIFF
--- a/unittests/cpp/REST/RESTTest.h
+++ b/unittests/cpp/REST/RESTTest.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief A utility class for using Sockets in REST API tests.
+ * @brief A parent class for REST test fixtures.
  * @author benjamin.whitten@rossvideo.com
  * @date 25/05/12
  * @copyright Copyright © 2025 Ross Video Ltd

--- a/unittests/cpp/gRPC/GRPCTest.h
+++ b/unittests/cpp/gRPC/GRPCTest.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief A parent class for gRPC test fixtures.
+ * @author christian.twarogn@rossvideo.com
+ * @date 16/06/25
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+#pragma once
+
+// gtest
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// std
+#include <string>
+
+// protobuf
+#include <interface/device.pb.h>
+#include <interface/service.grpc.pb.h>
+#include <google/protobuf/util/json_util.h>
+
+// common
+#include <Status.h>
+
+// boost
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+using boost::asio::ip::tcp;
+
+// gRPC
+#include "MockServer.h"
+
+using namespace catena::gRPC;
+
+/*
+ * GRPCTest class inherited by test fixtures to provide functions for
+ * writing, reading, and verifying requests and responses.
+ */
+class GRPCTest  : public ::testing::Test {
+  protected:
+    /*
+     * Sets up expectations for the creation of a new CallData obj.
+     */
+    void SetUp() override {
+        mockServer.start();
+        // Redirecting cout to a stringstream for testing.
+        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+        // We can always assume that a new CallData obj is created.
+        // Either from initialization or kProceed.
+        mockServer.expNew();
+    }
+
+    /*
+     * Restores cout after each test.
+     */
+    void TearDown() override {
+        std::cout.rdbuf(oldCout);
+
+        // Redirecting cout to a stringstream for testing.
+        std::stringstream MockConsole;
+        std::streambuf* oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+        // Destroying the server.
+        //TODO: GET NUM TIMES MAYBE
+        EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).WillRepeatedly(::testing::Invoke([this]() {
+            delete this->mockServer.testCall;
+            this->mockServer.testCall = nullptr;
+        }));
+        mockServer.shutdown();
+        // Restoring cout
+        std::cout.rdbuf(oldCout);
+    }
+
+    // Console variables
+    std::stringstream MockConsole;
+    std::streambuf* oldCout;
+    // Client variables.
+    grpc::ClientContext clientContext;
+    bool done = false;
+    std::condition_variable cv;
+    std::mutex cv_mtx;
+    std::unique_lock<std::mutex> lock{cv_mtx};
+    grpc::Status outRc;
+    // Expected variables
+    catena::Empty expVal;
+    grpc::Status expRc;
+
+    MockServer mockServer;
+};

--- a/unittests/cpp/gRPC/mocks/MockServer.h
+++ b/unittests/cpp/gRPC/mocks/MockServer.h
@@ -40,7 +40,7 @@
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 
-#include "../../common/mocks/MockDevice.h"
+#include "MockDevice.h"
 
 // common
 #include <ISubscriptionManager.h>
@@ -105,11 +105,11 @@ class MockServer {
      * Functions to expect when creating a new CallData object.
      */
     void expNew() {
-        EXPECT_CALL(*service, registerItem(::testing::_)).Times(1)
-            .WillOnce(::testing::Invoke([this](ICallData* cd) {
+        EXPECT_CALL(*service, registerItem(::testing::_))
+            .WillRepeatedly(::testing::Invoke([this](ICallData* cd) {
                 asyncCall = cd;
             }));
-        EXPECT_CALL(*service, cq()).Times(2).WillRepeatedly(::testing::Return(cq.get()));
+        EXPECT_CALL(*service, cq()).WillRepeatedly(::testing::Return(cq.get()));
     }
 
     void expectAuthz(grpc::ClientContext* clientContext = nullptr, const std::string& mockToken = "") {

--- a/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
@@ -47,49 +47,31 @@
 #include <google/protobuf/util/json_util.h>
 
 // Test helpers
-#include "MockServer.h"
-#include "MockSubscriptionManager.h"
+#include "GRPCTest.h"
 
 // gRPC
+#include "MockSubscriptionManager.h"
 #include "controllers/DeviceRequest.h"
 
 using namespace catena::common;
 using namespace catena::gRPC;
 
 // Fixture
-class gRPCDeviceRequestTests : public ::testing::Test {
+class gRPCDeviceRequestTests : public GRPCTest {
   protected:
-    /*
-     * Called at the start of all tests.
-     * Starts the mockServer and initializes the static inVal.
-     */
-    static void SetUpTestSuite() {
-        mockServer.start();
-    }
-
-    /*
-     * Sets up expectations for the creation of a new CallData obj.
-     */
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-        // We can always assume that a new CallData obj is created.
-        // Either from initialization or kProceed.
-        mockServer.expNew();
-    }
 
     /*
      * This is a test class which makes an async RPC to the MockServer on
      * construction and compares the streamed-back response.
      */
-    class TestRPC : public grpc::ClientReadReactor<catena::DeviceComponent> {
+    class StreamReader : public grpc::ClientReadReactor<catena::DeviceComponent> {
         public:
             /*
              * This sets up the expected values for the RPC with one of
              * everything. They only have their OID set, which is enough to
              * make sure the correct obj is being passed back.
              */
-            TestRPC() {
+            StreamReader() {
                 expVals.push_back(catena::DeviceComponent()); // [0] Device
                 expVals.push_back(catena::DeviceComponent()); // [1] Menu
                 expVals.push_back(catena::DeviceComponent()); // [2] Language pack
@@ -157,40 +139,8 @@ class gRPCDeviceRequestTests : public ::testing::Test {
             std::unique_lock<std::mutex> lock{cv_mtx};
     };
 
-    /*
-     * Restores cout after each test.
-     */
-    void TearDown() override {
-        std::cout.rdbuf(oldCout);
-    }
-
-    /*
-     * Called at the end of all tests, shuts down the server and cleans up.
-     */
-    static void TearDownTestSuite() {
-        // Redirecting cout to a stringstream for testing.
-        std::stringstream MockConsole;
-        std::streambuf* oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-        // Destroying the server.
-        EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
-            delete mockServer.testCall;
-            mockServer.testCall = nullptr;
-        }));
-        mockServer.shutdown();
-        // Restoring cout
-        std::cout.rdbuf(oldCout);
-    }
-
-    // Console variables
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-
-    TestRPC testRPC;
-
-    static MockServer mockServer;
+    StreamReader client;
 };
-
-MockServer gRPCDeviceRequestTests::mockServer;
 
 /*
  * ============================================================================
@@ -210,8 +160,10 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_create) {
  * TEST 2 - Normal case for DeviceRequest proceed().
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedNormal) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("", catena::StatusCode::OK);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     catena::DeviceRequestPayload inVal;
     // No bearing just to make sure the currect val is being passed in.
     inVal.set_detail_level(catena::Device_DetailLevel::Device_DetailLevel_MINIMAL);
@@ -229,12 +181,12 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedNormal) {
     //Mocking kWrite functions
     EXPECT_CALL(*mockServer.dm, mutex()).Times(6).WillRepeatedly(::testing::ReturnRef(mockServer.mtx));
     EXPECT_CALL(*mockSerializer, getNext()).Times(6)
-        .WillOnce(::testing::Return(testRPC.expVals[0]))
-        .WillOnce(::testing::Return(testRPC.expVals[1]))
-        .WillOnce(::testing::Return(testRPC.expVals[2]))
-        .WillOnce(::testing::Return(testRPC.expVals[3]))
-        .WillOnce(::testing::Return(testRPC.expVals[4]))
-        .WillOnce(::testing::Return(testRPC.expVals[5]));
+        .WillOnce(::testing::Return(client.expVals[0]))
+        .WillOnce(::testing::Return(client.expVals[1]))
+        .WillOnce(::testing::Return(client.expVals[2]))
+        .WillOnce(::testing::Return(client.expVals[3]))
+        .WillOnce(::testing::Return(client.expVals[4]))
+        .WillOnce(::testing::Return(client.expVals[5]));
     EXPECT_CALL(*mockSerializer, hasMore()).Times(6)
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(true))
@@ -243,21 +195,23 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedNormal) {
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(false));
     // Mocking kFinish functions.
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
-    testRPC.MakeCall(mockServer.client.get(), inVal);
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), inVal);
+    client.Await();
 }
 
 /*
  * TEST 3 - DeviceRequest proceed() with detail_level subscriptions.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedSubscriptions) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("", catena::StatusCode::OK);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     catena::DeviceRequestPayload inVal;
     std::set<std::string> subscribedTestOids{"oid_test_1", "oid_test_2", "oid_test_3"};
     inVal.set_detail_level(catena::Device_DetailLevel::Device_DetailLevel_SUBSCRIPTIONS);
@@ -284,24 +238,26 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedSubscriptions) {
         }));
     //Mocking kWrite functions
     EXPECT_CALL(*mockServer.dm, mutex()).Times(1).WillRepeatedly(::testing::ReturnRef(mockServer.mtx));
-    EXPECT_CALL(*mockSerializer, getNext()).Times(1).WillOnce(::testing::Return(testRPC.expVals[0]));
+    EXPECT_CALL(*mockSerializer, getNext()).Times(1).WillOnce(::testing::Return(client.expVals[0]));
     EXPECT_CALL(*mockSerializer, hasMore()).Times(1).WillOnce(::testing::Return(false));
     // Mocking kFinish functions.
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
-    testRPC.MakeCall(mockServer.client.get(), inVal);
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), inVal);
+    client.Await();
 }
 
 /*
  * TEST 4 - DeviceRequest with authz on and valid token.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedAuthzValid) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("", catena::StatusCode::OK);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     catena::DeviceRequestPayload inVal;
     // No bearing just to make sure the currect val is being passed in.
     inVal.set_detail_level(catena::Device_DetailLevel::Device_DetailLevel_MINIMAL);
@@ -319,7 +275,7 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedAuthzValid) {
                             "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
                             "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
                             "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-    testRPC.clientContext.AddMetadata("authorization", "Bearer " + mockToken);
+    client.clientContext.AddMetadata("authorization", "Bearer " + mockToken);
 
     // Mocking kProcess functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(2).WillRepeatedly(::testing::Return(true));
@@ -333,12 +289,12 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedAuthzValid) {
     //Mocking kWrite functions
     EXPECT_CALL(*mockServer.dm, mutex()).Times(6).WillRepeatedly(::testing::ReturnRef(mockServer.mtx));
     EXPECT_CALL(*mockSerializer, getNext()).Times(6)
-        .WillOnce(::testing::Return(testRPC.expVals[0]))
-        .WillOnce(::testing::Return(testRPC.expVals[1]))
-        .WillOnce(::testing::Return(testRPC.expVals[2]))
-        .WillOnce(::testing::Return(testRPC.expVals[3]))
-        .WillOnce(::testing::Return(testRPC.expVals[4]))
-        .WillOnce(::testing::Return(testRPC.expVals[5]));
+        .WillOnce(::testing::Return(client.expVals[0]))
+        .WillOnce(::testing::Return(client.expVals[1]))
+        .WillOnce(::testing::Return(client.expVals[2]))
+        .WillOnce(::testing::Return(client.expVals[3]))
+        .WillOnce(::testing::Return(client.expVals[4]))
+        .WillOnce(::testing::Return(client.expVals[5]));
     EXPECT_CALL(*mockSerializer, hasMore()).Times(6)
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(true))
@@ -347,85 +303,93 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedAuthzValid) {
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(false));
     // Mocking kFinish functions.
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
-    testRPC.MakeCall(mockServer.client.get(), inVal);
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), inVal);
+    client.Await();
 }
 
 /*
  * TEST 5 - DeviceRequest with authz on and invalid token.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceeedAuthzInvalid) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Not a token so it should get rejected by the authorizer.
-    testRPC.clientContext.AddMetadata("authorization", "Bearer THIS SHOULD NOT PARSE");
+    client.clientContext.AddMetadata("authorization", "Bearer THIS SHOULD NOT PARSE");
 
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(2).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
     // Sending the RPC.
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }
 
 /*
  * TEST 6 - DeviceRequest with authz on and invalid token.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedAuthzJWSNotFound) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("JWS bearer token not found", catena::StatusCode::UNAUTHENTICATED);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Should not be able to find the bearer token.
-    testRPC.clientContext.AddMetadata("authorization", "NOT A BEARER TOKEN");
+    client.clientContext.AddMetadata("authorization", "NOT A BEARER TOKEN");
 
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(2).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
     // Sending the RPC.
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }
 
 /*
  * TEST 7 - dm.getComponentSerializer() returns nullptr.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetSerializerIllegalState) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Illegal state", catena::StatusCode::INTERNAL);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
     EXPECT_CALL(*mockServer.dm, getComponentSerializer(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([&rc](catena::common::Authorizer &authz, const std::set<std::string> &subscribedOids, catena::Device_DetailLevel dl, bool shallow){
             return nullptr;
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
     // Sending the RPC.
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }
 
 /*
  * TEST 8 - dm.getComponentSerializer() throws a catena::exception_with_status.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetSerializerThrowCatena) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Component not found", catena::StatusCode::INVALID_ARGUMENT);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
     EXPECT_CALL(*mockServer.dm, getComponentSerializer(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1)
@@ -433,22 +397,24 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetSerializerThrowCatena)
             throw catena::exception_with_status(rc.what(), rc.status);
             return nullptr;
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
     // Sending the RPC.
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }
 
 /*
  * TEST 9 - dm.getComponentSerializer() throws a std::runtime_exception.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetSerializerThrowUnknown) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
     EXPECT_CALL(*mockServer.dm, getComponentSerializer(::testing::_, ::testing::_, ::testing::_, ::testing::_)).Times(1)
@@ -456,22 +422,24 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetSerializerThrowUnknown
             throw std::runtime_error(rc.what());
             return nullptr;
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
     // Sending the RPC.
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }
 
 /*
  * TEST 10 - serializer.getNext() throws a catena::exception_with_status.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetNextThrowCatena) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Component not found", catena::StatusCode::INVALID_ARGUMENT);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     std::unique_ptr<MockDevice::MockDeviceSerializer> mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
 
     // Mocking kProcess functions
@@ -484,31 +452,33 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetNextThrowCatena) {
     EXPECT_CALL(*mockServer.dm, mutex()).Times(3).WillRepeatedly(::testing::ReturnRef(mockServer.mtx));
     // Reading 2 components successfully before throwing an exception.
     EXPECT_CALL(*mockSerializer, getNext()).Times(3)
-        .WillOnce(::testing::Return(testRPC.expVals[0]))
-        .WillOnce(::testing::Return(testRPC.expVals[1]))
+        .WillOnce(::testing::Return(client.expVals[0]))
+        .WillOnce(::testing::Return(client.expVals[1]))
         .WillOnce(::testing::Invoke([this, &rc](){
             throw catena::exception_with_status(rc.what(), rc.status);
-            return testRPC.expVals[2];
+            return client.expVals[2];
         }));
     EXPECT_CALL(*mockSerializer, hasMore()).Times(2)
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(true));
     // Mocking kFinish functions.
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }
 
 /*
  * TEST 11 - serializer.getNext() throws a std::runtime_exception.
  */
 TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetNextThrowUnknown) {
+    new DeviceRequest(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    testRPC.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
+    client.expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     std::unique_ptr<MockDevice::MockDeviceSerializer> mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
 
     // Mocking kProcess functions
@@ -521,21 +491,21 @@ TEST_F(gRPCDeviceRequestTests, DeviceRequest_proceedErrGetNextThrowUnknown) {
     EXPECT_CALL(*mockServer.dm, mutex()).Times(3).WillRepeatedly(::testing::ReturnRef(mockServer.mtx));
     // Reading 2 components successfully before throwing an exception.
     EXPECT_CALL(*mockSerializer, getNext()).Times(3)
-        .WillOnce(::testing::Return(testRPC.expVals[0]))
-        .WillOnce(::testing::Return(testRPC.expVals[1]))
+        .WillOnce(::testing::Return(client.expVals[0]))
+        .WillOnce(::testing::Return(client.expVals[1]))
         .WillOnce(::testing::Invoke([this, &rc](){
             throw std::runtime_error(rc.what());
-            return testRPC.expVals[2];
+            return client.expVals[2];
         }));
     EXPECT_CALL(*mockSerializer, hasMore()).Times(2)
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(true));
     // Mocking kFinish functions.
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
 
-    testRPC.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
-    testRPC.Await();
+    client.MakeCall(mockServer.client.get(), catena::DeviceRequestPayload());
+    client.Await();
 }

--- a/unittests/cpp/gRPC/tests/GetPopulatedSlots_test.cpp
+++ b/unittests/cpp/gRPC/tests/GetPopulatedSlots_test.cpp
@@ -47,7 +47,7 @@
 #include <google/protobuf/util/json_util.h>
 
 // Test helpers
-#include "MockServer.h"
+#include "GRPCTest.h"
 
 // gRPC
 #include "controllers/GetPopulatedSlots.h"
@@ -56,26 +56,9 @@ using namespace catena::common;
 using namespace catena::gRPC;
 
 // Fixture
-class gRPCGetPopulatedSlotsTests : public ::testing::Test {
-  protected:
-    /*
-     * Called at the start of all tests.
-     * Starts the mockServer.
-     */
-    static void SetUpTestSuite() {
-        mockServer.start();
-    }
-
-    /*
-     * Sets up expectations for the creation of a new CallData obj.
-     */
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-        // We can always assume that a new CallData obj is created.
-        // Either from initialization or kProceed.
-        mockServer.expNew();
-    }
+class gRPCGetPopulatedSlotsTests : public GRPCTest {
+  public:
+    gRPCGetPopulatedSlotsTests() : GRPCTest() {}
 
     /* 
      * Makes an async RPC to the MockServer and waits for a response before
@@ -95,39 +78,6 @@ class gRPCGetPopulatedSlotsTests : public ::testing::Test {
         EXPECT_EQ(outRc.error_message(), expRc.error_message());
     }
 
-    /*
-     * Restores cout after each test.
-     */
-    void TearDown() override {
-        std::cout.rdbuf(oldCout);
-    }
-
-    /*
-     * Called at the end of all tests, shuts down the server and cleans up.
-     */
-    static void TearDownTestSuite() {
-        // Redirecting cout to a stringstream for testing.
-        std::stringstream MockConsole;
-        std::streambuf* oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-        // Destroying the server.
-        EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
-            delete mockServer.testCall;
-            mockServer.testCall = nullptr;
-        }));
-        mockServer.shutdown();
-        // Restoring cout
-        std::cout.rdbuf(oldCout);
-    }
-
-    // Console variables
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    // Client variables.
-    grpc::ClientContext clientContext;
-    bool done = false;
-    std::condition_variable cv;
-    std::mutex cv_mtx;
-    std::unique_lock<std::mutex> lock{cv_mtx};
     catena::Empty inVal;
     catena::SlotList outVal;
     grpc::Status outRc;
@@ -135,11 +85,7 @@ class gRPCGetPopulatedSlotsTests : public ::testing::Test {
     catena::SlotList expVal;
     grpc::Status expRc;
     uint32_t testSlot = 1;
-
-    static MockServer mockServer;
 };
-
-MockServer gRPCGetPopulatedSlotsTests::mockServer;
 
 /*
  * ============================================================================
@@ -159,13 +105,15 @@ TEST_F(gRPCGetPopulatedSlotsTests, GetPopulatedSlots_create) {
  * TEST 2 - Normal case for GetPopulatedSlots proceed().
  */
 TEST_F(gRPCGetPopulatedSlotsTests, GetPopulatedSlots_proceedNormal) {
+    new GetPopulatedSlots(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("", catena::StatusCode::OK);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     expVal.add_slots(testSlot);
 
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.dm, slot()).Times(1).WillOnce(::testing::Return(testSlot));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));

--- a/unittests/cpp/gRPC/tests/GetValue_test.cpp
+++ b/unittests/cpp/gRPC/tests/GetValue_test.cpp
@@ -47,7 +47,7 @@
 #include <google/protobuf/util/json_util.h>
 
 // Test helpers
-#include "MockServer.h"
+#include "GRPCTest.h"
 
 // gRPC
 #include "controllers/GetValue.h"
@@ -56,28 +56,12 @@ using namespace catena::common;
 using namespace catena::gRPC;
 
 // Fixture
-class gRPCGetValueTests : public ::testing::Test {
-  protected:
-    /*
-     * Called at the start of all tests.
-     * Starts the mockServer and initializes the static inVal.
-     */
-    static void SetUpTestSuite() {
-        mockServer.start();
+class gRPCGetValueTests : public GRPCTest {
+  public:
+    gRPCGetValueTests() : GRPCTest() {
         // Setting up the inVal used across all tests.
         inVal.set_slot(1);
         inVal.set_oid("/test_oid");
-    }
-
-    /*
-     * Sets up expectations for the creation of a new CallData obj.
-     */
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-        // We can always assume that a new CallData obj is created.
-        // Either from initialization or kProceed.
-        mockServer.expNew();
     }
 
     /* 
@@ -98,53 +82,13 @@ class gRPCGetValueTests : public ::testing::Test {
         EXPECT_EQ(outRc.error_message(), expRc.error_message());
     }
 
-    /*
-     * Restores cout after each test.
-     */
-    void TearDown() override {
-        std::cout.rdbuf(oldCout);
-    }
-
-    /*
-     * Called at the end of all tests, shuts down the server and cleans up.
-     */
-    static void TearDownTestSuite() {
-        // Redirecting cout to a stringstream for testing.
-        std::stringstream MockConsole;
-        std::streambuf* oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-        // Destroying the server.
-        EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
-            delete mockServer.testCall;
-            mockServer.testCall = nullptr;
-        }));
-        mockServer.shutdown();
-        // Restoring cout
-        std::cout.rdbuf(oldCout);
-    }
-
-    // Console variables
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    // Client variables.
-    grpc::ClientContext clientContext;
-    bool done = false;
-    std::condition_variable cv;
-    std::mutex cv_mtx;
-    std::unique_lock<std::mutex> lock{cv_mtx};
-    static catena::GetValuePayload inVal;
+    catena::GetValuePayload inVal;
     catena::Value outVal;
     grpc::Status outRc;
     // Expected variables
     catena::Value expVal;
     grpc::Status expRc;
-
-    static MockServer mockServer;
 };
-
-MockServer gRPCGetValueTests::mockServer;
-// Static as its only used to make sure the correct obj is passed into mocked
-// functions.
-catena::GetValuePayload gRPCGetValueTests::inVal;
 
 /*
  * ============================================================================
@@ -164,6 +108,8 @@ TEST_F(gRPCGetValueTests, GetValue_create) {
  * TEST 2 - Normal case for GetValue proceed().
  */
 TEST_F(gRPCGetValueTests, GetValue_proceed) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("", catena::StatusCode::OK);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     expVal.set_string_value("test_value");
@@ -178,7 +124,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceed) {
             value.CopyFrom(expVal);
             return catena::exception_with_status(rc.what(), rc.status);
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
@@ -191,6 +137,8 @@ TEST_F(gRPCGetValueTests, GetValue_proceed) {
  * TEST 3 - GetValue with authz on and valid token.
  */
 TEST_F(gRPCGetValueTests, GetValue_proceedAuthzValid) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+    
     catena::exception_with_status rc("", catena::StatusCode::OK);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     expVal.set_string_value("test_value");
@@ -219,7 +167,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceedAuthzValid) {
             value.CopyFrom(expVal);
             return catena::exception_with_status(rc.what(), rc.status);
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
@@ -232,6 +180,8 @@ TEST_F(gRPCGetValueTests, GetValue_proceedAuthzValid) {
  * TEST 4 - GetValue with authz on and invalid token.
  */
 TEST_F(gRPCGetValueTests, GetValue_proceedAuthzInvalid) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+    
     catena::exception_with_status rc("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Not a token so it should get rejected by the authorizer.
@@ -239,7 +189,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceedAuthzInvalid) {
 
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(2).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
@@ -252,6 +202,8 @@ TEST_F(gRPCGetValueTests, GetValue_proceedAuthzInvalid) {
  * TEST 5 - GetValue with authz on and invalid token.
  */
 TEST_F(gRPCGetValueTests, GetValue_proceedAuthzJWSNotFound) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+    
     catena::exception_with_status rc("JWS bearer token not found", catena::StatusCode::UNAUTHENTICATED);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
     // Should not be able to find the bearer token.
@@ -259,7 +211,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceedAuthzJWSNotFound) {
 
     // Mocking kProcess and kFinish functions
     EXPECT_CALL(*mockServer.service, authorizationEnabled()).Times(2).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
@@ -272,6 +224,8 @@ TEST_F(gRPCGetValueTests, GetValue_proceedAuthzJWSNotFound) {
  * TEST 6 - dm.getValue() returns a catena::exception_with_status.
  */
 TEST_F(gRPCGetValueTests, GetValue_proceedErrReturnCatena) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+    
     catena::exception_with_status rc("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
 
@@ -282,7 +236,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceedErrReturnCatena) {
         .WillOnce(::testing::Invoke([this, &rc](const std::string& jptr, catena::Value& value, Authorizer& authz) {
             return catena::exception_with_status(rc.what(), rc.status);
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
@@ -295,6 +249,8 @@ TEST_F(gRPCGetValueTests, GetValue_proceedErrReturnCatena) {
  * TEST 7 - dm.getValue() throws a catena::exception_with_status.
  */
 TEST_F(gRPCGetValueTests, GetValue_proceedErrThrowCatena) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+    
     catena::exception_with_status rc("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
 
@@ -306,7 +262,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceedErrThrowCatena) {
             throw catena::exception_with_status(rc.what(), rc.status);
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));
@@ -319,6 +275,8 @@ TEST_F(gRPCGetValueTests, GetValue_proceedErrThrowCatena) {
  * TEST 8 - dm.getValue() throws a std::runtime_exception.
  */
 TEST_F(gRPCGetValueTests, GetValue_proceedErrThrowUnknown) {
+    new GetValue(mockServer.service, *mockServer.dm, true);
+
     catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
     expRc = grpc::Status(static_cast<grpc::StatusCode>(rc.status), rc.what());
 
@@ -330,7 +288,7 @@ TEST_F(gRPCGetValueTests, GetValue_proceedErrThrowUnknown) {
             throw std::runtime_error(rc.what());
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
-    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([]() {
+    EXPECT_CALL(*mockServer.service, deregisterItem(::testing::_)).Times(1).WillOnce(::testing::Invoke([this]() {
         delete mockServer.testCall;
         mockServer.testCall = nullptr;
     }));


### PR DESCRIPTION
Issue # 751

Server now starts and shuts down for every test case setup/teardown code inherited from common GRPCTest class