### PR TITLE
REST Unit Test Refactor

### DIFF
--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -90,10 +90,5 @@ void Connect::finish() {
     if (valueSetByClientId_ != 0) { dm_.valueSetByClient.disconnect(valueSetByClientId_); }
     if (valueSetByServerId_ != 0) { dm_.valueSetByServer.disconnect(valueSetByServerId_); }
     if (languageAddedId_ != 0) { dm_.languageAddedPushUpdate.disconnect(languageAddedId_); }
-    // Finishing and closing the socket.
-    if (socket_.is_open()) {
-        writer_.sendResponse(catena::exception_with_status("", catena::StatusCode::OK));
-        socket_.close();
-    }
     std::cout << "Connect[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
@@ -53,9 +53,6 @@ ParamInfoRequest::ParamInfoRequest(tcp::socket& socket, ISocketReader& context, 
     rc_("", catena::StatusCode::OK), recursive_{false} {
     objectId_ = objectCounter_++;
     writeConsole_(CallStatus::kCreate, socket_.is_open());
-    
-    // Get recursive from query parameters - presence alone means true
-    recursive_ = context_.hasField("recursive");
 }
 
 void ParamInfoRequest::proceed() {
@@ -66,6 +63,9 @@ void ParamInfoRequest::proceed() {
         catena::exception_with_status rc{"", catena::StatusCode::OK};
         std::shared_ptr<Authorizer> sharedAuthz;
         Authorizer* authz;
+
+        // Get recursive from query parameters - presence alone means true
+        recursive_ = context_.hasField("recursive");
         
         // Handle authorization setup
         try {

--- a/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
@@ -60,144 +60,114 @@ void ParamInfoRequest::proceed() {
 
     try {
         std::unique_ptr<IParam> param;
-        catena::exception_with_status rc{"", catena::StatusCode::OK};
         std::shared_ptr<Authorizer> sharedAuthz;
         Authorizer* authz;
 
         // Get recursive from query parameters - presence alone means true
         recursive_ = context_.hasField("recursive");
-        
+
         // Handle authorization setup
-        try {
-            if (context_.authorizationEnabled()) {
-                sharedAuthz = std::make_shared<Authorizer>(context_.jwsToken());
-                authz = sharedAuthz.get();
-            } else {
-                authz = &Authorizer::kAuthzDisabled;
-            }
-        } catch (const catena::exception_with_status& err) {
-            rc_ = catena::exception_with_status(err.what(), err.status);
-        } catch (const std::exception& e) {
-            rc_ = catena::exception_with_status(std::string("Authorization setup failed: ") + e.what(), catena::StatusCode::UNAUTHENTICATED);
+        if (context_.authorizationEnabled()) {
+            sharedAuthz = std::make_shared<Authorizer>(context_.jwsToken());
+            authz = sharedAuthz.get();
+        } else {
+            authz = &Authorizer::kAuthzDisabled;
         }
 
-        if (rc_.status == catena::StatusCode::OK) {
-            // Mode 1: Get all top-level parameters without recursion
-            if (context_.fqoid().empty() && !recursive_) {
-                std::vector<std::unique_ptr<IParam>> top_level_params;
-
-                {
-                    std::lock_guard lg(dm_.mutex());
-                    top_level_params = dm_.getTopLevelParams(rc, *authz);
-                }
-
-                if (rc.status != catena::StatusCode::OK) {
-                    rc_ = catena::exception_with_status(rc.what(), rc.status);
-                } else if (top_level_params.empty()) {
+        // Mode 1: Get all top-level parameters without recursion
+        if (context_.fqoid().empty() && !recursive_) {
+            std::vector<std::unique_ptr<IParam>> top_level_params;
+            {
+                std::lock_guard lg(dm_.mutex());
+                top_level_params = dm_.getTopLevelParams(rc_, *authz);
+            }
+                
+            // Process each top-level parameter
+            if (rc_.status == catena::StatusCode::OK)  {
+                if (top_level_params.empty()) {
                     rc_ = catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
                 } else {
                     std::lock_guard lg(dm_.mutex());
                     responses_.clear();
-                    // Process each top-level parameter
                     for (auto& top_level_param : top_level_params) {
-                        try {
-                            // Add the parameter to our response list
-                            addParamToResponses_(top_level_param.get(), *authz);
-                            // For array types, calculate and update array length
-                            if (top_level_param->isArrayType()) {
-                                uint32_t array_length = top_level_param->size();
-                                if (array_length > 0) {
-                                    updateArrayLengths_(top_level_param->getOid(), array_length);
-                                }
+                        // Add the parameter to our response list
+                        addParamToResponses_(top_level_param.get(), *authz);
+                        // For array types, calculate and update array length
+                        if (top_level_param->isArrayType()) {
+                            uint32_t array_length = top_level_param->size();
+                            if (array_length > 0) {
+                                updateArrayLengths_(top_level_param->getOid(), array_length);
                             }
-                        } catch (const catena::exception_with_status& err) {
-                            rc_ = catena::exception_with_status(err.what(), err.status);
-                            break;
                         }
                     }
                 }
             }
-            // Mode 2: Get all top-level parameters with recursion
-            else if (context_.fqoid().empty() && recursive_) {
-                std::vector<std::unique_ptr<IParam>> top_level_params;
-
-                {
-                    std::lock_guard lg(dm_.mutex());
-                    top_level_params = dm_.getTopLevelParams(rc, *authz);
-                }
-
-                if (rc.status != catena::StatusCode::OK) {
-                    rc_ = catena::exception_with_status(rc.what(), rc.status);
-                } else if (top_level_params.empty()) {
+        }
+        // Mode 2: Get all top-level parameters with recursion
+        else if (context_.fqoid().empty() && recursive_) {
+            std::vector<std::unique_ptr<IParam>> top_level_params;
+            {
+                std::lock_guard lg(dm_.mutex());
+                top_level_params = dm_.getTopLevelParams(rc_, *authz);
+            }
+            if (rc_.status == catena::StatusCode::OK) {
+                if (top_level_params.empty()) {
                     rc_ = catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
                 } else {
                     std::lock_guard lg(dm_.mutex());
                     responses_.clear();
                     // Process each top-level parameter recursively
                     for (auto& top_level_param : top_level_params) {
-                        try {
-                            // Add the parameter to our response list
-                            addParamToResponses_(top_level_param.get(), *authz);
-                            // For array types, calculate and update array length
-                            if (top_level_param->isArrayType()) {
-                                uint32_t array_length = top_level_param->size();
-                                if (array_length > 0) {
-                                    updateArrayLengths_(top_level_param->getOid(), array_length);
-                                }
+                        // Add the parameter to our response list
+                        addParamToResponses_(top_level_param.get(), *authz);
+                        // For array types, calculate and update array length
+                        if (top_level_param->isArrayType()) {
+                            uint32_t array_length = top_level_param->size();
+                            if (array_length > 0) {
+                                updateArrayLengths_(top_level_param->getOid(), array_length);
                             }
-                            // Recursively traverse all children of the top-level parameter
-                            ParamInfoVisitor visitor(dm_, *authz, responses_, *this);
-                            ParamVisitor::traverseParams(top_level_param.get(), "/" + top_level_param->getOid(), dm_, visitor);
-                        } catch (const catena::exception_with_status& err) {
-                            rc_ = catena::exception_with_status(err.what(), err.status);
-                            break;
                         }
+                        // Recursively traverse all children of the top-level parameter
+                        ParamInfoVisitor visitor(dm_, *authz, responses_, *this);
+                        ParamVisitor::traverseParams(top_level_param.get(), "/" + top_level_param->getOid(), dm_, visitor);
                     }
                 }
             }
-            // Mode 3: Get a specific parameter and its children
-            else if (!context_.fqoid().empty()) { 
-                {
-                    std::lock_guard lg(dm_.mutex());
-                    param = dm_.getParam(context_.fqoid(), rc, *authz);
-                }
+        }
+        // Mode 3: Get a specific parameter and its children
+        else if (!context_.fqoid().empty()) { 
+            {
+                std::lock_guard lg(dm_.mutex());
+                param = dm_.getParam(context_.fqoid(), rc_, *authz);
+            }
 
-                if (rc.status != catena::StatusCode::OK) {
-                    rc_ = catena::exception_with_status(rc.what(), rc.status);
-                } else if (!param) {
+            if (rc_.status == catena::StatusCode::OK) {
+                if (!param) {
                     rc_ = catena::exception_with_status("Parameter not found: " + context_.fqoid(), catena::StatusCode::NOT_FOUND);
                 } else {
                     responses_.clear();
-                    
-                    try {
-                        // Add the main parameter first 
-                        responses_.emplace_back();
-                        param->toProto(responses_.back(), *authz);
-                        
-                        // If the parameter is an array, update the array length
-                        if (param->isArrayType()) {
-                            uint32_t array_length = param->size();
-                            if (array_length > 0) {
-                                updateArrayLengths_(param->getOid(), array_length);
-                            }
+                    // Add the main parameter first 
+                    responses_.emplace_back();
+                    param->toProto(responses_.back(), *authz);
+                    // If the parameter is an array, update the array length
+                    if (param->isArrayType()) {
+                        uint32_t array_length = param->size();
+                        if (array_length > 0) {
+                            updateArrayLengths_(param->getOid(), array_length);
                         }
-                        
-                        // If recursive is true, collect all parameter info recursively through visitor pattern
-                        if (recursive_) {
-                            ParamInfoVisitor visitor(dm_, *authz, responses_, *this);
-                            ParamVisitor::traverseParams(param.get(), context_.fqoid(), dm_, visitor);
-                        }
-                    } catch (const catena::exception_with_status& err) {
-                        rc_ = catena::exception_with_status(err.what(), err.status);
+                    }
+                    // If recursive is true, collect all parameter info recursively through visitor pattern
+                    if (recursive_) {
+                        ParamInfoVisitor visitor(dm_, *authz, responses_, *this);
+                        ParamVisitor::traverseParams(param.get(), context_.fqoid(), dm_, visitor);
                     }
                 }
             }
-
         }
     } catch (const catena::exception_with_status& err) {
         rc_ = catena::exception_with_status(err.what(), err.status);
     } catch (const std::exception& e) {
-        rc_ = catena::exception_with_status(std::string("Unknown error in ParamInfoRequest: ") + e.what(), catena::StatusCode::UNKNOWN);
+        rc_ = catena::exception_with_status(std::string("Unknown error in ParamInfoRequest: ") + e.what(), catena::StatusCode::INTERNAL);
     } catch (...) {
         rc_ = catena::exception_with_status("Unknown error in ParamInfoRequest", catena::StatusCode::UNKNOWN);
     }

--- a/sdks/cpp/connections/REST/src/controllers/Subscriptions.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Subscriptions.cpp
@@ -38,16 +38,12 @@ int Subscriptions::objectCounter_ = 0;
 Subscriptions::Subscriptions(tcp::socket& socket, ISocketReader& context, IDevice& dm)
     : socket_(socket), context_(context), dm_(dm) {
     
-    // GET
-    if (context.method() == "GET") {
-        if (context.stream()) {
-            writer_ = std::make_unique<SSEWriter>(socket_, context_.origin());
-        } else {
-            writer_ = std::make_unique<SocketWriter>(socket_, context_.origin(), true);
-        }
-    // PUT
+    // GET (stream)
+    if (context.method() == "GET" && context.stream()) {
+        writer_ = std::make_unique<SSEWriter>(socket_, context_.origin());
+    // GET (no stream) or PUT
     } else {
-        writer_ = std::make_unique<SocketWriter>(socket_, context_.origin());
+        writer_ = std::make_unique<SocketWriter>(socket_, context_.origin(), true);
     }
 
     objectId_ = objectCounter_++;

--- a/unittests/cpp/REST/CMakeLists.txt
+++ b/unittests/cpp/REST/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     tests/BasicParamInfoRequest_test.cpp
     tests/Subscriptions_test.cpp
     tests/Connect_test.cpp
+    tests/ExecuteCommand_test.cpp
 
     ${CATENA_CPP_ROOT_DIR}/connections/REST/src/SocketReader.cpp
     ${CATENA_CPP_ROOT_DIR}/connections/REST/src/SocketWriter.cpp
@@ -36,6 +37,7 @@ set(SOURCES
     ${CATENA_CPP_ROOT_DIR}/connections/REST/src/controllers/GetParam.cpp
     ${CATENA_CPP_ROOT_DIR}/connections/REST/src/controllers/BasicParamInfoRequest.cpp
     ${CATENA_CPP_ROOT_DIR}/connections/REST/src/controllers/Subscriptions.cpp
+    ${CATENA_CPP_ROOT_DIR}/connections/REST/src/controllers/ExecuteCommand.cpp
 )	
 
 add_executable(${This} ${SOURCES})	

--- a/unittests/cpp/REST/RESTTest.h
+++ b/unittests/cpp/REST/RESTTest.h
@@ -191,6 +191,8 @@ class RESTTest {
     }
 
     std::string origin = "*";
+
+    // Read/write helper variables.
     boost::asio::io_context io_context;
     tcp::socket clientSocket{io_context};
     tcp::socket serverSocket{io_context};

--- a/unittests/cpp/REST/RESTTest.h
+++ b/unittests/cpp/REST/RESTTest.h
@@ -165,7 +165,7 @@ class RESTTest {
     inline std::string expectedResponse(const catena::exception_with_status& rc, const std::vector<std::string>& msgs) {
         // Compiling body response from messages.
         std::string jsonBody = "";
-        if (rc.status == catena::StatusCode::OK) {
+        if (rc.status == catena::StatusCode::OK && !msgs.empty()) {
             for (const std::string& msg : msgs) {
                 if (jsonBody.empty()) {
                     jsonBody += "{\"data\":[" + msg;
@@ -271,7 +271,7 @@ class RESTEndpointTest : public ::testing::Test, public RESTTest {
     std::string method_ = "GET";
     uint32_t slot_ = 0;
     std::string fqoid_ = "";
-    bool stream_ = true;
+    bool stream_ = false;
     bool authzEnabled_ = false;
     std::string jsonBody_ = "";
     std::string jwsToken_ = "";

--- a/unittests/cpp/REST/RESTTest.h
+++ b/unittests/cpp/REST/RESTTest.h
@@ -238,6 +238,7 @@ class RESTEndpointTest : public ::testing::Test, public RESTTest {
         EXPECT_CALL(context_, slot()).WillRepeatedly(::testing::Invoke([this]() { return slot_; }));
         EXPECT_CALL(context_, fqoid()).WillRepeatedly(::testing::ReturnRef(fqoid_));
         EXPECT_CALL(context_, jsonBody()).WillRepeatedly(::testing::ReturnRef(jsonBody_));
+        EXPECT_CALL(context_, jwsToken()).WillRepeatedly(::testing::ReturnRef(jwsToken_));
         EXPECT_CALL(context_, authorizationEnabled()).WillRepeatedly(::testing::Invoke([this]() { return authzEnabled_; }));
         EXPECT_CALL(context_, stream()).WillRepeatedly(::testing::Invoke([this]() { return stream_; }));
         // Default expectations for the device model.
@@ -263,6 +264,7 @@ class RESTEndpointTest : public ::testing::Test, public RESTTest {
     bool stream_ = true;
     bool authzEnabled_ = false;
     std::string jsonBody_ = "";
+    std::string jwsToken_ = "";
     // Expected variables
     catena::exception_with_status expRc_{"", catena::StatusCode::OK};
 

--- a/unittests/cpp/REST/tests/BasicParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/BasicParamInfoRequest_test.cpp
@@ -66,20 +66,20 @@ using namespace catena::REST;
 // Fixture
 class RESTBasicParamInfoRequestTests : public ::testing::Test, public RESTTest {
 protected:
-    RESTBasicParamInfoRequestTests() : RESTTest(&serverSocket, &clientSocket) {}
+    RESTBasicParamInfoRequestTests() : RESTTest(&serverSocket_, &clientSocket_) {}
 
     void SetUp() override {
         // Redirecting cout to a stringstream for testing
         oldCout = std::cout.rdbuf(MockConsole.rdbuf());
 
         // Set default actions for common mock calls
-        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin));
+        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin_));
         EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
         EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(empty_prefix));
         EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
         EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
 
-        request = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+        request = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
     }
 
     void TearDown() override {
@@ -216,7 +216,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_authz_valid_token) 
         }));
 
     // Make a new request for this test
-    auto authzRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto authzRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
     
     // Execute
     authzRequest->proceed();
@@ -500,7 +500,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
         ));
 
     // Create a new request after setting up all expectations
-    auto deepNestingRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto deepNestingRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     // Execute
     deepNestingRequest->proceed();
@@ -581,7 +581,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
             }));
 
     // Create a new request after setting up all expectations
-    auto arrayRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto arrayRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     // Execute
     arrayRequest->proceed();
@@ -668,7 +668,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
             }));
 
     // Create a new request after setting up all expectations
-    auto errorRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto errorRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     // Execute
     errorRequest->proceed();
@@ -697,7 +697,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
         }));
 
     // Create a new request after setting up all expectations
-    auto errorStatusRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto errorStatusRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     // Execute
     errorStatusRequest->proceed();
@@ -726,7 +726,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getTopLevelParamsWi
         }));
 
     // Create a new request after setting up all expectations
-    auto emptyListRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto emptyListRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     // Execute
     emptyListRequest->proceed();

--- a/unittests/cpp/REST/tests/BasicParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/BasicParamInfoRequest_test.cpp
@@ -761,7 +761,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_proceedSpecificPara
         ));
     
     // Create a new request for this test
-    auto specificRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto specificRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
     
     specificRequest->proceed();
     specificRequest->finish();
@@ -808,7 +808,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_getSpecificParamWit
         ));
 
     // Create a new request for this test
-    auto recursiveRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto recursiveRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     recursiveRequest->proceed();
     recursiveRequest->finish();
@@ -841,7 +841,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_parameterNotFound) 
         }));
 
     // Create a new request for this test
-    auto notFoundRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto notFoundRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     notFoundRequest->proceed();
     notFoundRequest->finish();
@@ -889,7 +889,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_catenaExceptionInGe
         ));
 
     // Create a new request for this test
-    auto exceptionRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto exceptionRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     exceptionRequest->proceed();
     exceptionRequest->finish();
@@ -922,7 +922,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_catchCatenaExceptio
         }));
 
     // Create a new request for this test
-    auto catenaExceptionRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto catenaExceptionRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     catenaExceptionRequest->proceed();
     catenaExceptionRequest->finish();
@@ -953,7 +953,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_catchStdException) 
         }));
 
     // Create a new request for this test
-    auto stdExceptionRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto stdExceptionRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     stdExceptionRequest->proceed();
     stdExceptionRequest->finish();
@@ -984,7 +984,7 @@ TEST_F(RESTBasicParamInfoRequestTests, BasicParamInfoRequest_catchUnknownExcepti
         }));
 
     // Create a new request for this test
-    auto unknownExceptionRequest = BasicParamInfoRequest::makeOne(serverSocket, context, dm);
+    auto unknownExceptionRequest = BasicParamInfoRequest::makeOne(serverSocket_, context, dm);
 
     unknownExceptionRequest->proceed();
     unknownExceptionRequest->finish();

--- a/unittests/cpp/REST/tests/Connect_test.cpp
+++ b/unittests/cpp/REST/tests/Connect_test.cpp
@@ -32,7 +32,7 @@
  * @brief This file is for testing the DeviceRequest.cpp file.
  * @author zuhayr.sarker@rossvideo.com
  * @author benjamin.whitten@rossvideo.com
- * @date 2025-06-20
+ * @date 2025-06-23
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 

--- a/unittests/cpp/REST/tests/Connect_test.cpp
+++ b/unittests/cpp/REST/tests/Connect_test.cpp
@@ -1,55 +1,70 @@
-#include <gtest/gtest.h>
-#include "controllers/Connect.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief This file is for testing the DeviceRequest.cpp file.
+ * @author zuhayr.sarker@rossvideo.com
+ * @author benjamin.whitten@rossvideo.com
+ * @date 2025-06-20
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+// Test helpers
 #include "RESTTest.h"
-#include "CommonTestHelpers.h"
 #include "MockSubscriptionManager.h"
+#include "MockParam.h"
 #include "MockLanguagePack.h"
-#include <boost/asio.hpp>
 
-using namespace catena::REST;
+// REST
+#include "controllers/Connect.h"
+
 using namespace catena::common;
-using namespace testing;
+using namespace catena::REST;
 
-class RESTConnectTest : public ::testing::Test, public RESTTest {
+class RESTConnectTest : public RESTEndpointTest {
 protected:
-    RESTConnectTest() : RESTTest(&serverSocket_, &clientSocket_) {}
-
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Set up common expectations
-        setupCommonExpectations();
-        
-        // Create Connect instance
-        connect_ = catena::REST::Connect::makeOne(serverSocket_, socket_reader_, device_);
+    RESTConnectTest() : RESTEndpointTest() {
+        EXPECT_CALL(context_, detailLevel())
+            .WillRepeatedly(testing::Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
+        EXPECT_CALL(context_, getSubscriptionManager())
+            .WillRepeatedly(testing::ReturnRef(subManager_));
+        EXPECT_CALL(context_, fields("user_agent"))
+            .WillRepeatedly(testing::ReturnRef(userAgent_));
+        EXPECT_CALL(context_, hasField("force_connection"))
+            .WillRepeatedly(testing::Return(false));
     }
 
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        
-        if (connect_) {
-            delete connect_;
-        }
-    }
-
-    // Helper function to set up common mock expectations
-    void setupCommonExpectations() {
-        EXPECT_CALL(socket_reader_, detailLevel())
-            .WillRepeatedly(Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
-        EXPECT_CALL(device_, slot())
-            .WillRepeatedly(Return(1));
-        EXPECT_CALL(socket_reader_, getSubscriptionManager())
-            .WillRepeatedly(ReturnRef(subscription_manager_));
-        EXPECT_CALL(socket_reader_, origin())
-            .WillRepeatedly(ReturnRef(origin_));
-        EXPECT_CALL(socket_reader_, fields("user_agent"))
-            .WillRepeatedly(ReturnRef(user_agent_));
-        EXPECT_CALL(socket_reader_, hasField("force_connection"))
-            .WillRepeatedly(Return(false));
-    }
+    /*
+     * Creates a Connect handler object.
+     */
+    ICallData* makeOne() override { return catena::REST::Connect::makeOne(serverSocket_, context_, dm0_); }
 
     // Helper function to build slot response
     std::string buildSlotResponse(uint32_t slot) {
@@ -91,198 +106,141 @@ protected:
         auto status = google::protobuf::util::MessageToJsonString(updateResponse, &updateJson, options);
         return updateJson;
     }
-    MockSocketReader socket_reader_;
-    MockDevice device_;
-    catena::REST::ICallData* connect_ = nullptr;
-    MockSubscriptionManager subscription_manager_;
-    std::string user_agent_ = "test_agent";
+
+    MockSubscriptionManager subManager_;
+    std::string userAgent_ = "test_agent";
     std::string paramOid_ = "test_param";
-    
-    // Cout variables.
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
 };
 
 // --- 0. INITIAL TESTS ---
 
 // Test 0.1: Test constructor initialization
-TEST_F(RESTConnectTest, ConstructorInitialization) {
-    ASSERT_NE(connect_, nullptr);
+TEST_F(RESTConnectTest, Connect_Create) {
+    ASSERT_TRUE(endpoint_);
+}
+
+// Test 2.1: Test finish behaviour with no active signal handlers
+TEST_F(RESTConnectTest, FinishClosesConnection) {
+    EXPECT_NO_THROW(endpoint_->finish());
+    ASSERT_TRUE(MockConsole_.str().find("Connect[1] finished\n") != std::string::npos);
 }
 
 // Test 0.2: Test unauthorized connection
 TEST_F(RESTConnectTest, ProceedHandlesAuthzError) {
-    std::string mockToken = "invalid_token";
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(mockToken));
+    jwsToken_ = "invalid_token";
+    authzEnabled_ = true;
+    expRc_ = catena::exception_with_status("", catena::StatusCode::UNAUTHENTICATED);
     
-    connect_->proceed();
-    EXPECT_EQ(readResponse(), expectedSSEResponse(rc));
+    endpoint_->proceed();
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 0.3: Test authorized connection
 TEST_F(RESTConnectTest, ProceedHandlesValidAuthz) {
-    std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
-                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
-                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
-                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
-                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
-                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
-                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
-                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
-                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
-                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
-                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
-                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-    catena::exception_with_status rc("", catena::StatusCode::OK);
+    jwsToken_ = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw"
+                "IiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uIiwiaWF0I"
+                "joxNTE2MjM5MDIyfQ.YkqS7hCxstpXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
+    authzEnabled_ = true;
 
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(mockToken));
-    EXPECT_CALL(device_, slot())
-        .WillRepeatedly(Return(1));
-    EXPECT_CALL(socket_reader_, detailLevel())
-        .WillRepeatedly(Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
-
-    std::string slotJson = buildSlotResponse(1);
+    std::string slotJson = buildSlotResponse(0);
 
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_EQ(readResponse(), expectedSSEResponse(rc, {slotJson}));
-
     catena::REST::Connect::shutdownSignal_.emit();
-    serverSocket_.close();
     proceed_thread.join();
+
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson}));
+
+    endpoint_->finish();
 }
 
 // --- 1. SIGNAL TESTS ---
 
 // Test 1.1: Test value set by server signal
 TEST_F(RESTConnectTest, HandlesValueSetByServer) {
-    std::string mockToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxM"
-                            "jM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJ"
-                            "zdDIxMzg6bW9uIiwiaWF0IjoxNTE2MjM5MDIyfQ.YkqS7hCxst"
-                            "pXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
-
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(mockToken));
-    EXPECT_CALL(device_, slot())
-        .WillRepeatedly(Return(1));
-    EXPECT_CALL(socket_reader_, detailLevel())
-        .WillRepeatedly(Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
+    jwsToken_ = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw"
+                "IiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uIiwiaWF0I"
+                "joxNTE2MjM5MDIyfQ.YkqS7hCxstpXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
+    authzEnabled_ = true;
 
     auto param = std::make_unique<MockParam>();
     EXPECT_CALL(*param, getOid())
-        .WillRepeatedly(ReturnRef(paramOid_));
+        .WillRepeatedly(testing::ReturnRef(paramOid_));
     EXPECT_CALL(*param, getScope())
-        .WillRepeatedly(ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
+        .WillRepeatedly(testing::ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
     EXPECT_CALL(*param, toProto(::testing::An<catena::Value&>(), ::testing::An<catena::common::Authorizer&>()))
         .WillOnce(::testing::Invoke([](catena::Value& value, catena::common::Authorizer&) {
             value.set_string_value("test_value");
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
 
-    std::set<std::string> subscribed_oids{paramOid_};
-    EXPECT_CALL(subscription_manager_, getAllSubscribedOids(::testing::Ref(device_)))
-        .WillRepeatedly(Return(subscribed_oids));
-
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string slotJson = buildSlotResponse(1);
-    std::string updateJson = buildParamUpdateResponse(1, paramOid_, "test_value");
+    std::string slotJson = buildSlotResponse(0);
+    std::string updateJson = buildParamUpdateResponse(0, paramOid_, "test_value");
 
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-    device_.valueSetByServer.emit(paramOid_, param.get());
+    dm0_.valueSetByServer.emit(paramOid_, param.get());
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-    EXPECT_EQ(readResponse(), expectedSSEResponse(rc, {slotJson, updateJson}));
-
     catena::REST::Connect::shutdownSignal_.emit();
-    serverSocket_.close();
     proceed_thread.join();
+
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson, updateJson}));
+
+    endpoint_->finish();
 }
 
 // Test 1.2: Test value set by client signal
 TEST_F(RESTConnectTest, HandlesValueSetByClient) {
-    std::string mockToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxM"
-                            "jM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJ"
-                            "zdDIxMzg6bW9uIiwiaWF0IjoxNTE2MjM5MDIyfQ.YkqS7hCxst"
-                            "pXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
-
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(mockToken));
-    EXPECT_CALL(device_, slot())
-        .WillRepeatedly(Return(1));
-    EXPECT_CALL(socket_reader_, detailLevel())
-        .WillRepeatedly(Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
+    jwsToken_ = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw"
+                "IiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uIiwiaWF0I"
+                "joxNTE2MjM5MDIyfQ.YkqS7hCxstpXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
+    authzEnabled_ = true;
 
     auto param = std::make_unique<MockParam>();
     EXPECT_CALL(*param, getOid())
-        .WillRepeatedly(ReturnRef(paramOid_));
+        .WillRepeatedly(testing::ReturnRef(paramOid_));
     EXPECT_CALL(*param, getScope())
-        .WillRepeatedly(ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
+        .WillRepeatedly(testing::ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
     EXPECT_CALL(*param, toProto(::testing::An<catena::Value&>(), ::testing::An<catena::common::Authorizer&>()))
         .WillOnce(::testing::Invoke([](catena::Value& value, catena::common::Authorizer&) {
             value.set_string_value("test_value");
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
 
-    std::set<std::string> subscribed_oids{paramOid_};
-    EXPECT_CALL(subscription_manager_, getAllSubscribedOids(::testing::Ref(device_)))
-        .WillRepeatedly(Return(subscribed_oids));
-
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string slotJson = buildSlotResponse(1);
-    std::string updateJson = buildParamUpdateResponse(1, paramOid_, "test_value");
+    std::string slotJson = buildSlotResponse(0);
+    std::string updateJson = buildParamUpdateResponse(0, paramOid_, "test_value");
 
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-    device_.valueSetByClient.emit(paramOid_, param.get());
+    dm0_.valueSetByClient.emit(paramOid_, param.get());
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-    EXPECT_EQ(readResponse(), expectedSSEResponse(rc, {slotJson, updateJson}));
-
     catena::REST::Connect::shutdownSignal_.emit();
-    serverSocket_.close();
     proceed_thread.join();
+
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson, updateJson}));
+
+    endpoint_->finish();
 }
 
 // Test 1.3: Test language signal
 TEST_F(RESTConnectTest, HandlesLanguage) {
-    std::string mockToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxM"
-                            "jM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJ"
-                            "zdDIxMzg6bW9uIiwiaWF0IjoxNTE2MjM5MDIyfQ.YkqS7hCxst"
-                            "pXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
-
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(mockToken));
-    EXPECT_CALL(device_, slot())
-        .WillRepeatedly(Return(1));
-    EXPECT_CALL(socket_reader_, detailLevel())
-        .WillRepeatedly(Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
+    jwsToken_ = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw"
+                "IiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uIiwiaWF0I"
+                "joxNTE2MjM5MDIyfQ.YkqS7hCxstpXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
+    authzEnabled_ = true;
 
     auto languagePack = std::make_unique<MockLanguagePack>();
     EXPECT_CALL(*languagePack, toProto(::testing::_))
@@ -291,113 +249,34 @@ TEST_F(RESTConnectTest, HandlesLanguage) {
             (*pack.mutable_words())["greeting"] = "Hello";
         }));
 
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string slotJson = buildSlotResponse(1);
-    std::string updateJson = buildLanguagePackUpdateResponse(1, "English", {{"greeting", "Hello"}});
+    std::string slotJson = buildSlotResponse(0);
+    std::string updateJson = buildLanguagePackUpdateResponse(0, "English", {{"greeting", "Hello"}});
 
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-    device_.languageAddedPushUpdate.emit(languagePack.get());
+    dm0_.languageAddedPushUpdate.emit(languagePack.get());
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_EQ(readResponse(), expectedSSEResponse(rc, {slotJson, updateJson}));
-
-    catena::REST::Connect::shutdownSignal_.emit();
-    serverSocket_.close();
-    proceed_thread.join();
-}
-
-// --- 2. FINISH TESTS ---
-
-// Test 2.1: Test normal finish behavior
-TEST_F(RESTConnectTest, FinishClosesConnection) {
-    static const std::string empty_token;
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(false));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(empty_token));
-    
-    // Run proceed() in a separate thread since it blocks
-    std::thread proceed_thread([this]() {
-        connect_->proceed();
-    });
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    connect_->finish();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_FALSE(serverSocket_.is_open());
 
     catena::REST::Connect::shutdownSignal_.emit();
     proceed_thread.join();
-}
 
-// Test 2.2: Test finish with active signal handlers
-TEST_F(RESTConnectTest, FinishDisconnectsSignalHandlers) {
-    static const std::string empty_token;
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(false));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(empty_token));
-    
-    // Run proceed() in a separate thread since it blocks
-    std::thread proceed_thread([this]() {
-        connect_->proceed();
-    });
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson, updateJson}));
 
-    std::string slotJson = buildSlotResponse(1);
-    connect_->finish();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_FALSE(serverSocket_.is_open());
-
-    // Verify signal handlers are disconnected by attempting to emit signals
-    auto param = std::make_unique<MockParam>();
-    device_.valueSetByServer.emit("test_oid", param.get());
-    device_.valueSetByClient.emit("test_oid", param.get());
-    
-    EXPECT_EQ(readResponse(), expectedSSEResponse(catena::exception_with_status("", catena::StatusCode::OK), {slotJson}));
-
-    catena::REST::Connect::shutdownSignal_.emit();
-    proceed_thread.join();
+    endpoint_->finish();
 }
 
 // --- 3. EXCEPTION TESTS ---
 
-// Test 3.1: Test catena::exception_with_status handling
-TEST_F(RESTConnectTest, ProceedHandlesCatenaException) {
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(Invoke([]() -> const std::string& {
-            static const std::string empty;
-            throw catena::exception_with_status("Auth error", catena::StatusCode::UNAUTHENTICATED);
-            return empty;
-        }));
-
-    // Run proceed() in a separate thread since it blocks
-    std::thread proceed_thread([this]() {
-        connect_->proceed();
-    });
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_EQ(readResponse(), expectedSSEResponse(catena::exception_with_status("Auth error", catena::StatusCode::UNAUTHENTICATED)));
-
-    serverSocket_.close();
-    proceed_thread.join();
-}
-
 // Test 3.2: Test std::exception handling
 TEST_F(RESTConnectTest, ProceedHandlesStdException) {
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(Invoke([]() -> const std::string& {
+    expRc_ = catena::exception_with_status("Connection setup failed: Runtime error", catena::StatusCode::INTERNAL);
+    authzEnabled_ = true;
+    EXPECT_CALL(context_, jwsToken())
+        .WillOnce(testing::Invoke([]() -> const std::string& {
             static const std::string empty;
             throw std::runtime_error("Runtime error");
             return empty;
@@ -405,82 +284,58 @@ TEST_F(RESTConnectTest, ProceedHandlesStdException) {
 
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_EQ(readResponse(), expectedSSEResponse(
-        catena::exception_with_status("Connection setup failed: Runtime error", catena::StatusCode::INTERNAL)));
-
-    serverSocket_.close();
     proceed_thread.join();
+
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 3.3: Test unknown exception handling
 TEST_F(RESTConnectTest, ProceedHandlesUnknownException) {
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(Invoke([]() -> const std::string& {
-            static const std::string empty;
-            throw 42; // Throw an int to trigger catch(...)
-            return empty;
-        }));
+    expRc_ = catena::exception_with_status("Unknown error during connection setup", catena::StatusCode::UNKNOWN);
+    authzEnabled_ = true;
+    EXPECT_CALL(context_, jwsToken())
+        .WillOnce(testing::Throw(42));
 
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-
-    EXPECT_EQ(readResponse(), expectedSSEResponse(
-        catena::exception_with_status("Unknown error during connection setup", catena::StatusCode::UNKNOWN)));
-
-    serverSocket_.close();
     proceed_thread.join();
+
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 3.4: Test socket close during response sending with writer failure
 TEST_F(RESTConnectTest, ProceedHandlesWriterFailure) {
-    std::string mockToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxM"
-                            "jM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJ"
-                            "zdDIxMzg6bW9uIiwiaWF0IjoxNTE2MjM5MDIyfQ.YkqS7hCxst"
-                            "pXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
-
-    EXPECT_CALL(socket_reader_, authorizationEnabled())
-        .WillOnce(Return(true));
-    EXPECT_CALL(socket_reader_, jwsToken())
-        .WillOnce(ReturnRef(mockToken));
-    EXPECT_CALL(device_, slot())
-        .WillRepeatedly(Return(1));
-    EXPECT_CALL(socket_reader_, detailLevel())
-        .WillRepeatedly(Return(catena::Device_DetailLevel::Device_DetailLevel_FULL));
+    jwsToken_ = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkw"
+                "IiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uIiwiaWF0I"
+                "joxNTE2MjM5MDIyfQ.YkqS7hCxstpXulFnR98q0m088pUj6Cnf5vW6xPX8aBQ";
+    authzEnabled_ = true;
 
     auto param = std::make_unique<MockParam>();
     EXPECT_CALL(*param, getOid())
-        .WillRepeatedly(ReturnRef(paramOid_));
+        .WillRepeatedly(testing::ReturnRef(paramOid_));
     EXPECT_CALL(*param, getScope())
-        .WillRepeatedly(ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
+        .WillRepeatedly(testing::ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
     EXPECT_CALL(*param, toProto(::testing::An<catena::Value&>(), ::testing::An<catena::common::Authorizer&>()))
-        .WillOnce(::testing::Invoke([](catena::Value& value, catena::common::Authorizer&) {
+        .WillOnce(testing::Invoke([](catena::Value& value, catena::common::Authorizer&) {
             value.set_string_value("test_value");
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
 
-    std::set<std::string> subscribed_oids{paramOid_};
-    EXPECT_CALL(subscription_manager_, getAllSubscribedOids(::testing::Ref(device_)))
-        .WillRepeatedly(Return(subscribed_oids));
-
     // Run proceed() in a separate thread since it blocks
     std::thread proceed_thread([this]() {
-        connect_->proceed();
+        endpoint_->proceed();
     });
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     clientSocket_.close();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
-    device_.valueSetByServer.emit(paramOid_, param.get());
+    dm0_.valueSetByServer.emit(paramOid_, param.get());
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     EXPECT_FALSE(serverSocket_.is_open());

--- a/unittests/cpp/REST/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/REST/tests/DeviceRequest_test.cpp
@@ -32,7 +32,7 @@
  * @brief This file is for testing the DeviceRequest.cpp file.
  * @author zuhayr.sarker@rossvideo.com
  * @author benjamin.whitten@rossvideo.com
- * @date 2025-06-20
+ * @date 2025-06-23
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 

--- a/unittests/cpp/REST/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/REST/tests/DeviceRequest_test.cpp
@@ -31,13 +31,13 @@
 /**
  * @brief This file is for testing the DeviceRequest.cpp file.
  * @author zuhayr.sarker@rossvideo.com
+ * @author benjamin.whitten@rossvideo.com
  * @date 2025-06-20
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 // Test helpers
 #include "RESTTest.h"
-#include "MockDevice.h"
 #include "MockDeviceSerializer.h"
 #include "MockSubscriptionManager.h"
 

--- a/unittests/cpp/REST/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/REST/tests/DeviceRequest_test.cpp
@@ -37,8 +37,8 @@
 
 // Test helpers
 #include "RESTTest.h"
-#include "MockCommandResponder.h"
-#include "MockParam.h"
+#include "MockDevice.h"
+#include "MockDeviceSerializer.h"
 #include "MockSubscriptionManager.h"
 
 // REST
@@ -133,7 +133,7 @@ TEST_F(RESTDeviceRequestTests, DeviceRequest_Normal) {
             EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
             EXPECT_EQ(dl, catena::Device_DetailLevel_FULL);
             EXPECT_TRUE(subscribedOids.empty());
-            auto mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
+            auto mockSerializer = std::make_unique<MockDeviceSerializer>();
             EXPECT_CALL(*mockSerializer, hasMore())
                 .WillOnce(testing::Return(true))
                 .WillOnce(testing::Return(true))
@@ -162,7 +162,7 @@ TEST_F(RESTDeviceRequestTests, DeviceRequest_Stream) {
             EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
             EXPECT_EQ(dl, catena::Device_DetailLevel_FULL);
             EXPECT_TRUE(subscribedOids.empty());
-            auto mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
+            auto mockSerializer = std::make_unique<MockDeviceSerializer>();
             EXPECT_CALL(*mockSerializer, hasMore()).Times(4)
                 .WillOnce(testing::Return(true))
                 .WillOnce(testing::Return(true))
@@ -197,7 +197,7 @@ TEST_F(RESTDeviceRequestTests, DeviceRequest_AuthzValid) {
             EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
             EXPECT_EQ(dl, catena::Device_DetailLevel_FULL);
             EXPECT_TRUE(subscribedOids.empty());
-            auto mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
+            auto mockSerializer = std::make_unique<MockDeviceSerializer>();
             EXPECT_CALL(*mockSerializer, hasMore()).WillOnce(testing::Return(false));
             EXPECT_CALL(*mockSerializer, getNext()).Times(0);
             return mockSerializer;
@@ -221,7 +221,7 @@ TEST_F(RESTDeviceRequestTests, DeviceRequest_Subscriptions) {
         .WillOnce(::testing::Invoke([&expectedSubscribedOids](catena::common::Authorizer &authz, const std::set<std::string> &subscribedOids, catena::Device_DetailLevel dl, bool shallow){
             EXPECT_EQ(subscribedOids, expectedSubscribedOids);
             EXPECT_EQ(dl, catena::Device_DetailLevel_SUBSCRIPTIONS);
-            auto mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
+            auto mockSerializer = std::make_unique<MockDeviceSerializer>();
             EXPECT_CALL(*mockSerializer, hasMore()).WillOnce(testing::Return(false));
             EXPECT_CALL(*mockSerializer, getNext()).Times(0);
             return mockSerializer;

--- a/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
@@ -271,20 +271,17 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
     expNoResponse();
     // Adding authorization mockToken metadata. This it a random RSA token
     authzEnabled_ = true;
-    std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
-                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
-                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
-                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
-                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
-                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
-                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
-                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
-                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
-                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
-                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
-                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+                "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
+                "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
+                "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
+                "okrEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko9653v0khyUT4UK"
+                "eOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKHkWi4P3-CYWrwe-g6b4-a33Q"
+                "0k6tSGI1hGf2bA9cRYr-VyQ_T3RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEm"
+                "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
+                "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
+                "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
     // Setting expectations
-    EXPECT_CALL(context_, jwsToken()).WillRepeatedly(::testing::ReturnRef(mockToken));
     EXPECT_CALL(dm0_, getCommand(fqoid_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             // Making sure the correct values were passed in.
@@ -314,9 +311,8 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) {
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
     // Not a token so it should get rejected by the authorizer
     authzEnabled_ = true;
-    std::string mockToken = "Bearer THIS SHOULD NOT PARSE";
+    jwsToken_ = "Bearer THIS SHOULD NOT PARSE";
     // Setting expectations
-    EXPECT_CALL(context_, jwsToken()).WillRepeatedly(::testing::ReturnRef(mockToken));
     EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
     EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
     // Sending the Call

--- a/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
@@ -49,6 +49,9 @@ using namespace catena::REST;
 // Fixture
 class RESTExecuteCommandTests : public RESTEndpointTest {
   protected:
+    /*
+     * Sets default expectations for hasField("respond").
+     */
     RESTExecuteCommandTests() : RESTEndpointTest() {
         EXPECT_CALL(context_, hasField("respond")).WillRepeatedly(::testing::Invoke([this]() { return respond_; }));
     }
@@ -56,10 +59,10 @@ class RESTExecuteCommandTests : public RESTEndpointTest {
     /*
      * Creates an ExecuteCommand handler object.
      */
-    ICallData* makeOne() override { return ExecuteCommand::makeOne(serverSocket, context_, dm0_); }
+    ICallData* makeOne() override { return ExecuteCommand::makeOne(serverSocket_, context_, dm0_); }
 
     /*
-     * Streamlines the creation of executeCommandPayloads. 
+     * Streamlines the creation of endpoint input. 
      */
     void initPayload(uint32_t slot, const std::string& oid, const std::string& value, bool respond = true) {
         slot_ = slot;
@@ -131,15 +134,15 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_Create) {
 }
 
 /*
- * TEST 17 - Writing to console with GetParam finish().
+ * TEST 2 - Writing to console with GetParam finish().
  */
-TEST_F(RESTExecuteCommandTests, ExecuteCommand_finish) {
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_Finish) {
     endpoint_->finish();
     ASSERT_TRUE(MockConsole_.str().find("ExecuteCommand[1] finished\n") != std::string::npos);
 }
 
 /*
- * TEST 2 - ExecuteCommand returns two CommandResponse responses.
+ * TEST 3 - ExecuteCommand returns two CommandResponse responses.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalResponse) {
     initPayload(0, "test_command", "test_value", true);
@@ -172,7 +175,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalResponse) {
 }
 
 /*
- * TEST 3 - ExecuteCommand returns a CommandResponse no response.
+ * TEST 4 - ExecuteCommand returns a CommandResponse no response.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalNoResponse) {
     initPayload(0, "test_command", "test_value", true);
@@ -201,7 +204,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalNoResponse) {
 }
 
 /*
- * TEST 4 - ExecuteCommand returns a CommandResponse exception.
+ * TEST 5 - ExecuteCommand returns a CommandResponse exception.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalException) {
     initPayload(0, "test_command", "test_value", true);
@@ -230,7 +233,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalException) {
 }
 
 /*
- * TEST 5 - ExecuteCommand returns no response (respond = false).
+ * TEST 6 - ExecuteCommand returns no response (respond = false).
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
     initPayload(0, "test_command", "test_value", false);
@@ -263,7 +266,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
 }
 
 /*
- * TEST 6 - ExecuteCommand returns a CommandResponse no response with authz
+ * TEST 7 - ExecuteCommand returns a CommandResponse no response with authz
  *          enabled.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
@@ -305,7 +308,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
 }
 
 /*
- * TEST 7 - ExecuteCommand fails from invalid JWS token.
+ * TEST 8 - ExecuteCommand fails from invalid JWS token.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) { 
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -320,7 +323,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) {
 }
 
 /*
- * TEST 8 - ExecuteCommand fails to parse the json body.
+ * TEST 9 - ExecuteCommand fails to parse the json body.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
     expRc_ = catena::exception_with_status("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
@@ -333,7 +336,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
 }
 
 /*
- * TEST 9 - getCommand does not find a command.
+ * TEST 10 - getCommand does not find a command.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
     expRc_ = catena::exception_with_status("Command not found", catena::StatusCode::INVALID_ARGUMENT);
@@ -349,7 +352,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
 }
 
 /*
- * TEST 10 - getCommand throws a catena::exception_with_status.
+ * TEST 11 - getCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -365,7 +368,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
 }
 
 /*
- * TEST 11 - getCommand throws an std::runtime error.
+ * TEST 12 - getCommand throws an std::runtime error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -378,7 +381,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
 }
 
 /*
- * TEST 12 - executeCommand returns a nullptr.
+ * TEST 13 - executeCommand returns a nullptr.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
     expRc_ = catena::exception_with_status("Illegal state", catena::StatusCode::INTERNAL);
@@ -398,7 +401,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
 }
 
 /*
- * TEST 13 - executeCommand throws a catena::exception_with_status.
+ * TEST 14 - executeCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -419,7 +422,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
 }
 
 /*
- * TEST 14 - executeCommand returns an std::runtime_error.
+ * TEST 15 - executeCommand returns an std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -437,7 +440,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
 }
 
 /*
- * TEST 15 - getNext throws a catena::exception_with_status.
+ * TEST 16 - getNext throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -464,7 +467,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
 }
 
 /*
- * TEST 16 - getNext throws a std::runtime_error.
+ * TEST 17 - getNext throws a std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);

--- a/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
@@ -68,7 +68,7 @@ class RESTExecuteCommandTests : public RESTEndpointTest {
         slot_ = slot;
         fqoid_ = oid;
         auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
-        EXPECT_TRUE(status.ok()) << "Failed to convert Value to JSON";
+        ASSERT_TRUE(status.ok()) << "Failed to convert Value to JSON";
         respond_ = respond;
     }
 
@@ -107,6 +107,7 @@ class RESTExecuteCommandTests : public RESTEndpointTest {
             for (const auto& expVal : expVals_) {
                 jsonBodies.push_back("");
                 auto status = google::protobuf::util::MessageToJsonString(expVal, &jsonBodies.back());
+                ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
             }
         }
         EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));

--- a/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
@@ -65,105 +65,123 @@ class RESTExecuteCommandTests : public ::testing::Test, public RESTTest {
   protected:
     RESTExecuteCommandTests() : RESTTest(&serverSocket, &clientSocket) {}
 
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Creating executeCommand object.
-        EXPECT_CALL(context, origin()).Times(1).WillOnce(::testing::ReturnRef(origin));
-        executeCommand = ExecuteCommand::makeOne(serverSocket, context, dm);
-    }
-    /*
-     * Adds a response to the expected values.
-     */
-    void expResponse(const std::string& stringVal) {
-        catena::CommandResponse res;
-        res.mutable_response()->set_string_value(stringVal);
-        expVals.push_back(res);
-    }
-    /* 
-     * Adds an exception to the expected values.
-     */
-    void expException(const std::string& type, const std::string& details) {
-        catena::CommandResponse res;
-        res.mutable_exception()->set_type(type);
-        res.mutable_exception()->set_details(details);
-        expVals.push_back(res);
-    }
     /*
      * Streamlines the creation of executeCommandPayloads. 
      */
-    void setInVal(const std::string& oid, const std::string& value, bool respond = true) {
-        inVal.set_oid(oid);
-        inVal.mutable_value()->set_string_value(value);
-        inVal.set_respond(respond);
-        auto status = google::protobuf::util::MessageToJsonString(inVal.value(), &inValJsonBody);
+    void initPayload(uint32_t slot, const std::string& oid, const std::string& value, bool respond = true) {
+        slot_ = slot;
+        fqoid_ = oid;
+        auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
+        EXPECT_TRUE(status.ok()) << "Failed to convert Value to JSON";
+        respond_ = respond;
     }
+
     /*
-     * Adds a no_response to the expected values.
+     * Streamlines the creation of executeCommandPayloads. 
      */
+    void initPayload(const std::string& oid, const std::string& value, bool respond = true) {
+        fqoid_ = oid;
+        catena::Value val;
+        val.set_string_value(value);
+        auto status = google::protobuf::util::MessageToJsonString(val, &jsonBody_);
+        EXPECT_TRUE(status.ok()) << "Failed to convert Value to JSON";
+        respond_ = respond;
+    }
+
+    /*
+    * Adds a response to the expected values.
+    */
+    void expResponse(const std::string& stringVal) {
+        expVals_.push_back(catena::CommandResponse());
+        expVals_.back().mutable_response()->set_string_value(stringVal);
+    }
+
+    /* 
+    * Adds an exception to the expected values.
+    */
+    void expException(const std::string& type, const std::string& details) {
+        expVals_.push_back(catena::CommandResponse());
+        expVals_.back().mutable_exception()->set_type(type);
+        expVals_.back().mutable_exception()->set_details(details);
+    }
+
+    /*
+    * Adds a no_response to the expected values.
+    */
     void expNoResponse() {
-        catena::CommandResponse res;
-        res.mutable_no_response();
-        expVals.push_back(res);
+        expVals_.push_back(catena::CommandResponse());
+        expVals_.back().mutable_no_response();
     }
-    /*
-     * A collection of expected calls to the context object across most tests.
-     */
-    void expContext() {
-        EXPECT_CALL(context, hasField("respond")).Times(1).WillOnce(::testing::Return(inVal.respond()));
-        if (inValJsonBody.empty()) {
-            EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(inValJsonBody));
-        } else {
-            EXPECT_CALL(context, jsonBody()).Times(2).WillRepeatedly(::testing::ReturnRef(inValJsonBody));
-        }
+
+    void SetUp() override {
+        // Redirecting cout to a stringstream for testing.
+        oldCout_ = std::cout.rdbuf(MockConsole_.rdbuf());
+
+        // Setting default expectations
+        // Default expectations for the context.
+        EXPECT_CALL(context_, method()).WillRepeatedly(::testing::ReturnRef(method_));
+        EXPECT_CALL(context_, origin()).WillRepeatedly(::testing::ReturnRef(origin));
+        EXPECT_CALL(context_, slot()).WillRepeatedly(::testing::Invoke([this]() { return slot_; }));
+        EXPECT_CALL(context_, fqoid()).WillRepeatedly(::testing::ReturnRef(fqoid_));
+        EXPECT_CALL(context_, jsonBody()).WillRepeatedly(::testing::ReturnRef(jsonBody_));
+        EXPECT_CALL(context_, authorizationEnabled()).WillRepeatedly(::testing::Invoke([this]() { return authzEnabled_; }));
+        EXPECT_CALL(context_, hasField("respond")).WillRepeatedly(::testing::Invoke([this]() { return respond_; }));
+        EXPECT_CALL(context_, stream()).WillRepeatedly(::testing::Invoke([this]() { return stream_; }));
+        // Default expectations for the device model.
+        EXPECT_CALL(dm0_, mutex()).WillRepeatedly(::testing::ReturnRef(mtx0_));
+        EXPECT_CALL(dm1_, mutex()).WillRepeatedly(::testing::ReturnRef(mtx1_));
+
+        ICallData* executeCommand = ExecuteCommand::makeOne(serverSocket, context_, dm0_);
+        endpoint_.reset(executeCommand);
     }
-    /*
-     * A collection of expected calls for authorization across most tests.
-     */
-    void expAuthz(const std::string& mockToken = "") {
-        EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(!mockToken.empty()));
-        if (!mockToken.empty()) {
-            EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-        }
-    }
+    
     /*
      * Calls proceed and tests the response.
      */
-    void testCall(catena::exception_with_status& rc, bool respond = true) {
-        executeCommand->proceed();
+    void testCall() {
+        endpoint_->proceed();
         std::vector<std::string> jsonBodies;
-        if (respond) {
-            for (const auto& expVal : expVals) {
+        if (respond_) {
+            for (const auto& expVal : expVals_) {
                 jsonBodies.push_back("");
                 auto status = google::protobuf::util::MessageToJsonString(expVal, &jsonBodies.back());
             }
         }
-        EXPECT_EQ(readResponse(), expectedSSEResponse(rc, jsonBodies));
+        EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
     }
 
     void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (executeCommand) {
-            delete executeCommand;
-        }
+        std::cout.rdbuf(oldCout_); // Restoring cout
     }
-    
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
 
-    std::vector<catena::CommandResponse> expVals;
-    catena::ExecuteCommandPayload inVal;
-    std::string inValJsonBody = "";
-    
-    MockSocketReader context;
-    std::mutex mockMtx;
-    MockDevice dm;
-    catena::REST::ICallData* executeCommand = nullptr;
+    // Cout variables
+    std::stringstream MockConsole_;
+    std::streambuf* oldCout_;
 
-    std::unique_ptr<MockParam> mockCommand = std::make_unique<MockParam>();
-    std::unique_ptr<MockCommandResponder> mockResponder = std::make_unique<MockCommandResponder>();
+    // in/out val
+    std::string jsonBody_ = "";
+    // Expected variables
+    std::vector<catena::CommandResponse> expVals_;
+    catena::exception_with_status expRc_{"", catena::StatusCode::OK};
+    std::string method_ = "GET";
+    catena::Value inVal_;
+
+    uint32_t slot_ = 0;
+    std::string fqoid_ = "";
+    bool respond_ = false;
+    bool stream_ = true;
+    bool authzEnabled_ = false;
+
+    MockSocketReader context_;
+    std::mutex mtx0_;
+    std::mutex mtx1_;
+    MockDevice dm0_;
+    MockDevice dm1_;
+
+    std::unique_ptr<ICallData> endpoint_;
+
+    std::unique_ptr<MockParam> mockCommand_ = std::make_unique<MockParam>();
+    std::unique_ptr<MockCommandResponder> mockResponder_ = std::make_unique<MockCommandResponder>();
 };
 
 /*
@@ -173,150 +191,138 @@ class RESTExecuteCommandTests : public ::testing::Test, public RESTTest {
  * 
  * TEST 1 - Creating a ExecuteCommand object with makeOne.
  */
-TEST_F(RESTExecuteCommandTests, ExecuteCommand_create) {
-    // Making sure executeCommand is created from the SetUp step.
-    ASSERT_TRUE(executeCommand);
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_Create) {
+    ASSERT_TRUE(endpoint_);
+}
+
+/*
+ * TEST 17 - Writing to console with GetParam finish().
+ */
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_finish) {
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("ExecuteCommand[1] finished\n") != std::string::npos);
 }
 
 /*
  * TEST 2 - ExecuteCommand returns two CommandResponse responses.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalResponse) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
+    initPayload(0, "test_command", "test_value", true);
     expResponse("test_response_1");
     expResponse("test_response_2");
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(&authz, &Authorizer::kAuthzDisabled);
-            status = catena::exception_with_status(rc.what(), rc.status);
-            return std::move(mockCommand);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(value.SerializeAsString(), inVal.value().SerializeAsString());
-            return std::move(mockResponder);
+            EXPECT_EQ(value.SerializeAsString(), inVal_.SerializeAsString());
+            return std::move(mockResponder_);
         }));
-    // Mocking kWrite functions
-    EXPECT_CALL(*mockResponder, hasMore()).Times(3)
+    EXPECT_CALL(*mockResponder_, getNext()).Times(3)
+        .WillOnce(::testing::Return(expVals_[0]))
+        .WillOnce(::testing::Return(expVals_[1]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(3)
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(false));
-    EXPECT_CALL(*mockResponder, getNext()).Times(2)
-        .WillOnce(::testing::Return(expVals[0]))
-        .WillOnce(::testing::Return(expVals[1]));
-    
-    testCall(rc, inVal.respond());
+    // Sending the call
+    testCall();
 }
 
 /*
  * TEST 3 - ExecuteCommand returns a CommandResponse no response.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalNoResponse) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
+    initPayload(0, "test_command", "test_value", true);
     expNoResponse();
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(&authz, &Authorizer::kAuthzDisabled);
-            status = catena::exception_with_status(rc.what(), rc.status);
-            return std::move(mockCommand);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(value.SerializeAsString(), inVal.value().SerializeAsString());
-            return std::move(mockResponder);
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder_);
         }));
-    // Mocking kWrite functions
-    EXPECT_CALL(*mockResponder, getNext()).Times(1).WillOnce(::testing::Return(expVals[0]));
-    EXPECT_CALL(*mockResponder, hasMore()).Times(2)
-        .WillOnce(::testing::Return(true))
-        .WillOnce(::testing::Return(false));
-
-    testCall(rc, inVal.respond());
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1).WillOnce(::testing::Return(expVals_[0]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(1).WillOnce(::testing::Return(false));
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 4 - ExecuteCommand returns a CommandResponse exception.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalException) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
+    initPayload(0, "test_command", "test_value", true);
     expException("test_exception_type", "test_exception_details");
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(&authz, &Authorizer::kAuthzDisabled);
-            status = catena::exception_with_status(rc.what(), rc.status);
-            return std::move(mockCommand);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(value.SerializeAsString(), inVal.value().SerializeAsString());
-            return std::move(mockResponder);
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder_);
         }));
-    // Mocking kWrite functions
-    EXPECT_CALL(*mockResponder, hasMore()).Times(2)
-        .WillOnce(::testing::Return(true))
-        .WillOnce(::testing::Return(false));
-    EXPECT_CALL(*mockResponder, getNext()).Times(1).WillOnce(::testing::Return(expVals[0]));
-    
-    testCall(rc, inVal.respond());
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1).WillOnce(::testing::Return(expVals_[0]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(1).WillOnce(::testing::Return(false));
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 5 - ExecuteCommand returns no response (respond = false).
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    // We should not read these in the asyncReader.
+    initPayload(0, "test_command", "test_value", false);
     expResponse("test_response_1");
     expResponse("test_response_2");
-    setInVal("test_command", "test_value", false);
-
+    expResponse("test_response_3");
     // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
-            status = catena::exception_with_status(rc.what(), rc.status);
-            return std::move(mockCommand);
+    EXPECT_CALL(dm0_, getCommand(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
-            return std::move(mockResponder);
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.string_value(), "test_value");
+            return std::move(mockResponder_);
         }));
-    // Mocking kWrite functions
-    EXPECT_CALL(*mockResponder, hasMore()).Times(3)
+    EXPECT_CALL(*mockResponder_, getNext()).Times(3)
+        .WillOnce(::testing::Return(expVals_[0]))
+        .WillOnce(::testing::Return(expVals_[1]))
+        .WillOnce(::testing::Return(expVals_[2]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(3)
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(true))
         .WillOnce(::testing::Return(false));
-    EXPECT_CALL(*mockResponder, getNext()).Times(2)
-        .WillOnce(::testing::Return(expVals[0]))
-        .WillOnce(::testing::Return(expVals[1]));
-    
-    testCall(rc, inVal.respond());
+    // Sending the Call
+    testCall();
 }
 
 /*
@@ -324,10 +330,10 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
  *          enabled.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
+    initPayload(0, "test_command", "test_value", true);
     expNoResponse();
-    setInVal("test_command", "test_value", true);
-    // Adding authorization mockToken metadata. This it a random RSA token.
+    // Adding authorization mockToken metadata. This it a random RSA token
+    authzEnabled_ = true;
     std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
                             "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
                             "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
@@ -340,253 +346,205 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
                             "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
                             "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
                             "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz(mockToken);
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(inVal.oid(), ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([this, &rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+    // Setting expectations
+    EXPECT_CALL(context_, jwsToken()).WillRepeatedly(::testing::ReturnRefOfCopy("Bearer" + mockToken));
+    EXPECT_CALL(dm0_, getCommand(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             // Making sure the correct values were passed in.
-            EXPECT_FALSE(&authz == &Authorizer::kAuthzDisabled);
-            status = catena::exception_with_status(rc.what(), rc.status);
-            return std::move(mockCommand);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
             // Making sure the correct values were passed in.
             EXPECT_EQ(value.string_value(), "test_value");
-            return std::move(mockResponder);
+            return std::move(mockResponder_);
         }));
-    // Mocking kWrite functions
-    EXPECT_CALL(*mockResponder, hasMore()).Times(2)
-        .WillOnce(::testing::Return(true))
-        .WillOnce(::testing::Return(false));
-    EXPECT_CALL(*mockResponder, getNext()).Times(1).WillOnce(::testing::Return(expVals[0]));
-    
-    testCall(rc, inVal.respond());
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1).WillOnce(::testing::Return(expVals_[0]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(1).WillOnce(::testing::Return(false));
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 7 - ExecuteCommand fails from invalid JWS token.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) { 
-    catena::exception_with_status rc("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
-    std::string mockToken = "THIS SHOULD NOT PARSE";
-
-    expContext();
-    expAuthz(mockToken);
-
-    testCall(rc);
+    expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
+    // Not a token so it should get rejected by the authorizer
+    authzEnabled_ = true;
+    // Setting expectations
+    EXPECT_CALL(context_, jwsToken()).WillRepeatedly(::testing::ReturnRefOfCopy("Bearer THIS SHOULD NOT PARSE"));
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 8 - ExecuteCommand fails to parse the json body.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
-    catena::exception_with_status rc("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
-    setInVal("test_command", "test_value", true);
-    inValJsonBody = "THIS SHOULD NOT PARSE"; // Invalid JSON body.
-
-    // Mocking kProcess functions
-    expContext();
-
-    testCall(rc);
+    expRc_ = catena::exception_with_status("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
+    jsonBody_ = "THIS SHOULD NOT PARSE"; // Invalid JSON body.
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 9 - getCommand does not find a command.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
-    catena::exception_with_status rc("Command not found", catena::StatusCode::INVALID_ARGUMENT);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
-            status = catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Command not found", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
             return nullptr;
         }));
-
-    testCall(rc);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 10 - getCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
-    catena::exception_with_status rc("Threw error", catena::StatusCode::INVALID_ARGUMENT);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return nullptr;
         }));
-        
-    testCall(rc);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 11 - getCommand throws an std::runtime error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Throw(std::runtime_error(rc.what())));
-        
-    testCall(rc);
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 12 - executeCommand returns a nullptr.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
-    catena::exception_with_status rc("Illegal state", catena::StatusCode::INTERNAL);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+    expRc_ = catena::exception_with_status("Illegal state", catena::StatusCode::INTERNAL);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockCommand);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1).WillOnce(::testing::Return(nullptr));
-        
-    testCall(rc);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([](const catena::Value& value) {
+            return nullptr;
+        }));
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 13 - executeCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
-    catena::exception_with_status rc("Threw error", catena::StatusCode::INVALID_ARGUMENT);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+    expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockCommand);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const catena::Value& value) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const catena::Value& value) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return nullptr;
         }));
-        
-    testCall(rc);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 14 - executeCommand returns an std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockCommand);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const catena::Value& value) {
-            throw std::runtime_error(rc.what());
-            return nullptr;
-        }));
-        
-    testCall(rc);
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 15 - getNext throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
-    catena::exception_with_status rc("Threw error", catena::StatusCode::INVALID_ARGUMENT);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+    expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "test_command", "test_value", false);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockCommand);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
-            return std::move(mockResponder);
+            return std::move(mockResponder_);
         }));
-    EXPECT_CALL(*mockResponder, hasMore()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*mockResponder, getNext()).Times(1)
-        .WillOnce(::testing::Invoke([&rc]() {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1)
+        .WillOnce(::testing::Invoke([this]() {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::CommandResponse();
         }));
-        
-    testCall(rc);
+    // Sending the Call
+    testCall();
 }
 
 /*
  * TEST 16 - getNext throws a std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    setInVal("test_command", "test_value", true);
-
-    // Mocking kProcess functions
-    expContext();
-    expAuthz();
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(inVal.oid()));
-    EXPECT_CALL(dm, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    initPayload(0, "test_command", "test_value", false);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockCommand);
+            return std::move(mockCommand_);
         }));
-    EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
+    EXPECT_CALL(dm1_, getCommand(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockCommand_, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
-            return std::move(mockResponder);
+            return std::move(mockResponder_);
         }));
-    EXPECT_CALL(*mockResponder, hasMore()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(*mockResponder, getNext()).Times(1)
-        .WillOnce(::testing::Invoke([&rc]() {
-            throw std::runtime_error(rc.what());
-            return catena::CommandResponse();
-        }));
-        
-    testCall(rc);
-}
-
-/*
- * TEST 17 - Writing to console with GetParam finish().
- */
-TEST_F(RESTExecuteCommandTests, ExecuteCommand_finish) {
-    // Calling finish and expecting the console output.
-    executeCommand->finish();
-    ASSERT_TRUE(MockConsole.str().find("ExecuteCommand[16] finished\n") != std::string::npos);
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the Call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/GetParam_test.cpp
+++ b/unittests/cpp/REST/tests/GetParam_test.cpp
@@ -48,8 +48,6 @@ using namespace catena::REST;
 // Fixture
 class RESTGetParamTests : public RESTEndpointTest {
   protected:
-    RESTGetParamTests() : RESTEndpointTest() {}
-
     /*
      * Creates a GetParam handler object.
      */
@@ -142,20 +140,17 @@ TEST_F(RESTGetParamTests, GetParam_AuthzValid) {
     initExpVal("/test_oid", "test_value", "test_alias", "Test Param");
     // Adding authorization mockToken metadata. This it a random RSA token.
     authzEnabled_ = true;
-    std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
-                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
-                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
-                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
-                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
-                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
-                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
-                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
-                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
-                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
-                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
-                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+                "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
+                "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
+                "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
+                "okrEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko9653v0khyUT4UK"
+                "eOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKHkWi4P3-CYWrwe-g6b4-a33Q"
+                "0k6tSGI1hGf2bA9cRYr-VyQ_T3RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEm"
+                "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
+                "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
+                "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
     // Setting expectations
-    EXPECT_CALL(context_, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
     EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
         [this](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz) {
             // Checking that function gets correct inputs.
@@ -182,9 +177,8 @@ TEST_F(RESTGetParamTests, GetParam_AuthzInvalid) {
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
     // Not a token so it should get rejected by the authorizer.
     authzEnabled_ = true;
-    std::string mockToken = "THIS SHOULD NOT PARSE";
+    jwsToken_ = "THIS SHOULD NOT PARSE";
     // Setting expectations
-    EXPECT_CALL(context_, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
     EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(0);
     EXPECT_CALL(*mockParam_, getOid()).Times(0);
     EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(0);

--- a/unittests/cpp/REST/tests/GetParam_test.cpp
+++ b/unittests/cpp/REST/tests/GetParam_test.cpp
@@ -51,16 +51,19 @@ class RESTGetParamTests : public RESTEndpointTest {
     /*
      * Creates a GetParam handler object.
      */
-    ICallData* makeOne() override { return GetParam::makeOne(serverSocket, context_, dm0_); }
+    ICallData* makeOne() override { return GetParam::makeOne(serverSocket_, context_, dm0_); }
 
     /*
-     * Streamlines the creation of GetParamPayload. 
+     * Streamlines the creation of endpoint input. 
      */
     void initPayload(uint32_t slot, const std::string& oid) {
         slot_ = slot;
         fqoid_ = oid;
     }
 
+    /*
+     * Streamlines the creation of the expected output ComponentParam. 
+     */
     void initExpVal(const std::string& oid, const std::string& value, const std::string& alias, const std::string& enName) {
         expVal_.set_oid(oid);
         auto param = expVal_.mutable_param();
@@ -94,20 +97,20 @@ class RESTGetParamTests : public RESTEndpointTest {
  * 
  * TEST 1 - Creating a GetParam object.
  */
-TEST_F(RESTGetParamTests, GetParam_create) {
+TEST_F(RESTGetParamTests, GetParam_Create) {
     EXPECT_TRUE(endpoint_);
 }
 
 /* 
  * TEST 2 - Writing to console with GetParam finish().
  */
-TEST_F(RESTGetParamTests, GetParam_finish) {
+TEST_F(RESTGetParamTests, GetParam_Finish) {
     endpoint_->finish();
     ASSERT_TRUE(MockConsole_.str().find("GetParam[1] finished\n") != std::string::npos);
 }
 
 /*
- * TEST 2 - Normal case for GetParam proceed().
+ * TEST 3 - Normal case for GetParam proceed().
  */
 TEST_F(RESTGetParamTests, GetParam_Normal) {
     initPayload(0, "/test_oid");
@@ -133,7 +136,7 @@ TEST_F(RESTGetParamTests, GetParam_Normal) {
 }
 
 /*
- * TEST 3 - GetParam with authz on and valid token.
+ * TEST 4 - GetParam with authz on and valid token.
  */
 TEST_F(RESTGetParamTests, GetParam_AuthzValid) {
     initPayload(0, "/test_oid");
@@ -171,7 +174,7 @@ TEST_F(RESTGetParamTests, GetParam_AuthzValid) {
 }
 
 /*
- * TEST 4 - GetParam with authz on and invalid token.
+ * TEST 5 - GetParam with authz on and invalid token.
  */
 TEST_F(RESTGetParamTests, GetParam_AuthzInvalid) {
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -238,7 +241,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowStd) {
 }
 
 /*
- * TEST 8 - dm.getParam() throws an unknown error.
+ * TEST 9 - dm.getParam() throws an unknown error.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -253,7 +256,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowUnknown) {
 }
 
 /*
- * TEST 9 - param->toProto() returns a catena::exception_with_status.
+ * TEST 10 - param->toProto() returns a catena::exception_with_status.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoReturnCatena) {
     expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
@@ -269,7 +272,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrToProtoReturnCatena) {
 }
 
 /*
- * TEST 10 - param->toProto() throws a catena::exception_with_status.
+ * TEST 11 - param->toProto() throws a catena::exception_with_status.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowCatena) {
     expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
@@ -288,7 +291,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowCatena) {
 }
 
 /*
- * TEST 11 - param->toProto() throws a std::runtime_exception.
+ * TEST 12 - param->toProto() throws a std::runtime_exception.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowStd) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -304,7 +307,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowStd) {
 }
 
 /*
- * TEST 11 - param->toProto() throws an unknown error.
+ * TEST 13 - param->toProto() throws an unknown error.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);

--- a/unittests/cpp/REST/tests/GetParam_test.cpp
+++ b/unittests/cpp/REST/tests/GetParam_test.cpp
@@ -35,59 +35,58 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
 #include "MockParam.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/GetParam.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTGetParamTests : public ::testing::Test, public RESTTest {
+class RESTGetParamTests : public RESTEndpointTest {
   protected:
-    RESTGetParamTests() : RESTTest(&serverSocket, &clientSocket) {}
+    RESTGetParamTests() : RESTEndpointTest() {}
 
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+    /*
+     * Creates a GetParam handler object.
+     */
+    ICallData* makeOne() override { return GetParam::makeOne(serverSocket, context_, dm0_); }
 
-        // Creating getParam object.
-        EXPECT_CALL(context, origin()).Times(1).WillOnce(::testing::ReturnRef(origin));
-        getParam = GetParam::makeOne(serverSocket, context, dm);
+    /*
+     * Streamlines the creation of GetParamPayload. 
+     */
+    void initPayload(uint32_t slot, const std::string& oid) {
+        slot_ = slot;
+        fqoid_ = oid;
     }
 
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (getParam) {
-            delete getParam;
-        }
+    void initExpVal(const std::string& oid, const std::string& value, const std::string& alias, const std::string& enName) {
+        expVal_.set_oid(oid);
+        auto param = expVal_.mutable_param();
+        param->set_type(catena::ParamType::STRING);
+        param->mutable_value()->set_string_value(value);
+        param->add_oid_aliases(alias);
+        (*param->mutable_name()->mutable_display_strings())["en"] = enName;
+        auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson_);
+        EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
     }
-    
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    
-    MockSocketReader context;
-    std::mutex mockMtx;
-    MockDevice dm;
-    catena::REST::ICallData* getParam = nullptr;
+
+    /*
+     * Calls proceed and tests the response.
+     */
+    void testCall() {
+        endpoint_->proceed();
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson_));
+    }
+
+    // Expected variables
+    catena::DeviceComponent_ComponentParam expVal_;
+    std::string expJson_ = "";
+
+    std::unique_ptr<MockParam> mockParam_ = std::make_unique<MockParam>();
 };
 
 /*
@@ -95,67 +94,54 @@ class RESTGetParamTests : public ::testing::Test, public RESTTest {
  *                               GetParam tests
  * ============================================================================
  * 
- * TEST 1 - Creating a GetParam object with makeOne.
+ * TEST 1 - Creating a GetParam object.
  */
 TEST_F(RESTGetParamTests, GetParam_create) {
-    // Making sure getParam is created from the SetUp step.
-    ASSERT_TRUE(getParam);
+    EXPECT_TRUE(endpoint_);
+}
+
+/* 
+ * TEST 2 - Writing to console with GetParam finish().
+ */
+TEST_F(RESTGetParamTests, GetParam_finish) {
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("GetParam[1] finished\n") != std::string::npos);
 }
 
 /*
  * TEST 2 - Normal case for GetParam proceed().
  */
-TEST_F(RESTGetParamTests, GetParam_proceedNormal) {
-    // Setting up the returnVal to test with.
-    catena::DeviceComponent_ComponentParam returnVal;
-    std::string jsonBody = "{\"oid\":\"/test_oid\",\"param\":{}}";
-    google::protobuf::util::JsonPrintOptions options; // Default options
-    auto status = google::protobuf::util::JsonStringToMessage(absl::string_view(jsonBody), &returnVal);
-    // Other variables.
-    std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(returnVal.oid()));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(returnVal.oid(), ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&mockParam, &rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockParam);
+TEST_F(RESTGetParamTests, GetParam_Normal) {
+    initPayload(0, "/test_oid");
+    initExpVal("/test_oid", "test_value", "test_alias", "Test Param");
+    // Setting expectations
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+        [this](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockParam_);
         }));
-    // Defining param->toProto()
-    EXPECT_CALL(*mockParam, getOid()).Times(1).WillOnce(::testing::ReturnRef(returnVal.oid()));
-    EXPECT_CALL(*mockParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&returnVal, &rc](catena::Param &param, catena::common::Authorizer &authz)
-        -> catena::exception_with_status {
-            param.CopyFrom(returnVal.param());
-            return catena::exception_with_status("", catena::StatusCode::OK);
+    EXPECT_CALL(*mockParam_, getOid()).Times(1).WillOnce(::testing::ReturnRef(fqoid_));
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+        [this](catena::Param &param, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            param.CopyFrom(expVal_.param());
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    jsonBody = "";
-    status = google::protobuf::util::MessageToJsonString(returnVal, &jsonBody, options);
-    EXPECT_EQ(readResponse(), expectedResponse(rc, jsonBody));
+    // Sending the call
+    testCall();
 }
 
 /*
  * TEST 3 - GetParam with authz on and valid token.
  */
-TEST_F(RESTGetParamTests, GetParam_proceedAuthzValid) {
-    // Setting up the returnVal to test with.
-    catena::DeviceComponent_ComponentParam returnVal;
-    std::string jsonBody = "{\"oid\":\"/test_oid\",\"param\":{}}";
-    google::protobuf::util::JsonPrintOptions options; // Default options
-    auto status = google::protobuf::util::JsonStringToMessage(absl::string_view(jsonBody), &returnVal);
-    // Other variables.
-    /* Authz just tests for a properly encrypted token, proxy handles authz.
-     * This is a random RSA token I made jwt.io it is not a security risk I
-     * swear. */
+TEST_F(RESTGetParamTests, GetParam_AuthzValid) {
+    initPayload(0, "/test_oid");
+    initExpVal("/test_oid", "test_value", "test_alias", "Test Param");
+    // Adding authorization mockToken metadata. This it a random RSA token.
+    authzEnabled_ = true;
     std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
                             "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
                             "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
@@ -168,256 +154,173 @@ TEST_F(RESTGetParamTests, GetParam_proceedAuthzValid) {
                             "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
                             "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
                             "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-    std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(returnVal.oid()));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(returnVal.oid(), ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&mockParam, &rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockParam);
+    // Setting expectations
+    EXPECT_CALL(context_, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+        [this](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockParam_);
         }));
-    // Defining param->toProto()
-    EXPECT_CALL(*mockParam, getOid()).Times(1).WillOnce(::testing::ReturnRef(returnVal.oid()));
-    EXPECT_CALL(*mockParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&returnVal, &rc](catena::Param &param, catena::common::Authorizer &authz)
-        -> catena::exception_with_status {
-            param.CopyFrom(returnVal.param());
-            return catena::exception_with_status("", catena::StatusCode::OK);
+    EXPECT_CALL(*mockParam_, getOid()).Times(1).WillOnce(::testing::ReturnRef(fqoid_));
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+        [this](catena::Param &param, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            param.CopyFrom(expVal_.param());
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    jsonBody = "";
-    status = google::protobuf::util::MessageToJsonString(returnVal, &jsonBody, options);
-    EXPECT_EQ(readResponse(), expectedResponse(rc, jsonBody));
+    // Sending the call
+    testCall();
 }
 
 /*
  * TEST 4 - GetParam with authz on and invalid token.
  */
-TEST_F(RESTGetParamTests, GetParam_proceedAuthzInvalid) {
+TEST_F(RESTGetParamTests, GetParam_AuthzInvalid) {
+    expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
     // Not a token so it should get rejected by the authorizer.
+    authzEnabled_ = true;
     std::string mockToken = "THIS SHOULD NOT PARSE";
-    // Test status
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Setting expectations
+    EXPECT_CALL(context_, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockParam_, getOid()).Times(0);
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
 }
 
 /*
- * TEST 5 - dm.getParam() returns a catena::exception_with_status.
+ * TEST 6 - dm.getParam() returns a catena::exception_with_status.
  */
-TEST_F(RESTGetParamTests, GetParam_getParamErrReturnCatena) {
-    // Test status
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockOid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            status = catena::exception_with_status(rc.what(), rc.status);
+TEST_F(RESTGetParamTests, GetParam_ErrGetParamReturnCatena) {
+    expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz) {
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
             return nullptr;
         }));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(*mockParam_, getOid()).Times(0);
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
 }
 
 /*
- * TEST 6 - dm.getParam() throws a catena::exception_with_status.
+ * TEST 7 - dm.getParam() throws a catena::exception_with_status.
  */
-TEST_F(RESTGetParamTests, GetParam_getParamErrThrowCatena) {
-    // Test status
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockOid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            throw catena::exception_with_status(rc.what(), rc.status);
+TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowCatena) {
+    expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return nullptr;
         }));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(*mockParam_, getOid()).Times(0);
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
 }
 
 /*
- * TEST 7 - dm.getParam() throws an std::runtime_error.
+ * TEST 8 - dm.getParam() throws a std::runtime_exception.
  */
-TEST_F(RESTGetParamTests, GetParam_getParamErrThrowUnknown) {
-    // Test status
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    std::string mockOid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Throw(std::runtime_error("Unknown error")));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowStd) {
+    expRc_ = catena::exception_with_status("Std error", catena::StatusCode::INTERNAL);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    EXPECT_CALL(*mockParam_, getOid()).Times(0);
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
 }
 
 /*
- * TEST 8 - param->toProto() returns a catena::exception_with_status.
+ * TEST 8 - dm.getParam() throws an unknown error.
  */
-TEST_F(RESTGetParamTests, GetParam_toProtoErrReturnCatena) {
-    // Other variables.
-    std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockOid = "/test_oid";
+TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowUnknown) {
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    EXPECT_CALL(*mockParam_, getOid()).Times(0);
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
+}
 
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&mockParam, &rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockParam);
+/*
+ * TEST 9 - param->toProto() returns a catena::exception_with_status.
+ */
+TEST_F(RESTGetParamTests, GetParam_ErrToProtoReturnCatena) {
+    expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](){ return std::move(mockParam_); }));
+    EXPECT_CALL(*mockParam_, getOid()).WillRepeatedly(::testing::ReturnRef(fqoid_));
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
+        .WillOnce(::testing::Return(catena::exception_with_status(expRc_.what(), expRc_.status)));
+    // Sending the call
+    testCall();
+}
+
+/*
+ * TEST 10 - param->toProto() throws a catena::exception_with_status.
+ */
+TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowCatena) {
+    expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](){ return std::move(mockParam_); }));
+    EXPECT_CALL(*mockParam_, getOid()).WillRepeatedly(::testing::ReturnRef(fqoid_));
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::Param &param, catena::common::Authorizer &authz)  {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
+            return catena::exception_with_status("", catena::StatusCode::OK);
         }));
-    // Defining param->toProto()
-    EXPECT_CALL(*mockParam, getOid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    EXPECT_CALL(*mockParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
-        .WillOnce(::testing::Return(catena::exception_with_status(rc.what(), rc.status)));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the call
+    testCall();
 }
 
 /*
- * TEST 9 - param->toProto() throws a catena::exception_with_status.
+ * TEST 11 - param->toProto() throws a std::runtime_exception.
  */
-TEST_F(RESTGetParamTests, GetParam_toProtoErrThrowCatena) {
-    // Other variables.
-    std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockOid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&mockParam, &rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockParam);
-        }));
-    // Defining param->toProto()
-    EXPECT_CALL(*mockParam, getOid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    EXPECT_CALL(*mockParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::Param &param, catena::common::Authorizer &authz)
-        -> catena::exception_with_status {
-            throw catena::exception_with_status(rc.what(), rc.status);
-        }));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowStd) {
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](){ return std::move(mockParam_); }));
+    EXPECT_CALL(*mockParam_, getOid()).WillRepeatedly(::testing::ReturnRef(fqoid_));
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the call
+    testCall();
 }
 
 /*
- * TEST 10 - param->toProto() throws an std::runtime_error.
+ * TEST 11 - param->toProto() throws an unknown error.
  */
-TEST_F(RESTGetParamTests, GetParam_toProtoErrThrowUnknown) {
-    // Other variables.
-    std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    std::string mockOid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam()
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&mockParam, &rc](const std::string &fqoid, catena::exception_with_status &status, catena::common::Authorizer &authz)
-        -> std::unique_ptr<IParam> {
-            status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(mockParam);
-        }));
-    // Defining param->toProto()
-    EXPECT_CALL(*mockParam, getOid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    EXPECT_CALL(*mockParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
-        .WillOnce(::testing::Throw(std::runtime_error("Unknown error")));
-    
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/*
- * TEST 11 - dm.getParam() throws a non-standard exception.
- */
-TEST_F(RESTGetParamTests, GetParam_getParamErrThrowUnknownType) {
-    // Test status
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    std::string mockOid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMtx));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockOid));
-    // Defining Device.getParam() to throw a non-std exception (e.g., int)
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status&, catena::common::Authorizer&) -> std::unique_ptr<IParam> {
-            throw 42; // Throw an int to trigger catch(...)
-            return nullptr;
-        }));
-
-    // Calling proceed() and checking written response.
-    getParam->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/*
- * TEST 12 - Writing to console with GetParam finish().
- */
-TEST_F(RESTGetParamTests, GetParam_finish) {
-    // Calling finish and expecting the console output.
-    getParam->finish();
-    ASSERT_TRUE(MockConsole.str().find("GetParam[11] finished\n") != std::string::npos);
+TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowUnknown) {
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](){ return std::move(mockParam_); }));
+    EXPECT_CALL(*mockParam_, getOid()).WillRepeatedly(::testing::ReturnRef(fqoid_));
+    EXPECT_CALL(*mockParam_, toProto(::testing::An<catena::Param&>(), ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending the call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/GetParam_test.cpp
+++ b/unittests/cpp/REST/tests/GetParam_test.cpp
@@ -72,7 +72,7 @@ class RESTGetParamTests : public RESTEndpointTest {
         param->add_oid_aliases(alias);
         (*param->mutable_name()->mutable_display_strings())["en"] = enName;
         auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson_);
-        EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+        ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
     }
 
     /*

--- a/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
+++ b/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
@@ -47,7 +47,10 @@ using namespace catena::REST;
 // Fixture
 class RESTGetPopulatedSlotsTests : public RESTEndpointTest {
   protected:
-    ICallData* makeOne() override { return GetPopulatedSlots::makeOne(serverSocket, context_, dm0_); }
+    /*
+     * Creates a GetPopulatedSlots handler object.
+     */
+    ICallData* makeOne() override { return GetPopulatedSlots::makeOne(serverSocket_, context_, dm0_); }
 
     /*
      * Calls proceed and tests the response.
@@ -80,7 +83,7 @@ TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Create) {
 /* 
  * TEST 2 - Writing to console with GetPopulatedSlots finish().
  */
-TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_finish) {
+TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Finish) {
     endpoint_->finish();
     ASSERT_TRUE(MockConsole_.str().find("GetPopulatedSlots[1] finished\n") != std::string::npos);
 }

--- a/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
+++ b/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
@@ -60,7 +60,7 @@ class RESTGetPopulatedSlotsTests : public RESTEndpointTest {
         std::string expJson = "";
         if (!expVal_.slots().empty()) {
             auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
-            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+            ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
         }
         EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }

--- a/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
+++ b/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
@@ -35,57 +35,35 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/GetPopulatedSlots.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTGetPopulatedSlotsTests : public ::testing::Test, public RESTTest {
+class RESTGetPopulatedSlotsTests : public RESTEndpointTest {
   protected:
-    RESTGetPopulatedSlotsTests() : RESTTest(&serverSocket, &clientSocket) {}
+    ICallData* makeOne() override { return GetPopulatedSlots::makeOne(serverSocket, context_, dm0_); }
 
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Creating GetPopulatedSlots object.
-        EXPECT_CALL(context, origin()).Times(1).WillOnce(::testing::ReturnRef(origin));
-        getPopulatedSlots = GetPopulatedSlots::makeOne(serverSocket, context, dm);
-    }
-
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (getPopulatedSlots) {
-            delete getPopulatedSlots;
+    /*
+     * Calls proceed and tests the response.
+     */
+    void testCall() {
+        endpoint_->proceed();
+        std::string expJson = "";
+        if (!expVal_.slots().empty()) {
+            auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
+            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
         }
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    
-    MockSocketReader context;
-    MockDevice dm;
-    std::mutex mockMutex;
-    catena::REST::ICallData* getPopulatedSlots = nullptr;
+
+    // Expected values
+    catena::SlotList expVal_;
 };
 
 /*
@@ -95,46 +73,34 @@ class RESTGetPopulatedSlotsTests : public ::testing::Test, public RESTTest {
  * 
  * TEST 1 - Creating a GetPopulatedSlots object with makeOne.
  */
-TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_create) {
-    ASSERT_TRUE(getPopulatedSlots);
+TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Create) {
+    ASSERT_TRUE(endpoint_);
 }
 
 /* 
- * TEST 2 - Normal case for GetPopulatedSlots proceed().
- */
-TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_proceedNormal) {
-    catena::exception_with_status rc("OK", catena::StatusCode::OK);
-    uint32_t slot = 1;
-    // Expected JSON response.
-    catena::SlotList slotList;
-    slotList.add_slots(slot);
-
-    EXPECT_CALL(dm, slot()).Times(1).WillOnce(::testing::Return(1));
-
-    getPopulatedSlots->proceed();
-
-    std::string jsonBody;
-    google::protobuf::util::JsonPrintOptions options; // Default options
-    auto status = google::protobuf::util::MessageToJsonString(slotList, &jsonBody, options);
-    EXPECT_EQ(readResponse(), expectedResponse(rc, jsonBody));
-}
-
-/* 
- * TEST 3 - dm.slot() throws an error.
- */
-TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_proceedErr) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    EXPECT_CALL(dm, slot()).Times(1).WillOnce(::testing::Throw(std::runtime_error("Unknown error")));
-    getPopulatedSlots->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 4 - Writing to console with GetPopulatedSlots finish().
+ * TEST 2 - Writing to console with GetPopulatedSlots finish().
  */
 TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_finish) {
-    // Calling finish and expecting the console output.
-    getPopulatedSlots->finish();
-    // Idk why I cant use .contains() here :/
-    ASSERT_TRUE(MockConsole.str().find("GetPopulatedSlots[3] finished\n") != std::string::npos);
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("GetPopulatedSlots[1] finished\n") != std::string::npos);
+}
+
+/*
+ * TEST 3 - Normal case for GetPopulatedSlots proceed().
+ */
+TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Normal) {
+    expVal_.add_slots(dm0_.slot());
+    // Sending the call
+    testCall();
+}
+
+/* 
+ * TEST 4 - dm.slot() throws an error.
+ */
+TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_proceedErr) {
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, slot()).Times(1).WillOnce(::testing::Throw(std::runtime_error("Unknown error")));
+    // Sending the call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/GetValue_test.cpp
+++ b/unittests/cpp/REST/tests/GetValue_test.cpp
@@ -50,19 +50,18 @@ class RESTGetValueTests : public RESTEndpointTest {
     /*
      * Creates a GetValue handler object.
      */
-    ICallData* makeOne() override { return GetValue::makeOne(serverSocket, context_, dm0_); }
+    ICallData* makeOne() override { return GetValue::makeOne(serverSocket_, context_, dm0_); }
 
     /*
-     * Helper function which initializes a GetValuePayload object.
+     * Streamlines the creation of endpoint input. 
      */
     void initPayload(uint32_t slot, const std::string& oid) {
         slot_ = slot;
         fqoid_ = oid;
     }
 
-    /* 
-     * Makes an async RPC to the MockServer and waits for a response before
-     * comparing output.
+    /*
+     * Calls proceed and tests the response.
      */
     void testRPC() {
         endpoint_->proceed();
@@ -89,8 +88,16 @@ TEST_F(RESTGetValueTests, GetValue_Create) {
     EXPECT_TRUE(endpoint_);
 }
 
+/* 
+ * TEST 2 - Writing to console with GetValue finish().
+ */
+TEST_F(RESTGetValueTests, GetValue_Finish) {
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("GetValue[1] finished\n") != std::string::npos);
+}
+
 /*
- * TEST 2 - Normal case for GetValue proceed().
+ * TEST 3 - Normal case for GetValue proceed().
  */
 TEST_F(RESTGetValueTests, GetValue_Normal) {
     initPayload(0, "/test_oid");
@@ -108,7 +115,7 @@ TEST_F(RESTGetValueTests, GetValue_Normal) {
 }
 
 /*
- * TEST 3 - GetValue with authz on and valid token.
+ * TEST 4 - GetValue with authz on and valid token.
  */
 TEST_F(RESTGetValueTests, GetValue_AuthzValid) {
     initPayload(0, "/test_oid");
@@ -138,7 +145,7 @@ TEST_F(RESTGetValueTests, GetValue_AuthzValid) {
 }
 
 /*
- * TEST 4 - GetValue with authz on and invalid token.
+ * TEST 5 - GetValue with authz on and invalid token.
  */
 TEST_F(RESTGetValueTests, GetValue_AuthzInvalid) {
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -196,7 +203,7 @@ TEST_F(RESTGetValueTests, GetValue_ErrThrowStd) {
 }
 
 /*
- * TEST 8 - dm.getValue() throws an unknown error.
+ * TEST 9 - dm.getValue() throws an unknown error.
  */
 TEST_F(RESTGetValueTests, GetValue_ErrThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);

--- a/unittests/cpp/REST/tests/GetValue_test.cpp
+++ b/unittests/cpp/REST/tests/GetValue_test.cpp
@@ -35,56 +35,47 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/GetValue.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTGetValueTests : public ::testing::Test, public RESTTest {
+class RESTGetValueTests : public RESTEndpointTest {
   protected:
-    RESTGetValueTests() : RESTTest(&serverSocket, &clientSocket) {}
+    /*
+     * Creates a GetValue handler object.
+     */
+    ICallData* makeOne() override { return GetValue::makeOne(serverSocket, context_, dm0_); }
 
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Creating getValue object.
-        EXPECT_CALL(context, origin()).Times(1).WillOnce(::testing::ReturnRef(origin));
-        getValue = GetValue::makeOne(serverSocket, context, dm);
+    /*
+     * Helper function which initializes a GetValuePayload object.
+     */
+    void initPayload(uint32_t slot, const std::string& oid) {
+        slot_ = slot;
+        fqoid_ = oid;
     }
 
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (getValue) {
-            delete getValue;
+    /* 
+     * Makes an async RPC to the MockServer and waits for a response before
+     * comparing output.
+     */
+    void testRPC() {
+        endpoint_->proceed();
+        std::string expJson = "";
+        if (!expVal_.string_value().empty()) {
+            auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
+            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
         }
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    
-    MockSocketReader context;
-    MockDevice dm;
-    catena::REST::ICallData* getValue = nullptr;
+
+    // Expected variables
+    catena::Value expVal_;
 };
 
 /*
@@ -92,226 +83,127 @@ class RESTGetValueTests : public ::testing::Test, public RESTTest {
  *                               GetValue tests
  * ============================================================================
  * 
- * TEST 1 - Creating a GetValue object with makeOne.
+ * TEST 1 - Creating a GetValue object.
  */
-TEST_F(RESTGetValueTests, GetValue_create) {
-    // Making sure getValue is created from the SetUp step.
-    ASSERT_TRUE(getValue);
+TEST_F(RESTGetValueTests, GetValue_Create) {
+    EXPECT_TRUE(endpoint_);
 }
 
-/* 
+/*
  * TEST 2 - Normal case for GetValue proceed().
  */
-TEST_F(RESTGetValueTests, GetValue_proceedNormal) {
-    // Setting up the returnVal to test with.
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string mockFqoid = "/test_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    // dm.getValue()
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([returnVal, &rc](const std::string& jptr, catena::Value& value, Authorizer& authz) -> catena::exception_with_status {
-            value.CopyFrom(returnVal);
-            return catena::exception_with_status(rc.what(), rc.status);
+TEST_F(RESTGetValueTests, GetValue_Normal) {
+    initPayload(0, "/test_oid");
+    expVal_.set_string_value("test_value");
+    // Setting expectations
+    EXPECT_CALL(dm0_, getValue(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& jptr, catena::Value& value, Authorizer& authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            value.CopyFrom(expVal_);
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-
-    std::string jsonBody;
-    google::protobuf::util::JsonPrintOptions options; // Default options
-    auto status = google::protobuf::util::MessageToJsonString(returnVal, &jsonBody, options);
-    EXPECT_EQ(readResponse(), expectedResponse(rc, jsonBody));
+    // Sending the RPC.
+    testRPC();
 }
 
-/* 
- * TEST 3 - dm.getValue() returns an catena::exception_with_status.
+/*
+ * TEST 3 - GetValue with authz on and valid token.
  */
-TEST_F(RESTGetValueTests, GetValue_proceedErrReturnCatena) {
-    // Setting up the returnVal to test with.
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockFqoid = "/invalid_oid";
-
-    // Defining mock functions
-    // authz = false, fields("oid") = "/text_oid"
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    // dm.getValue()
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([returnVal, &rc](const std::string& jptr, catena::Value& value, Authorizer& authz) -> catena::exception_with_status {
-            return catena::exception_with_status(rc.what(), rc.status);
+TEST_F(RESTGetValueTests, GetValue_AuthzValid) {
+    initPayload(0, "/test_oid");
+    expVal_.set_string_value("test_value");
+    // Adding authorization mockToken metadata. This it a random RSA token.
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+                "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
+                "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
+                "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
+                "okrEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko9653v0khyUT4UK"
+                "eOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKHkWi4P3-CYWrwe-g6b4-a33Q"
+                "0k6tSGI1hGf2bA9cRYr-VyQ_T3RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEm"
+                "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
+                "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
+                "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
+    // Setting expectations
+    EXPECT_CALL(dm0_, getValue(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& jptr, catena::Value& value, Authorizer& authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            value.CopyFrom(expVal_);
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the RPC.
+    testRPC();
 }
 
-/* 
- * TEST 4 - GetValue with authz on and valid token.
+/*
+ * TEST 4 - GetValue with authz on and invalid token.
  */
-TEST_F(RESTGetValueTests, GetValue_proceedAuthzValid) {
-    // Setting up the returnVal to test with.
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string mockFqoid = "/test_oid";
-    /* Authz just tests for a properly encrypted token, proxy handles authz.
-     * This is a random RSA token I made jwt.io it is not a security risk I
-     * swear. */
-    std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
-                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
-                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
-                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
-                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
-                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
-                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
-                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
-                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
-                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
-                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
-                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-
-    // Defining mock functions
-    // authz = false, fields("oid") = "/text_oid"
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    // dm.getValue()
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([returnVal, &rc](const std::string& jptr, catena::Value& value, Authorizer& authz) -> catena::exception_with_status {
-            value.CopyFrom(returnVal);
-            return catena::exception_with_status(rc.what(), rc.status);
-        }));
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-
-    std::string jsonBody;
-    google::protobuf::util::JsonPrintOptions options; // Default options
-    auto status = google::protobuf::util::MessageToJsonString(returnVal, &jsonBody, options);
-    EXPECT_EQ(readResponse(), expectedResponse(rc, jsonBody));
-}
-
-/* 
- * TEST 5 - GetValue with authz on and an invalid token.
- */
-TEST_F(RESTGetValueTests, GetValue_proceedAuthzInvalid) {
-    // Setting up the returnVal to test with.
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
+TEST_F(RESTGetValueTests, GetValue_AuthzInvalid) {
+    expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
     // Not a token so it should get rejected by the authorizer.
-    std::string mockToken = "THIS SHOULD NOT PARSE";
-
-    // Defining mock functions
-    // authz = false, fields("oid") = "/text_oid"
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-    // Should NOT make it this far.
-    EXPECT_CALL(context, fqoid()).Times(0);
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(0);
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    authzEnabled_ = true;
+    jwsToken_ = "THIS SHOULD NOT PARSE";
+    // Setting expectations
+    EXPECT_CALL(dm0_, getValue(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the RPC.
+    testRPC();
 }
 
-/* 
- * TEST 6 - dm.getValue() throws a catena::exception_with_status.
+/*
+ * TEST 6 - dm.getValue() returns a catena::exception_with_status.
  */
-TEST_F(RESTGetValueTests, GetValue_proceedErrThrowCatena) {
-    // Setting up the returnVal to test with.
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockFqoid = "/invalid_oid";
+TEST_F(RESTGetValueTests, GetValue_ErrReturnCatena) {
+    expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "/test_oid");
+    // Mocking kProcess and kFinish functions
+    EXPECT_CALL(dm0_, getValue(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& jptr, catena::Value& value, Authorizer& authz) {
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
+        }));
+    // Sending the RPC.
+    testRPC();
+}
 
-    // Defining mock functions
-    // authz = false, fields("oid") = "/text_oid"
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    // dm.getValue()
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([returnVal, &rc](const std::string& jptr, catena::Value& value, Authorizer& authz) -> catena::exception_with_status {
-            throw catena::exception_with_status(rc.what(), rc.status);
+/*
+ * TEST 7 - dm.getValue() throws a catena::exception_with_status.
+ */
+TEST_F(RESTGetValueTests, GetValue_ErrThrowCatena) {
+    expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
+    initPayload(0, "/test_oid");
+    // Setting expectations
+    EXPECT_CALL(dm0_, getValue(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string& jptr, catena::Value& value, Authorizer& authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the RPC.
+    testRPC();
 }
 
-/* 
- * TEST 7 - dm.getValue() throws an std::runtime_error.
+/*
+ * TEST 8 - dm.getValue() throws a std::runtime_exception.
  */
-TEST_F(RESTGetValueTests, GetValue_proceedErrThrowUnknown) {
-    // Setting up the returnVal to test with.
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("", catena::StatusCode::UNKNOWN);
-    std::string mockFqoid = "/invalid_oid";
-
-    // Defining mock functions
-    // authz = false, fields("oid") = "/text_oid"
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    // dm.getValue()
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([returnVal, &rc](const std::string& jptr, catena::Value& value, Authorizer& authz) -> catena::exception_with_status {
-            throw std::runtime_error("Unknown error");
-            return catena::exception_with_status("", catena::StatusCode::OK);
-        }));
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+TEST_F(RESTGetValueTests, GetValue_ErrThrowStd) {
+    expRc_ = catena::exception_with_status("std error", catena::StatusCode::INTERNAL);
+    initPayload(0, "/test_oid");
+    // Setting expectations
+    EXPECT_CALL(dm0_, getValue(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the RPC.
+    testRPC();
 }
 
-/* 
- * TEST 8 - dm.getValue() throws a non-standard exception (e.g., int) to cover catch(...)
+/*
+ * TEST 8 - dm.getValue() throws an unknown error.
  */
-TEST_F(RESTGetValueTests, GetValue_proceedErrThrowUnknownType) {
-    catena::Value returnVal;
-    returnVal.set_string_value("Test string");
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    std::string mockFqoid = "/invalid_oid";
-
-    // Defining mock functions
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    // dm.getValue() throws a non-std exception (e.g., int)
-    EXPECT_CALL(dm, getValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([](const std::string&, catena::Value&, Authorizer&) -> catena::exception_with_status {
-            throw 42; // Throw an int to trigger catch(...)
-            return catena::exception_with_status("", catena::StatusCode::OK);
-        }));
-
-    // Calling proceed() and checking written response.
-    getValue->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+TEST_F(RESTGetValueTests, GetValue_ErrThrowUnknown) {
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    initPayload(0, "/test_oid");
+    // Setting expectations
+    EXPECT_CALL(dm0_, getValue(fqoid_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending the RPC.
+    testRPC();
 }
-
-/* 
- * TEST 9 - Writing to console with GetValue finish().
- */
-TEST_F(RESTGetValueTests, GetValue_finish) {
-    // Calling finish and expecting the console output.
-    getValue->finish();
-    // Idk why I cant use .contains() here :/
-    ASSERT_TRUE(MockConsole.str().find("GetValue[8] finished\n") != std::string::npos);
-}
-
-

--- a/unittests/cpp/REST/tests/GetValue_test.cpp
+++ b/unittests/cpp/REST/tests/GetValue_test.cpp
@@ -68,7 +68,7 @@ class RESTGetValueTests : public RESTEndpointTest {
         std::string expJson = "";
         if (!expVal_.string_value().empty()) {
             auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
-            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+            ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
         }
         EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }

--- a/unittests/cpp/REST/tests/LanguagePack_test.cpp
+++ b/unittests/cpp/REST/tests/LanguagePack_test.cpp
@@ -50,10 +50,10 @@ class RESTLanguagePackTests : public RESTEndpointTest {
     /*
      * Creates a LanguagePack handler object.
      */
-    ICallData* makeOne() override { return LanguagePack::makeOne(serverSocket, context_, dm0_); }
+    ICallData* makeOne() override { return LanguagePack::makeOne(serverSocket_, context_, dm0_); }
 
     /*
-     * Streamlines the creation of LanguagePack Payload. 
+     * Streamlines the creation of endpoint input. 
      */
     void initPayload(uint32_t slot, const std::string& language) {
         slot_ = slot;
@@ -61,7 +61,7 @@ class RESTLanguagePackTests : public RESTEndpointTest {
         fqoid_ = "/" + language;
     }
     /*
-     * Streamlines the creation of LanguagePack payload with json body. 
+     * Streamlines the creation of endpoint input with json body. 
      */
     void initPayload(uint32_t slot, const std::string& language, const std::string& name, 
                      const std::unordered_map<std::string, std::string>& words) {
@@ -73,8 +73,9 @@ class RESTLanguagePackTests : public RESTEndpointTest {
         auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
         EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
     }
+
     /*
-     * Streamlines the creation of expected LanguagePack. 
+     * Streamlines the creation of the expected output ComponentLanguagePack. 
      */
     void initExpVal(const std::string& language, const std::string& name, 
                     const std::unordered_map<std::string, std::string>& words) {
@@ -85,6 +86,7 @@ class RESTLanguagePackTests : public RESTEndpointTest {
             pack->mutable_words()->insert({word.first, word.second});
         }
     }
+
     /*
      * Calls proceed and tests the response.
      */
@@ -98,7 +100,8 @@ class RESTLanguagePackTests : public RESTEndpointTest {
         EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }
 
-    std::string language_;
+    // In vals
+    std::string language_; // fqoid_ without the leading "/"
     catena::LanguagePack inVal_;
     // Expected values
     catena::DeviceComponent_ComponentLanguagePack expVal_;

--- a/unittests/cpp/REST/tests/LanguagePack_test.cpp
+++ b/unittests/cpp/REST/tests/LanguagePack_test.cpp
@@ -1,4 +1,4 @@
-/*
+testCall();\/*
  * Copyright 2025 Ross Video Ltd
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,105 +35,91 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/LanguagePack.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTLanguagePackTests : public ::testing::Test, public RESTTest {
+class RESTLanguagePackTests : public RESTEndpointTest {
   protected:
-    RESTLanguagePackTests() : RESTTest(&serverSocket, &clientSocket) {}
-
-    /*
-     * Redirects cout and sets default expectations for each method.
-     */
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Default expectations for the context.
-        EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRefOfCopy("/" + testLanguage));
-        EXPECT_CALL(context, method()).WillRepeatedly(::testing::ReturnRef(testMethod));
-        EXPECT_CALL(context, slot()).WillRepeatedly(::testing::Return(0));
-        EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::ReturnRef(testToken));
-        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin));
-        EXPECT_CALL(context, jsonBody()).WillRepeatedly(::testing::ReturnRef(testJsonBody));
-        EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Invoke([this](){ return authzEnabled; }));
-
-        // Default expectations for the device model.
-        EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMutex));
-        EXPECT_CALL(dm, hasLanguage(testLanguage)).WillRepeatedly(::testing::Invoke([this](){ return testMethod == "PUT"; }));
-
-        // Init testVal.
-        testVal.set_language(testLanguage);
-        catena::LanguagePack *pack = testVal.mutable_language_pack();
-        pack->set_name("English");
-        pack->mutable_words()->insert({"Hello", "Goodbye"});
-        auto status = google::protobuf::util::MessageToJsonString(*pack, &testJsonBody);
-        ASSERT_TRUE(status.ok());
-
-        // Creating LanguagePack object.
-        endpoint.reset(LanguagePack::makeOne(serverSocket, context, dm));
+    RESTLanguagePackTests() : RESTEndpointTest() {
+        EXPECT_CALL(dm0_, hasLanguage(fqoid_)).WillRepeatedly(::testing::Invoke([this](){ return method_ == "PUT"; }));
     }
 
     /*
-     * Restores cout after each test.
+     * Creates a LanguagePack handler object.
      */
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
+    ICallData* makeOne() override { return LanguagePack::makeOne(serverSocket, context__, dm0_); }
+
+    /*
+     * Streamlines the creation of LanguagePack Payload. 
+     */
+    void initPayload(uint32_t slot, const std::string& language) {
+        slot_ = slot;
+        fqoid_ = "/" + language;
+    }
+    /*
+     * Streamlines the creation of LanguagePack payload with json body. 
+     */
+    void initPayload(uint32_t slot, const std::string& language, const std::string& name, 
+                     const std::unordered_map<std::string, std::string>& words) {
+        initPayload(slot, language);
+        catena::DeviceComponent_ComponentLanguagePack lp;
+        lp.set_language(language);
+        catena::LanguagePack *pack = lp.mutable_language_pack();
+        pack->set_name(name);
+        for (const auto& word : words) {
+            pack->mutable_words()->insert({word.first, word.second});
+        }
+        auto status = google::protobuf::util::MessageToJsonString(lp, &jsonBody_);
+        EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+    }
+    /*
+     * Streamlines the creation of expected LanguagePack. 
+     */
+    void initExpVal(const std::string& language, const std::string& name, 
+                    const std::unordered_map<std::string, std::string>& words) {
+        expVal_.set_language(language);
+        catena::LanguagePack *pack = expVal_.mutable_language_pack();
+        pack->set_name(name);
+        for (const auto& word : words) {
+            pack->mutable_words()->insert({word.first, word.second});
+        }
+    }
+    /*
+     * Calls proceed and tests the response.
+     */
+    void testCall() {
+        endpoint__->proceed();
+        std::string expJson = "";
+        if (!expVal_.language().empty()) {
+            auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
+            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+        }
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }
 
-    // Cout variables.
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    // Context variables.
-    std::string testMethod = "GET";
-    std::string testLanguage = "en";
-    std::string testToken = "";
-    std::string testJsonBody;
-    bool authzEnabled = false;
-    // Mock objects and endpoint.
-    MockSocketReader context;
-    std::mutex mockMutex;
-    MockDevice dm;
-    std::unique_ptr<ICallData> endpoint = nullptr;
-    // Test value.
-    catena::DeviceComponent_ComponentLanguagePack testVal;
+    // Expected values
+    catena::DeviceComponent_ComponentLanguagePack expVal_;
 };
 
 /*
  * TEST 0.1 - Creating a LanguagePack object with makeOne.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_Create) {
-    // Making sure languagePack is created from the SetUp step.
-    ASSERT_TRUE(endpoint);
+    ASSERT_TRUE(endpoint_);
 }
 
 /* 
  * TEST 0.2 - Writing to console with LanguagePack finish().
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_Finish) {
-    // Calling finish and expecting the console output.
-    endpoint->finish();
+    endpoint_->finish();
     ASSERT_TRUE(MockConsole.str().find("LanguagePack[1] finished\n") != std::string::npos);
 }
 
@@ -141,17 +127,14 @@ TEST_F(RESTLanguagePackTests, LanguagePack_Finish) {
  * TEST 0.3 - LanguagePack proceed() with an invalid method.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_BadMethod) {
-    catena::exception_with_status rc("Bad method", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "BAD_METHOD";
+    expRc_ = catena::exception_with_status("Bad method", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "BAD_METHOD";
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0);
-    // Should not call any of these on a bad method.
-    EXPECT_CALL(dm, getLanguagePack(::testing::_, ::testing::_)).Times(0);
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    EXPECT_CALL(dm, removeLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, getLanguagePack(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(dm0_, removeLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /*
@@ -162,84 +145,71 @@ TEST_F(RESTLanguagePackTests, LanguagePack_BadMethod) {
  * TEST 1.1 - GET LangaugePack normal case.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_GETNormal) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testJsonBody.clear();
-    auto status = google::protobuf::util::MessageToJsonString(testVal, &testJsonBody);
-    ASSERT_TRUE(status.ok());
+    initPayload(0, "tl");
+    initExpVal("tl", "Test Language", {{"hello", "world"}});
     // Setting expectations.
-    EXPECT_CALL(context, authorizationEnabled()).Times(0); // No authz on GET.
-    EXPECT_CALL(context, jwsToken()).Times(0);             // No authz on GET.
-    EXPECT_CALL(dm, getLanguagePack(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc, this](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
-            pack.CopyFrom(testVal);
-            return catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(context_, authorizationEnabled()).Times(0); // No authz on GET.
+    EXPECT_CALL(context_, jwsToken()).Times(0);             // No authz on GET.
+    EXPECT_CALL(dm0_, getLanguagePack(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
+            pack.CopyFrom(expVal_);
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc, testJsonBody));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.2 - GET LanguagePack dm.getLanguagePack() returns a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_GETErrReturn) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    // Defining mock fuctions
-    EXPECT_CALL(dm, getLanguagePack(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
-            return catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getLanguagePack(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.3 - GET LanguagePack dm.getLanguagePack() throws a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_GETErrThrowCat) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    // Defining mock fuctions
-    EXPECT_CALL(dm, getLanguagePack(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getLanguagePack(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.4 - GET LanguagePack dm.getLanguagePack() throws a std::runtime error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_GETErrThrowStd) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::INTERNAL);
-    // Defining mock fuctions
-    EXPECT_CALL(dm, getLanguagePack(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
-            throw std::runtime_error(rc.what());
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("std error", catena::StatusCode::INTERNAL);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getLanguagePack(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.5 - GET LanguagePack dm.getLanguagePack() throws an unknown error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_GETErrThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    // Defining mock fuctions
-    EXPECT_CALL(dm, getLanguagePack(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::DeviceComponent_ComponentLanguagePack &pack) {
-            throw 0;
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, getLanguagePack(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending call
+    testCall();
 }
 
 /*
@@ -250,31 +220,27 @@ TEST_F(RESTLanguagePackTests, LanguagePack_GETErrThrowUnknown) {
  * TEST 2.1 - POST LanguagePack normal case.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTNormal) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testMethod = "POST";
+    method_ = "POST";
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz disabled.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc, this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
             // Make sure correct values are passed in.
-            EXPECT_EQ(&authz, &catena::common::Authorizer::kAuthzDisabled);
-            EXPECT_EQ(language.id(), testVal.language());
-            EXPECT_EQ(language.language_pack().SerializeAsString(), testVal.language_pack().SerializeAsString());
-            return catena::exception_with_status(rc.what(), rc.status);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            EXPECT_EQ(language.id(), expVal_.language());
+            EXPECT_EQ(language.language_pack().SerializeAsString(), expVal_.language_pack().SerializeAsString());
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.2 - POST LanguagePack with a valid token.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTAuthzValid) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testMethod = "POST";
-    authzEnabled = true;
-    testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+    method_ = "POST";
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
                 "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
                 "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
                 "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
@@ -285,130 +251,114 @@ TEST_F(RESTLanguagePackTests, LanguagePack_POSTAuthzValid) {
                 "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
                 "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc, this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
             // Make sure correct values are passed in.
-            EXPECT_FALSE(&authz == &catena::common::Authorizer::kAuthzDisabled);
-            EXPECT_EQ(language.id(), testVal.language());
-            EXPECT_EQ(language.language_pack().SerializeAsString(), testVal.language_pack().SerializeAsString());
-            return catena::exception_with_status(rc.what(), rc.status);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            EXPECT_EQ(language.id(), expVal_.language());
+            EXPECT_EQ(language.language_pack().SerializeAsString(), expVal_.language_pack().SerializeAsString());
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.3 - POST LanguagePack with an invalid token.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTAuthzInvalid) {
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-    testMethod = "POST";
-    authzEnabled = true;
-    testToken = "Invalid token";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::UNAUTHENTICATED);
+    method_ = "POST";
+    authzEnabled_ = true;
+    jwsToken_ = "Bearer THIS SHOULD NOT PARSE";
     // Setting expectations.
-    // Should not call if authz fails.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.4 - POST LanguagePack with invalid json.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTFailParse) {
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "POST";
-    testJsonBody = "Not a JSON string";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "POST";
+    jsonBody_ = "Not a JSON string";
     // Setting expectations.
-    // Should not call if json fails to parse.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.5 - POST LanguagePack overwrite error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTOverwrite) {
-    catena::exception_with_status rc("", catena::StatusCode::PERMISSION_DENIED);
-    testMethod = "POST";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::PERMISSION_DENIED);
+    method_ = "POST";
     // Setting expectations.
-    EXPECT_CALL(dm, hasLanguage(testLanguage)).WillOnce(::testing::Return(true));
+    EXPECT_CALL(dm0_, hasLanguage(fqoid_)).WillOnce(::testing::Return(true));
     // Should not call if trying to overwrite on POST.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.6 - POST LanguagePack returns a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTErrReturn) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "POST";
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "POST";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            return catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.7 - POST LanguagePack throws a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTErrThrowCat) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "POST";
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "POST";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.8 - POST LanguagePack throws a std::runtime error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTErrThrowStd) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::INTERNAL);
-    testMethod = "POST";
+    expRc_ = catena::exception_with_status("std error", catena::StatusCode::INTERNAL);
+    method_ = "POST";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            throw std::runtime_error(rc.what());
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.9 - POST LanguagePack throws an unknown error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_POSTErrThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    testMethod = "POST";
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    method_ = "POST";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            throw 0;
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending call
+    testCall();
 }
 
 /*
@@ -419,30 +369,27 @@ TEST_F(RESTLanguagePackTests, LanguagePack_POSTErrThrowUnknown) {
  * TEST 3.1 - PUT LanguagePack normal case.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTNormal) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testMethod = "PUT";
+    method_ = "PUT";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc, this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
             // Make sure correct values are passed in.
-            EXPECT_EQ(&authz, &catena::common::Authorizer::kAuthzDisabled);
-            EXPECT_EQ(language.id(), testVal.language());
-            EXPECT_EQ(language.language_pack().SerializeAsString(), testVal.language_pack().SerializeAsString());
-            return catena::exception_with_status(rc.what(), rc.status);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            EXPECT_EQ(language.id(), expVal_.language());
+            EXPECT_EQ(language.language_pack().SerializeAsString(), expVal_.language_pack().SerializeAsString());
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.2 - PUT LanguagePack with a valid token.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTAuthzValid) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testMethod = "PUT";
-    authzEnabled = true;
-    testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+    method_ = "PUT";
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
                 "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
                 "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
                 "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
@@ -453,131 +400,114 @@ TEST_F(RESTLanguagePackTests, LanguagePack_PUTAuthzValid) {
                 "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
                 "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc, this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
             // Make sure correct values are passed in.
-            EXPECT_FALSE(&authz == &catena::common::Authorizer::kAuthzDisabled);
-            EXPECT_EQ(language.id(), testVal.language());
-            EXPECT_EQ(language.language_pack().SerializeAsString(), testVal.language_pack().SerializeAsString());
-            return catena::exception_with_status(rc.what(), rc.status);
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            EXPECT_EQ(language.id(), expVal_.language());
+            EXPECT_EQ(language.language_pack().SerializeAsString(), expVal_.language_pack().SerializeAsString());
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.3 - PUT LanguagePack with an invalid token.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTAuthzInvalid) {
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-    testMethod = "PUT";
-    authzEnabled = true;
-    testToken = "Invalid token";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::UNAUTHENTICATED);
+    method_ = "PUT";
+    authzEnabled_ = true;
+    jwsToken_ = "Bearer THIS SHOULD NOT PARSE";
     // Setting expectations.
-    // Should not call if authz fails.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.4 - PUT LanguagePack with invalid json.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTFailParse) {
-    catena::exception_with_status rc("", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "PUT";
-    testJsonBody = "Not a JSON string";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "PUT";
+    jsonBody_ = "Not a JSON string";
     // Setting expectations.
-    // Should not call if json fails to parse.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.5 - PUT LanguagePack add error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTNew) {
-    catena::exception_with_status rc("", catena::StatusCode::PERMISSION_DENIED);
-    testMethod = "PUT";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::PERMISSION_DENIED);
+    method_ = "PUT";
     // Setting expectations.
-    EXPECT_CALL(dm, hasLanguage(testLanguage)).WillOnce(::testing::Return(false));
+    EXPECT_CALL(dm0_, hasLanguage(fqoid_)).WillOnce(::testing::Return(false));
     // Should not call if trying to add on PUT.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.6 - PUT LanguagePack returns a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTErrReturn) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "PUT";
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "PUT";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            return catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.7 - PUT LanguagePack throws a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTErrThrowCat) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "PUT";
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "PUT";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.8 - PUT LanguagePack throws a std::runtime error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTErrThrowStd) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::INTERNAL);
-    testMethod = "PUT";
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::INTERNAL);
+    method_ = "PUT";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            throw std::runtime_error(rc.what());
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 3.9 - PUT LanguagePack throws an unknown error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_PUTErrThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    testMethod = "PUT";
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    method_ = "PUT";
     // Setting expectations.
-    EXPECT_CALL(dm, addLanguage(::testing::_, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::AddLanguagePayload &language, catena::common::Authorizer &authz) {
-            throw 0;
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, addLanguage(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending call
+    testCall();
 }
 
 /*
@@ -588,27 +518,24 @@ TEST_F(RESTLanguagePackTests, LanguagePack_PUTErrThrowUnknown) {
  * TEST 4.1 - DELETE LangaugePack normal case.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETENormal) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testMethod = "DELETE";
+    method_ = "DELETE";
     // Setting expectations.
-    EXPECT_CALL(dm, removeLanguage(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::common::Authorizer &authz) {
-            EXPECT_EQ(&authz, &catena::common::Authorizer::kAuthzDisabled);
-            return catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, removeLanguage(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::common::Authorizer &authz) {
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 4.2 - PUT LanguagePack with a valid token.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETEAuthzValid) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    testMethod = "DELETE";
-    authzEnabled = true;
-    testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+    method_ = "DELETE";
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
                 "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
                 "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
                 "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
@@ -619,96 +546,83 @@ TEST_F(RESTLanguagePackTests, LanguagePack_DELETEAuthzValid) {
                 "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
                 "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
     // Setting expectations.
-    EXPECT_CALL(dm, removeLanguage(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::common::Authorizer &authz) {
-            EXPECT_FALSE(&authz == &catena::common::Authorizer::kAuthzDisabled);
-            return catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, removeLanguage(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::common::Authorizer &authz) {
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 4.3 - DELETE LanguagePack with an invalid token.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETEAuthzInvalid) {
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-    testMethod = "DELETE";
-    authzEnabled = true;
-    testToken = "Invalid token";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::UNAUTHENTICATED);
+    method_ = "DELETE";
+    authzEnabled_ = true;
+    jwsToken_ = "Bearer THIS SHOULD NOT PARSE";
     // Setting expectations.
-    // Should not call if authz fails.
-    EXPECT_CALL(dm, removeLanguage(::testing::_, ::testing::_)).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, removeLanguage(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 4.4 - DELETE LanguagePack dm.getLanguagePack() returns a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETEErrReturn) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "DELETE";
-    // Defining mock fuctions
-    EXPECT_CALL(dm, removeLanguage(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::common::Authorizer &authz) {
-            return catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "DELETE";
+    // Setting expectations
+    EXPECT_CALL(dm0_, removeLanguage(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::common::Authorizer &authz) {
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
 
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 4.5 - DELETE LanguagePack dm.getLanguagePack() throws a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETEErrThrowCat) {
-    catena::exception_with_status rc("Test error", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "DELETE";
-    // Defining mock fuctions
-    EXPECT_CALL(dm, removeLanguage(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::common::Authorizer &authz) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Test error", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "DELETE";
+    // Setting expectations
+    EXPECT_CALL(dm0_, removeLanguage(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](const std::string &languageId, catena::common::Authorizer &authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 4.6 - DELETE LanguagePack dm.getLanguagePack() throws a std::runtime error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETEErrThrowStd) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::INTERNAL);
-    testMethod = "DELETE";
-    // Defining mock fuctions
-    EXPECT_CALL(dm, removeLanguage(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::common::Authorizer &authz) {
-            throw std::runtime_error(rc.what());
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::INTERNAL);
+    method_ = "DELETE";
+    // Setting expectations
+    EXPECT_CALL(dm0_, removeLanguage(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 4.6 - DELETE LanguagePack dm.getLanguagePack() throws an unknown error.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_DELETEErrThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    testMethod = "DELETE";
-    // Defining mock fuctions
-    EXPECT_CALL(dm, removeLanguage(testLanguage, ::testing::_)).Times(1)
-        .WillOnce(::testing::Invoke([&rc](const std::string &languageId, catena::common::Authorizer &authz) {
-            throw 0;
-            return catena::exception_with_status("", catena::StatusCode::OK); // should not return.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    method_ = "DELETE";
+    // Setting expectations
+    EXPECT_CALL(dm0_, removeLanguage(fqoid_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/LanguagePack_test.cpp
+++ b/unittests/cpp/REST/tests/LanguagePack_test.cpp
@@ -71,7 +71,7 @@ class RESTLanguagePackTests : public RESTEndpointTest {
             inVal_.mutable_words()->insert({word.first, word.second});
         }
         auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
-        EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+        ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
     }
 
     /*
@@ -95,7 +95,7 @@ class RESTLanguagePackTests : public RESTEndpointTest {
         std::string expJson = "";
         if (!expVal_.language().empty()) {
             auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
-            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+            ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
         }
         EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }

--- a/unittests/cpp/REST/tests/Languages_test.cpp
+++ b/unittests/cpp/REST/tests/Languages_test.cpp
@@ -60,7 +60,7 @@ class RESTLanguagesTests : public RESTEndpointTest {
         std::string expJson = "";
         if (!expVal_.languages().empty()) {
             auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
-            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+            ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
         }
         EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }

--- a/unittests/cpp/REST/tests/Languages_test.cpp
+++ b/unittests/cpp/REST/tests/Languages_test.cpp
@@ -37,8 +37,6 @@
 
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/Languages.h"
@@ -49,9 +47,14 @@ using namespace catena::REST;
 // Fixture
 class RESTLanguagesTests : public RESTEndpointTest {
   protected:
+    /*
+     * Creates a Languages handler object.
+     */
+    ICallData* makeOne() override { return Languages::makeOne(serverSocket_, context_, dm0_); }  
 
-    ICallData* makeOne() override { return Languages::makeOne(serverSocket, context_, dm0_); }  
-
+    /*
+     * Calls proceed and tests the response.
+     */
     void testCall() {
         endpoint_->proceed();
         std::string expJson = "";

--- a/unittests/cpp/REST/tests/Languages_test.cpp
+++ b/unittests/cpp/REST/tests/Languages_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
 #include "MockSocketReader.h"
@@ -53,80 +42,55 @@
 
 // REST
 #include "controllers/Languages.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTLanguagesTests : public ::testing::Test, public RESTTest {
+class RESTLanguagesTests : public RESTEndpointTest {
   protected:
-    RESTLanguagesTests() : RESTTest(&serverSocket, &clientSocket) {}
 
-    /*
-     * Redirects cout and sets default expectations for each method.
-     */
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
+    ICallData* makeOne() override { return Languages::makeOne(serverSocket, context_, dm0_); }  
 
-        // Default expectations for the context.
-        EXPECT_CALL(context, method()).WillRepeatedly(::testing::ReturnRef(testMethod));
-        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin));
-
-        // Default expectations for the device model.
-        EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMutex));
-
-        // Creating Languages object.
-        endpoint.reset(Languages::makeOne(serverSocket, context, dm));
+    void testCall() {
+        endpoint_->proceed();
+        std::string expJson = "";
+        if (!expVal_.languages().empty()) {
+            auto status = google::protobuf::util::MessageToJsonString(expVal_, &expJson);
+            EXPECT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+        }
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_, expJson));
     }
 
-    /*
-     * Restores cout after each test.
-     */
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-    }
-
-    // Cout variables.
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    // Context variables.
-    std::string testMethod = "GET";
-    // Mock objects and endpoint.
-    MockSocketReader context;
-    std::mutex mockMutex;
-    MockDevice dm;
-    std::unique_ptr<ICallData> endpoint = nullptr;
+    // Expected values
+    catena::LanguageList expVal_;
 };
 
 /* 
  * TEST 0.1 - Creating a Languages object with makeOne.
  */
 TEST_F(RESTLanguagesTests, Languages_Create) {
-    ASSERT_TRUE(endpoint);
+    ASSERT_TRUE(endpoint_);
 }
 
 /* 
  * TEST 0.2 - Writing to console with Languages finish().
  */
 TEST_F(RESTLanguagesTests, Languages_Finish) {
-    // Calling finish and expecting the console output.
-    endpoint->finish();
-    ASSERT_TRUE(MockConsole.str().find("Languages[1] finished\n") != std::string::npos);
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("Languages[1] finished\n") != std::string::npos);
 }
 
 /* 
  * TEST 0.3 - Languages proceed() with an invalid method.
  */
 TEST_F(RESTLanguagesTests, Languages_BadMethod) {
-    catena::exception_with_status rc("Bad method", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "BAD_METHOD";
-    // Should not call any of these on a bad method.
-    EXPECT_CALL(dm, toProto(::testing::An<catena::LanguageList&>())).Times(0);
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("Bad method", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "BAD_METHOD";
+    // Setting expectations
+    EXPECT_CALL(dm0_, toProto(::testing::An<catena::LanguageList&>())).Times(0);
+    // Sending the call
+    testCall();
 }
 
 /*
@@ -137,86 +101,64 @@ TEST_F(RESTLanguagesTests, Languages_BadMethod) {
  * TEST 1.1 - GET Languages normal case.
  */
 TEST_F(RESTLanguagesTests, Languages_GETNormal) {
-    // Setting up the returnVal to test with.
-    catena::LanguageList returnVal;
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    returnVal.add_languages("en");
-    returnVal.add_languages("fr");
-    returnVal.add_languages("es");
-    // Defining mock fuctions
-    EXPECT_CALL(dm, toProto(::testing::An<catena::LanguageList&>())).Times(1)
-        .WillOnce(::testing::Invoke([&returnVal](catena::LanguageList& list) {
-            list.CopyFrom(returnVal);
+    expVal_.add_languages("en");
+    expVal_.add_languages("fr");
+    expVal_.add_languages("es");
+    // Setting expectations
+    EXPECT_CALL(dm0_, toProto(::testing::An<catena::LanguageList&>())).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::LanguageList& list) {
+            list.CopyFrom(expVal_);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-
-    std::string jsonBody;
-    auto status = google::protobuf::util::MessageToJsonString(returnVal, &jsonBody);
-    EXPECT_EQ(readResponse(), expectedResponse(rc, jsonBody));
+    // Sending the call
+    testCall();
 }
 
 /* 
  * TEST 1.2 - GET langauges returns an empty list.
  */
 TEST_F(RESTLanguagesTests, Languages_GETEmpty) {
-    // Setting up empty language list
-    catena::LanguageList returnVal;
-    catena::exception_with_status rc("No languages found", catena::StatusCode::NOT_FOUND);
-    // Defining mock functions
-    EXPECT_CALL(dm, toProto(::testing::An<catena::LanguageList&>())).Times(1)
-        .WillOnce(::testing::Invoke([&returnVal](catena::LanguageList& list) {
-            list.CopyFrom(returnVal);
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("No languages found", catena::StatusCode::NOT_FOUND);
+    // Setting expectations
+    EXPECT_CALL(dm0_, toProto(::testing::An<catena::LanguageList&>())).Times(1)
+        .WillOnce(::testing::Return());
+    // Sending the call
+    testCall();
 }
 
 /* 
  * TEST 1.3 - GET Languages throws a catena::exception_with_status error.
  */
 TEST_F(RESTLanguagesTests, Languages_GETErrThrowCat) {
-    // Setting up the rc to test with.
-    catena::exception_with_status rc("Device not found", catena::StatusCode::NOT_FOUND);
-    // Defining mock functions
-    EXPECT_CALL(dm, toProto(::testing::An<catena::LanguageList&>())).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::LanguageList& list) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    expRc_ = catena::exception_with_status("Device not found", catena::StatusCode::NOT_FOUND);
+    // Setting expectations
+    EXPECT_CALL(dm0_, toProto(::testing::An<catena::LanguageList&>())).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::LanguageList& list) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the call
+    testCall();
 }
 
 /* 
  * TEST 1.4 - GET Languages throws a std::runtime error.
  */
 TEST_F(RESTLanguagesTests, Languages_GETErrThrowStd) {
-    // Setting up the rc to test with.
-    catena::exception_with_status rc("Standard error", catena::StatusCode::INTERNAL);
-    // Defining mock functions
-    EXPECT_CALL(dm, toProto(::testing::An<catena::LanguageList&>())).Times(1)
-        .WillOnce(::testing::Invoke([&rc](catena::LanguageList& list) {
-            throw std::runtime_error(rc.what());
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("Standard error", catena::StatusCode::INTERNAL);
+    // Setting expectations
+    EXPECT_CALL(dm0_, toProto(::testing::An<catena::LanguageList&>())).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the call
+    testCall();
 }
 
 /* 
  * TEST 1.5 - GET Languages throws an unknown error.
  */
 TEST_F(RESTLanguagesTests, Languages_GetErrThrowUnknown) {
-    // Setting up the rc to test with.
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-    // Defining mock functions
-    EXPECT_CALL(dm, toProto(::testing::An<catena::LanguageList&>())).Times(1)
-        .WillOnce(::testing::Invoke([](catena::LanguageList& list) {
-            throw 0;
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, toProto(::testing::An<catena::LanguageList&>())).Times(1)
+        .WillOnce(::testing::Throw(0));
+    // Sending the call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/MultiSetValue_test.cpp
+++ b/unittests/cpp/REST/tests/MultiSetValue_test.cpp
@@ -50,10 +50,10 @@ class RESTMultiSetValueTests : public RESTEndpointTest {
     /*
      * Creates a MultiSetValue handler object.
      */
-    ICallData* makeOne() override { return MultiSetValue::makeOne(serverSocket, context_, dm0_); }
+    ICallData* makeOne() override { return MultiSetValue::makeOne(serverSocket_, context_, dm0_); }
 
     /*
-     * Streamlines the creation of MultiSetValuePayload. 
+     * Streamlines the creation of endpoint input. 
      */
     void initPayload(uint32_t slot, const std::vector<std::pair<std::string, std::string>>& setValues) {
         slot_ = slot;

--- a/unittests/cpp/REST/tests/MultiSetValue_test.cpp
+++ b/unittests/cpp/REST/tests/MultiSetValue_test.cpp
@@ -35,62 +35,47 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/MultiSetValue.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTMultiSetValueTests : public ::testing::Test, public RESTTest {
+class RESTMultiSetValueTests : public RESTEndpointTest {
   protected:
-    RESTMultiSetValueTests() : RESTTest(&serverSocket, &clientSocket) {}
+    /*
+     * Creates a MultiSetValue handler object.
+     */
+    ICallData* makeOne() override { return MultiSetValue::makeOne(serverSocket, context_, dm0_); }
 
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Creating multiSetValue object.
-        EXPECT_CALL(context, origin()).Times(1).WillOnce(::testing::ReturnRef(origin));
-        multiSetValue = MultiSetValue::makeOne(serverSocket, context, dm);
-    }
-
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (multiSetValue) {
-            delete multiSetValue;
+    /*
+     * Streamlines the creation of MultiSetValuePayload. 
+     */
+    void initPayload(uint32_t slot, const std::vector<std::pair<std::string, std::string>>& setValues) {
+        slot_ = slot;
+        for (auto& [oid, value] : setValues) {
+            auto addedVal = inVal_.add_values();
+            addedVal->set_oid(oid);
+            addedVal->mutable_value()->set_string_value(value);
         }
+        auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
+        EXPECT_TRUE(status.ok()) << "Failed to convert input value to JSON";
     }
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    
-    MockSocketReader context;
-    MockDevice dm;
-    catena::REST::ICallData* multiSetValue = nullptr;
 
-    std::mutex mockMutex;
-    std::string jsonBody = "{\"values\":["
-                           "{\"oid\":\"/text_box\",\"value\":{\"string_value\":\"test value 1\"}},"
-                           "{\"oid\":\"/text_box\",\"value\":{\"string_value\":\"test value 2\"}}"
-                           "]}";
+    /*
+     * Calls proceed and tests the response.
+     */
+    void testCall() {
+        endpoint_->proceed();
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_));
+    }
+
+    // in vals
+    catena::MultiSetValuePayload inVal_;
 };
 
 /*
@@ -98,254 +83,208 @@ class RESTMultiSetValueTests : public ::testing::Test, public RESTTest {
  *                               MultiSetValue tests
  * ============================================================================
  * 
- * TEST 1 - Creating a MultiSetValue object with makeOne.
+ * TEST 1 - Creating a MultiSetValue object.
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_create) {
-    // Making sure multiSetValue is created from the SetUp step.
-    ASSERT_TRUE(multiSetValue);
+TEST_F(RESTMultiSetValueTests, MultiSetValue_Create) {
+    EXPECT_TRUE(endpoint_);
 }
 
 /* 
- * TEST 2 - Normal case for MultiSetValue proceed().
+ * TEST 2 - Writing to console with MultiSetValue finish().
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedNormal) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(catena::exception_with_status(rc.what(), rc.status)));
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+TEST_F(RESTMultiSetValueTests, MultiSetValue_Finish) {
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("MultiSetValue[1] finished\n") != std::string::npos);
 }
 
-/* 
- * TEST 3 - trySetValue returns an error.
+/*
+ * TEST 3 - Normal case for MultiSetValue proceed().
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedTryErr) {
-    catena::exception_with_status rc("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
+TEST_F(RESTMultiSetValueTests, MultiSetValue_Normal) {
+    initPayload(0, {{"/test_oid_1", "test_value_1"},{"/test_oid_2", "test_value_2"}});
+    expRc_ = catena::exception_with_status("", catena::StatusCode::OK);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::exception_with_status &ans, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(src.SerializeAsString(), inVal_.SerializeAsString());
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            // Setting the output status and returning true.
+            ans = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return true;
+        }));
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(src.SerializeAsString(), inVal_.SerializeAsString());
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            // Setting the output status and returning true.
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
+        }));
+    // Sending the call
+    testCall();
+}
 
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([&rc](catena::MultiSetValuePayload src, catena::exception_with_status &ans, Authorizer &authz) -> bool {
-            ans = catena::exception_with_status(rc.what(), rc.status);
+/*
+ * TEST 4 - MultiSetValue with authz on and valid token.
+ */
+TEST_F(RESTMultiSetValueTests, MultiSetValue_AuthzValid) {
+    initPayload(0, {{"/test_oid_1", "test_value_1"},{"/test_oid_2", "test_value_2"}});
+    expRc_ = catena::exception_with_status("", catena::StatusCode::OK);
+    // Adding authorization mockToken metadata. This it a random RSA token.
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+                "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
+                "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
+                "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
+                "okrEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko9653v0khyUT4UK"
+                "eOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKHkWi4P3-CYWrwe-g6b4-a33Q"
+                "0k6tSGI1hGf2bA9cRYr-VyQ_T3RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEm"
+                "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
+                "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
+                "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::exception_with_status &ans, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(src.SerializeAsString(), inVal_.SerializeAsString());
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            // Setting the output status and returning true.
+            ans = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return true;
+        }));
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            EXPECT_EQ(src.SerializeAsString(), inVal_.SerializeAsString());
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            // Setting the output status and returning true.
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
+        }));
+    // Sending the call
+    testCall();
+}
+
+/*
+ * TEST 5 - MultiSetValue with authz on and invalid token.
+ */
+TEST_F(RESTMultiSetValueTests, MultiSetValue_AuthzInvalid) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
+    // Not a token so it should get rejected by the authorizer.
+    authzEnabled_ = true;
+    jwsToken_ = "Bearer THIS SHOULD NOT PARSE";
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
+}
+
+/*
+ * TEST 6 - MultiSetValue fails to parse the json body.
+ */
+TEST_F(RESTMultiSetValueTests, MultiSetValue_FailParse) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("Failed to convert JSON to protobuf", catena::StatusCode::INVALID_ARGUMENT);
+    jsonBody_ = "Not a JSON string";
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    // Sending the call
+    testCall();
+}
+
+/*
+ * TEST 7 - dm.trySetValue returns a catena::Exception_With_Status.
+ */
+TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrTryReturnCatena) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::exception_with_status &ans, catena::common::Authorizer &authz) {
+            // Setting the output status and returning false.
+            ans = catena::exception_with_status(expRc_.what(), expRc_.status);
             return false;
         }));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(0);
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the call
+    testCall();
 }
 
-/* 
- * TEST 4 - trySetValue throws a catena::exception_with_status.
+/*
+ * TEST 8 - dm.trySetValue throws a catena::Exception_With_Status.
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedTryThrowCatena) {
-    catena::exception_with_status rc("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([&rc](catena::MultiSetValuePayload src, catena::exception_with_status &ans, Authorizer &authz) -> bool {
-            throw catena::exception_with_status(rc.what(), rc.status);
+TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrTryThrowCatena) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::exception_with_status &ans, catena::common::Authorizer &authz) {
+            // Throwing error and returning true.
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return true;
         }));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(0);
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the call
+    testCall();
 }
 
-/* 
- * TEST 5 - trySetValue throws an std::runtime_error.
+/*
+ * TEST 9 - dm.trySetValue throws a std::runtime_error.
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedTryThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
+TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrTryThrowUnknown) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the call
+    testCall();
+}
 
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([&rc](catena::MultiSetValuePayload src, catena::exception_with_status &ans, Authorizer &authz) -> bool {
-            throw std::runtime_error(rc.what());
-            return true;
+/*
+ * TEST 10 - dm.commitSetValue returns a catena::Exception_With_Status.
+ */
+TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrCommitReturnCatena) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::common::Authorizer &authz) {
+            // Returning error status.
+            return catena::exception_with_status(expRc_.what(), expRc_.status);
         }));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(0);
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the call
+    testCall();
 }
 
-/* 
- * TEST 6 - commitSetValue returns an error.
- * This should not be possible in a normal run.
+/*
+ * TEST 11 - dm.commitSetValue throws a catena::Exception_With_Status.
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedCommitErr) {
-    catena::exception_with_status rc("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(catena::exception_with_status(rc.what(), rc.status)));
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 7 - commitSetValue throws a catena::exception_with_status.
- * This should not be possible in a normal run.
- */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedCommitThrowCatena) {
-    catena::exception_with_status rc("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([&rc](catena::MultiSetValuePayload src, Authorizer &authz) -> catena::exception_with_status {
-            throw catena::exception_with_status(rc.what(), rc.status);
+TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrCommitThrowCatena) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::common::Authorizer &authz) {
+            // Throwing error and returning ok.
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending the call
+    testCall();
 }
 
-/* 
- * TEST 8 - commitSetValue throws an std::runtime_error.
- * This should not be possible in a normal run.
+/*
+ * TEST 12 - dm.commitSetValue throws a std::runtime_error.
  */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedCommitThrowUnknown) {
-    catena::exception_with_status rc("Unknown error", catena::StatusCode::UNKNOWN);
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(1);
-    ON_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_))
-        .WillByDefault(::testing::Invoke([&rc](catena::MultiSetValuePayload src, Authorizer &authz) -> catena::exception_with_status {
-            throw std::runtime_error(rc.what());
-            return catena::exception_with_status("", catena::StatusCode::OK);
-        }));
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 9 - MultiSetValue with authz on and an valid token.
- */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedAuthzValid) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    /* Authz just tests for a properly encrypted token, proxy handles authz.
-     * This is a random RSA token I made jwt.io it is not a security risk I
-     * swear. */
-    std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
-                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
-                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
-                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
-                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
-                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
-                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
-                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
-                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
-                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
-                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
-                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(catena::exception_with_status(rc.what(), rc.status)));
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 10 - MultiSetValue with authz on and an invalid token.
- */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedAuthzInvalid) {
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-    // Not a token so it should get rejected by the authorizer.
-    std::string mockToken = "THIS SHOULD NOT PARSE";
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).Times(1).WillOnce(::testing::ReturnRef(mockToken));
-    EXPECT_CALL(dm, mutex()).Times(0);
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(0);
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(0);
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 11 - MultiSetValue toMulti fails to parse the JSON.
- */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_proceedFailParse) {
-    catena::exception_with_status rc("Failed to convert JSON to protobuf", catena::StatusCode::INVALID_ARGUMENT);
-    jsonBody = "Not a JSON string";
-
-    // Defining mock functions
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(jsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(0);
-
-    multiSetValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 12 - Writing to console with MultiSetValue finish().
- */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_finish) {
-    // Calling finish and expecting the console output.
-    multiSetValue->finish();
-    // Idk why I cant use .contains() here :/
-    ASSERT_TRUE(MockConsole.str().find("MultiSetValue[11] finished\n") != std::string::npos);
+TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrCommitThrowUnknown) {
+    initPayload(0, {});
+    expRc_ = catena::exception_with_status("unknown error", catena::StatusCode::UNKNOWN);
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending the call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/MultiSetValue_test.cpp
+++ b/unittests/cpp/REST/tests/MultiSetValue_test.cpp
@@ -63,7 +63,7 @@ class RESTMultiSetValueTests : public RESTEndpointTest {
             addedVal->mutable_value()->set_string_value(value);
         }
         auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
-        EXPECT_TRUE(status.ok()) << "Failed to convert input value to JSON";
+        ASSERT_TRUE(status.ok()) << "Failed to convert input value to JSON";
     }
 
     /*

--- a/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
@@ -36,59 +36,28 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-#include <memory>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
-#include "MockSocketReader.h"
-#include "MockLanguagePack.h"
-#include "MockParam.h"
-#include "MockDevice.h"
 #include "RESTTest.h"
+#include "MockParam.h"
 #include "RESTTestHelpers.h"
 #include "CommonTestHelpers.h"
 
 // REST
 #include <controllers/ParamInfoRequest.h>
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
-class RESTParamInfoRequestTests : public ::testing::Test, public RESTTest {
+class RESTParamInfoRequestTests : public RESTEndpointTest {
 protected:
-    RESTParamInfoRequestTests() : RESTTest(&serverSocket_, &clientSocket_) {}
-
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Set default actions for common mock calls
-        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin_));
-        EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-        EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(empty_prefix));
-        EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-        EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-
-        request = ParamInfoRequest::makeOne(serverSocket_, context, dm);
+    RESTParamInfoRequestTests() : RESTEndpointTest() {
+        EXPECT_CALL(context_, hasField("recursive")).WillRepeatedly(::testing::Return(false));
     }
 
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (request) {
-            delete request;
-        }
-    }
+    /*
+     * Creates a ParamInfoRequest handler object.
+     */
+    ICallData* makeOne() override { return ParamInfoRequest::makeOne(serverSocket_, context_, dm0_); }
 
     // Helper method to setup parameter hierarchy
     struct ParamHierarchy {
@@ -115,15 +84,6 @@ protected:
 
         return {std::move(parentDesc), std::move(childDesc), nested_oid};
     }
-
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    std::mutex mockMtx;
-    
-    MockSocketReader context;
-    MockDevice dm;
-    ICallData* request = nullptr;
-    std::string empty_prefix;
 };
 
 /*
@@ -133,61 +93,52 @@ protected:
  */
 
 // Preliminary test: Creating a ParamInfoRequest object
-TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_create) {
-    ASSERT_TRUE(request);
+TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_Create) {
+    ASSERT_TRUE(endpoint_);
 }
 
 // Test 0.1: Authorization test with std::exception
-TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_authz_std_exception) {
-    catena::exception_with_status rc("Authorization setup failed: Test auth setup failure", catena::StatusCode::UNAUTHENTICATED);
+TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzStdException) {
+    expRc_ = catena::exception_with_status("Authorization setup failed: Test auth setup failure", catena::StatusCode::UNAUTHENTICATED);
+    authzEnabled_ = true;
 
     // Setup mock expectations
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::Throw(std::runtime_error("Test auth setup failure")));
+    EXPECT_CALL(context_, jwsToken()).WillRepeatedly(::testing::Throw(std::runtime_error("Test auth setup failure")));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 0.2: Authorization test with invalid token
-TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_authz_invalid_token) {
-    std::string mockToken = "test_token";
-    catena::exception_with_status rc("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
+TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzInvalid) {
+    expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
+    jwsToken_ = "test_token";
+    authzEnabled_ = true;
 
-    // Override default behaviors for this test
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::ReturnRef(mockToken));
-
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 0.3: Authorization test with valid token
-TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_authz_valid_token) {
+TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzValid) {
     // Use a valid JWT token that was borrowed from GetValue_test.cpp
-    std::string mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIi"
-                            "OiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2Nvc"
-                            "GUiOiJzdDIxMzg6bW9uOncgc3QyMTM4Om9wOncgc3QyMTM4Om"
-                            "NmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MTUxNjIzOTAyMiw"
-                            "ibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dTo"
-                            "krEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko965"
-                            "3v0khyUT4UKeOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKH"
-                            "kWi4P3-CYWrwe-g6b4-a33Q0k6tSGI1hGf2bA9cRYr-VyQ_T3"
-                            "RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEmuIwNOVM3EcVEaL"
-                            "yISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg_w"
-                            "bOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9M"
-                            "dvJH-cx1s146M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-    catena::exception_with_status rc("", catena::StatusCode::OK);
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+                "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
+                "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
+                "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
+                "okrEPi_kyety6KCsfJdqHMbYkFljL0KUkokutXg4HN288Ko9653v0khyUT4UK"
+                "eOMGJsitMaSS0uLf_Zc-JaVMDJzR-0k7jjkiKHkWi4P3-CYWrwe-g6b4-a33Q"
+                "0k6tSGI1hGf2bA9cRYr-VyQ_T3RQyHgGb8vSsOql8hRfwqgvcldHIXjfT5wEm"
+                "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
+                "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
+                "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
+    authzEnabled_ = true;
     
     // Setup mock parameter
     auto param = std::make_unique<MockParam>();
@@ -197,43 +148,29 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_authz_valid_token) {
     };
     auto desc = ParamHierarchyBuilder::createDescriptor("/" + param_info.oid);
     catena::REST::test::setupMockParam(param.get(), param_info, desc.descriptor.get());
+    fqoid_ = param_info.oid;
 
     // Add isArrayType expectation
     EXPECT_CALL(*param, isArrayType()).WillRepeatedly(::testing::Return(false));
 
-    // Override default behaviors for this test
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::ReturnRef(mockToken));
-    
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(param_info.oid));
-    EXPECT_CALL(dm, getParam(param_info.oid, ::testing::_, ::testing::_))
-       .WillRepeatedly(::testing::Invoke([&param, &rc](const std::string&, catena::exception_with_status &status, catena::common::Authorizer &) {
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
+       .WillRepeatedly(::testing::Invoke([&param](const std::string&, catena::exception_with_status &status, catena::common::Authorizer &) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(param);
         }));
-
-    // Make a new request for this test
-    auto authzRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
     
-    authzRequest->proceed();
-    authzRequest->finish();
-
-    delete authzRequest;
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(param_info);
-    std::string expected = expectedSSEResponse(rc, {jsonBody});
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {jsonBody}));
 }
 
 // == MODE 1 TESTS: Get all top-level parameters without recursion ==
 
 // Test 1.1: Get all top-level parameters without recursion
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParams) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-
     // Setup mock parameters
     catena::REST::test::ParamInfo param1_info{ .oid = "param1", .type = catena::ParamType::STRING };
     catena::REST::test::ParamInfo param2_info{ .oid = "param2", .type = catena::ParamType::STRING };
@@ -255,68 +192,60 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParams) {
     top_level_params.push_back(std::move(param2));
 
     // Setup mock expectations
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
-        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) -> std::vector<std::unique_ptr<IParam>> {
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) -> std::vector<std::unique_ptr<IParam>> {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(top_level_params);
         }));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::vector<std::string> jsonBodies;
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(param1_info));
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(param2_info));
-    std::string expected = expectedSSEResponse(rc, jsonBodies);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
 }
 
 // Test 1.2: Get top-level parameters with error returned from getTopLevelParams
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsError) {
-    catena::exception_with_status rc("Error getting top-level parameters", catena::StatusCode::INTERNAL);
+    expRc_ = catena::exception_with_status("Error getting top-level parameters", catena::StatusCode::INTERNAL);
     
     // Setup mock expectations 
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("Error getting top-level parameters", catena::StatusCode::INTERNAL);
             return std::vector<std::unique_ptr<IParam>>();
         }));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 1.3: Get top-level parameters with empty list returned from getTopLevelParams
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getEmptyTopLevelParams) {
-    catena::exception_with_status rc("No top-level parameters found", catena::StatusCode::NOT_FOUND);
+    expRc_ = catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
     
     // Setup mock expectations
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK); 
             return std::vector<std::unique_ptr<IParam>>();  
         }));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 1.4: Get top-level parameters with array type
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithArray) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    
     // Setup mock parameters
     std::vector<std::unique_ptr<IParam>> top_level_params;
     catena::REST::test::ParamInfo arrayParamInfo{ .oid = "array_param", .type = catena::ParamType::STRING_ARRAY, .array_length = 5 };
@@ -326,25 +255,23 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithArray) {
     top_level_params.push_back(std::move(arrayParam));
 
     // Setup mock expectations
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
-        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) {
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(top_level_params);
         }));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(arrayParamInfo);
-    std::string expected = expectedSSEResponse(rc, {jsonBody});
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {jsonBody}));
 }
 
 // Test 1.5: Get top-level parameters with error status in returned parameters
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsProcessingError) {
-    catena::exception_with_status rc("Error processing parameter", catena::StatusCode::INTERNAL);
+    expRc_ = catena::exception_with_status("Error processing parameter", catena::StatusCode::INTERNAL);
     
     // Setup mock parameters
     std::vector<std::unique_ptr<IParam>> top_level_params;
@@ -355,24 +282,22 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsProcessingEr
     top_level_params.push_back(std::move(errorParam));
 
     // Setup mock expectations   
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("Error processing parameter", catena::StatusCode::INTERNAL);
             return std::move(top_level_params);
         }));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 1.6: Get top-level parameters with exception thrown during parameter processing
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsThrow) {
-    catena::exception_with_status rc("Error getting top-level parameters", catena::StatusCode::INTERNAL);
+    expRc_ = catena::exception_with_status("Error getting top-level parameters", catena::StatusCode::INTERNAL);
     
     // Setup mock parameters
     catena::REST::test::ParamInfo param1_info{ .oid = "param1", .type = catena::ParamType::STRING };
@@ -398,27 +323,23 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsThrow) {
     top_level_params.push_back(std::move(param2));
 
     // Setup mock expectations
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(top_level_params);
         }));
 
-    request->proceed();
-    request->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // == MODE 2 TESTS: Get all top-level parameters with recursion ==
 
 // Test 2.1: Get top-level parameters with recursion and deep nesting
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithDeepNesting) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-
     // Define parameter info structs first
     catena::REST::test::ParamInfo level1_info{.oid = "level1", .type = catena::ParamType::STRING};
     catena::REST::test::ParamInfo level2_info{.oid = "level2", .type = catena::ParamType::STRING};
@@ -460,18 +381,18 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithDeepNest
     top_level_params.push_back(std::move(level1));
 
     // Enable recursion and stream
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, stream()).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(context_, hasField("recursive")).WillOnce(::testing::Return(true));
+    stream_ = true;
 
     // Setup mock expectations
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
-        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) {
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(top_level_params);
         }));
 
     // Setup mock expectations for getParam to handle child traversal
-    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+    EXPECT_CALL(dm0_, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
         .WillRepeatedly(::testing::Invoke(
             [&level2, &level3, level2Desc, level3Desc]
             (const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
@@ -489,29 +410,19 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithDeepNest
             }
         ));
 
-    // Create a new request after setting up all expectations
-    auto deepNestingRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    deepNestingRequest->proceed();
-    deepNestingRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::vector<std::string> jsonBodies;
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(level1_info));
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(level2_info));
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(level3_info));
-    std::string expected = expectedSSEResponse(rc, jsonBodies);
-    std::string actual = readResponse();
-    
-    delete deepNestingRequest;
-
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
 }
 
 // Test 2.2: Get top-level parameters with recursion and arrays
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursionAndArrays) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-
     // Define parameter info
     catena::REST::test::ParamInfo parent_info{
         .oid = "parent",
@@ -547,18 +458,18 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
     top_level_params.push_back(std::move(parentParam));
 
     // Enable recursion and stream
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, stream()).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(context_, hasField("recursive")).WillOnce(::testing::Return(true));
+    stream_ = true;
 
     // Setup mock expectations for getTopLevelParams
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
-        .WillOnce(::testing::Invoke([&top_level_params, &rc](catena::exception_with_status& status, Authorizer&) {
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
+        .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(top_level_params);
         }));
 
     // Setup mock expectations for getParam to handle child traversal
-    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+    EXPECT_CALL(dm0_, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
         .WillRepeatedly(::testing::Invoke([this, &arrayChild, childOid, arrayChild_info, childDesc]
             (const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
                 if (fqoid == childOid) {
@@ -569,27 +480,19 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
                 return nullptr;
             }));
 
-    // Create a new request after setting up all expectations
-    auto arrayRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    arrayRequest->proceed();
-    arrayRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::vector<std::string> jsonBodies;
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(parent_info));
     jsonBodies.push_back(catena::REST::test::createParamInfoJson(arrayChild_info));
-    std::string expected = expectedSSEResponse(rc, jsonBodies);
-    std::string actual = readResponse();
-    
-    delete arrayRequest;
-
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
 }
 
 // Test 2.3: Get top-level parameters with recursion and error in child processing
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursionError) {
-    catena::exception_with_status rc("Error processing child parameter", catena::StatusCode::INTERNAL);
+    expRc_ = catena::exception_with_status("Error processing child parameter", catena::StatusCode::INTERNAL);
 
     // Define parameter info
     catena::REST::test::ParamInfo parent_info{
@@ -633,18 +536,18 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
     top_level_params.push_back(std::move(parentParam));
 
     // Enable recursion and stream
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, stream()).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(context_, hasField("recursive")).WillOnce(::testing::Return(true));
+    stream_ = true;
 
     // Setup mock expectations for getTopLevelParams
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([&top_level_params](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::move(top_level_params);
         }));
 
     // Setup mock expectations for getParam to handle child traversal
-    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
+    EXPECT_CALL(dm0_, getParam(::testing::An<const std::string&>(), ::testing::An<catena::exception_with_status&>(), ::testing::An<Authorizer&>()))
         .WillRepeatedly(::testing::Invoke([&errorChild, childOid]
             (const std::string& fqoid, catena::exception_with_status& status, Authorizer&) -> std::unique_ptr<IParam> {
                 if (fqoid == childOid) {
@@ -655,88 +558,64 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
                 return nullptr;
             }));
 
-    // Create a new request after setting up all expectations
-    auto errorRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    errorRequest->proceed();
-    errorRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    
-    delete errorRequest;
-
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 2.4: Get top-level parameters with error status from getTopLevelParams
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithErrorStatus) {
-    catena::exception_with_status rc("Error getting parameters", catena::StatusCode::INTERNAL);
+    expRc_ = catena::exception_with_status("Error getting parameters", catena::StatusCode::INTERNAL);
 
     // Setup mock expectations
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, stream()).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(context_, hasField("recursive")).WillOnce(::testing::Return(true));
+    EXPECT_CALL(context_, stream()).WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("Error getting parameters", catena::StatusCode::INTERNAL);
             return std::vector<std::unique_ptr<IParam>>();
         }));
 
-    // Create a new request after setting up all expectations
-    auto errorStatusRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    errorStatusRequest->proceed();
-    errorStatusRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    
-    delete errorStatusRequest;
-
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 2.5: Get top-level parameters with empty list and recursion
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithEmptyListAndRecursion) {
-    catena::exception_with_status rc("No top-level parameters found", catena::StatusCode::NOT_FOUND);
+    expRc_ = catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
 
     // Setup mock expectations
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, stream()).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(dm, getTopLevelParams(::testing::_, ::testing::_))
+    EXPECT_CALL(context_, hasField("recursive")).WillOnce(::testing::Return(true));
+    stream_ = true;
+    EXPECT_CALL(dm0_, getTopLevelParams(::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return std::vector<std::unique_ptr<IParam>>();
         }));
 
-    // Create a new request after setting up all expectations
-    auto emptyListRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    emptyListRequest->proceed();
-    emptyListRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    
-    delete emptyListRequest;
-
-    EXPECT_EQ(actual, expected);
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // == MODE 3 TESTS: Get a specific parameter and its children if recursive ==
 
 // Test 3.1: Get specific parameter without recursion
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_proceedSpecificParam) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string mockOid = "mockOid";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::OK);
+    fqoid_ = "mockOid";
 
     // Setup mock parameter with our helper
     std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
     catena::REST::test::ParamInfo paramInfo{
-        .oid = mockOid,
+        .oid = fqoid_,
         .type = catena::ParamType::STRING_ARRAY,
         .array_length = 5
     };
@@ -747,12 +626,7 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_proceedSpecificParam) {
     EXPECT_CALL(*mockParam, size()).WillRepeatedly(::testing::Return(5));
 
     // Setup mock expectations for mode 2 (specific parameter)
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(mockOid));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke(
             [&mockParam](const std::string&, catena::exception_with_status& status, Authorizer&) {
                 status = catena::exception_with_status("", catena::StatusCode::OK);
@@ -760,46 +634,35 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_proceedSpecificParam) {
             }
         ));
     
-    // Create a new request for this test
-    auto specificRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-    
-    specificRequest->proceed();
-    specificRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(paramInfo);
-    std::string expected = expectedSSEResponse(rc, {jsonBody});
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete specificRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {jsonBody}));
 }
 
 // Test 3.2: Get specific parameter with recursion
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getSpecificParamWithRecursion) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::string mockOid = "mockOid";
+    expRc_ = catena::exception_with_status("", catena::StatusCode::OK);
+    fqoid_ = "mockOid";
     
     // Create parameter hierarchy using ParamHierarchyBuilder
-    auto mockDesc = ParamHierarchyBuilder::createDescriptor("/" + mockOid);
-    std::string mockOidWSlash = "/" + mockOid;
+    auto mockDesc = ParamHierarchyBuilder::createDescriptor("/" + fqoid_);
+    std::string mockOidWSlash = "/" + fqoid_;
     EXPECT_CALL(*mockDesc.descriptor, getOid()).WillRepeatedly(::testing::ReturnRef(mockOidWSlash));
     
     // Setup mock parameter with our helper
     std::unique_ptr<MockParam> mockParam = std::make_unique<MockParam>();
     catena::REST::test::ParamInfo paramInfo{
-        .oid = mockOid,
+        .oid = fqoid_,
         .type = catena::ParamType::STRING
     };
     catena::REST::test::setupMockParam(mockParam.get(), paramInfo, mockDesc.descriptor.get());
 
     // Setup mock expectations
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(mockOid));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(mockOid, ::testing::_, ::testing::_))
+    EXPECT_CALL(context_, hasField("recursive")).WillOnce(::testing::Return(true));
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke(
             [&mockParam](const std::string&, catena::exception_with_status& status, Authorizer&) {
                 status = catena::exception_with_status("", catena::StatusCode::OK);
@@ -807,176 +670,105 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getSpecificParamWithRecursion
             }
         ));
 
-    // Create a new request for this test
-    auto recursiveRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    recursiveRequest->proceed();
-    recursiveRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(paramInfo);
-    std::string expected = expectedSSEResponse(rc, {jsonBody});
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete recursiveRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {jsonBody}));
 }
 
 // Test 3.3: Error case - parameter not found
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_parameterNotFound) {
-    catena::exception_with_status rc("Parameter not found: missing_param", catena::StatusCode::NOT_FOUND);
-    
-    std::string missing_param = "missing_param";
+    expRc_ = catena::exception_with_status("Parameter not found: missing_param", catena::StatusCode::NOT_FOUND);
+    fqoid_ = "missing_param";
 
     // Setup mock expectations
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(missing_param));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(missing_param, ::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("", catena::StatusCode::OK);
             return nullptr;
         }));
 
-    // Create a new request for this test
-    auto notFoundRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    notFoundRequest->proceed();
-    notFoundRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete notFoundRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 3.4: Error case - catena exception in getParam
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catenaExceptionInGetParam) {
-    catena::exception_with_status rc("Error processing parameter", catena::StatusCode::INTERNAL);
-    
-    std::string test_param = "test_param";
+    expRc_ = catena::exception_with_status("Error processing parameter", catena::StatusCode::INTERNAL);
+    fqoid_ = "test_param";
 
     // Setup mock expectations
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(test_param));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(test_param, ::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status& status, Authorizer&) {
             status = catena::exception_with_status("Error processing parameter", catena::StatusCode::INTERNAL);
             return nullptr;
         }));
 
-    // Create a new request for this test
-    auto exceptionRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    exceptionRequest->proceed();
-    exceptionRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete exceptionRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // == SECTION 4 TESTS: Catch blocks at the end of proceed() ==
 
 // Test 4.1: Error case - catena exception in proceed()
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catchCatenaException) {
-    catena::exception_with_status rc("Test catena exception", catena::StatusCode::INTERNAL);
-    
-    std::string test_param = "test_param";
+    expRc_ = catena::exception_with_status("Test catena exception", catena::StatusCode::INTERNAL);
+    fqoid_ = "test_param";
     
     // Setup mock expectations to trigger an exception during proceed()
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(test_param));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(test_param, ::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status&, Authorizer&) -> std::unique_ptr<IParam> {
             throw catena::exception_with_status("Test catena exception", catena::StatusCode::INTERNAL);
         }));
 
-    // Create a new request for this test
-    auto catenaExceptionRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    catenaExceptionRequest->proceed();
-    catenaExceptionRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete catenaExceptionRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 4.2: Error case - std::exception in proceed()
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catchStdException) {
-    catena::exception_with_status rc("Unknown error in ParamInfoRequest: Test std exception", catena::StatusCode::UNKNOWN);
-    
-    std::string test_param = "test_param";
+    expRc_ = catena::exception_with_status("Unknown error in ParamInfoRequest: Test std exception", catena::StatusCode::UNKNOWN);
+    fqoid_ = "test_param";
     
     // Setup mock expectations to trigger a std::exception during proceed()
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(test_param));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(test_param, ::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status&, Authorizer&) -> std::unique_ptr<IParam> {
             throw std::runtime_error("Test std exception");
         }));
 
-    // Create a new request for this test
-    auto stdExceptionRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    stdExceptionRequest->proceed();
-    stdExceptionRequest->finish();
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete stdExceptionRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
 // Test 4.3: Error case - unknown exception in proceed()
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catchUnknownException) {
-    catena::exception_with_status rc("Unknown error in ParamInfoRequest", catena::StatusCode::UNKNOWN);
-    
-    std::string test_param = "test_param";
+    expRc_ = catena::exception_with_status("Unknown error in ParamInfoRequest", catena::StatusCode::UNKNOWN);
+    fqoid_ = "test_param";
     
     // Setup mock expectations to trigger an unknown exception during proceed()
-    EXPECT_CALL(context, hasField("recursive")).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(context, fqoid()).WillRepeatedly(::testing::ReturnRef(test_param));
-    EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMtx));
-    
-    EXPECT_CALL(dm, getParam(test_param, ::testing::_, ::testing::_))
+    EXPECT_CALL(dm0_, getParam(fqoid_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Invoke([](const std::string&, catena::exception_with_status&, Authorizer&) -> std::unique_ptr<IParam> {
             throw 42; // Throw an int
         }));
 
-    // Create a new request for this test
-    auto unknownExceptionRequest = ParamInfoRequest::makeOne(serverSocket_, context, dm);
-
-    unknownExceptionRequest->proceed();
-    unknownExceptionRequest->finish();
+    // Create a new endpoint_ for this test
+    endpoint_->proceed();
+    endpoint_->finish();
 
     // Match expected and actual responses
-    std::string expected = expectedSSEResponse(rc);
-    std::string actual = readResponse();
-    EXPECT_EQ(actual, expected);
-
-    delete unknownExceptionRequest;
+    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }

--- a/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
@@ -99,7 +99,7 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_Create) {
 
 // Test 0.1: Authorization test with std::exception
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzStdException) {
-    expRc_ = catena::exception_with_status("Authorization setup failed: Test auth setup failure", catena::StatusCode::UNAUTHENTICATED);
+    expRc_ = catena::exception_with_status("Authorization setup failed: Test auth setup failure", catena::StatusCode::INTERNAL);
     authzEnabled_ = true;
 
     // Setup mock expectations

--- a/unittests/cpp/REST/tests/SetValue_test.cpp
+++ b/unittests/cpp/REST/tests/SetValue_test.cpp
@@ -60,7 +60,7 @@ class RESTSetValueTests : public RESTEndpointTest {
         fqoid_ = oid;
         inVal_.set_string_value(value);
         auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
-        EXPECT_TRUE(status.ok()) << "Failed to convert input value to JSON";
+        ASSERT_TRUE(status.ok()) << "Failed to convert input value to JSON";
     }
 
     /*

--- a/unittests/cpp/REST/tests/SetValue_test.cpp
+++ b/unittests/cpp/REST/tests/SetValue_test.cpp
@@ -48,12 +48,12 @@ using namespace catena::REST;
 class RESTSetValueTests : public RESTEndpointTest {
   protected:
     /*
-     * Creates a MultiSetValue handler object.
+     * Creates a SetValue handler object.
      */
-    ICallData* makeOne() override { return SetValue::makeOne(serverSocket, context_, dm0_); }
+    ICallData* makeOne() override { return SetValue::makeOne(serverSocket_, context_, dm0_); }
 
     /*
-     * Streamlines the creation of SetValuePayload. 
+     * Streamlines the creation of endpoint input. 
      */
     void initPayload(uint32_t slot, const std::string& oid, const std::string& value) {
         slot_ = slot;
@@ -87,7 +87,7 @@ TEST_F(RESTSetValueTests, SetValue_Create) {
 }
 
 /* 
- * TEST 4 - Writing to console with SetValue finish().
+ * TEST 2 - Writing to console with SetValue finish().
  */
 TEST_F(RESTSetValueTests, SetValue_Finish) {
     endpoint_->finish();
@@ -95,7 +95,7 @@ TEST_F(RESTSetValueTests, SetValue_Finish) {
 }
 
 /* 
- * TEST 2 - Normal case for SetValue toMulti_().
+ * TEST 3 - Normal case for SetValue toMulti_().
  */
 TEST_F(RESTSetValueTests, SetValue_Normal) {
     initPayload(0, "/test_oid", "test_value");
@@ -114,7 +114,7 @@ TEST_F(RESTSetValueTests, SetValue_Normal) {
 }
 
 /* 
- * TEST 3 - SetValue toMulti_() fails to parse the JSON.
+ * TEST 4 - SetValue toMulti_() fails to parse the JSON.
  */
 TEST_F(RESTSetValueTests, SetValue_FailParse) {
     expRc_ = catena::exception_with_status("Failed to convert JSON to protobuf", catena::StatusCode::INVALID_ARGUMENT);

--- a/unittests/cpp/REST/tests/SetValue_test.cpp
+++ b/unittests/cpp/REST/tests/SetValue_test.cpp
@@ -35,57 +35,44 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
-#include "MockDevice.h"
 
 // REST
 #include "controllers/SetValue.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTSetValueTests : public ::testing::Test, public RESTTest {
+class RESTSetValueTests : public RESTEndpointTest {
   protected:
-    RESTSetValueTests() : RESTTest(&serverSocket, &clientSocket) {}
+    /*
+     * Creates a MultiSetValue handler object.
+     */
+    ICallData* makeOne() override { return SetValue::makeOne(serverSocket, context_, dm0_); }
 
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Creating setValue object.
-        EXPECT_CALL(context, origin()).Times(1).WillOnce(::testing::ReturnRef(origin));
-        setValue = SetValue::makeOne(serverSocket, context, dm);
+    /*
+     * Streamlines the creation of SetValuePayload. 
+     */
+    void initPayload(uint32_t slot, const std::string& oid, const std::string& value) {
+        slot_ = slot;
+        fqoid_ = oid;
+        inVal_.set_string_value(value);
+        auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
+        EXPECT_TRUE(status.ok()) << "Failed to convert input value to JSON";
     }
 
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (setValue) {
-            delete setValue;
-        }
+    /*
+     * Calls proceed and tests the response.
+     */
+    void testCall() {
+        endpoint_->proceed();
+        EXPECT_EQ(readResponse(), expectedResponse(expRc_));
     }
 
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    
-    MockSocketReader context;
-    MockDevice dm;
-    catena::REST::ICallData* setValue = nullptr;
+    // in vals
+    catena::Value inVal_;
 };
 
 /*
@@ -95,59 +82,46 @@ class RESTSetValueTests : public ::testing::Test, public RESTTest {
  * 
  * TEST 1 - Creating a SetValue object with makeOne.
  */
-TEST_F(RESTSetValueTests, SetValue_create) {
-    // Making sure setValue is created from the SetUp step.
-    ASSERT_TRUE(setValue);
-}
-
-/* 
- * TEST 2 - Normal case for SetValue toMulti_().
- */
-TEST_F(RESTSetValueTests, SetValue_proceedNormal) {
-    catena::exception_with_status rc("", catena::StatusCode::OK);
-    std::mutex mockMutex;
-    std::string mockJsonBody = "{\"string_value\": \"test value 1\"}";
-    std::string mockFqoid = "/text_box";
-
-    // Defining mock functions
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(mockJsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(1).WillOnce(::testing::Return(false));
-    EXPECT_CALL(dm, mutex()).Times(1).WillOnce(::testing::ReturnRef(mockMutex));
-    EXPECT_CALL(dm, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(true));
-    EXPECT_CALL(dm, commitMultiSetValue(::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(catena::exception_with_status(rc.what(), rc.status)));
-
-    setValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-}
-
-/* 
- * TEST 3 - TEST 11 - SetValue toMulti_() fails to parse the JSON.
- */
-TEST_F(RESTSetValueTests, SetValue_proceedFailParse) {
-    catena::exception_with_status rc("Failed to convert JSON to protobuf", catena::StatusCode::INVALID_ARGUMENT);
-    std::string mockJsonBody = "Not a JSON string";
-    std::string mockFqoid = "";
-
-    // Defining mock functions
-    EXPECT_CALL(context, fqoid()).Times(1).WillOnce(::testing::ReturnRef(mockFqoid));
-    EXPECT_CALL(context, jsonBody()).Times(1).WillOnce(::testing::ReturnRef(mockJsonBody));
-    EXPECT_CALL(context, slot()).Times(1).WillOnce(::testing::Return(1));
-    EXPECT_CALL(context, authorizationEnabled()).Times(0);
-
-    setValue->proceed();
-
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+TEST_F(RESTSetValueTests, SetValue_Create) {
+    ASSERT_TRUE(endpoint_);
 }
 
 /* 
  * TEST 4 - Writing to console with SetValue finish().
  */
-TEST_F(RESTSetValueTests, SetValue_finish) {
-    // Calling finish and expecting the console output.
-    setValue->finish();
-    // Idk why I cant use .contains() here :/
-    ASSERT_TRUE(MockConsole.str().find("SetValue[3] finished\n") != std::string::npos);
+TEST_F(RESTSetValueTests, SetValue_Finish) {
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("SetValue[1] finished\n") != std::string::npos);
+}
+
+/* 
+ * TEST 2 - Normal case for SetValue toMulti_().
+ */
+TEST_F(RESTSetValueTests, SetValue_Normal) {
+    initPayload(0, "/test_oid", "test_value");
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Invoke([this](catena::MultiSetValuePayload src, catena::exception_with_status &ans, catena::common::Authorizer &authz) {
+            // Checking that function gets correct inputs.
+            auto val = (*src.mutable_values())[0];
+            EXPECT_EQ(val.oid(), fqoid_);
+            EXPECT_EQ(val.value().SerializeAsString(), inVal_.SerializeAsString());
+            return true;
+        }));
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Return(catena::exception_with_status(expRc_.what(), expRc_.status)));
+    // Sending call
+    testCall();
+}
+
+/* 
+ * TEST 3 - SetValue toMulti_() fails to parse the JSON.
+ */
+TEST_F(RESTSetValueTests, SetValue_FailParse) {
+    expRc_ = catena::exception_with_status("Failed to convert JSON to protobuf", catena::StatusCode::INVALID_ARGUMENT);
+    jsonBody_ = "Not a JSON string";
+    // Setting expectations
+    EXPECT_CALL(dm0_, tryMultiSetValue(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(dm0_, commitMultiSetValue(::testing::_, ::testing::_)).Times(0);
+    // Sending call
+    testCall();
 }

--- a/unittests/cpp/REST/tests/SocketReader_test.cpp
+++ b/unittests/cpp/REST/tests/SocketReader_test.cpp
@@ -55,11 +55,11 @@ using namespace catena::REST;
 class RESTSocketReaderTests : public ::testing::Test, public RESTTest {
   protected:
     // Defining the in/out sockets.
-    RESTSocketReaderTests() : RESTTest(&clientSocket, &serverSocket) {}
+    RESTSocketReaderTests() : RESTTest(&clientSocket_, &serverSocket_) {}
 
     // Writes a request to a socket to later be read by the SocketReader.
     void SetUp() override {
-        origin = "test_origin";
+        origin_ = "test_origin";
         // Making sure the reader properly adds the subscriptions manager.
         EXPECT_EQ(&socketReader.getSubscriptionManager(), &sm);
         EXPECT_EQ(socketReader.EOPath(), EOPath);
@@ -82,7 +82,7 @@ class RESTSocketReaderTests : public ::testing::Test, public RESTTest {
         // Writing the request to the socket and reading.
         writeRequest(method, slot, endpoint, fqoid, stream, fields,
                      jwsToken, origin, detailLevel, language, jsonBody);
-        socketReader.read(serverSocket, authz);
+        socketReader.read(serverSocket_, authz);
         // Validating the results.
         if (!authz) { jwsToken = ""; }
         if (detailLevel.empty()) { detailLevel = "NONE"; }

--- a/unittests/cpp/REST/tests/SocketWriter_test.cpp
+++ b/unittests/cpp/REST/tests/SocketWriter_test.cpp
@@ -55,8 +55,8 @@ using namespace catena::REST;
 // Fixture
 class RESTSocketWriterTests : public ::testing::Test, public RESTTest {
   protected:
-    RESTSocketWriterTests() : RESTTest(&serverSocket, &clientSocket) {
-        origin = "test-origin.com";
+    RESTSocketWriterTests() : RESTTest(&serverSocket_, &clientSocket_) {
+        origin_ = "test-origin.com";
     }
   
     void SetUp() override { /* Setup code here */ }
@@ -77,11 +77,11 @@ TEST_F(RESTSocketWriterTests, SocketWriter_Write200) {
     catena::Value msg;
     msg.set_string_value("Test string");
 
-    // Initializing SocketWriter with serverSocket and writing message.
-    SocketWriter writer(serverSocket, origin);
+    // Initializing SocketWriter with serverSocket_ and writing message.
+    SocketWriter writer(serverSocket_, origin_);
     writer.sendResponse(rc, msg);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     std::string jsonBody;
     google::protobuf::util::JsonPrintOptions options; // Default options
     auto status = google::protobuf::util::MessageToJsonString(msg, &jsonBody, options);
@@ -96,11 +96,11 @@ TEST_F(RESTSocketWriterTests, SocketWriter_Write204) {
     catena::exception_with_status rc("", catena::StatusCode::NO_CONTENT);
     catena::Empty emptyMsg = catena::Empty();
 
-    // Initializing SocketWriter with serverSocket and writing message.
-    SocketWriter writer(serverSocket, origin);
+    // Initializing SocketWriter with serverSocket_ and writing message.
+    SocketWriter writer(serverSocket_, origin_);
     writer.sendResponse(rc, emptyMsg);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedResponse(rc));
 }
 
@@ -113,11 +113,11 @@ TEST_F(RESTSocketWriterTests, SocketWriter_WriteErr) {
     catena::Value msg;
     msg.set_string_value("Test string");
 
-    // Initializing SocketWriter with serverSocket and writing message.
-    SocketWriter writer(serverSocket, origin);
+    // Initializing SocketWriter with serverSocket_ and writing message.
+    SocketWriter writer(serverSocket_, origin_);
     writer.sendResponse(rc, msg);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedResponse(rc));
 }
 
@@ -134,8 +134,8 @@ TEST_F(RESTSocketWriterTests, SocketWriter_Buffer200) {
     std::string expJson = "";
     google::protobuf::util::JsonPrintOptions options; // Default options
 
-    // Initializing SocketWriter with serverSocket and writing messages.
-    SocketWriter writer(serverSocket, origin, true);
+    // Initializing SocketWriter with serverSocket_ and writing messages.
+    SocketWriter writer(serverSocket_, origin_, true);
     for (const auto& msg : msgs) {
         writer.sendResponse(rc, msg);
         // Adding to expected response.
@@ -151,7 +151,7 @@ TEST_F(RESTSocketWriterTests, SocketWriter_Buffer200) {
     // Writing an empty message to flush response.
     writer.sendResponse(rc);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedResponse(rc, expJson));
 }
 
@@ -162,11 +162,11 @@ TEST_F(RESTSocketWriterTests, SocketWriter_BufferErrBegin) {
     // msg variables.
     catena::exception_with_status rc("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
     
-    // Initializing SocketWriter with serverSocket and writing error.
-    SocketWriter writer(serverSocket, origin, true);
+    // Initializing SocketWriter with serverSocket_ and writing error.
+    SocketWriter writer(serverSocket_, origin_, true);
     writer.sendResponse(rc);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedResponse(rc));
 }
 
@@ -181,15 +181,15 @@ TEST_F(RESTSocketWriterTests, SocketWriter_BufferErrEnd) {
     msgs[1].set_string_value("test-string-2");
     msgs[2].set_string_value("test-string-3");
 
-    // Initializing SocketWriter with serverSocket and writing messages.
-    SocketWriter writer(serverSocket, origin, true);
+    // Initializing SocketWriter with serverSocket_ and writing messages.
+    SocketWriter writer(serverSocket_, origin_, true);
     for (const auto& msg : msgs) {
         writer.sendResponse(catena::exception_with_status("", catena::StatusCode::OK), msg);
     }
     // Writing error.
     writer.sendResponse(rc);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedResponse(rc));
 }
 
@@ -211,15 +211,15 @@ TEST_F(RESTSocketWriterTests, SSEWriter_Write200) {
         "{\"int32Value\":5}",
     };
 
-    // Initializing SSEWriter with serverSocket and writing messages.
-    SSEWriter writer(serverSocket, origin);
+    // Initializing SSEWriter with serverSocket_ and writing messages.
+    SSEWriter writer(serverSocket_, origin_);
     for (std::string msgJson : msgs) {
         catena::Value msg;
         auto status = google::protobuf::util::JsonStringToMessage(absl::string_view(msgJson), &msg);
         writer.sendResponse(rc, msg);
     }
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedSSEResponse(rc, msgs));
 }
 
@@ -232,11 +232,11 @@ TEST_F(RESTSocketWriterTests, SSEWriter_WriteEmpty) {
     std::vector<std::string> msgs = {};
     catena::Empty emptyMsg = catena::Empty();
 
-    // Initializing SSEWriter with serverSocket and writing messages.
-    SSEWriter writer(serverSocket, origin);
+    // Initializing SSEWriter with serverSocket_ and writing messages.
+    SSEWriter writer(serverSocket_, origin_);
     writer.sendResponse(rc, emptyMsg);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedSSEResponse(rc, msgs));
 }
 
@@ -252,8 +252,8 @@ TEST_F(RESTSocketWriterTests, SSEWriter_WriteEmptyEnd) {
     };
     catena::Empty emptyMsg = catena::Empty();
 
-    // Initializing SSEWriter with serverSocket and writing messages.
-    SSEWriter writer(serverSocket, origin);
+    // Initializing SSEWriter with serverSocket_ and writing messages.
+    SSEWriter writer(serverSocket_, origin_);
     for (std::string msgJson : msgs) {
         catena::Value msg;
         auto status = google::protobuf::util::JsonStringToMessage(absl::string_view(msgJson), &msg);
@@ -261,7 +261,7 @@ TEST_F(RESTSocketWriterTests, SSEWriter_WriteEmptyEnd) {
     }
     writer.sendResponse(rc, emptyMsg);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedSSEResponse(rc, msgs));
 }
 
@@ -273,11 +273,11 @@ TEST_F(RESTSocketWriterTests, SSEWriter_WriteErrBegin) {
     catena::exception_with_status rc("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
     catena::Empty emptyMsg = catena::Empty();
 
-    // Initializing SSEWriter with serverSocket and writing error.
-    SSEWriter writer(serverSocket, origin);
+    // Initializing SSEWriter with serverSocket_ and writing error.
+    SSEWriter writer(serverSocket_, origin_);
     writer.sendResponse(rc);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedSSEResponse(rc));
 }
 
@@ -294,8 +294,8 @@ TEST_F(RESTSocketWriterTests, SSEWriter_WriteErrEnd) {
     catena::exception_with_status err("Invalid argument", catena::StatusCode::INVALID_ARGUMENT);
     catena::Empty emptyMsg = catena::Empty();
 
-    // Initializing SSEWriter with serverSocket and writing messages.
-    SSEWriter writer(serverSocket, origin);
+    // Initializing SSEWriter with serverSocket_ and writing messages.
+    SSEWriter writer(serverSocket_, origin_);
     for (std::string msgJson : msgs) {
         catena::Value msg;
         auto status = google::protobuf::util::JsonStringToMessage(absl::string_view(msgJson), &msg);
@@ -303,6 +303,6 @@ TEST_F(RESTSocketWriterTests, SSEWriter_WriteErrEnd) {
     }
     writer.sendResponse(rc, emptyMsg);
 
-    // Reading from clientSocket and checking the response.
+    // Reading from clientSocket_ and checking the response.
     EXPECT_EQ(readResponse(), expectedSSEResponse(rc, msgs));
 }

--- a/unittests/cpp/REST/tests/Subscriptions_test.cpp
+++ b/unittests/cpp/REST/tests/Subscriptions_test.cpp
@@ -271,7 +271,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETNormal) {
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETStream) {
     initPayload(0);
     // Remaking with stream enabled.
-    EXPECT_CALL(context_, stream()).WillOnce(::testing::Return(true));
+    stream_ = true;
     endpoint_.reset(makeOne());
     // Sending call
     testCall();

--- a/unittests/cpp/REST/tests/Subscriptions_test.cpp
+++ b/unittests/cpp/REST/tests/Subscriptions_test.cpp
@@ -63,7 +63,7 @@ using namespace catena::REST;
 // Fixture
 class RESTSubscriptionsTests : public ::testing::Test, public RESTTest {
   protected:
-    RESTSubscriptionsTests() : RESTTest(&serverSocket, &clientSocket) {}
+    RESTSubscriptionsTests() : RESTTest(&serverSocket_, &clientSocket_) {}
 
     /*
      * Redirects cout and sets default expectations for each method.
@@ -76,7 +76,7 @@ class RESTSubscriptionsTests : public ::testing::Test, public RESTTest {
         EXPECT_CALL(context, method()).WillRepeatedly(::testing::ReturnRef(testMethod));
         EXPECT_CALL(context, slot()).WillRepeatedly(::testing::Return(0));
         EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::ReturnRef(testToken));
-        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin));
+        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin_));
         EXPECT_CALL(context, jsonBody()).WillRepeatedly(::testing::ReturnRef(testJsonBody));
         EXPECT_CALL(context, getSubscriptionManager()).WillRepeatedly(::testing::ReturnRef(subManager));
         EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Invoke([this](){ return authzEnabled; }));
@@ -194,7 +194,7 @@ class RESTSubscriptionsTests : public ::testing::Test, public RESTTest {
  * TEST 0.1 - Creating a Subscriptions object with makeOne.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_create) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     ASSERT_TRUE(endpoint);
 }
 
@@ -202,7 +202,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_create) {
  * TEST 0.2 - Writing to console with Subscriptions finish().
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_Finish) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     endpoint->finish();
     ASSERT_TRUE(MockConsole.str().find("Subscriptions[1] finished\n") != std::string::npos);
 }
@@ -211,7 +211,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_Finish) {
  * TEST 0.3 - Subscriptions with a device which does not support them.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_NotSupported) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc("Subscriptions are not enabled for this device", catena::StatusCode::FAILED_PRECONDITION);
     // Setting expectations.
     EXPECT_CALL(dm, subscriptions()).WillOnce(::testing::Return(false));
@@ -225,7 +225,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_NotSupported) {
  * TEST 0.4 - Subscriptions with an invalid token.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_AuthzInalid) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
     testToken = "Invalid token";
     authzEnabled = true;
@@ -241,7 +241,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_AuthzInalid) {
  * TEST 0.5 - Subscriptions with an invalid method.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_BadMethod) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc("Bad method", catena::StatusCode::INVALID_ARGUMENT);
     testMethod = "BAD_METHOD";
     // Setting expectations.
@@ -260,7 +260,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_BadMethod) {
  * TEST 1.1 - GET Subscriptions normal case.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETNormal) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     // Setting expectations.
     EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
@@ -275,7 +275,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETNormal) {
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETStream) {
     // Enabling stream.
     EXPECT_CALL(context, stream()).WillOnce(::testing::Return(true));
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     // Setting expectations.
     EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
@@ -288,7 +288,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETStream) {
  * TEST 1.3 - GET Subscriptions with a valid token.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETAuthzValid) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     authzEnabled = true;
     testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
@@ -310,7 +310,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETAuthzValid) {
  * TEST 1.4 - GET Subscriptions fail to retrieve a param.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamReturnErr) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     oids.insert(oids.begin(), "errParam");
     // Setting expectations.
@@ -328,7 +328,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamReturnErr) {
  * TEST 1.5 - GET Subscriptions call to GetParam throws a catena::exception_with_status.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamThrowCatena) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Param not found", catena::StatusCode::NOT_FOUND};
     oids.insert(oids.begin(), "errParam");
     // Setting expectations.
@@ -346,7 +346,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamThrowCatena) {
  * TEST 1.6 - GET Subscriptions call to GetParam throws an std::runtime_error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamThrowUnknown) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
     oids.insert(oids.begin(), "errParam");
     // Setting expectations.
@@ -364,7 +364,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamThrowUnknown) {
  * TEST 1.7 - GET Subscriptions fails to convert param to proto.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoReturnErr) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     oids.insert(oids.begin(), "errParam");
     std::unique_ptr<MockParam> errParam = std::make_unique<MockParam>();
@@ -388,7 +388,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoReturnErr) {
  * TEST 1.8 - GET Subscriptions call to toProto throws an catena::exception_with_status.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowCatena) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Param not found", catena::StatusCode::NOT_FOUND};
     oids.insert(oids.begin(), "errParam");
     std::unique_ptr<MockParam> errParam = std::make_unique<MockParam>();
@@ -413,7 +413,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowCatena) {
  * TEST 1.9 - GET Subscriptions call to toProto throws an std::runtime_error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowUnknown) {
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
     oids.insert(oids.begin(), "errParam");
     std::unique_ptr<MockParam> errParam = std::make_unique<MockParam>();
@@ -443,7 +443,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowUnknown) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTNormal) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     initPayload({"param1", "param2"}, {"param1", "param2"});
     // Setting expectations.
@@ -460,7 +460,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTNormal) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAuthzValid) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     initPayload({"param1", "param2"}, {"param1", "param2"});
     authzEnabled = true;
@@ -486,7 +486,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAuthzValid) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTFailParse) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc("Failed to parse JSON Body", catena::StatusCode::INVALID_ARGUMENT);
     testJsonBody = "Not a JSON string";
     // Setting expectations.
@@ -503,7 +503,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTFailParse) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTReturnErr) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     initPayload({"errParam", "param1", "param2"}, {"errParam", "param1", "param2"});
     // Setting expectations.
@@ -532,7 +532,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTReturnErr) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTRemThrowCatena) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT};
     initPayload({}, {"errParam", "param1", "param2"});
     // Setting expectations.
@@ -555,7 +555,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTRemThrowCatena) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTRemThrowUnknown) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
     initPayload({}, {"errParam", "param1", "param2"});
     // Setting expectations.
@@ -578,7 +578,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTRemThrowUnknown) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAddThrowCatena) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT};
     initPayload({"errParam", "param1", "param2"}, {});
     // Setting expectations.
@@ -601,7 +601,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAddThrowCatena) {
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAddThrowUnknown) {
     testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket, context, dm);
+    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
     catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
     initPayload({"errParam", "param1", "param2"}, {});
     // Setting expectations.

--- a/unittests/cpp/REST/tests/Subscriptions_test.cpp
+++ b/unittests/cpp/REST/tests/Subscriptions_test.cpp
@@ -61,194 +61,194 @@ using namespace catena::common;
 using namespace catena::REST;
 
 // Fixture
-class RESTSubscriptionsTests : public ::testing::Test, public RESTTest {
+class RESTSubscriptionsTests : public RESTEndpointTest {
   protected:
-    RESTSubscriptionsTests() : RESTTest(&serverSocket_, &clientSocket_) {}
-
     /*
-     * Redirects cout and sets default expectations for each method.
+     * Sets default expectations for the Subscriptions tests.
      */
-    void SetUp() override {
-        // Redirecting cout to a stringstream for testing.
-        oldCout = std::cout.rdbuf(MockConsole.rdbuf());
-
-        // Default expectations for the context.
-        EXPECT_CALL(context, method()).WillRepeatedly(::testing::ReturnRef(testMethod));
-        EXPECT_CALL(context, slot()).WillRepeatedly(::testing::Return(0));
-        EXPECT_CALL(context, jwsToken()).WillRepeatedly(::testing::ReturnRef(testToken));
-        EXPECT_CALL(context, origin()).WillRepeatedly(::testing::ReturnRef(origin_));
-        EXPECT_CALL(context, jsonBody()).WillRepeatedly(::testing::ReturnRef(testJsonBody));
-        EXPECT_CALL(context, getSubscriptionManager()).WillRepeatedly(::testing::ReturnRef(subManager));
-        EXPECT_CALL(context, authorizationEnabled()).WillRepeatedly(::testing::Invoke([this](){ return authzEnabled; }));
-        EXPECT_CALL(context, stream()).WillRepeatedly(::testing::Return(false));
-
-        // Default expectations for subscription manger.
-        EXPECT_CALL(subManager, getAllSubscribedOids(::testing::_))
+    RESTSubscriptionsTests() : RESTEndpointTest() {
+        // Default expectations for context_.
+        EXPECT_CALL(context_, getSubscriptionManager()).WillRepeatedly(::testing::ReturnRef(subManager_));
+        // Default expectations for device model.
+        EXPECT_CALL(dm0_, subscriptions()).WillRepeatedly(::testing::Return(true));
+        // Default expectations for sub manager.
+        EXPECT_CALL(subManager_, getAllSubscribedOids(::testing::_))
             .WillRepeatedly(::testing::Invoke([this](const catena::common::IDevice &dm){
                 // Make sure device is passed in.
-                EXPECT_EQ(&dm, &this->dm);
-                return std::set<std::string>(oids.begin(), oids.end());
+                EXPECT_EQ(&dm, &dm0_);
+                return std::set<std::string>(oids_.begin(), oids_.end());
             }));
-
-        // default expectations for the device model.
-        EXPECT_CALL(dm, subscriptions()).WillRepeatedly(::testing::Return(true));
-        EXPECT_CALL(dm, mutex()).WillRepeatedly(::testing::ReturnRef(mockMutex));
-
         // Default expectations for each test param.
-        for (size_t i = 0; i < oids.size(); ++i) {
-            // Initializing test parameters and their expected responses.
-            params.emplace_back();
-            params.back() = std::make_unique<MockParam>();
-            responses.emplace_back();
-            responses.back().set_oid(oids[i]);
-            responses.back().mutable_param()->mutable_value()->set_string_value("value" + std::to_string(i + 1));
-            responsesJson.emplace_back();
-            auto status = google::protobuf::util::MessageToJsonString(responses.back(), &responsesJson.back());
-            EXPECT_TRUE(status.ok());
+        for (size_t i = 0; i < oids_.size(); ++i) {
+            // Initializing test parameters and their expected responses_.
+            params_.emplace_back();
+            params_.back() = std::make_unique<MockParam>();
+            responses_.emplace_back();
+            responses_.back().set_oid(oids_[i]);
+            responses_.back().mutable_param()->mutable_value()->set_string_value("value" + std::to_string(i + 1));
+            responsesJson_.emplace_back();
+            auto status = google::protobuf::util::MessageToJsonString(responses_.back(), &responsesJson_.back());
+            EXPECT_TRUE(status.ok()) << "Failed to convert test response to JSON";
 
-            // Default expectations for test params for GET calls.
-            EXPECT_CALL(dm, getParam(oids[i], ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+            // Default expectations for test params_ for GET calls.
+            EXPECT_CALL(dm0_, getParam(oids_[i], ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
                 [this, i](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
                     // Make sure authz is correctly passed in.
-                    EXPECT_EQ(!authzEnabled, &authz == &catena::common::Authorizer::kAuthzDisabled);
-                    return std::move(params[i]);
+                    EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+                    return std::move(params_[i]);
                 }));
-            EXPECT_CALL(*params.back(), getOid()).WillRepeatedly(::testing::ReturnRefOfCopy(oids[i]));
-            EXPECT_CALL(*params.back(), toProto(::testing::An<catena::Param&>(), ::testing::_)).WillRepeatedly(::testing::Invoke(
+            EXPECT_CALL(*params_.back(), getOid()).WillRepeatedly(::testing::ReturnRefOfCopy(oids_[i]));
+            EXPECT_CALL(*params_.back(), toProto(::testing::An<catena::Param&>(), ::testing::_)).WillRepeatedly(::testing::Invoke(
                 [this, i](catena::Param &param, catena::common::Authorizer &authz) {
                     // Make sure authz is correctly passed in.
-                    EXPECT_EQ(!authzEnabled, &authz == &catena::common::Authorizer::kAuthzDisabled);
-                    param.CopyFrom(responses[i].param());
+                    EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+                    param.CopyFrom(responses_[i].param());
                     return catena::exception_with_status("", catena::StatusCode::OK);
                 }));
 
-            // Default expectations for test params for PUT calls.
-            EXPECT_CALL(subManager, removeSubscription(oids[i], ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+            // Default expectations for test params_ for PUT calls.
+            EXPECT_CALL(subManager_, removeSubscription(oids_[i], ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
                 [this](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc) {
                     // Make sure device is correctly passed in.
-                    EXPECT_EQ(&dm, &this->dm);
-                    this->removed_oids++;
+                    EXPECT_EQ(&dm, &dm0_);
+                    this->removedOids_++;
                     return true;
                 }));
-            EXPECT_CALL(subManager, addSubscription(oids[i], ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+            EXPECT_CALL(subManager_, addSubscription(oids_[i], ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
                 [this](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc, catena::common::Authorizer& authz) {
                     // Make sure authz and device are correctly passed in.
-                    EXPECT_EQ(!authzEnabled, &authz == &catena::common::Authorizer::kAuthzDisabled);
-                    EXPECT_EQ(&dm, &this->dm);
-                    this->added_oids++;
+                    EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+                    EXPECT_EQ(&dm, &dm0_);
+                    this->addedOids_++;
                     return true;
                 }));
         }
     }
 
     /*
-     * Helper to initialize a jsonBody via UpdateSubscriptionsPayload.
+     * Creates a Subscriptions handler object.
      */
-    void initPayload(const std::vector<std::string> &addOids, const std::vector<std::string> &remOids) {
-        catena::UpdateSubscriptionsPayload payload;
+    ICallData* makeOne() override { return Subscriptions::makeOne(serverSocket_, context_, dm0_); }
+
+    /*
+     * Streamlines the creation of endpoint_ input. 
+     */
+    void initPayload(uint32_t slot, const std::vector<std::string> &addOids= {}, const std::vector<std::string> &remOids = {}) {
+        slot_ = slot;
         // Adding addOids.
-        for (const auto& oid : addOids) { payload.add_added_oids(oid); }
+        for (const auto& oid : addOids) { inVal_.add_added_oids(oid); }
         // Adding remOids.
-        for (const auto& oid : remOids) { payload.add_removed_oids(oid); }
+        for (const auto& oid : remOids) { inVal_.add_removed_oids(oid); }
         // Converting to JSON body.
-        auto status = google::protobuf::util::MessageToJsonString(payload, &testJsonBody);
-        EXPECT_TRUE(status.ok());
+        auto status = google::protobuf::util::MessageToJsonString(inVal_, &jsonBody_);
+        ASSERT_TRUE(status.ok()) << "Failed to convert input value to JSON";
     }
 
     /*
-     * Restores cout and deletes endpoint.
+     * Calls proceed and tests the response.
      */
-    void TearDown() override {
-        std::cout.rdbuf(oldCout); // Restoring cout
-        // Cleanup code here
-        if (endpoint) {
-            delete endpoint;
+    void testCall() {
+        endpoint_->proceed();
+        std::vector<std::string> jsonBodies;
+        // Additional stuff based on method used.
+        if (expRc_.status == catena::StatusCode::OK) {
+            if (method_ == "GET") {
+                for (auto param : responses_) {
+                    jsonBodies.emplace_back();
+                    auto status = google::protobuf::util::MessageToJsonString(param, &jsonBodies.back());
+                    ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
+                }
+            } else if (method_ == "PUT") {
+                // We should expect either 0 or 2 added oids.
+                if (inVal_.added_oids().empty()) {
+                    EXPECT_EQ(addedOids_, 0);
+                } else {
+                    EXPECT_EQ(addedOids_, 2);
+                }
+                // We should expect either 0 or 2 removed oids.
+                if (inVal_.removed_oids().empty()) {
+                    EXPECT_EQ(removedOids_, 0);
+                } else {
+                    EXPECT_EQ(removedOids_, 2);
+                }
+            }
+        }
+        // Response format based on stream or unary.
+        if (stream_) {
+            EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
+        } else {
+            EXPECT_EQ(readResponse(), expectedResponse(expRc_, jsonBodies));
         }
     }
-    
-    // Cout variables.
-    std::stringstream MockConsole;
-    std::streambuf* oldCout;
-    // Context variables.
-    std::string testMethod = "GET";
-    std::string testToken = "";
-    std::string testJsonBody;
-    bool authzEnabled = false;
-    // Mock objects and endpoint.
-    MockSocketReader context;
-    std::mutex mockMutex;
-    MockDevice dm;
-    MockSubscriptionManager subManager;
-    catena::REST::ICallData* endpoint = nullptr;
-    // Test params.
-    std::vector<std::string> oids{"param1", "param2"};
-    std::vector<std::unique_ptr<MockParam>> params;
-    std::vector<catena::DeviceComponent_ComponentParam> responses;
-    std::vector<std::string> responsesJson;
+
+    // in vals
+    catena::UpdateSubscriptionsPayload inVal_;
+    // Test params_.
+    std::vector<std::string> oids_{"param1", "param2"};
+    std::vector<std::unique_ptr<MockParam>> params_;
+    std::vector<catena::DeviceComponent_ComponentParam> responses_;
+    std::vector<std::string> responsesJson_;
     // Trackers for calls to add/remove subscriptions.
-    uint32_t added_oids = 0;
-    uint32_t removed_oids = 0;
+    uint32_t addedOids_ = 0;
+    uint32_t removedOids_ = 0;
+
+    MockSubscriptionManager subManager_;
 };
 
 /* 
  * TEST 0.1 - Creating a Subscriptions object with makeOne.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_create) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    ASSERT_TRUE(endpoint);
+    ASSERT_TRUE(endpoint_);
 }
 
 /* 
  * TEST 0.2 - Writing to console with Subscriptions finish().
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_Finish) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    endpoint->finish();
-    ASSERT_TRUE(MockConsole.str().find("Subscriptions[1] finished\n") != std::string::npos);
+    endpoint_->finish();
+    ASSERT_TRUE(MockConsole_.str().find("Subscriptions[1] finished\n") != std::string::npos);
 }
 
 /* 
  * TEST 0.3 - Subscriptions with a device which does not support them.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_NotSupported) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc("Subscriptions are not enabled for this device", catena::StatusCode::FAILED_PRECONDITION);
+    initPayload(0);
+    expRc_ = catena::exception_with_status("Subscriptions are not enabled for this device", catena::StatusCode::FAILED_PRECONDITION);
     // Setting expectations.
-    EXPECT_CALL(dm, subscriptions()).WillOnce(::testing::Return(false));
-    EXPECT_CALL(context, getSubscriptionManager()).Times(0); // Should not call.
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, subscriptions()).WillOnce(::testing::Return(false));
+    EXPECT_CALL(context_, getSubscriptionManager()).Times(0); // Should not call.
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 0.4 - Subscriptions with an invalid token.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_AuthzInalid) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc("", catena::StatusCode::UNAUTHENTICATED);
-    testToken = "Invalid token";
-    authzEnabled = true;
+    initPayload(0);
+    expRc_ = catena::exception_with_status("", catena::StatusCode::UNAUTHENTICATED);
+    authzEnabled_ = true;
+    jwsToken_ = "Invalid token";
     // Setting expectations.
-    EXPECT_CALL(dm, getParam(::testing::An<const std::string&>(), ::testing::_, ::testing::_)).Times(0);
-    EXPECT_CALL(context, getSubscriptionManager()).Times(0); // Should not call.
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, getParam(::testing::An<const std::string&>(), ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(context_, getSubscriptionManager()).Times(0); // Should not call.
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 0.5 - Subscriptions with an invalid method.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_BadMethod) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc("Bad method", catena::StatusCode::INVALID_ARGUMENT);
-    testMethod = "BAD_METHOD";
+    initPayload(0);
+    expRc_ = catena::exception_with_status("Bad method", catena::StatusCode::INVALID_ARGUMENT);
+    method_ = "BAD_METHOD";
     // Setting expectations.
-    EXPECT_CALL(context, getSubscriptionManager()).Times(0); // Should not call.
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(context_, getSubscriptionManager()).Times(0); // Should not call.
+    // Sending call
+    testCall();
 }
 
 
@@ -260,38 +260,30 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_BadMethod) {
  * TEST 1.1 - GET Subscriptions normal case.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETNormal) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc, responsesJson));
+    initPayload(0);
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.2 - GET Stream normal case.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETStream) {
-    // Enabling stream.
-    EXPECT_CALL(context, stream()).WillOnce(::testing::Return(true));
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedSSEResponse(rc, responsesJson));
+    initPayload(0);
+    // Remaking with stream enabled.
+    EXPECT_CALL(context_, stream()).WillOnce(::testing::Return(true));
+    endpoint_.reset(makeOne());
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.3 - GET Subscriptions with a valid token.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETAuthzValid) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    authzEnabled = true;
-    testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+    initPayload(0);
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
                 "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
                 "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
                 "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
@@ -301,137 +293,120 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETAuthzValid) {
                 "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
                 "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
                 "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc, responsesJson));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.4 - GET Subscriptions fail to retrieve a param.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamReturnErr) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    oids.insert(oids.begin(), "errParam");
+    initPayload(0);
+    oids_.insert(oids_.begin(), "errParam");
     // Setting expectations.
-    EXPECT_CALL(dm, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+    EXPECT_CALL(dm0_, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
         [](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
             status = catena::exception_with_status("Param not found", catena::StatusCode::NOT_FOUND);
             return nullptr; // Simulating an error.
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc, responsesJson));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.5 - GET Subscriptions call to GetParam throws a catena::exception_with_status.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamThrowCatena) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Param not found", catena::StatusCode::NOT_FOUND};
-    oids.insert(oids.begin(), "errParam");
+    initPayload(0);
+    expRc_ = catena::exception_with_status{"Param not found", catena::StatusCode::NOT_FOUND};
+    oids_.insert(oids_.begin(), "errParam");
     // Setting expectations.
-    EXPECT_CALL(dm, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
-        [&rc](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+    EXPECT_CALL(dm0_, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+        [this](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return nullptr; // Simulating an error.
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.6 - GET Subscriptions call to GetParam throws an std::runtime_error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETGetParamThrowUnknown) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
-    oids.insert(oids.begin(), "errParam");
+    initPayload(0);
+    expRc_ = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
+    oids_.insert(oids_.begin(), "errParam");
     // Setting expectations.
-    EXPECT_CALL(dm, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
-        [](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
-            throw std::runtime_error("Unknown error occurred");
-            return nullptr; // Simulating an error.
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(dm0_, getParam("errParam", ::testing::_, ::testing::_)).Times(1)
+        .WillOnce(::testing::Throw(std::runtime_error("Unknown error occurred")));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.7 - GET Subscriptions fails to convert param to proto.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoReturnErr) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    oids.insert(oids.begin(), "errParam");
+    initPayload(0);
+    oids_.insert(oids_.begin(), "errParam");
     std::unique_ptr<MockParam> errParam = std::make_unique<MockParam>();
     // Setting expectations.
-    EXPECT_CALL(dm, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+    EXPECT_CALL(dm0_, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
         [&errParam](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
             return std::move(errParam);
         }));
-    EXPECT_CALL(*errParam, getOid()).WillRepeatedly(::testing::ReturnRef(oids[0]));
+    EXPECT_CALL(*errParam, getOid()).WillRepeatedly(::testing::ReturnRef(oids_[0]));
     EXPECT_CALL(*errParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).WillRepeatedly(::testing::Invoke(
         [](catena::Param &param, catena::common::Authorizer &authz) {
             // Simulating an error in conversion.
             return catena::exception_with_status("Failed to convert to proto", catena::StatusCode::UNKNOWN);
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc, responsesJson));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.8 - GET Subscriptions call to toProto throws an catena::exception_with_status.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowCatena) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Param not found", catena::StatusCode::NOT_FOUND};
-    oids.insert(oids.begin(), "errParam");
+    initPayload(0);
+    expRc_ = catena::exception_with_status{"Param not found", catena::StatusCode::NOT_FOUND};
+    oids_.insert(oids_.begin(), "errParam");
     std::unique_ptr<MockParam> errParam = std::make_unique<MockParam>();
 
-    EXPECT_CALL(dm, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+    EXPECT_CALL(dm0_, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
         [&errParam](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
             return std::move(errParam);
         }));
-    EXPECT_CALL(*errParam, getOid()).WillRepeatedly(::testing::ReturnRef(oids[0]));
+    EXPECT_CALL(*errParam, getOid()).WillRepeatedly(::testing::ReturnRef(oids_[0]));
     EXPECT_CALL(*errParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).WillRepeatedly(::testing::Invoke(
-        [&rc](catena::Param &param, catena::common::Authorizer &authz) {
-            throw catena::exception_with_status(rc.what(), rc.status);
+        [this](catena::Param &param, catena::common::Authorizer &authz) {
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
-    
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 1.9 - GET Subscriptions call to toProto throws an std::runtime_error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowUnknown) {
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
-    oids.insert(oids.begin(), "errParam");
+    initPayload(0);
+    expRc_ = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
+    oids_.insert(oids_.begin(), "errParam");
     std::unique_ptr<MockParam> errParam = std::make_unique<MockParam>();
     // Setting expectations.
-    EXPECT_CALL(dm, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
+    EXPECT_CALL(dm0_, getParam("errParam", ::testing::_, ::testing::_)).Times(1).WillOnce(::testing::Invoke(
         [&errParam](const std::string& oid, catena::exception_with_status& status, catena::common::Authorizer& authz) {
             return std::move(errParam);
         }));
-    EXPECT_CALL(*errParam, getOid()).WillRepeatedly(::testing::ReturnRef(oids[0]));
-    EXPECT_CALL(*errParam, toProto(::testing::An<catena::Param&>(), ::testing::_)).WillRepeatedly(::testing::Invoke(
-        [](catena::Param &param, catena::common::Authorizer &authz) {
-            // Simulating an error in conversion.
-            throw std::runtime_error("Unknown error");
-            return catena::exception_with_status("", catena::StatusCode::OK);
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
+    EXPECT_CALL(*errParam, getOid()).WillRepeatedly(::testing::ReturnRef(oids_[0]));
+    EXPECT_CALL(*errParam, toProto(::testing::An<catena::Param&>(), ::testing::_))
+        .WillRepeatedly(::testing::Throw(std::runtime_error("Unknown error")));
+    // Sending call
+    testCall();
 }
 
 /*
@@ -442,29 +417,20 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_GETToProtoThrowUnknown) {
  * TEST 2.1 - PUT Subscriptions normal case.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTNormal) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    initPayload({"param1", "param2"}, {"param1", "param2"});
-    // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 2); // Both oids should be added.
-    EXPECT_EQ(removed_oids, 2); // Both oids should be removed.
+    method_ = "PUT";
+    initPayload(0, {"param1", "param2"}, {"param1", "param2"});
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.2 - PUT Subscriptions with a valid token.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAuthzValid) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    initPayload({"param1", "param2"}, {"param1", "param2"});
-    authzEnabled = true;
-    testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
+    method_ = "PUT";
+    initPayload(0, {"param1", "param2"}, {"param1", "param2"});
+    authzEnabled_ = true;
+    jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
                 "ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NvcGUiOiJzdDIxMzg6bW9uOncgc"
                 "3QyMTM4Om9wOncgc3QyMTM4OmNmZzp3IHN0MjEzODphZG06dyIsImlhdCI6MT"
                 "UxNjIzOTAyMiwibmJmIjoxNzQwMDAwMDAwLCJleHAiOjE3NTAwMDAwMDB9.dT"
@@ -474,147 +440,106 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAuthzValid) {
                 "uIwNOVM3EcVEaLyISFj8L4IDNiarVD6b1x8OXrL4vrGvzesaCeRwP8bxg4zlg"
                 "_wbOSA8JaupX9NvB4qssZpyp_20uHGh8h_VC10R0k9NKHURjs9MdvJH-cx1s1"
                 "46M27UmngWUCWH6dWHaT2au9en2zSFrcWHw";
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 2); // Both oids should be added.
-    EXPECT_EQ(removed_oids, 2); // Both oids should be removed.
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.3 - PUT Subscriptions normal case.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTFailParse) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc("Failed to parse JSON Body", catena::StatusCode::INVALID_ARGUMENT);
-    testJsonBody = "Not a JSON string";
+    method_ = "PUT";
+    expRc_ = catena::exception_with_status("Failed to parse JSON Body", catena::StatusCode::INVALID_ARGUMENT);
+    jsonBody_ = "Not a JSON string";
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 0); // No oids should be added.
-    EXPECT_EQ(removed_oids, 0); // No oids should be removed.
+    EXPECT_CALL(context_, jwsToken()).Times(0); // Authz false
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.4 - PUT Subscriptions add and remove return an error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTReturnErr) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"", catena::StatusCode::OK};
-    initPayload({"errParam", "param1", "param2"}, {"errParam", "param1", "param2"});
+    method_ = "PUT";
+    initPayload(0, {"errParam", "param1", "param2"}, {"errParam", "param1", "param2"});
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    EXPECT_CALL(subManager, removeSubscription("errParam", ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+    EXPECT_CALL(subManager_, removeSubscription("errParam", ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
         [](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc) {
             // Simulating an error in removing subscription.
             rc = catena::exception_with_status("Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT);
             return false;
         }));
-    EXPECT_CALL(subManager, addSubscription("errParam", ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+    EXPECT_CALL(subManager_, addSubscription("errParam", ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
         [](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc, catena::common::Authorizer& authz) {
             // Simulating an error in adding subscription.
             rc = catena::exception_with_status("Failed to add subscription", catena::StatusCode::INVALID_ARGUMENT);
             return false;
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 2); // All oids but errParam should be added.
-    EXPECT_EQ(removed_oids, 2); // All oids but errParam should be removed.
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.5 - PUT Subscriptions remove throws a catena::exception_with_status.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTRemThrowCatena) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT};
-    initPayload({}, {"errParam", "param1", "param2"});
+    method_ = "PUT";
+    expRc_ = catena::exception_with_status{"Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT};
+    initPayload(0, {}, {"errParam", "param1", "param2"});
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    EXPECT_CALL(subManager, removeSubscription("errParam", ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
-        [testRc = &rc](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc) {
+    EXPECT_CALL(subManager_, removeSubscription("errParam", ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+        [this](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc) {
             // Simulating an error in removing subscription.
-            throw catena::exception_with_status(testRc->what(), testRc->status);
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return false;
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 0); // No oids should be added.
-    EXPECT_EQ(removed_oids, 0); // No oids should be removed.
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.6 - PUT Subscriptions remove throws a std::runtime_error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTRemThrowUnknown) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
-    initPayload({}, {"errParam", "param1", "param2"});
+    method_ = "PUT";
+    expRc_ = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
+    initPayload(0, {}, {"errParam", "param1", "param2"});
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    EXPECT_CALL(subManager, removeSubscription("errParam", ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
-        [testRc = &rc](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc) {
-            // Simulating an error in removing subscription.
-            throw std::runtime_error(testRc->what());
-            return false;
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 0); // No oids should be added.
-    EXPECT_EQ(removed_oids, 0); // No oids should be removed.
+    EXPECT_CALL(subManager_, removeSubscription("errParam", ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.7 - PUT Subscriptions add throws a catena::exception_with_status.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAddThrowCatena) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT};
-    initPayload({"errParam", "param1", "param2"}, {});
+    method_ = "PUT";
+    expRc_ = catena::exception_with_status{"Failed to remove subscription", catena::StatusCode::INVALID_ARGUMENT};
+    initPayload(0, {"errParam", "param1", "param2"}, {});
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    EXPECT_CALL(subManager, addSubscription("errParam", ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
-        [testRc = &rc](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc, catena::common::Authorizer& authz) {
+    EXPECT_CALL(subManager_, addSubscription("errParam", ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
+        [this](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc, catena::common::Authorizer& authz) {
             // Simulating an error in adding subscription.
-            throw catena::exception_with_status(testRc->what(), testRc->status);
+            throw catena::exception_with_status(expRc_.what(), expRc_.status);
             return false;
         }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 0); // No oids should be added.
-    EXPECT_EQ(removed_oids, 0); // No oids should be removed.
+    // Sending call
+    testCall();
 }
 
 /* 
  * TEST 2.8 - PUT Subscriptions add throws a std::runtime_error.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_PUTAddThrowUnknown) {
-    testMethod = "PUT";
-    endpoint = Subscriptions::makeOne(serverSocket_, context, dm);
-    catena::exception_with_status rc{"Unknown error", catena::StatusCode::UNKNOWN};
-    initPayload({"errParam", "param1", "param2"}, {});
+    method_ = "PUT";
+    expRc_ = catena::exception_with_status{"Unknown error", catena::StatusCode::UNKNOWN};
+    initPayload(0, {"errParam", "param1", "param2"}, {});
     // Setting expectations.
-    EXPECT_CALL(context, jwsToken()).Times(0); // Authz false
-    EXPECT_CALL(subManager, addSubscription("errParam", ::testing::_, ::testing::_, ::testing::_)).WillRepeatedly(::testing::Invoke(
-        [testRc = &rc](const std::string& oid, const catena::common::IDevice& dm, catena::exception_with_status& rc, catena::common::Authorizer& authz) {
-            // Simulating an error in adding subscription.
-            throw std::runtime_error(testRc->what());
-            return false;
-        }));
-    // Calling proceed() and checking written response.
-    endpoint->proceed();
-    EXPECT_EQ(readResponse(), expectedResponse(rc));
-    EXPECT_EQ(added_oids, 0); // No oids should be added.
-    EXPECT_EQ(removed_oids, 0); // No oids should be removed.
+    EXPECT_CALL(subManager_, addSubscription("errParam", ::testing::_, ::testing::_, ::testing::_))
+        .WillRepeatedly(::testing::Throw(std::runtime_error(expRc_.what())));
+    // Sending call
+    testCall();
 }

--- a/unittests/cpp/common/mocks/MockDevice.h
+++ b/unittests/cpp/common/mocks/MockDevice.h
@@ -63,7 +63,7 @@ class MockDevice : public IDevice {
     MOCK_METHOD(uint32_t, default_total_length, (), (const, override));
     MOCK_METHOD(void, set_default_max_length, (const uint32_t default_max_length), (override));
     MOCK_METHOD(void, set_default_total_length, (const uint32_t default_total_length), (override));
-    MOCK_METHOD(void, toProto, (Device& dst, Authorizer& authz, bool shallow), (const, override));
+    MOCK_METHOD(void, toProto, (::catena::Device& dst, Authorizer& authz, bool shallow), (const, override));
     MOCK_METHOD(void, toProto, (LanguagePacks& packs), (const, override));
     MOCK_METHOD(void, toProto, (LanguageList& list), (const, override));
     MOCK_METHOD(bool, hasLanguage, (const std::string& LanguageId), (const, override));

--- a/unittests/cpp/common/mocks/MockDevice.h
+++ b/unittests/cpp/common/mocks/MockDevice.h
@@ -70,11 +70,6 @@ class MockDevice : public IDevice {
     MOCK_METHOD(exception_with_status, addLanguage, (AddLanguagePayload& language, Authorizer& authz), (override));
     MOCK_METHOD(exception_with_status, removeLanguage, (const std::string& LanguageId, Authorizer& authz), (override));
     MOCK_METHOD(exception_with_status, getLanguagePack, (const std::string& languageId, ComponentLanguagePack& pack), (const, override));
-    class MockDeviceSerializer : public IDeviceSerializer {
-      public:
-        MOCK_METHOD(bool, hasMore, (), (const, override));
-        MOCK_METHOD(DeviceComponent, getNext, (), (override));
-    };
     MOCK_METHOD(std::unique_ptr<IDeviceSerializer>, getComponentSerializer, (Authorizer& authz, const std::set<std::string>& subscribedOids, Device_DetailLevel dl, bool shallow), (const, override));
     MOCK_METHOD(void, addItem, (const std::string& key, IParam* item), (override));
     MOCK_METHOD(void, addItem, (const std::string& key, IConstraint* item), (override));

--- a/unittests/cpp/common/mocks/MockDeviceSerializer.h
+++ b/unittests/cpp/common/mocks/MockDeviceSerializer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Mock device serializer object.
+ * @author benjamin.whitten@rossvideo.com
+ * @date 25/06/23
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <IDevice.h>
+
+namespace catena {
+namespace common {
+
+class MockDeviceSerializer : public IDevice::IDeviceSerializer {
+  public:
+    MOCK_METHOD(bool, hasMore, (), (const, override));
+    MOCK_METHOD(DeviceComponent, getNext, (), (override));
+};
+
+}; // namespace common
+}; // namespace catena

--- a/unittests/cpp/gRPC/GRPCTest.h
+++ b/unittests/cpp/gRPC/GRPCTest.h
@@ -47,11 +47,13 @@
 
 #include "MockDevice.h"
 #include "MockServiceImpl.h"
+#include "interface/ICallData.h"
 
 // protobuf
 #include <interface/device.pb.h>
 #include <interface/service.grpc.pb.h>
 #include <google/protobuf/util/json_util.h>
+#include <grpcpp/grpcpp.h>
 
 // common
 #include <Status.h>
@@ -67,7 +69,7 @@ using namespace catena::gRPC;
  * GRPCTest class inherited by test fixtures to provide functions for
  * writing, reading, and verifying requests and responses.
  */
-class GRPCTest  : public ::testing::Test {
+class GRPCTest : public ::testing::Test {
   protected:
     /*
      * Virtual function which creates a single CallData object for the test.

--- a/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
@@ -51,6 +51,7 @@
 
 // gRPC
 #include "MockSubscriptionManager.h"
+#include "MockDeviceSerializer.h"
 #include "controllers/DeviceRequest.h"
 
 using namespace catena::common;
@@ -179,7 +180,7 @@ class gRPCDeviceRequestTests : public GRPCTest {
     // Expected variables
     std::vector<catena::DeviceComponent> expVals;
 
-    std::unique_ptr<MockDevice::MockDeviceSerializer> mockSerializer = std::make_unique<MockDevice::MockDeviceSerializer>();
+    std::unique_ptr<MockDeviceSerializer> mockSerializer = std::make_unique<MockDeviceSerializer>();
 };
 
 /*

--- a/unittests/cpp/gRPC/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/gRPC/tests/ExecuteCommand_test.cpp
@@ -214,7 +214,7 @@ TEST_F(gRPCExecuteCommandTests, ExecuteCommand_NormalResponse) {
     EXPECT_CALL(*mockCommand, executeCommand(::testing::_)).Times(1)
         .WillOnce(::testing::Invoke([this](const catena::Value& value) {
             // Making sure the correct values were passed in.
-            EXPECT_EQ(value.string_value(), "test_value");
+            EXPECT_EQ(value.SerializeAsString(), inVal.value().SerializeAsString());
             return std::move(mockResponder);
         }));
     EXPECT_CALL(*mockResponder, getNext()).Times(3)


### PR DESCRIPTION
**Changelog:**
- Created RESTEndpointTest class which (similar to the gRPCTest class) contains a number of variables and expectations used across all REST unit tests.
- Updated REST unit tests to use this new class.
- Cleaned up many of the REST unit tests.
- Removed unnecessary unit tests from DeviceRequest and added one which tests a stream response.
- Refactored REST Param Info Request unit tests saving ~200 lines.
- Refactored REST Param Info Endpoint slightly to achieve 100% coverage.
    - We previously had many redundant, nested try-catches where the same behaviour could be achieved by just throwing to the outer try-catch.
- Included ExecuteCommand REST unit tests.
- Moved MockDeviceSerializer into its own file (similar to MockCommandResponder)