### PR TITLE
Unit Tests - Mock function Documentation and Header Cleanup

### DIFF
--- a/unittests/cpp/REST/RESTTest.h
+++ b/unittests/cpp/REST/RESTTest.h
@@ -65,15 +65,19 @@ using boost::asio::ip::tcp;
 #include "interface/ICallData.h"
 
 using namespace catena::common;
-using namespace catena::REST;
+
+namespace catena {
+namespace REST {
 
 /*
- * RESTTest class inherited by test fixtures to provide functions for
- * writing, reading, and verifying requests and responses.
+ * Surface level RESTTest class inherited by test fixtures to provide functions
+ * for writing, reading, and verifying requests and responses.
  */
 class RESTTest {
   protected:
-    // Constructor to connecting sockets (write(in) -> read(out)).
+    /*
+     * Connects sockets (write(in) -> read(out)).
+     */
     RESTTest(tcp::socket* in, tcp::socket* out) : writeSocket_(in), readSocket_(out) {
         // Neither can be nullptr.
         if (!writeSocket_ || !readSocket_) {
@@ -84,7 +88,10 @@ class RESTTest {
         acceptor_.accept(*writeSocket_);
     }
 
-    // Writes a request to the writeSocket_ which can later be read by SocketReader.
+    /*
+     * Writes a request to the writeSocket_ which can later be read by
+     * SocketReader.
+     */
     void writeRequest(catena::REST::RESTMethod method,
                       uint32_t slot,
                       const std::string& endpoint,
@@ -140,9 +147,12 @@ class RESTTest {
         boost::asio::write(*writeSocket_, boost::asio::buffer(request));
     }
 
-    // Returns whatever has been writen to the readSocket_..
-    // *Note: This only reads a limited amount of data (up to 4096 bytes). This
-    // suffices for testing, mostly because I don't feel like making it dynamic.
+    /*
+     * Returns whatever has been writen to the readSocket_..
+     *
+     * Note: This only reads a limited amount of data (up to 4096 bytes). This
+     * suffices for testing because I don't feel like making it dynamic.
+     */
     std::string readResponse() {
         boost::asio::streambuf buffer;
         boost::asio::read_until(*readSocket_, buffer, "\r\n\r\n");
@@ -150,7 +160,9 @@ class RESTTest {
         return std::string(std::istreambuf_iterator<char>(response_stream), std::istreambuf_iterator<char>());
     }
 
-    // Returns what an expect response from SocketWriter should look like.
+    /*
+     * Returns what an expect response from SocketWriter should look like.
+     */
     inline std::string expectedResponse(const catena::exception_with_status& rc, const std::string& jsonBody = "") {
         http_exception_with_status httpStatus = codeMap_.at(rc.status);
         return "HTTP/1.1 " + std::to_string(httpStatus.first) + " " + httpStatus.second + "\r\n"
@@ -164,7 +176,10 @@ class RESTTest {
                jsonBody;
     }
 
-    // Returns what an expect response from SocketWriter with buffer=true should look like.
+    /*
+     * Returns what an expect response from SocketWriter with buffer == true
+     * should look like.
+     */
     inline std::string expectedResponse(const catena::exception_with_status& rc, const std::vector<std::string>& msgs) {
         // Compiling body response from messages.
         std::string jsonBody = "";
@@ -181,7 +196,9 @@ class RESTTest {
         return expectedResponse(rc, jsonBody);
     }
 
-    // Returns what an expect response from SSEWriter should look like.
+    /*
+     *Returns what an expect response from SSEWriter should look like.
+     */
     inline std::string expectedSSEResponse(const catena::exception_with_status& rc, const std::vector<std::string>& msgs = {}) {
         http_exception_with_status httpStatus = codeMap_.at(rc.status);
         // Compiling body response from messages.
@@ -202,14 +219,15 @@ class RESTTest {
                jsonBody;
     }
 
-    // Debug helper to check socket status
+    /*
+     * Debug helper to check socket status
+     */
     std::string getSocketStatus() const {
         return "available: " + std::to_string(readSocket_->available()) + 
                ", open: " + std::to_string(readSocket_->is_open());
     }
 
     std::string origin_ = "*";
-
     // Read/write helper variables.
     boost::asio::io_context io_context_;
     tcp::socket clientSocket_{io_context_};
@@ -221,6 +239,11 @@ class RESTTest {
     tcp::socket* readSocket_ = nullptr;
 };
 
+/*
+ * In depth RESTTest class inherited by endpoint test fixtures to provide 
+ * uniform variable names, uniform endpoint creation, and functions for
+ * writing, reading, and verifying requests and responses.
+ */
 class RESTEndpointTest : public ::testing::Test, public RESTTest {
   protected:
     /*
@@ -269,7 +292,6 @@ class RESTEndpointTest : public ::testing::Test, public RESTTest {
     // Cout variables
     std::stringstream MockConsole_;
     std::streambuf* oldCout_;
-
     // in/out val
     catena::REST::RESTMethod method_ = Method_GET;
     uint32_t slot_ = 0;
@@ -280,7 +302,6 @@ class RESTEndpointTest : public ::testing::Test, public RESTTest {
     std::string jwsToken_ = "";
     // Expected variables
     catena::exception_with_status expRc_{"", catena::StatusCode::OK};
-
     // Mock objects and endpoint.
     MockSocketReader context_;
     std::mutex mtx0_;
@@ -289,3 +310,6 @@ class RESTEndpointTest : public ::testing::Test, public RESTTest {
     MockDevice dm1_;
     std::unique_ptr<ICallData> endpoint_;
 };
+
+} // namespace REST
+} // namespace catena

--- a/unittests/cpp/REST/mocks/MockSocketReader.h
+++ b/unittests/cpp/REST/mocks/MockSocketReader.h
@@ -29,10 +29,9 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
+ * @brief Mock implementation for the ISocketReader class.
  * @author benjamin.whitten@rossvideo.com
- * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
@@ -40,12 +39,11 @@
 
 #include <gmock/gmock.h>
 #include <interface/ISocketReader.h>
-#include <ISubscriptionManager.h>
-#include <IDevice.h>
 
-using namespace catena::REST;
+namespace catena {
+namespace REST {
 
-// Mocking the ISocketReader interface
+// Mock implementation for the ISocketReader class.
 class MockSocketReader : public ISocketReader {
   public:
     MOCK_METHOD(void, read, (tcp::socket& socket, bool authz, const std::string& version), (override));
@@ -63,4 +61,7 @@ class MockSocketReader : public ISocketReader {
     MOCK_METHOD(bool, authorizationEnabled, (), (const, override));
     MOCK_METHOD(bool, stream, (), (const, override));
     MOCK_METHOD(const std::string&, EOPath, (), (const, override));
-}; 
+};
+
+} // namespace REST
+} // namespace catena

--- a/unittests/cpp/REST/tests/SocketReader_test.cpp
+++ b/unittests/cpp/REST/tests/SocketReader_test.cpp
@@ -35,12 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
- // gtest
-#include <gtest/gtest.h>
-
-// std
-#include <string>
-
 // Common
 #include <SubscriptionManager.h>
 
@@ -49,6 +43,7 @@
 
 // REST
 #include "SocketReader.h"
+
 using namespace catena::REST;
 
 // Fixture

--- a/unittests/cpp/REST/tests/SocketWriter_test.cpp
+++ b/unittests/cpp/REST/tests/SocketWriter_test.cpp
@@ -35,21 +35,12 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
- // gtest
-#include <gtest/gtest.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
 
 // REST
 #include "SocketWriter.h"
+
 using namespace catena::REST;
 
 // Fixture

--- a/unittests/cpp/REST/tests/Subscriptions_test.cpp
+++ b/unittests/cpp/REST/tests/Subscriptions_test.cpp
@@ -35,27 +35,13 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "RESTTest.h"
-#include "MockSocketReader.h"
 #include "MockParam.h"
-#include "MockDevice.h"
 #include "MockSubscriptionManager.h"
 
 // REST
 #include "controllers/Subscriptions.h"
-#include "SocketWriter.h"
 
 using namespace catena::common;
 using namespace catena::REST;

--- a/unittests/cpp/common/mocks/MockCommandResponder.h
+++ b/unittests/cpp/common/mocks/MockCommandResponder.h
@@ -29,28 +29,21 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
+ * @brief Mock implementation for the ICommandResponder class.
  * @author benjamin.whitten@rossvideo.com
- * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
 #include <gmock/gmock.h>
-#include <IDevice.h>
-#include <IParam.h>
-#include <ISubscriptionManager.h>
-#include <rpc/IConnect.h>
 #include <IParamDescriptor.h>
-#include <Status.h>
-#include <Authorization.h>
 
 namespace catena {
 namespace common {
 
-// Mock implemenetation of ICommandResponder for testing commands.
+// Mock implementation for the ICommandResponder class.
 class MockCommandResponder : public IParamDescriptor::ICommandResponder {
   public:
     MOCK_METHOD(bool, hasMore, (), (const, override));

--- a/unittests/cpp/common/mocks/MockDevice.h
+++ b/unittests/cpp/common/mocks/MockDevice.h
@@ -29,10 +29,9 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
+ * @brief Mock implementation for the IDevice class.
  * @author benjamin.whitten@rossvideo.com
- * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
@@ -40,16 +39,11 @@
 
 #include <gmock/gmock.h>
 #include <IDevice.h>
-#include <IParam.h>
-#include <ISubscriptionManager.h>
-#include <rpc/IConnect.h>
-#include <IParamDescriptor.h>
-#include <Status.h>
-#include <Authorization.h>
 
 namespace catena {
 namespace common {
 
+// Mock implementation for the IDevice class.
 class MockDevice : public IDevice {
   public:
     MOCK_METHOD(void, slot, (const uint32_t slot), (override));

--- a/unittests/cpp/common/mocks/MockDeviceSerializer.h
+++ b/unittests/cpp/common/mocks/MockDeviceSerializer.h
@@ -29,9 +29,9 @@
  */
 
 /**
- * @brief Mock device serializer object.
+ * @brief Mock implementation for the IDeviceSerializer class.
  * @author benjamin.whitten@rossvideo.com
- * @date 25/06/23
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
@@ -43,6 +43,7 @@
 namespace catena {
 namespace common {
 
+// Mock implementation for the IDeviceSerializer class.
 class MockDeviceSerializer : public IDevice::IDeviceSerializer {
   public:
     MOCK_METHOD(bool, hasMore, (), (const, override));

--- a/unittests/cpp/common/mocks/MockLanguagePack.h
+++ b/unittests/cpp/common/mocks/MockLanguagePack.h
@@ -29,33 +29,27 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
- * @author benjamin.whitten@rossvideo.com
+ * @brief Mock implementation for the ILanguagePack class.
  * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
 #include <gmock/gmock.h>
-#include <IDevice.h>
-#include <IParam.h>
-#include <ISubscriptionManager.h>
-#include <rpc/IConnect.h>
-#include <IParamDescriptor.h>
-#include <Status.h>
-#include <Authorization.h>
+#include <ILanguagePack.h>
 
 namespace catena {
 namespace common {
 
+// Mock implementation for the ILanguagePack class.
 class MockLanguagePack : public ILanguagePack {
   public:
-      MOCK_METHOD(void, toProto, (catena::LanguagePack&), (const, override));
-      MOCK_METHOD(void, fromProto, (const catena::LanguagePack&), (override));
-      MOCK_METHOD(const_iterator, begin, (), (const, override));
-      MOCK_METHOD(const_iterator, end, (), (const, override));
+    MOCK_METHOD(void, toProto, (catena::LanguagePack&), (const, override));
+    MOCK_METHOD(void, fromProto, (const catena::LanguagePack&), (override));
+    MOCK_METHOD(const_iterator, begin, (), (const, override));
+    MOCK_METHOD(const_iterator, end, (), (const, override));
 };
 
 } // namespace common

--- a/unittests/cpp/common/mocks/MockParam.h
+++ b/unittests/cpp/common/mocks/MockParam.h
@@ -29,27 +29,23 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
+ * @brief Mock implementation for the IParam class.
  * @author benjamin.whitten@rossvideo.com
- * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
 #include <gmock/gmock.h>
-#include <IDevice.h>
 #include <IParam.h>
-#include <IParamDescriptor.h>
-#include <Status.h>
-#include <Authorization.h>
 
 namespace catena {
 namespace common {
 
+// Mock implementation for the IParam class.
 class MockParam : public IParam {
-public:
+	public:
     MockParam() = default;
     virtual ~MockParam() = default;
 

--- a/unittests/cpp/common/mocks/MockParam.h
+++ b/unittests/cpp/common/mocks/MockParam.h
@@ -45,18 +45,7 @@ namespace common {
 
 // Mock implementation for the IParam class.
 class MockParam : public IParam {
-	public:
-    MockParam() = default;
-    virtual ~MockParam() = default;
-
-    // Explicitly declare move semantics
-    MockParam(MockParam&&) = default;
-    MockParam& operator=(MockParam&&) = default;
-
-    // Explicitly delete copy semantics
-    MockParam(const MockParam&) = delete;
-    MockParam& operator=(const MockParam&) = delete;
-
+  public:
     MOCK_METHOD(std::unique_ptr<IParam>, copy, (), (const, override));
     MOCK_METHOD(catena::exception_with_status, toProto, (catena::Value& dst, Authorizer& authz), (const, override));
     MOCK_METHOD(catena::exception_with_status, fromProto, (const catena::Value& src, Authorizer& authz), (override));

--- a/unittests/cpp/common/mocks/MockParam.h
+++ b/unittests/cpp/common/mocks/MockParam.h
@@ -30,7 +30,7 @@
 
 /**
  * @brief Mock implementation for the IParam class.
- * @author benjamin.whitten@rossvideo.com
+ * @author zuhayr.sarker@rossvideo.com
  * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */

--- a/unittests/cpp/common/mocks/MockParamDescriptor.h
+++ b/unittests/cpp/common/mocks/MockParamDescriptor.h
@@ -29,26 +29,21 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
+ * @brief Mock implementation for the IParamDescriptor class.
  * @author benjamin.whitten@rossvideo.com
- * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
 #include <gmock/gmock.h>
-#include <IDevice.h>
-#include <IParam.h>
 #include <IParamDescriptor.h>
-#include <Status.h>
-#include <Authorization.h>
 
 namespace catena {
 namespace common {
 
-//Mock implementation of ParamDescriptor for testing
+// Mock implementation for the IParamDescriptor class.
 class MockParamDescriptor : public IParamDescriptor {
   public:
     MOCK_METHOD(ParamType, type, (), (const, override));

--- a/unittests/cpp/common/mocks/MockSubscriptionManager.h
+++ b/unittests/cpp/common/mocks/MockSubscriptionManager.h
@@ -29,34 +29,28 @@
  */
 
 /**
- * @brief A collection of mock classes used across the REST tests.
- * @author benjamin.whitten@rossvideo.com
+ * @brief Mock implementation for the ISubscriptionManager class.
  * @author zuhayr.sarker@rossvideo.com
- * @date 25/05/13
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
 #include <gmock/gmock.h>
-#include <IDevice.h>
-#include <IParam.h>
 #include <ISubscriptionManager.h>
-#include <rpc/IConnect.h>
-#include <IParamDescriptor.h>
-#include <Status.h>
-#include <Authorization.h>
 
 namespace catena {
 namespace common {
 
+// Mock implementation for the ISubscriptionManager class.
 class MockSubscriptionManager : public ISubscriptionManager {
   public:
-      MOCK_METHOD(bool, addSubscription, (const std::string& oid, IDevice& dm, exception_with_status& rc, Authorizer& authz), (override));
-      MOCK_METHOD(bool, removeSubscription, (const std::string& oid, const IDevice& dm, exception_with_status& rc), (override));
-      MOCK_METHOD(std::set<std::string>, getAllSubscribedOids, (const IDevice& dm), (override));
-      MOCK_METHOD(bool, isWildcard, (const std::string& oid), (override));
-      MOCK_METHOD(bool, isSubscribed, (const std::string& oid, const IDevice& dm), (override));
+    MOCK_METHOD(bool, addSubscription, (const std::string& oid, IDevice& dm, exception_with_status& rc, Authorizer& authz), (override));
+    MOCK_METHOD(bool, removeSubscription, (const std::string& oid, const IDevice& dm, exception_with_status& rc), (override));
+    MOCK_METHOD(std::set<std::string>, getAllSubscribedOids, (const IDevice& dm), (override));
+    MOCK_METHOD(bool, isWildcard, (const std::string& oid), (override));
+    MOCK_METHOD(bool, isSubscribed, (const std::string& oid, const IDevice& dm), (override));
 };
 
 } // namespace common

--- a/unittests/cpp/gRPC/GRPCTest.h
+++ b/unittests/cpp/gRPC/GRPCTest.h
@@ -58,12 +58,8 @@
 // common
 #include <Status.h>
 
-// boost
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-using boost::asio::ip::tcp;
-
-using namespace catena::gRPC;
+namespace catena {
+namespace gRPC {
 
 /*
  * GRPCTest class inherited by test fixtures to provide functions for
@@ -171,3 +167,6 @@ class GRPCTest : public ::testing::Test {
     std::unique_ptr<ICallData> testCall = nullptr;
     std::unique_ptr<ICallData> asyncCall = nullptr;
 };
+
+} // namespace gRPC
+} // namespace catena

--- a/unittests/cpp/gRPC/mocks/MockServiceImpl.h
+++ b/unittests/cpp/gRPC/mocks/MockServiceImpl.h
@@ -29,26 +29,23 @@
  */
 
 /**
- * @brief A collection of mock classes used across the gRPC tests.
+ * @brief Mock implementation for the gRPC ICatenaServiceImpl class.
  * @author benjamin.whitten@rossvideo.com
- * @date 25/05/22
+ * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
 #pragma once
 
 #include <gmock/gmock.h>
-#include <grpcpp/grpcpp.h>
-
-// common
-#include <ISubscriptionManager.h>
-
-// gRPC
-#include "interface/IServiceImpl.h"
+#include <interface/IServiceImpl.h>
 
 using namespace catena::common;
-using namespace catena::gRPC;
 
+namespace catena {
+namespace gRPC {
+
+// Mock implementation for the gRPC ICatenaServiceImpl class.
 class MockServiceImpl : public ICatenaServiceImpl {
   public:
     MOCK_METHOD(void, init, (), (override));
@@ -61,3 +58,6 @@ class MockServiceImpl : public ICatenaServiceImpl {
     MOCK_METHOD(void, registerItem, (ICallData* cd), (override));
     MOCK_METHOD(void, deregisterItem, (ICallData* cd), (override));
 };
+
+} // namespace gRPC
+} // namespace catena

--- a/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 

--- a/unittests/cpp/gRPC/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/gRPC/tests/ExecuteCommand_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "MockParam.h"
 #include "MockCommandResponder.h"

--- a/unittests/cpp/gRPC/tests/GetParam_test.cpp
+++ b/unittests/cpp/gRPC/tests/GetParam_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 #include "MockParam.h"

--- a/unittests/cpp/gRPC/tests/GetPopulatedSlots_test.cpp
+++ b/unittests/cpp/gRPC/tests/GetPopulatedSlots_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 

--- a/unittests/cpp/gRPC/tests/GetValue_test.cpp
+++ b/unittests/cpp/gRPC/tests/GetValue_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 

--- a/unittests/cpp/gRPC/tests/LanguagePackRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/LanguagePackRequest_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 

--- a/unittests/cpp/gRPC/tests/ListLanguages_test.cpp
+++ b/unittests/cpp/gRPC/tests/ListLanguages_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 

--- a/unittests/cpp/gRPC/tests/MultiSetValue_test.cpp
+++ b/unittests/cpp/gRPC/tests/MultiSetValue_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 

--- a/unittests/cpp/gRPC/tests/SetValue_test.cpp
+++ b/unittests/cpp/gRPC/tests/SetValue_test.cpp
@@ -35,17 +35,6 @@
  * @copyright Copyright © 2025 Ross Video Ltd
  */
 
-// gtest
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
-
-// std
-#include <string>
-
-// protobuf
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
 // Test helpers
 #include "GRPCTest.h"
 


### PR DESCRIPTION
**Changlog**
- Cleaned up headers across test files.
    - Namely the mock class files and the endpoint test files
- Fixed documentation across mock classes and inherited test fixtures
- Moved RESTTest and GRPCTest into namespaces catena::REST and catena::gRPC respectively