### PR TITLE
Duplicate subscription bug fix

### DIFF
--- a/sdks/cpp/common/include/Path.h
+++ b/sdks/cpp/common/include/Path.h
@@ -271,6 +271,13 @@ class Path {
         segments_.emplace_back(std::in_place_type<Index>, idx);
     }
 
+    /**
+     * @brief Create a Path from a string that may contain multiple segments
+     * @param pathString The path string to parse (e.g., "/param/0/subparam")
+     * @return Path object with properly parsed segments
+     */
+    static Path fromPath(const std::string& pathString);
+
   private:
     using Segments = std::vector<Segment>;
     Segments segments_{}; /**< the path split into its components */

--- a/sdks/cpp/common/include/SubscriptionManager.h
+++ b/sdks/cpp/common/include/SubscriptionManager.h
@@ -132,12 +132,11 @@ class SubscriptionManager : public ISubscriptionManager {
              * @param path The path of the parameter
              */
             void visit(catena::common::IParam* param, const std::string& path) override {
-                // Filter out array elements (paths ending with indices) to prevent invalid paths
+                // Skip array elements (paths ending with indices) to prevent invalid paths
                 Path pathObj = Path(path);
-                if (pathObj.back_is_index()) {
-                    return;  // Skip array elements but continue traversal
+                if (!pathObj.back_is_index()) {
+                    oids_.insert(path);
                 }
-                oids_.insert(path);
             }
             
             /**

--- a/sdks/cpp/common/include/SubscriptionManager.h
+++ b/sdks/cpp/common/include/SubscriptionManager.h
@@ -133,7 +133,7 @@ class SubscriptionManager : public ISubscriptionManager {
              */
             void visit(catena::common::IParam* param, const std::string& path) override {
                 // Filter out array elements (paths ending with indices) to prevent invalid paths
-                Path pathObj = Path::fromPath(path);
+                Path pathObj = Path(path);
                 if (pathObj.back_is_index()) {
                     return;  // Skip array elements but continue traversal
                 }

--- a/sdks/cpp/common/include/SubscriptionManager.h
+++ b/sdks/cpp/common/include/SubscriptionManager.h
@@ -132,6 +132,11 @@ class SubscriptionManager : public ISubscriptionManager {
              * @param path The path of the parameter
              */
             void visit(catena::common::IParam* param, const std::string& path) override {
+                // Filter out array elements (paths ending with indices) to prevent invalid paths
+                Path pathObj = Path::fromPath(path);
+                if (pathObj.back_is_index()) {
+                    return;  // Skip array elements but continue traversal
+                }
                 oids_.insert(path);
             }
             

--- a/sdks/cpp/common/src/ParamVisitor.cpp
+++ b/sdks/cpp/common/src/ParamVisitor.cpp
@@ -41,7 +41,7 @@ void ParamVisitor::traverseParams(IParam* param, const std::string& path, IDevic
     // First visit the current parameter itself
     visitor.visit(param, path);
 
-    Path current_path = Path::fromPath(path);
+    Path current_path(path);
     
     // Special handling for array-type parameters
     if (param->isArrayType()) {
@@ -51,20 +51,18 @@ void ParamVisitor::traverseParams(IParam* param, const std::string& path, IDevic
             visitor.visitArray(param, path, array_length);
             
             // Only process array elements if we're not already inside an array element
-            //if (!current_path.back_is_index()) {
-                for (uint32_t i = 0; i < array_length; i++) {
-                    // Create path for this array element (e.g., "/params/array/0")
-                    Path indexed_path{path, std::to_string(i)};
-                    catena::exception_with_status rc{"", catena::StatusCode::OK};
-                    
-                    // Get the parameter for this array index
-                    auto indexed_param = device.getParam(indexed_path.toString(), rc);
-                    if (indexed_param) {
-                        // Recursively process this array element and all its children
-                        traverseParams(indexed_param.get(), indexed_path.toString(), device, visitor);
-                    }
+            for (uint32_t i = 0; i < array_length; i++) {
+                // Create path for this array element (e.g., "/params/array/0")
+                Path indexed_path{path, std::to_string(i)};
+                catena::exception_with_status rc{"", catena::StatusCode::OK};
+                
+                // Get the parameter for this array index
+                auto indexed_param = device.getParam(indexed_path.toString(), rc);
+                if (indexed_param) {
+                    // Recursively process this array element and all its children
+                    traverseParams(indexed_param.get(), indexed_path.toString(), device, visitor);
                 }
-            //}
+            }
         }
     }
     

--- a/sdks/cpp/common/src/ParamVisitor.cpp
+++ b/sdks/cpp/common/src/ParamVisitor.cpp
@@ -41,6 +41,8 @@ void ParamVisitor::traverseParams(IParam* param, const std::string& path, IDevic
     // First visit the current parameter itself
     visitor.visit(param, path);
 
+    Path current_path = Path::fromPath(path);
+    
     // Special handling for array-type parameters
     if (param->isArrayType()) {
         uint32_t array_length = param->size();
@@ -49,8 +51,7 @@ void ParamVisitor::traverseParams(IParam* param, const std::string& path, IDevic
             visitor.visitArray(param, path, array_length);
             
             // Only process array elements if we're not already inside an array element
-            Path current_path{path};
-            if (!current_path.back_is_index()) {
+            //if (!current_path.back_is_index()) {
                 for (uint32_t i = 0; i < array_length; i++) {
                     // Create path for this array element (e.g., "/params/array/0")
                     Path indexed_path{path, std::to_string(i)};
@@ -63,7 +64,7 @@ void ParamVisitor::traverseParams(IParam* param, const std::string& path, IDevic
                         traverseParams(indexed_param.get(), indexed_path.toString(), device, visitor);
                     }
                 }
-            }
+            //}
         }
     }
     
@@ -72,6 +73,7 @@ void ParamVisitor::traverseParams(IParam* param, const std::string& path, IDevic
     if (descriptor.getAllSubParams().empty()) {
         return;  // No children to traverse
     }
+    
     
     for (const auto& [child_name, child_desc] : descriptor.getAllSubParams()) {
         // Skip invalid child names (empty or absolute paths)

--- a/sdks/cpp/common/src/Path.cpp
+++ b/sdks/cpp/common/src/Path.cpp
@@ -228,3 +228,37 @@ std::string Path::fqoid() const {
 Path operator"" _path(const char *lit, std::size_t sz) {
     return Path(lit);
 }
+
+// This function is used to create a Path object from a string that may contain multiple segments   
+Path Path::fromPath(const std::string& pathString) {
+    Path result;
+    std::string path = pathString;
+    
+    // Ensure path starts with '/' for proper parsing
+    if (!path.empty() && path[0] != '/') {
+        path = "/" + path;
+    }
+    
+    // Split by '/' and add each segment
+    std::stringstream ss(path);
+    std::string segment;
+    bool first = true;
+    
+    while (std::getline(ss, segment, '/')) {
+        if (first) {
+            first = false;
+            continue; // Skip empty first segment
+        }
+        
+        if (segment.empty()) continue;
+        
+        // Check if segment is a number (index)
+        if (std::all_of(segment.begin(), segment.end(), ::isdigit)) {
+            result.push_back(std::stoul(segment));
+        } else {
+            result.push_back(segment);
+        }
+    }
+    
+    return result;
+}

--- a/sdks/cpp/common/src/Path.cpp
+++ b/sdks/cpp/common/src/Path.cpp
@@ -228,37 +228,3 @@ std::string Path::fqoid() const {
 Path operator"" _path(const char *lit, std::size_t sz) {
     return Path(lit);
 }
-
-// This function is used to create a Path object from a string that may contain multiple segments   
-Path Path::fromPath(const std::string& pathString) {
-    Path result;
-    std::string path = pathString;
-    
-    // Ensure path starts with '/' for proper parsing
-    if (!path.empty() && path[0] != '/') {
-        path = "/" + path;
-    }
-    
-    // Split by '/' and add each segment
-    std::stringstream ss(path);
-    std::string segment;
-    bool first = true;
-    
-    while (std::getline(ss, segment, '/')) {
-        if (first) {
-            first = false;
-            continue; // Skip empty first segment
-        }
-        
-        if (segment.empty()) continue;
-        
-        // Check if segment is a number (index)
-        if (std::all_of(segment.begin(), segment.end(), ::isdigit)) {
-            result.push_back(std::stoul(segment));
-        } else {
-            result.push_back(segment);
-        }
-    }
-    
-    return result;
-}

--- a/sdks/cpp/connections/REST/examples/structs_with_authz_REST/device.AudioDeck.yaml
+++ b/sdks/cpp/connections/REST/examples/structs_with_authz_REST/device.AudioDeck.yaml
@@ -1,5 +1,6 @@
 slot: 1
 multi_set_enabled: true
+subscriptions: true
 detail_level: FULL
 access_scopes: ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"]
 default_scope: st2138:mon

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/device.AudioDeck.yaml
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/device.AudioDeck.yaml
@@ -1,5 +1,6 @@
 slot: 1
 multi_set_enabled: true
+subscriptions: true
 detail_level: FULL
 access_scopes: ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"]
 default_scope: st2138:mon


### PR DESCRIPTION
Good grief, this bug took me so long for what was so small. Quite literally the only thing I had to change was to skip adding any oids that ended in an index.

There is a whole lot of yap here if you want to understand why it took me so long. And if someone thinks this was a waste of time, my IDE is currently frozen trying to build and my day is almost over. Also +1 for documentation... ?

Anyway, feel free to ignore it, or read it if you want to learn about paths.

## Context

For reference, oids that end in an index are CRITICAL for traversing through ParamVisitor, HOWEVER, these should not be sent to the client, because you end up with corrupted OIDs. 

So, for something like `/audio_deck/0/eq_list` you need the visitor to first stumble across `/audio_deck/0`, and then it goes "oh, this has children, therefore we should traverse", and then it finds eq_list. However, if you add this `/audio_deck/0`, it is not a valid param! Again, you NEED it to traverse, but it should not be sent to the client, it is nonsensical.

## Process

I spent far too long sitting in ParamVisitor trying to see if perhaps the issue was there. I noticed how it was skipping params that had an index in the back, and at first I was like ok that doesn't quite make sense. Then I realized there was a sub-bug (#783) where the paths weren't correctly forming. This doesn't actually break implementation in the context of ParamVisitor, because params are fetched via strings, not path objects. 

However, it brought about a certain revelation - using back_is_index is POINTLESS if it doesn't even build the path correctly. So the first idea was to just implement a cheap fix where it split the path into segments from a string (function called fromPath). I then tried using this fromPath in ParamVisitor to try and fix the segment issues. It correctly split the segments, sure, but it still wasn't quite working. Even worse, when I tried to try and skip back_is_index, it would effectively skip the arrays and never bother exploring them. I spent a ludricuous amount of time playing with back_is_index and path segments.

This is important - remember how in context I said you need the /index in order to traverse? Yes - you need it to traverse, but it should not be sent to the client. Therefore, the issue was never actually in ParamVisitor, it was at the responsibility of whichever part of the code was next in the next in the pipeline to send oids to the client - **SubscriptionManager**.

So lo and behold, I just added the function to SubscriptionManager and my bug was gone! 

Then I realized this too was stupid because why not just fix the central issue in the Path class? Maybe it's not splitting correctly there. This was about an hour of tomfoolery only for @BenWhitten-RV to point out that it worked by using () instead of {} to build the path. The best part is I literally created that constructor. So I forgot about my own creation. 

I was then effectively able to remove the fromPath function and simply use Path() in the submanager to skip invalid params.

So in other words, in typical softdev fashion, 

### I spent 2 days for 2 lines



