### PR TITLE
Common Unit Tests - Menu and MenuGroup

### DIFF
--- a/sdks/cpp/common/include/IMenuGroup.h
+++ b/sdks/cpp/common/include/IMenuGroup.h
@@ -1,21 +1,34 @@
 #pragma once
 
-/** Copyright 2024 Ross Video Ltd
-
- Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, 
- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
- INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-//
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
  * @file IMenuGroup.h
@@ -25,24 +38,26 @@
  * @copyright Copyright (c) 2024 Ross Video
  */
 
+// protobuf interface
+#include <interface/menu.pb.h>
+
+// Common
+#include <IMenu.h>
+
+// Common
 #include <string>
 #include <unordered_map>
 
 namespace catena {
-
-class MenuGroup; // forward reference
-
-namespace common{
-    class Menu; // forward reference
-}
-
 namespace common {
 
 /**
  * @brief Interface for Menu Group
  */
 class IMenuGroup {
-public:
+  public:
+    using MenuMap = std::unordered_map<std::string, std::unique_ptr<IMenu>>;
+
     IMenuGroup() = default;
     IMenuGroup(IMenuGroup&&) = default;
     IMenuGroup& operator=(IMenuGroup&&) = default;
@@ -55,10 +70,18 @@ public:
     virtual void toProto(catena::MenuGroup& menuGroup, bool shallow) const = 0;
 
     /**
+     * @brief add a menu to the group using move semantics
+     * @param oid the key of the menu
+     * @param menu the menu
+     */
+    virtual void addMenu(const std::string& oid, std::unique_ptr<IMenu> menu) = 0;
+
+    /**
      * @brief get menus from menu group
      * @return a map of menus
      */
-    virtual const std::unordered_map<std::string, catena::common::Menu>* menus() const = 0;
+    virtual const MenuMap* menus() const = 0;
 };
+
 }  // namespace common
 }  // namespace catena

--- a/sdks/cpp/common/include/Menu.h
+++ b/sdks/cpp/common/include/Menu.h
@@ -40,8 +40,7 @@
 
 // common
 #include <IMenu.h>
-
-// common
+#include <IMenuGroup.h>
 #include <IDevice.h>
 #include <PolyglotText.h>
 
@@ -52,17 +51,13 @@
 #include <unordered_map>
 #include <vector>
 
-
-
 namespace catena {
 namespace common {
-
-class MenuGroup; // forward declaration
 
 /**
  * @brief A device menu
  */
-class Menu : public common::IMenu {
+class Menu : public IMenu {
   public:
     /**
      * @brief a list of oids, used by main constructor
@@ -115,7 +110,7 @@ class Menu : public common::IMenu {
          const OidInitializer param_oids,
          const OidInitializer command_oids,
          const PairInitializer& client_hints, 
-         std::string oid, catena::common::MenuGroup& menuGroup);
+         std::string oid, IMenuGroup& menuGroup);
 
 
     /**

--- a/sdks/cpp/common/include/Menu.h
+++ b/sdks/cpp/common/include/Menu.h
@@ -1,29 +1,34 @@
 #pragma once
 
-/** Copyright 2024 Ross Video Ltd
-
- Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- following disclaimer in the documentation and/or other materials provided with the distribution.
-
- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or
- promote products derived from this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- DAMAGE.
-*/
-//
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
  * @file Menu.h
@@ -69,7 +74,6 @@ class Menu : public common::IMenu {
      */
     using PairInitializer = std::initializer_list<std::pair<std::string, std::string>>;
 
-  public:
     Menu() = delete;
     /**
      * @brief Menu does not have copy semantics

--- a/sdks/cpp/common/include/MenuGroup.h
+++ b/sdks/cpp/common/include/MenuGroup.h
@@ -102,10 +102,13 @@ class MenuGroup : public IMenuGroup {
      * @param menu the menu
      */
     void addMenu(const std::string& oid, std::unique_ptr<IMenu> menu) override {
-        if (menu) { // Sanitzing menu first.
-            menus_.emplace(oid, std::move(menu));
-        } else {
+        // Sanitizes input before adding.
+        if (!menu) {
             throw std::runtime_error("Cannot add a nullptr menu to MenuGroup");
+        } else if (oid.empty()) {
+            throw std::runtime_error("Cannot assign a menu to an empty oid in MenuGroup");
+        } else {
+            menus_.emplace(oid, std::move(menu));
         }
     }
 

--- a/sdks/cpp/common/include/MenuGroup.h
+++ b/sdks/cpp/common/include/MenuGroup.h
@@ -1,29 +1,34 @@
 #pragma once
 
-/** Copyright 2024 Ross Video Ltd
-
- Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- following disclaimer in the documentation and/or other materials provided with the distribution.
-
- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or
- promote products derived from this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- DAMAGE.
-*/
-//
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
  * @file MenuGroup.h
@@ -36,18 +41,9 @@
 // common
 #include <IMenuGroup.h>
 #include <PolyglotText.h>
-
-// common
 #include <IDevice.h>
-#include <Menu.h>
 
-// protobuf interface
-#include <interface/menu.pb.h>
-
-#include <string>
-#include <unordered_map>
 #include <initializer_list>
-#include <vector>
 
 namespace catena {
 namespace common {
@@ -55,7 +51,7 @@ namespace common {
 /**
  * @brief A Group of device menus
  */
-class MenuGroup : public common::IMenuGroup {
+class MenuGroup : public IMenuGroup {
 
   public:
     MenuGroup() = delete;
@@ -94,7 +90,6 @@ class MenuGroup : public common::IMenuGroup {
         dev.addItem(oid, this);
     }
 
-
     /**
      * @brief serialize a menu group to a protobuf message
      * @param menuGroup the protobuf message
@@ -106,18 +101,17 @@ class MenuGroup : public common::IMenuGroup {
      * @param oid the key of the menu
      * @param menu the menu
      */
-    void addMenu(const std::string& oid, catena::common::Menu&& menu) { menus_.emplace(oid, std::move(menu)); }
+    void addMenu(const std::string& oid, std::unique_ptr<IMenu> menu) override { menus_.emplace(oid, std::move(menu)); }
 
     /**
      * @brief get menus from menu group
      * @return a map of menus
      */
-    const std::unordered_map<std::string, catena::common::Menu>* menus() const override { return &menus_; }
+    const MenuMap* menus() const override { return &menus_; }
 
   private:
     PolyglotText name_;
-    std::unordered_map<std::string, catena::common::Menu> menus_;
-    
+    MenuMap menus_;
 };
 
 

--- a/sdks/cpp/common/include/MenuGroup.h
+++ b/sdks/cpp/common/include/MenuGroup.h
@@ -101,7 +101,13 @@ class MenuGroup : public IMenuGroup {
      * @param oid the key of the menu
      * @param menu the menu
      */
-    void addMenu(const std::string& oid, std::unique_ptr<IMenu> menu) override { menus_.emplace(oid, std::move(menu)); }
+    void addMenu(const std::string& oid, std::unique_ptr<IMenu> menu) override {
+        if (menu) { // Sanitzing menu first.
+            menus_.emplace(oid, std::move(menu));
+        } else {
+            throw std::runtime_error("Cannot add a nullptr menu to MenuGroup");
+        }
+    }
 
     /**
      * @brief get menus from menu group

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -485,7 +485,7 @@ Device::DeviceSerializer Device::getDeviceSerializer(Authorizer& authz, const st
                         co_yield component;
                         component.Clear();
                         ::catena::Menu* dstMenu = component.mutable_menu()->mutable_menu();
-                        menu.toProto(*dstMenu);
+                        menu->toProto(*dstMenu);
                         component.mutable_menu()->set_oid(oid);
                     }
                 }

--- a/sdks/cpp/common/src/Menu.cpp
+++ b/sdks/cpp/common/src/Menu.cpp
@@ -1,27 +1,32 @@
-/** Copyright 2024 Ross Video Ltd
-
- Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- following disclaimer in the documentation and/or other materials provided with the distribution.
-
- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or
- promote products derived from this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- DAMAGE.
-*/
-//
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
  * @file Menu.cpp
@@ -43,7 +48,7 @@ Menu::Menu(const catena::common::PolyglotText::ListInitializer name, bool hidden
            catena::common::MenuGroup& menuGroup)
     : name_{name}, hidden_{hidden}, disabled_{disabled}, param_oids_{param_oids}, command_oids_{command_oids},
       client_hints_{client_hints.begin(), client_hints.end()} {
-    menuGroup.addMenu(oid, std::move(*this));
+    menuGroup.addMenu(oid, std::make_unique<Menu>(std::move(*this)));
 }
 
 

--- a/sdks/cpp/common/src/MenuGroup.cpp
+++ b/sdks/cpp/common/src/MenuGroup.cpp
@@ -1,27 +1,32 @@
-/** Copyright 2024 Ross Video Ltd
-
- Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- the following conditions are met:
-
- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- following disclaimer.
-
- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- following disclaimer in the documentation and/or other materials provided with the distribution.
-
- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or
- promote products derived from this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- DAMAGE.
-*/
-//
+/*
+ * Copyright 2024 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
  * @file MenuGroup.cpp
@@ -32,12 +37,9 @@
  */
 
 // common
-
 #include <MenuGroup.h>
 
 using namespace catena::common;
-using catena::common::MenuGroupTag;
-
 
 void MenuGroup::toProto(::catena::MenuGroup& menuGroup, bool shallow = false) const {
     for (const auto& [lang, name] : name_.displayStrings()) {
@@ -46,7 +48,7 @@ void MenuGroup::toProto(::catena::MenuGroup& menuGroup, bool shallow = false) co
     if (!shallow) {
         for (const auto& [oid, srcMenu] : menus_) {
             catena::Menu& dstMenu = (*menuGroup.mutable_menus())[oid];
-            srcMenu.toProto(dstMenu);
+            srcMenu->toProto(dstMenu);
         }
     }   
 }

--- a/sdks/cpp/common/src/MenuGroup.cpp
+++ b/sdks/cpp/common/src/MenuGroup.cpp
@@ -38,7 +38,6 @@
 
 // common
 #include <MenuGroup.h>
-
 using namespace catena::common;
 
 void MenuGroup::toProto(::catena::MenuGroup& menuGroup, bool shallow = false) const {

--- a/unittests/cpp/common/CMakeLists.txt
+++ b/unittests/cpp/common/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
     tests/param_visitor_test.cpp
     tests/Authorization_test.cpp
     tests/Connect_test.cpp
+    # tests/Menu_test.cpp
+    tests/MenuGroup_test.cpp
 )
 
 add_executable(${This} ${SOURCES})

--- a/unittests/cpp/common/CMakeLists.txt
+++ b/unittests/cpp/common/CMakeLists.txt
@@ -26,8 +26,8 @@ set(SOURCES
     tests/param_visitor_test.cpp
     tests/Authorization_test.cpp
     tests/Connect_test.cpp
-    # tests/Menu_test.cpp
     tests/MenuGroup_test.cpp
+    tests/Menu_test.cpp
 )
 
 add_executable(${This} ${SOURCES})

--- a/unittests/cpp/common/mocks/MockMenu.h
+++ b/unittests/cpp/common/mocks/MockMenu.h
@@ -1,7 +1,5 @@
-#pragma once
-
 /*
- * Copyright 2024 Ross Video Ltd
+ * Copyright 2025 Ross Video Ltd
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -31,36 +29,25 @@
  */
 
 /**
- * @file IMenu.h
- * @brief Interface for Menus
- * @author Ben Mostafa Ben.Mostafa@rossvideo.com
- * @date 2024-10-04
- * @copyright Copyright (c) 2024 Ross Video
+ * @brief A collection of mock classes used across the REST tests.
+ * @author benjamin.whitten@rossvideo.com
+ * @author zuhayr.sarker@rossvideo.com
+ * @date 25/05/13
+ * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// protobuf interface
-#include <interface/menu.pb.h>
+#pragma once
+
+#include <gmock/gmock.h>
+#include "IMenu.h"
 
 namespace catena {
 namespace common {
 
-/**
- * @brief Interface for Menus
- */
-class IMenu {
+class MockMenu : public IMenu {
   public:
-    IMenu() = default;
-    IMenu(IMenu&&) = default;
-    IMenu& operator=(IMenu&&) = default;
-    virtual ~IMenu() = default;
-
-    /**
-     * @brief serialize a menu to a protobuf message
-     * @param menu the protobuf message
-     */
-    virtual void toProto(catena::Menu& menu) const = 0;
-
+    MOCK_METHOD(void, toProto, (catena::Menu& menu), (const, override));
 };
 
-}  // namespace common
-}  // namespace catena
+} // namespace common
+} // namespace catena

--- a/unittests/cpp/common/mocks/MockMenu.h
+++ b/unittests/cpp/common/mocks/MockMenu.h
@@ -29,10 +29,9 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
+ * @brief Mock class for the IMenu object.
  * @author benjamin.whitten@rossvideo.com
- * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 

--- a/unittests/cpp/common/mocks/MockMenuGroup.h
+++ b/unittests/cpp/common/mocks/MockMenuGroup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Ross Video Ltd
+ * Copyright 2025 Ross Video Ltd
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,39 +29,26 @@
  */
 
 /**
- * @file Menu.cpp
- * @brief Implements the Menu class
- * @author Ben Mostafa Ben.Mostafa@rossvideo.com
- * @date 2024-10-10
- * @copyright Copyright (c) 2024 Ross Video
+ * @brief Mock class for the IMenuGroup object.
+ * @author benjamin.whitten@rossvideo.com
+ * @date 25/06/26
+ * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// common
-#include <Menu.h>
-using namespace catena::common;
+#pragma once
 
-Menu::Menu(const catena::common::PolyglotText::ListInitializer name, bool hidden, bool disabled, const OidInitializer param_oids,
-           const OidInitializer command_oids, const PairInitializer& client_hints, std::string oid,
-           IMenuGroup& menuGroup)
-    : name_{name}, hidden_{hidden}, disabled_{disabled}, param_oids_{param_oids}, command_oids_{command_oids},
-      client_hints_{client_hints.begin(), client_hints.end()} {
-    menuGroup.addMenu(oid, std::make_unique<Menu>(std::move(*this)));
-}
+#include <gmock/gmock.h>
+#include "IMenuGroup.h"
 
-void Menu::toProto(::catena::Menu& menu) const {
-    name_.toProto(*menu.mutable_name());
-    menu.set_hidden(hidden_);
-    menu.set_disabled(disabled_);
-    menu.clear_param_oids();
-    menu.clear_command_oids();
-    menu.clear_client_hints();
-    for (const auto& oid : param_oids_) {
-        menu.add_param_oids(oid);
-    }
-    for (const auto& oid : command_oids_) {
-        menu.add_command_oids(oid);
-    }
-    for (const auto& [key, value] : client_hints_) {
-        (*menu.mutable_client_hints())[key] = value;
-    }
-}
+namespace catena {
+namespace common {
+
+class MockMenuGroup : public IMenuGroup {
+  public:
+    MOCK_METHOD(void, toProto, (catena::MenuGroup& menuGroup, bool shallow), (const, override));
+    MOCK_METHOD(void, addMenu, (const std::string& oid, std::unique_ptr<IMenu> menu), (override));
+    MOCK_METHOD(const MenuMap*, menus, (), (const, override));
+};
+
+} // namespace common
+} // namespace catena

--- a/unittests/cpp/common/tests/MenuGroup_test.cpp
+++ b/unittests/cpp/common/tests/MenuGroup_test.cpp
@@ -43,11 +43,6 @@
 #include <mocks/MockDevice.h>
 #include <mocks/MockMenu.h>
 
-// protobuf
-#include <interface/device.pb.h>
-#include <interface/service.grpc.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // common
 #include "MenuGroup.h"
 
@@ -84,7 +79,7 @@ TEST_F(MenuGroupTest, MenuGroup_Create) {
 /*
  * TEST 2 - MenuGroup constructor error handling.
  */
-TEST_F(MenuGroupTest, MenuGroup_CreateErr) {
+TEST_F(MenuGroupTest, MenuGroup_ErrCreate) {
     MockDevice errDm;
     EXPECT_CALL(errDm, addItem(oid_, testing::An<IMenuGroup*>())).Times(1)
         .WillOnce(testing::Throw(std::runtime_error("Device error")));
@@ -119,7 +114,14 @@ TEST_F(MenuGroupTest, MenuGroup_ErrAddNullMenu) {
 }
 
 /*
- * TEST 5 - MenuGroup toProto serialization.
+ * TEST 5 - Adding menu with invalid oid to MenuGroup.
+ */
+TEST_F(MenuGroupTest, MenuGroup_ErrAddNoOid) {
+    EXPECT_THROW(menuGroup_->addMenu("", std::make_unique<MockMenu>()), std::runtime_error) << "Expected to throw when adding a nullptr menu";
+}
+
+/*
+ * TEST 6 - MenuGroup toProto serialization.
  */
 TEST_F(MenuGroupTest, MenuGroup_ToProto) {
     // Adding two menus and setting expectations.
@@ -147,7 +149,7 @@ TEST_F(MenuGroupTest, MenuGroup_ToProto) {
 }
 
 /*
- * TEST 6 - MenuGroup toProto shallow serialization.
+ * TEST 7 - MenuGroup toProto shallow serialization.
  */
 TEST_F(MenuGroupTest, MenuGroup_ToProtoShallow) {
     // Adding two menus and setting expectations.
@@ -168,7 +170,7 @@ TEST_F(MenuGroupTest, MenuGroup_ToProtoShallow) {
 }
 
 /*
- * TEST 7 - MenuGroup toProto error handling.
+ * TEST 8 - MenuGroup toProto error handling.
  */
 TEST_F(MenuGroupTest, MenuGroup_ErrMenuToProto) {
     // Adding a menu and setting expectations.

--- a/unittests/cpp/common/tests/MenuGroup_test.cpp
+++ b/unittests/cpp/common/tests/MenuGroup_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief This file is for testing the MenuGroup.cpp file.
+ * @author benjamin.whitten@rossvideo.com
+ * @date 25/06/26
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+// gtest
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+// Mock objects
+#include <mocks/MockDevice.h>
+#include <mocks/MockMenu.h>
+
+// protobuf
+#include <interface/device.pb.h>
+#include <interface/service.grpc.pb.h>
+#include <google/protobuf/util/json_util.h>
+
+// common
+#include "MenuGroup.h"
+
+using namespace catena::common;
+
+class MenuGroupTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        EXPECT_CALL(dm_, addItem(oid_, testing::An<IMenuGroup*>())).Times(1).WillOnce(
+            testing::Invoke([](const std::string &key, IMenuGroup *item){
+                EXPECT_TRUE(item) << "No item passed into dm.addItem()";
+            }));
+        menuGroup_.reset(new MenuGroup(oid_, {name_[0], name_[1]}, dm_));
+    }
+
+    void TearDown() override {
+        // Cleanup code if needed
+    }
+
+    std::unique_ptr<MenuGroup> menuGroup_;
+
+    std::string oid_ = "menu_group";
+    std::vector<std::pair<std::string, std::string>> name_ = {
+        {"en", "Menu Group"},
+        {"fr", "Groupe de menus"}
+    };
+    MockDevice dm_;
+    
+};
+
+TEST_F(MenuGroupTest, MenuGroup_Create) {
+    EXPECT_TRUE(menuGroup_) << "Failed to create MenuGroup";
+}
+
+TEST_F(MenuGroupTest, MenuGroup_addMenu) {
+    // Adding two menus.
+    std::unordered_map<std::string, IMenu*> menus;
+    menus["menu1"] = nullptr;
+    menus["menu2"] = nullptr;
+    for (auto& [oid, menuRef] : menus) {
+        std::unique_ptr<MockMenu> menu = std::make_unique<MockMenu>();
+        menuRef = menu.get();
+        menuGroup_->addMenu(oid, std::move(menu));
+    }
+    // Retrieving menus and making sure the above were added.
+    const auto* retrievedMenus = menuGroup_->menus();
+    for (auto& [oid, menuRef] : menus) {
+        EXPECT_EQ(retrievedMenus->at(oid).get(), menuRef);
+    }
+}
+
+TEST_F(MenuGroupTest, MenuGroup_toProto) {
+    // Adding two menus and setting expectations.
+    std::vector<std::string> menus = {"menu1", "menu2"};
+    for (auto& oid : menus) {
+        std::unique_ptr<MockMenu> menu = std::make_unique<MockMenu>();
+        EXPECT_CALL(*menu, toProto(::testing::_)).Times(1)
+            .WillOnce(::testing::Invoke([&oid](catena::Menu& menu) {
+                // Just enough to ensure its copying the proper menu.
+                auto& name = *menu.mutable_name();
+                name.mutable_display_strings()->insert({"en", oid});
+            }));
+        menuGroup_->addMenu(oid, std::move(menu));
+    }
+    // Calling toProto
+    catena::MenuGroup protoMenuGroup;
+    menuGroup_->toProto(protoMenuGroup, false);
+    // Comparing names and menus
+    for (auto& [lang, name] : name_) {
+        EXPECT_EQ(protoMenuGroup.name().display_strings().at(lang), name);
+    }
+    for (auto& oid : menus) {
+        EXPECT_EQ(protoMenuGroup.menus().at(oid).name().display_strings().at("en"), oid);
+    }
+}
+
+TEST_F(MenuGroupTest, MenuGroup_toProtoShallow) {
+    // Adding two menus and setting expectations.
+    std::vector<std::string> menus = {"menu1", "menu2"};
+    for (auto& oid : menus) {
+        std::unique_ptr<MockMenu> menu = std::make_unique<MockMenu>();
+        EXPECT_CALL(*menu, toProto(::testing::_)).Times(0);
+        menuGroup_->addMenu(oid, std::move(menu));
+    }
+    // Calling toProto
+    catena::MenuGroup protoMenuGroup;
+    menuGroup_->toProto(protoMenuGroup, true);
+    // Comparing names and menus
+    for (auto& [lang, name] : name_) {
+        EXPECT_EQ(protoMenuGroup.name().display_strings().at(lang), name);
+    }
+    EXPECT_TRUE(protoMenuGroup.menus().empty()) << "Menus should not be serialized in shallow mode";
+}

--- a/unittests/cpp/common/tests/MenuGroup_test.cpp
+++ b/unittests/cpp/common/tests/MenuGroup_test.cpp
@@ -65,8 +65,7 @@ class MenuGroupTest : public ::testing::Test {
         {"en", "Menu Group"},
         {"fr", "Groupe de menus"}
     };
-    MockDevice dm_;
-    
+    MockDevice dm_;    
 };
 
 /*

--- a/unittests/cpp/common/tests/Menu_test.cpp
+++ b/unittests/cpp/common/tests/Menu_test.cpp
@@ -1,7 +1,5 @@
-#pragma once
-
 /*
- * Copyright 2024 Ross Video Ltd
+ * Copyright 2025 Ross Video Ltd
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -17,7 +15,7 @@
  * contributors may be used to endorse or promote products derived from this
  * software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
@@ -31,36 +29,63 @@
  */
 
 /**
- * @file IMenu.h
- * @brief Interface for Menus
- * @author Ben Mostafa Ben.Mostafa@rossvideo.com
- * @date 2024-10-04
- * @copyright Copyright (c) 2024 Ross Video
+ * @brief This file is for testing the Menu.cpp file.
+ * @author benjamin.whitten@rossvideo.com
+ * @date 25/06/26
+ * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// protobuf interface
-#include <interface/menu.pb.h>
+// gtest
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
-namespace catena {
-namespace common {
+// protobuf
+#include <interface/device.pb.h>
+#include <interface/service.grpc.pb.h>
+#include <google/protobuf/util/json_util.h>
 
-/**
- * @brief Interface for Menus
- */
-class IMenu {
-  public:
-    IMenu() = default;
-    IMenu(IMenu&&) = default;
-    IMenu& operator=(IMenu&&) = default;
-    virtual ~IMenu() = default;
+// common
+#include "Menu.h"
 
-    /**
-     * @brief serialize a menu to a protobuf message
-     * @param menu the protobuf message
-     */
-    virtual void toProto(catena::Menu& menu) const = 0;
+using namespace catena::common;
 
+class MenuTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        // Setup code if needed
+
+    }
+
+    void TearDown() override {
+        // Cleanup code if needed
+    }
+
+    std::unique_ptr<Menu> menu_;
+    std::vector<std::pair<std::string, std::string>> names = {
+        {"en", "Name"},
+        {"fr", "Name but in French"}
+    };
+    bool hidden = true;
+    bool disabled = true;
+    std::vector<std::string> paramOids_ = {
+        "param1",
+        "param2"
+    };
+    std::vector<std::string> commandOids_ {
+        "command1",
+        "command2"
+    };
+    std::vector<std::pair<std::string, std::string>> clientHints_ = {
+        {"hint1", "This is a hint"},
+        {"hint2", "This is another hint"}
+    };
 };
 
-}  // namespace common
-}  // namespace catena
+TEST_F(MenuTest, Menu_Create) {
+
+}
+
+TEST_F(MenuTest, Menu_Move) {
+    
+}
+


### PR DESCRIPTION
Changelog:
- Created unit tests covering the Menu Object
- Created unit tests covering the MenuGroup object.
- Created MockMenu and MockMenuGroup.
- Updated MenuGroup to use IMenu instead of Menu
- Updated Menu to use IMenuGroup instead of MenuGroup
- Cleaned up headers across Menu and MenuGroup files