### PR TITLE
Small UpdateSubs bug fix + other misc. things

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
         },
 
         {
-            "label": "Generate Coverage",
+            "label": "Generate Coverage Report",
             "type": "shell",
             "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh",
             "group": {
@@ -36,7 +36,7 @@
             "problemMatcher": []
         },
         {
-            "label": "Generate Coverage with HTML",
+            "label": "Generate Coverage Report with HTML Server",
             "type": "shell",
             "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh --html && cd coverage && echo 'Starting server...' && echo 'Coverage report available at: http://0.0.0.0:8000/index.html' && echo 'Press Ctrl+C to stop the server' && python3 -m http.server 8000",
             "group": {
@@ -51,6 +51,17 @@
                 "focus": true
             },
             "isBackground": true
+        },
+        {
+            "label": "Generate Clean Coverage Report (Rebuild)",
+            "type": "shell",
+            // This triggers a rebuild on coverage
+            "command": "cd ${workspaceFolder} && ./scripts/run_coverage.sh --clean",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
         },
         {
             "label": "Run Ninja",
@@ -84,6 +95,34 @@
                 "isDefault": true
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Clean Coverage Files",
+            "type": "shell",
+            // Removes coverage files and devcontainer artifact build directory
+            "command": "cd ${workspaceFolder} && if [ -d coverage ]; then rm -rf coverage; fi && if [ -d sdks/cpp/build ]; then rm -rf sdks/cpp/build; fi && sudo find . -type f \\( -name \"*.gcov\" -o -name \"*.gcda\" -o -name \"*.gcno\" \\) -delete",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Fresh Build with HTML Coverage Report",
+            "type": "shell",
+            "command": "", // The actual "command" is the set of processes below
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "Clean Coverage Files",
+                "Fresh Build",
+                "Generate Clean Coverage Report (Rebuild)",
+                "Generate Coverage Report with HTML Server"
+            ]
         }
     ],
     "version": "2.0.0"


### PR DESCRIPTION
This is a really small bug fix just to make it so it correctly handles update subscriptions setting both a add and remove simultaneously. I also updated the unit test files.

In the REST subscriptions unit test file I also explicitly test adding and removing. The old method of hardcoding 0 and 2 isn't really modular or good unit test design, in my opinon (feel free to disagree). 

I also added .gcov to gitignore because it was weird trying to sift my git changes whilst seeing the gcov files during the coverage build process.

Then there's me just tweaking the tasks.json which is just my own preferential thing. I'm honestly with the idea that .vscode shouldn't even be shared on the codebase, but whatever.