### PR TITLE
Fixed bug with IParamDescriptor #include

### DIFF
--- a/sdks/cpp/common/include/IParamDescriptor.h
+++ b/sdks/cpp/common/include/IParamDescriptor.h
@@ -42,6 +42,9 @@
 #include <Tags.h>
 #include <PolyglotText.h>
 
+// protobuf interface
+#include <interface/param.pb.h>
+
 namespace catena {
 namespace common {
 

--- a/sdks/cpp/common/include/ParamDescriptor.h
+++ b/sdks/cpp/common/include/ParamDescriptor.h
@@ -46,9 +46,6 @@
 #include <IDevice.h>
 #include <Authorization.h>  
 
-// protobuf interface
-#include <interface/param.pb.h>
-
 #include <vector>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Moved the #include for the param protobuf definition from ParamDescriptor to IParamDescriptor 

Since the headers were cleaned up in MockParamDescriptor to only include gmock and IParamDescriptor, this previously caused a situational compilation issue when including either the Mock or IParamDescriptor without also including some other reference to the param protobuf definition (ex. IParam, IDevice, etc.)

At the moment this was only an issue with the StructInfo tests I'm working on since all other instances of MockParamDescriptor also include a number of other files. I am making this a separate PR however to avoid other developers running into the same issue in the meantime before I make my PR for that.