### PR TITLE
Removed Finish() from REST endpoints

### DIFF
--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -41,19 +41,6 @@
 // connections/REST
 #include "interface/ISocketWriter.h"
 
-// boost
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-using boost::asio::ip::tcp;
-
-// protobuf interface
-#include <interface/device.pb.h>
-#include <google/protobuf/util/json_util.h>
-
-// common
-#include <Status.h>
-#include <utils.h>
-
 namespace catena {
 namespace REST {
 
@@ -71,11 +58,13 @@ class SocketWriter : public ISocketWriter {
     SocketWriter(tcp::socket& socket, const std::string& origin = "*", bool buffer = false) : socket_{socket}, origin_{origin}, buffer_{buffer} {}
 
     /**
-     * @brief Finishes writing the HTTP response.
-     * @param msg The protobuf message to write (if status is OK). An empty
-     * message signals the writer to flush the response if buffer is on.
-     * @param err The error status to finish with. If status is OK, writes the
-     * message, otherwise writes the error.
+     * @brief Writes a HTTP response to the socket.
+     * 
+     * If the message is being buffered, a call to this function with an empty
+     * message will flush the response. 
+     * 
+     * @param msg The protobuf message to write (if status is OK).
+     * @param err The error status to of the response.
      */
     void sendResponse(const catena::exception_with_status& err, const google::protobuf::Message& msg = catena::Empty()) override;
 
@@ -112,9 +101,12 @@ class SSEWriter : public ISocketWriter {
     SSEWriter(tcp::socket& socket, const std::string& origin = "*") : socket_{socket}, origin_{origin}, headers_sent_{false} {}
 
     /**
-     * @brief Sends a response as a Server-Sent Event.
+     * @brief Writes a Server-Sent Event HTTP response.
      * @param msg The protobuf message to write as JSON.
-     * @param err The error status to finish with.
+     * @param err The error status of the response.
+     * 
+     * Due to the nature of Server-Sent Events, only the first err status sent
+     * with the response.
      */
     void sendResponse(const catena::exception_with_status& err, const google::protobuf::Message& msg = catena::Empty()) override;
 
@@ -128,7 +120,7 @@ class SSEWriter : public ISocketWriter {
      */
     std::string origin_;
     /**
-     * @brief Whether the headers have been sent.
+     * @brief Flag indicating whether the headers have been sent.
      */
     bool headers_sent_;
 };

--- a/sdks/cpp/connections/REST/include/SocketWriter.h
+++ b/sdks/cpp/connections/REST/include/SocketWriter.h
@@ -59,8 +59,6 @@ namespace REST {
 
 /**
  * @brief Helper class used to write a unary response to a socket using boost.
- * 
- * This writer buffers the response until a call to finish() is made.
  */
 class SocketWriter : public ISocketWriter {
   public:
@@ -74,8 +72,10 @@ class SocketWriter : public ISocketWriter {
 
     /**
      * @brief Finishes writing the HTTP response.
-     * @param msg The protobuf message to write (if status is OK)
-     * @param err The error status to finish with. If status is OK, writes the message, otherwise writes the error.
+     * @param msg The protobuf message to write (if status is OK). An empty
+     * message signals the writer to flush the response if buffer is on.
+     * @param err The error status to finish with. If status is OK, writes the
+     * message, otherwise writes the error.
      */
     void sendResponse(const catena::exception_with_status& err, const google::protobuf::Message& msg = catena::Empty()) override;
 

--- a/sdks/cpp/connections/REST/include/controllers/AssetRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/AssetRequest.h
@@ -84,11 +84,6 @@ class AssetRequest : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the AssetRequest process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -89,11 +89,6 @@ class Connect : public ICallData, public catena::common::Connect {
     void proceed() override;
     
     /**
-     * @brief Finishes the Connect process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -82,11 +82,6 @@ class DeviceRequest : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the DeviceRequest process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -79,11 +79,6 @@ class ExecuteCommand : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the ExecuteCommand process
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/GetParam.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetParam.h
@@ -82,11 +82,6 @@ class GetParam : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the GetParam process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
@@ -82,11 +82,6 @@ class GetPopulatedSlots : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the GetPopulatedSlots process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -82,11 +82,6 @@ class GetValue : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the GetValue process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/LanguagePack.h
+++ b/sdks/cpp/connections/REST/include/controllers/LanguagePack.h
@@ -80,11 +80,6 @@ class LanguagePack : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the LanguagePack process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/Languages.h
+++ b/sdks/cpp/connections/REST/include/controllers/Languages.h
@@ -81,11 +81,6 @@ class Languages : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the Languages process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
@@ -82,11 +82,6 @@ class MultiSetValue : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the MultiSetValue process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/ParamInfoRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/ParamInfoRequest.h
@@ -86,11 +86,6 @@ class ParamInfoRequest : public ICallData {
     void proceed() override;
     
     /**
-     * @brief Finishes the ParamInfoRequest process
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/controllers/Subscriptions.h
+++ b/sdks/cpp/connections/REST/include/controllers/Subscriptions.h
@@ -78,11 +78,6 @@ public:
     void proceed() override;
     
     /**
-     * @brief Finishes the Subscriptions process.
-     */
-    void finish() override;
-    
-    /**
      * @brief Creates a new controller object for use with GenericFactory.
      * 
      * @param socket The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/include/interface/ICallData.h
+++ b/sdks/cpp/connections/REST/include/interface/ICallData.h
@@ -71,10 +71,6 @@ class ICallData {
 		 * @brief The controller's main process.
 		 */
 		virtual void proceed() = 0;
-		/**
-		 * @brief Finishes the controller.
-		 */
-		virtual void finish() = 0;
 
 	protected:
 		/**

--- a/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketWriter.h
@@ -68,9 +68,9 @@ class ISocketWriter {
     virtual ~ISocketWriter() = default;
 
     /**
-     * @brief Finishes writing the HTTP response.
+     * @brief Writes a HTTP response.
      * @param msg The protobuf message to write as JSON.
-     * @param err The error status to finish with.
+     * @param err The error status of the response.
      */
     virtual void sendResponse(const catena::exception_with_status& err, const google::protobuf::Message& msg = catena::Empty()) = 0;
 };

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -111,7 +111,6 @@ void CatenaServiceImpl::run() {
                     } else if (router_.canMake(requestKey)) {
                         std::unique_ptr<ICallData> request = router_.makeProduct(requestKey, socket, context, dms_);
                         request->proceed();
-                        request->finish();
                     // ERROR
                     } else { 
                         rc = catena::exception_with_status("Request " + requestKey + " does not exist", catena::StatusCode::UNIMPLEMENTED);

--- a/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
@@ -74,9 +74,8 @@ void AssetRequest::proceed() {
 
     // Finishing by writing answer to client.
     writer_.sendResponse(rc, obj);
-}
 
-void AssetRequest::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "AssetRequest[" + std::to_string(objectId_) + "] for file: " + context_.fqoid() +" finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -103,9 +103,8 @@ void Connect::proceed() {
         }
         lock.unlock();
     }
-}
 
-void Connect::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "Connect[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/DeviceRequest.cpp
@@ -84,9 +84,8 @@ void DeviceRequest::proceed() {
     }
     // empty msg signals unary to send response. Does nothing for stream.
     writer_->sendResponse(rc);
-}
 
-void DeviceRequest::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "DeviceRequest[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -80,9 +80,8 @@ void ExecuteCommand::proceed() {
     if (rc.status != catena::StatusCode::OK || !respond) {
         writer_.sendResponse(rc);
     }
-}
 
-void ExecuteCommand::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "ExecuteCommand[" << objectId_ << "] finished\n";
-} 
+}

--- a/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetParam.cpp
@@ -56,11 +56,9 @@ void GetParam::proceed() {
         rc = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
     }
 
-    // Finishing by writing answer to client.
+    // Finishing by writing answer to client and writing the final status to the console.
     writer_.sendResponse(rc, ans);
-}
 
-void GetParam::finish() {
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "GetParam[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetPopulatedSlots.cpp
@@ -24,9 +24,8 @@ void GetPopulatedSlots::proceed() {
     }
     // Writing response.
     writer_.sendResponse(catena::exception_with_status("", catena::StatusCode::OK), slotList);
-}
 
-void GetPopulatedSlots::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "GetPopulatedSlots[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/GetValue.cpp
@@ -46,9 +46,8 @@ void GetValue::proceed() {
 
     // Finishing by writing answer to client.
     writer_.sendResponse(rc, ans);
-}
 
-void GetValue::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << "GetValue[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/LanguagePack.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/LanguagePack.cpp
@@ -95,9 +95,8 @@ void LanguagePack::proceed() {
         // For POST, PUT and DELETE we do not return a message.
         writer_.sendResponse(rc);
     }
-}
 
-void LanguagePack::finish() {
+    // Wiring the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << RESTMethodMap().getForwardMap().at(context_.method())
               << " LanguagePack[" << objectId_ << "] finished\n";

--- a/sdks/cpp/connections/REST/src/controllers/Languages.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Languages.cpp
@@ -50,9 +50,8 @@ void Languages::proceed() {
 
     // Finishing by writing answer to client.
     writer_.sendResponse(rc, ans);
-}
 
-void Languages::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << RESTMethodMap().getForwardMap().at(context_.method())
               << "Languages[" << objectId_ << "] finished\n";

--- a/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/MultiSetValue.cpp
@@ -65,9 +65,8 @@ void MultiSetValue::proceed() {
     }
     // Writing response.
     writer_.sendResponse(rc);
-}
 
-void MultiSetValue::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << typeName_ << "SetValue[" << objectId_ << "] finished\n";
 }

--- a/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
@@ -181,12 +181,8 @@ void ParamInfoRequest::proceed() {
     } catch (...) {
         rc_ = catena::exception_with_status("Unknown error in ParamInfoRequest", catena::StatusCode::UNKNOWN);
     }
-}
-
-void ParamInfoRequest::finish() {
-    writeConsole_(CallStatus::kFinish, socket_.is_open());
-    std::cout << "ParamInfoRequest[" << objectId_ << "] finished\n";
     
+    // Writing responses to the client.
     if (responses_.empty()) {
         // If no responses, send at least one response with the error status
         writer_.sendResponse(rc_);
@@ -196,7 +192,9 @@ void ParamInfoRequest::finish() {
         }
     }
     
-    socket_.close();
+    // Writing the final status to the console.
+    writeConsole_(CallStatus::kFinish, socket_.is_open());
+    std::cout << "ParamInfoRequest[" << objectId_ << "] finished\n";
 }
 
 // Helper method to add a parameter to the responses

--- a/sdks/cpp/connections/REST/src/controllers/Subscriptions.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Subscriptions.cpp
@@ -132,9 +132,8 @@ void Subscriptions::proceed() {
 
     // Finishing by writing rc to client.
     writer_->sendResponse(rc);
-}
 
-void Subscriptions::finish() {
+    // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     std::cout << context_.method() << " Subscriptions[" << objectId_ << "] finished\n";
 }

--- a/unittests/cpp/REST/tests/Connect_test.cpp
+++ b/unittests/cpp/REST/tests/Connect_test.cpp
@@ -123,12 +123,6 @@ TEST_F(RESTConnectTest, Connect_Create) {
     ASSERT_TRUE(endpoint_);
 }
 
-// Test 2.1: Test finish behaviour with no active signal handlers
-TEST_F(RESTConnectTest, Connect_FinishClosesConnection) {
-    EXPECT_NO_THROW(endpoint_->finish());
-    ASSERT_TRUE(MockConsole_.str().find("Connect[1] finished\n") != std::string::npos);
-}
-
 // Test 0.2: Test unauthorized connection
 TEST_F(RESTConnectTest, Connect_HandlesAuthzError) {
     jwsToken_ = "invalid_token";
@@ -157,8 +151,6 @@ TEST_F(RESTConnectTest, Connect_HandlesValidAuthz) {
     proceed_thread.join();
 
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson}));
-
-    endpoint_->finish();
 }
 
 // --- 1. SIGNAL TESTS ---
@@ -197,8 +189,6 @@ TEST_F(RESTConnectTest, Connect_HandlesValueSetByServer) {
     proceed_thread.join();
 
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson, updateJson}));
-
-    endpoint_->finish();
 }
 
 // Test 1.2: Test value set by client signal
@@ -235,8 +225,6 @@ TEST_F(RESTConnectTest, Connect_HandlesValueSetByClient) {
     proceed_thread.join();
 
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson, updateJson}));
-
-    endpoint_->finish();
 }
 
 // Test 1.3: Test language signal
@@ -269,8 +257,6 @@ TEST_F(RESTConnectTest, Connect_HandlesLanguage) {
     proceed_thread.join();
 
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, {slotJson, updateJson}));
-
-    endpoint_->finish();
 }
 
 // --- 3. EXCEPTION TESTS ---

--- a/unittests/cpp/REST/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/REST/tests/DeviceRequest_test.cpp
@@ -118,13 +118,6 @@ TEST_F(RESTDeviceRequestTests, DeviceRequest_Create) {
     ASSERT_TRUE(endpoint_);
 }
 
-// Test 0.2: Test finish method functionality
-TEST_F(RESTDeviceRequestTests, DeviceRequest_Finish) {
-    // Test that finish method does not throw
-    EXPECT_NO_THROW(endpoint_->finish());
-    ASSERT_TRUE(MockConsole_.str().find("DeviceRequest[1] finished\n") != std::string::npos);
-}
-
 // --- 1. PROCEED TESTS ---
 // Test 1.1: Test proceed unary response with multiple components
 TEST_F(RESTDeviceRequestTests, DeviceRequest_Normal) {

--- a/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
@@ -137,15 +137,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_Create) {
 }
 
 /*
- * TEST 2 - Writing to console with GetParam finish().
- */
-TEST_F(RESTExecuteCommandTests, ExecuteCommand_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("ExecuteCommand[1] finished\n") != std::string::npos);
-}
-
-/*
- * TEST 3 - ExecuteCommand returns two CommandResponse responses.
+ * TEST 2 - ExecuteCommand returns two CommandResponse responses.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalResponse) {
     initPayload(0, "test_command", "test_value", true);
@@ -177,7 +169,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalResponse) {
 }
 
 /*
- * TEST 4 - ExecuteCommand returns a CommandResponse no response.
+ * TEST 3 - ExecuteCommand returns a CommandResponse no response.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalNoResponse) {
     initPayload(0, "test_command", "test_value", true);
@@ -205,7 +197,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalNoResponse) {
 }
 
 /*
- * TEST 5 - ExecuteCommand returns a CommandResponse exception.
+ * TEST 4 - ExecuteCommand returns a CommandResponse exception.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalException) {
     initPayload(0, "test_command", "test_value", true);
@@ -233,7 +225,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_NormalException) {
 }
 
 /*
- * TEST 6 - ExecuteCommand returns no response (respond = false).
+ * TEST 5 - ExecuteCommand returns no response (respond = false).
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
     initPayload(0, "test_command", "test_value", false);
@@ -265,7 +257,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
 }
 
 /*
- * TEST 7 - ExecuteCommand returns a CommandResponse no response with authz
+ * TEST 6 - ExecuteCommand returns a CommandResponse no response with authz
  *          enabled.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
@@ -306,7 +298,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
 }
 
 /*
- * TEST 8 - ExecuteCommand fails from invalid JWS token.
+ * TEST 7 - ExecuteCommand fails from invalid JWS token.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) { 
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -320,7 +312,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) {
 }
 
 /*
- * TEST 9 - No device in the specified slot.
+ * TEST 8 - No device in the specified slot.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ErrInvalidSlot) {
     initPayload(dms_.size(), "test_command", "test_value", true);
@@ -333,7 +325,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ErrInvalidSlot) {
 }
 
 /*
- * TEST 10 - ExecuteCommand fails to parse the json body.
+ * TEST 9 - ExecuteCommand fails to parse the json body.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
     expRc_ = catena::exception_with_status("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
@@ -345,7 +337,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
 }
 
 /*
- * TEST 11 - getCommand does not find a command.
+ * TEST 10 - getCommand does not find a command.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
     expRc_ = catena::exception_with_status("Command not found", catena::StatusCode::INVALID_ARGUMENT);
@@ -360,7 +352,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
 }
 
 /*
- * TEST 12 - getCommand throws a catena::exception_with_status.
+ * TEST 11 - getCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -375,7 +367,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
 }
 
 /*
- * TEST 13 - getCommand throws an std::runtime error.
+ * TEST 12 - getCommand throws an std::runtime error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -387,7 +379,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
 }
 
 /*
- * TEST 14 - executeCommand returns a nullptr.
+ * TEST 13 - executeCommand returns a nullptr.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
     expRc_ = catena::exception_with_status("Illegal state", catena::StatusCode::INTERNAL);
@@ -406,7 +398,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
 }
 
 /*
- * TEST 15 - executeCommand throws a catena::exception_with_status.
+ * TEST 14 - executeCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -426,7 +418,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
 }
 
 /*
- * TEST 16 - executeCommand returns an std::runtime_error.
+ * TEST 15 - executeCommand returns an std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -443,7 +435,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
 }
 
 /*
- * TEST 17 - getNext throws a catena::exception_with_status.
+ * TEST 16 - getNext throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -469,7 +461,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
 }
 
 /*
- * TEST 18 - getNext throws a std::runtime_error.
+ * TEST 17 - getNext throws a std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);

--- a/unittests/cpp/REST/tests/GetParam_test.cpp
+++ b/unittests/cpp/REST/tests/GetParam_test.cpp
@@ -104,17 +104,8 @@ class RESTGetParamTests : public RESTEndpointTest {
 TEST_F(RESTGetParamTests, GetParam_Create) {
     EXPECT_TRUE(endpoint_);
 }
-
-/* 
- * TEST 2 - Writing to console with GetParam finish().
- */
-TEST_F(RESTGetParamTests, GetParam_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("GetParam[1] finished\n") != std::string::npos);
-}
-
 /*
- * TEST 3 - Normal case for GetParam proceed().
+ * TEST 2 - Normal case for GetParam proceed().
  */
 TEST_F(RESTGetParamTests, GetParam_Normal) {
     initPayload(0, "/test_oid");
@@ -140,7 +131,7 @@ TEST_F(RESTGetParamTests, GetParam_Normal) {
 }
 
 /*
- * TEST 4 - GetParam with authz on and valid token.
+ * TEST 3 - GetParam with authz on and valid token.
  */
 TEST_F(RESTGetParamTests, GetParam_AuthzValid) {
     initPayload(0, "/test_oid");
@@ -178,7 +169,7 @@ TEST_F(RESTGetParamTests, GetParam_AuthzValid) {
 }
 
 /*
- * TEST 5 - GetParam with authz on and invalid token.
+ * TEST 4 - GetParam with authz on and invalid token.
  */
 TEST_F(RESTGetParamTests, GetParam_AuthzInvalid) {
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -194,7 +185,7 @@ TEST_F(RESTGetParamTests, GetParam_AuthzInvalid) {
 }
 
 /*
- * TEST 6 - No device in the specified slot.
+ * TEST 5 - No device in the specified slot.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrInvalidSlot) {
     initPayload(dms_.size(), "/test_oid");
@@ -207,7 +198,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrInvalidSlot) {
 }
 
 /*
- * TEST 7 - dm.getParam() returns a catena::exception_with_status.
+ * TEST 6 - dm.getParam() returns a catena::exception_with_status.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrGetParamReturnCatena) {
     expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
@@ -225,7 +216,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrGetParamReturnCatena) {
 }
 
 /*
- * TEST 8 - dm.getParam() throws a catena::exception_with_status.
+ * TEST 7 - dm.getParam() throws a catena::exception_with_status.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowCatena) {
     expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
@@ -243,7 +234,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowCatena) {
 }
 
 /*
- * TEST 9 - dm.getParam() throws a std::runtime_exception.
+ * TEST 8 - dm.getParam() throws a std::runtime_exception.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowStd) {
     expRc_ = catena::exception_with_status("Std error", catena::StatusCode::INTERNAL);
@@ -258,7 +249,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowStd) {
 }
 
 /*
- * TEST 10 - dm.getParam() throws an unknown error.
+ * TEST 9 - dm.getParam() throws an unknown error.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -273,7 +264,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrGetParamThrowUnknown) {
 }
 
 /*
- * TEST 11 - param->toProto() returns a catena::exception_with_status.
+ * TEST 10 - param->toProto() returns a catena::exception_with_status.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoReturnCatena) {
     expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
@@ -289,7 +280,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrToProtoReturnCatena) {
 }
 
 /*
- * TEST 12 - param->toProto() throws a catena::exception_with_status.
+ * TEST 11 - param->toProto() throws a catena::exception_with_status.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowCatena) {
     expRc_ = catena::exception_with_status("Oid does not exist", catena::StatusCode::INVALID_ARGUMENT);
@@ -308,7 +299,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowCatena) {
 }
 
 /*
- * TEST 13 - param->toProto() throws a std::runtime_exception.
+ * TEST 12 - param->toProto() throws a std::runtime_exception.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowStd) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -324,7 +315,7 @@ TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowStd) {
 }
 
 /*
- * TEST 14 - param->toProto() throws an unknown error.
+ * TEST 13 - param->toProto() throws an unknown error.
  */
 TEST_F(RESTGetParamTests, GetParam_ErrToProtoThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);

--- a/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
+++ b/unittests/cpp/REST/tests/GetPopulatedSlots_test.cpp
@@ -79,17 +79,8 @@ class RESTGetPopulatedSlotsTests : public RESTEndpointTest {
 TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Create) {
     ASSERT_TRUE(endpoint_);
 }
-
-/* 
- * TEST 2 - Writing to console with GetPopulatedSlots finish().
- */
-TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("GetPopulatedSlots[1] finished\n") != std::string::npos);
-}
-
 /*
- * TEST 3 - Normal case for GetPopulatedSlots proceed().
+ * TEST 2 - Normal case for GetPopulatedSlots proceed().
  */
 TEST_F(RESTGetPopulatedSlotsTests, GetPopulatedSlots_Normal) {
     for (auto& [slot, dm] : dms_) {

--- a/unittests/cpp/REST/tests/GetValue_test.cpp
+++ b/unittests/cpp/REST/tests/GetValue_test.cpp
@@ -92,16 +92,8 @@ TEST_F(RESTGetValueTests, GetValue_Create) {
     EXPECT_TRUE(endpoint_);
 }
 
-/* 
- * TEST 2 - Writing to console with GetValue finish().
- */
-TEST_F(RESTGetValueTests, GetValue_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("GetValue[1] finished\n") != std::string::npos);
-}
-
 /*
- * TEST 3 - Normal case for GetValue proceed().
+ * TEST 2 - Normal case for GetValue proceed().
  */
 TEST_F(RESTGetValueTests, GetValue_Normal) {
     initPayload(0, "/test_oid");
@@ -119,7 +111,7 @@ TEST_F(RESTGetValueTests, GetValue_Normal) {
 }
 
 /*
- * TEST 4 - GetValue with authz on and valid token.
+ * TEST 3 - GetValue with authz on and valid token.
  */
 TEST_F(RESTGetValueTests, GetValue_AuthzValid) {
     initPayload(0, "/test_oid");
@@ -149,7 +141,7 @@ TEST_F(RESTGetValueTests, GetValue_AuthzValid) {
 }
 
 /*
- * TEST 5 - GetValue with authz on and invalid token.
+ * TEST 4 - GetValue with authz on and invalid token.
  */
 TEST_F(RESTGetValueTests, GetValue_AuthzInvalid) {
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -163,7 +155,7 @@ TEST_F(RESTGetValueTests, GetValue_AuthzInvalid) {
 }
 
 /*
- * TEST 6 - No device in the specified slot.
+ * TEST 5 - No device in the specified slot.
  */
 TEST_F(RESTGetValueTests, GetValue_ErrInvalidSlot) {
     initPayload(dms_.size(), "/test_oid");

--- a/unittests/cpp/REST/tests/LanguagePack_test.cpp
+++ b/unittests/cpp/REST/tests/LanguagePack_test.cpp
@@ -122,15 +122,7 @@ TEST_F(RESTLanguagePackTests, LanguagePack_Create) {
 }
 
 /* 
- * TEST 0.2 - Writing to console with LanguagePack finish().
- */
-TEST_F(RESTLanguagePackTests, LanguagePack_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("LanguagePack[1] finished\n") != std::string::npos);
-}
-
-/* 
- * TEST 0.3 - LanguagePack proceed() with an invalid method.
+ * TEST 0.2 - LanguagePack proceed() with an invalid method.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_BadMethod) {
     expRc_ = catena::exception_with_status("Bad method", catena::StatusCode::UNIMPLEMENTED);
@@ -145,7 +137,7 @@ TEST_F(RESTLanguagePackTests, LanguagePack_BadMethod) {
 }
 
 /* 
- * TEST 0.4 - LanguagePack proceed() with an invalid slot.
+ * TEST 0.3 - LanguagePack proceed() with an invalid slot.
  */
 TEST_F(RESTLanguagePackTests, LanguagePack_InvalidSlot) {
     initPayload(dms_.size(), "tl");

--- a/unittests/cpp/REST/tests/Languages_test.cpp
+++ b/unittests/cpp/REST/tests/Languages_test.cpp
@@ -81,15 +81,7 @@ TEST_F(RESTLanguagesTests, Languages_Create) {
 }
 
 /* 
- * TEST 0.2 - Writing to console with Languages finish().
- */
-TEST_F(RESTLanguagesTests, Languages_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("Languages[1] finished\n") != std::string::npos);
-}
-
-/* 
- * TEST 0.3 - Languages proceed() with an invalid method.
+ * TEST 0.2 - Languages proceed() with an invalid method.
  */
 TEST_F(RESTLanguagesTests, Languages_BadMethod) {
     expRc_ = catena::exception_with_status("Bad method", catena::StatusCode::UNIMPLEMENTED);

--- a/unittests/cpp/REST/tests/MultiSetValue_test.cpp
+++ b/unittests/cpp/REST/tests/MultiSetValue_test.cpp
@@ -95,16 +95,8 @@ TEST_F(RESTMultiSetValueTests, MultiSetValue_Create) {
     EXPECT_TRUE(endpoint_);
 }
 
-/* 
- * TEST 2 - Writing to console with MultiSetValue finish().
- */
-TEST_F(RESTMultiSetValueTests, MultiSetValue_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("MultiSetValue[1] finished\n") != std::string::npos);
-}
-
 /*
- * TEST 3 - Normal case for MultiSetValue proceed().
+ * TEST 2 - Normal case for MultiSetValue proceed().
  */
 TEST_F(RESTMultiSetValueTests, MultiSetValue_Normal) {
     initPayload(0, {{"/test_oid_1", "test_value_1"},{"/test_oid_2", "test_value_2"}});
@@ -132,7 +124,7 @@ TEST_F(RESTMultiSetValueTests, MultiSetValue_Normal) {
 }
 
 /*
- * TEST 4 - MultiSetValue with authz on and valid token.
+ * TEST 3 - MultiSetValue with authz on and valid token.
  */
 TEST_F(RESTMultiSetValueTests, MultiSetValue_AuthzValid) {
     initPayload(0, {{"/test_oid_1", "test_value_1"},{"/test_oid_2", "test_value_2"}});
@@ -172,7 +164,7 @@ TEST_F(RESTMultiSetValueTests, MultiSetValue_AuthzValid) {
 }
 
 /*
- * TEST 5 - MultiSetValue with authz on and invalid token.
+ * TEST 4 - MultiSetValue with authz on and invalid token.
  */
 TEST_F(RESTMultiSetValueTests, MultiSetValue_AuthzInvalid) {
     initPayload(0, {});
@@ -187,7 +179,7 @@ TEST_F(RESTMultiSetValueTests, MultiSetValue_AuthzInvalid) {
 }
 
 /*
- * TEST 6 - No device in the specified slot.
+ * TEST 5 - No device in the specified slot.
  */
 TEST_F(RESTMultiSetValueTests, MultiSetValue_ErrInvalidSlot) {
     initPayload(dms_.size(), {});

--- a/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
@@ -109,7 +109,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzStdException) {
     EXPECT_CALL(context_, jwsToken()).WillRepeatedly(testing::Throw(std::runtime_error("Test auth setup failure")));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -122,7 +121,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzInvalid) {
     authzEnabled_ = true;
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -134,13 +132,12 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_InvalidSlot) {
     expRc_ = catena::exception_with_status("device not found in slot " + std::to_string(slot_), catena::StatusCode::NOT_FOUND);
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
-// Test 0.3: Authorization test with valid token
+// Test 0.4: Authorization test with valid token
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzValid) {
     // Use a valid JWT token that was borrowed from GetValue_test.cpp
     jwsToken_ = "eyJhbGciOiJSUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJzdWIiOiIxMjM0NTY3"
@@ -175,7 +172,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_AuthzValid) {
         }));
     
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(param_info);
@@ -214,7 +210,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParams) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::vector<std::string> jsonBodies;
@@ -235,7 +230,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsError) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -253,7 +247,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getEmptyTopLevelParams) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -277,7 +270,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithArray) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(arrayParamInfo);
@@ -304,7 +296,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsProcessingEr
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -345,7 +336,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsThrow) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -426,7 +416,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithDeepNest
         ));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::vector<std::string> jsonBodies;
@@ -496,7 +485,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
             }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::vector<std::string> jsonBodies;
@@ -574,7 +562,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
             }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -594,7 +581,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithErrorSta
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -614,7 +600,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithEmptyLis
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -650,7 +635,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_proceedSpecificParam) {
         ));
     
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(paramInfo);
@@ -686,7 +670,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getSpecificParamWithRecursion
         ));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     std::string jsonBody = catena::REST::test::createParamInfoJson(paramInfo);
@@ -706,7 +689,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_parameterNotFound) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -725,7 +707,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catenaExceptionInGetParam) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -745,7 +726,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catchCatenaException) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -763,7 +743,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catchStdException) {
         }));
 
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
@@ -782,7 +761,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_catchUnknownException) {
 
     // Create a new endpoint_ for this test
     endpoint_->proceed();
-    endpoint_->finish();
 
     // Match expected and actual responses
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));

--- a/unittests/cpp/REST/tests/SetValue_test.cpp
+++ b/unittests/cpp/REST/tests/SetValue_test.cpp
@@ -92,15 +92,7 @@ TEST_F(RESTSetValueTests, SetValue_Create) {
 }
 
 /* 
- * TEST 2 - Writing to console with SetValue finish().
- */
-TEST_F(RESTSetValueTests, SetValue_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("SetValue[1] finished\n") != std::string::npos);
-}
-
-/* 
- * TEST 3 - Normal case for SetValue toMulti_().
+ * TEST 2 - Normal case for SetValue toMulti_().
  */
 TEST_F(RESTSetValueTests, SetValue_Normal) {
     initPayload(0, "/test_oid", "test_value");
@@ -119,7 +111,7 @@ TEST_F(RESTSetValueTests, SetValue_Normal) {
 }
 
 /* 
- * TEST 4 - SetValue toMulti_() fails to parse the JSON.
+ * TEST 3 - SetValue toMulti_() fails to parse the JSON.
  */
 TEST_F(RESTSetValueTests, SetValue_FailParse) {
     expRc_ = catena::exception_with_status("Failed to convert JSON to protobuf", catena::StatusCode::INVALID_ARGUMENT);

--- a/unittests/cpp/REST/tests/Subscriptions_test.cpp
+++ b/unittests/cpp/REST/tests/Subscriptions_test.cpp
@@ -182,15 +182,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_create) {
 }
 
 /* 
- * TEST 0.2 - Writing to console with Subscriptions finish().
- */
-TEST_F(RESTSubscriptionsTests, Subscriptions_Finish) {
-    endpoint_->finish();
-    ASSERT_TRUE(MockConsole_.str().find("Subscriptions[1] finished\n") != std::string::npos);
-}
-
-/* 
- * TEST 0.3 - Subscriptions with a device which does not support them.
+ * TEST 0.2 - Subscriptions with a device which does not support them.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_NotSupported) {
     initPayload(0);
@@ -203,7 +195,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_NotSupported) {
 }
 
 /* 
- * TEST 0.4 - Subscriptions with an invalid token.
+ * TEST 0.3 - Subscriptions with an invalid token.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_AuthzInalid) {
     initPayload(0);
@@ -218,7 +210,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_AuthzInalid) {
 }
 
 /* 
- * TEST 0.5 - Subscriptions with an invalid method.
+ * TEST 0.4 - Subscriptions with an invalid method.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_BadMethod) {
     initPayload(0);
@@ -231,7 +223,7 @@ TEST_F(RESTSubscriptionsTests, Subscriptions_BadMethod) {
 }
 
 /* 
- * TEST 0.6 - Subscriptions with an invalid slot.
+ * TEST 0.5 - Subscriptions with an invalid slot.
  */
 TEST_F(RESTSubscriptionsTests, Subscriptions_InvalidSlot) {
     initPayload(dms_.size());


### PR DESCRIPTION
**Changelog:**
- Removed the Finish() function from REST endpoints.
    - After moving connect signal disconnects to the destructor this was rendered obsolete, at most being 2 lines in each endpoint printing a message to the console. These 2 lines have been moved to the end of Proceed().
- Fixed some outdated comments in SocketWriter and removed duplicate includes.