### PR TITLE
Fixed param json schema structField issue

### DIFF
--- a/schema/catena.param_schema.json
+++ b/schema/catena.param_schema.json
@@ -642,11 +642,7 @@
             "struct_values": {
               "type": "array",
               "items": {
-                "properties": {
-                  "fields": {
-                    "$ref": "#/$defs/struct_fields"
-                  }
-                }
+                "$ref": "#/$defs/struct_value"
               }
             },
             "additionalItems": false
@@ -678,7 +674,7 @@
     },
     "struct_value": {
       "title": "STRUCT",
-      "description": "Wrapper round the struct_fields schema.",
+      "description": "Defines STRUCT as a type.",
       "type": "object",
       "$comment": "pattern properties must be same regex as for oid",
       "properties": {
@@ -686,57 +682,45 @@
           "type": "object",
           "properties": {
             "fields": {
-              "$ref": "#/$defs/struct_fields"
+              "struct_fields": {
+                "title": "struct definition",
+                "description": "holds struct data fields",
+                "type": "object",
+                "patternProperties": {
+                  "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/$defs/float32_value"
+                      },
+                      {
+                        "$ref": "#/$defs/int32_value"
+                      },
+                      {
+                        "$ref": "#/$defs/string_value"
+                      },
+                      {
+                        "$ref": "#/$defs/struct_value"
+                      },
+                      {
+                        "$ref": "#/$defs/int32_array_values"
+                      },
+                      {
+                        "$ref": "#/$defs/float32_array_values"
+                      },
+                      {
+                        "$ref": "#/$defs/string_array_values"
+                      },
+                      {
+                        "$ref": "#/$defs/struct_array_values"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
             }
           },
           "additionalProperties": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "struct_fields": {
-      "title": "struct definition",
-      "description": "holds struct data fields",
-      "type": "object",
-      "patternProperties": {
-        "(^(?!_)(?!\\d)(?![\\w\\.]*\\.\\d+?$)[\\w\\.]+$)": {
-          "$ref": "#/$defs/field_value"
-        }
-      },
-      "additionalProperties": false
-    },
-    "field_value": {
-      "title": "Struct Field Value",
-      "description": "holds struct data field",
-      "type": "object",
-      "properties": {
-        "value": {
-          "oneOf": [
-            {
-              "$ref": "#/$defs/float32_value"
-            },
-            {
-              "$ref": "#/$defs/int32_value"
-            },
-            {
-              "$ref": "#/$defs/string_value"
-            },
-            {
-              "$ref": "#/$defs/struct_value"
-            },
-            {
-              "$ref": "#/$defs/int32_array_values"
-            },
-            {
-              "$ref": "#/$defs/float32_array_values"
-            },
-            {
-              "$ref": "#/$defs/string_array_values"
-            },
-            {
-              "$ref": "#/$defs/struct_array_values"
-            }
-          ]
         }
       },
       "additionalProperties": false

--- a/sdks/cpp/common/examples/import_params/device.import_params.json
+++ b/sdks/cpp/common/examples/import_params/device.import_params.json
@@ -27,39 +27,29 @@
       "value": {
         "struct_value": {
           "fields": {
-            "departure": {
-              "value": {}
-            },
+            "departure": {},
             "destination": {
-              "value": {
-                "struct_value": {
-                  "fields": {
-                    "name": {"value": {"string_value": "Paris"}},
-                    "location": {
-                      "value": {
-                        "struct_value": {
-                          "fields": {
-                            "latitude": {
-                              "value": {
-                                "struct_value": {
-                                  "fields": {
-                                    "degrees": {"value": {"int32_value": 48}},
-                                    "minutes": {"value": {"int32_value": 43}},
-                                    "seconds": {"value": {"float32_value": 49.1}}
-                                  }
-                                }
-                              }
-                            },
-                            "longitude": {
-                              "value": {
-                                "struct_value": {
-                                  "fields": {
-                                    "degrees": {"value": {"int32_value": 2}},
-                                    "minutes": {"value": {"int32_value": 22}},
-                                    "seconds": {"value": {"float32_value": 22.1}}
-                                  }
-                                }
-                              }
+              "struct_value": {
+                "fields": {
+                  "name": {"string_value": "Paris"},
+                  "location": {
+                    "struct_value": {
+                      "fields": {
+                        "latitude": {
+                          "struct_value": {
+                            "fields": {
+                              "degrees": {"int32_value": 48},
+                              "minutes": {"int32_value": 43},
+                              "seconds": {"float32_value": 49.1}
+                            }
+                          }
+                        },
+                        "longitude": {
+                          "struct_value": {
+                            "fields": {
+                              "degrees": {"int32_value": 2},
+                              "minutes": {"int32_value": 22},
+                              "seconds": {"float32_value": 22.1}
                             }
                           }
                         }

--- a/sdks/cpp/common/examples/import_params/params/param.city.json
+++ b/sdks/cpp/common/examples/import_params/params/param.city.json
@@ -1,15 +1,15 @@
 {
-    "type": "STRUCT",
-    "read_only": false,
-    "name": { "display_strings": { "en": "City" } },
-    "params": {
-        "name": {
-            "type": "STRING",
-            "name": { "display_strings": { "en": "City Name" } }
-        },
-        "location": {
-            "import": { "file": "params/param.location.json" }
-        }
+  "type": "STRUCT",
+  "read_only": false,
+  "name": { "display_strings": { "en": "City" } },
+  "params": {
+    "name": {
+      "type": "STRING",
+      "name": { "display_strings": { "en": "City Name" } }
+    },
+    "location": {
+      "import": { "file": "params/param.location.json" }
     }
+  }
 }
   

--- a/sdks/cpp/common/examples/import_params/params/param.location.json
+++ b/sdks/cpp/common/examples/import_params/params/param.location.json
@@ -44,24 +44,20 @@
     "struct_value": {
       "fields": {
         "latitude": {
-          "value": {
-            "struct_value": {
-              "fields": {
-                "degrees": { "value": { "int32_value": 1 } },
-                "minutes": { "value": { "int32_value": 2 } },
-                "seconds": { "value": { "float32_value": 3 } }
-              }
+          "struct_value": {
+            "fields": {
+              "degrees": {"int32_value": 1},
+              "minutes": {"int32_value": 2},
+              "seconds": {"float32_value": 3}
             }
           }
         },
         "longitude": {
-          "value": {
-            "struct_value": {
-              "fields": {
-                "degrees": { "value": { "int32_value": 4 } },
-                "minutes": { "value": { "int32_value": 5 } },
-                "seconds": { "value": { "float32_value": 6 } }
-              }
+          "struct_value": {
+            "fields": {
+              "degrees": {"int32_value": 4},
+              "minutes": {"int32_value": 5},
+              "seconds": {"float32_value": 6}
             }
           }
         }

--- a/sdks/cpp/common/examples/import_params/params/param.ottawa.json
+++ b/sdks/cpp/common/examples/import_params/params/param.ottawa.json
@@ -1,74 +1,40 @@
 {
-    "name": {
-        "display_strings": {
-            "en": "Ottawa"
-        }
-    },
-    "type": "STRUCT",
-    "template_oid": "/city",
-    "value": {
-        "struct_value": {
+  "name": {
+      "display_strings": {
+          "en": "Ottawa"
+      }
+  },
+  "type": "STRUCT",
+  "template_oid": "/city",
+  "value": {
+    "struct_value": {
+      "fields": {
+        "name": {"string_value": "Ottawa"},
+        "location": {
+          "struct_value": {
             "fields": {
-                "name": {
-                    "value": {
-                        "string_value": "Ottawa"
-                    }
-                },
-                "location": {
-                    "value": {
-                        "struct_value": {
-                            "fields": {
-                                "latitude": {
-                                    "value": {
-                                        "struct_value": {
-                                            "fields": {
-                                                "degrees": {
-                                                    "value": {
-                                                        "int32_value": 45
-                                                    }
-                                                },
-                                                "minutes": {
-                                                    "value": {
-                                                        "int32_value": 19
-                                                    }
-                                                },
-                                                "seconds": {
-                                                    "value": {
-                                                        "float32_value": 4.9
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "longitude": {
-                                    "value": {
-                                        "struct_value": {
-                                            "fields": {
-                                                "degrees": {
-                                                    "value": {
-                                                        "int32_value": 75
-                                                    }
-                                                },
-                                                "minutes": {
-                                                    "value": {
-                                                        "int32_value": 39
-                                                    }
-                                                },
-                                                "seconds": {
-                                                    "value": {
-                                                        "float32_value": 56.7
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+              "latitude": {
+                "struct_value": {
+                  "fields": {
+                    "degrees": {"int32_value": 45},
+                    "minutes": {"int32_value": 19},
+                    "seconds": {"float32_value": 4.9}
+                  }
                 }
+              },
+              "longitude": {
+                "struct_value": {
+                  "fields": {
+                    "degrees": {"int32_value": 75},
+                    "minutes": {"int32_value": 39},
+                    "seconds": {"float32_value": 56.7}
+                  }
+                }
+              }
             }
+          }
         }
+      }
     }
+  }
 }

--- a/sdks/cpp/common/examples/use_struct_arrays/device.AudioDeck.json
+++ b/sdks/cpp/common/examples/use_struct_arrays/device.AudioDeck.json
@@ -46,20 +46,20 @@
                 {
                   "struct_value": {
                     "fields": {
-                      "response": { "value": {"int32_value": 0}},
-                      "frequency": { "value": {"float32_value": 0}},
-                      "gain": { "value": {"float32_value": 0}},
-                      "q_factor": { "value": {"float32_value": 0}}
+                      "response": {"int32_value": 0},
+                      "frequency": {"float32_value": 0},
+                      "gain": {"float32_value": 0},
+                      "q_factor": {"float32_value": 0}
                     }
                   }
                 },
                 {
                   "struct_value": {
                     "fields": {
-                      "response": { "value": {"int32_value": 0}},
-                      "frequency": { "value": {"float32_value": 0}},
-                      "gain": { "value": {"float32_value": 0}},
-                      "q_factor": { "value": {"float32_value": 0}}
+                      "response": {"int32_value": 0},
+                      "frequency": {"float32_value": 0},
+                      "gain": {"float32_value": 0},
+                      "q_factor": {"float32_value": 0}
                     }
                   }
                 }
@@ -79,33 +79,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.0}},
+                  "fader": {"float32_value": 0.0},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 1}},
-                                "frequency": { "value": {"float32_value": 100}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 2}},
-                                "frequency": { "value": {"float32_value": 200}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 1},
+                              "frequency": {"float32_value": 100},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 2},
+                              "frequency": {"float32_value": 200},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -114,33 +112,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.1}},
+                  "fader":{"float32_value": 0.1},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 3}},
-                                "frequency": { "value": {"float32_value": 300}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 4}},
-                                "frequency": { "value": {"float32_value": 400}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 3},
+                              "frequency": {"float32_value": 300},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 4},
+                              "frequency": {"float32_value": 400},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -149,33 +145,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.2}},
+                  "fader":{"float32_value": 0.2},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 5}},
-                                "frequency": { "value": {"float32_value": 500}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 6}},
-                                "frequency": { "value": {"float32_value": 600}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 5},
+                              "frequency": {"float32_value": 500},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 6},
+                              "frequency": {"float32_value": 600},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -184,33 +178,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.3}},
+                  "fader":{"float32_value": 0.3},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 7}},
-                                "frequency": { "value": {"float32_value": 700}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 8}},
-                                "frequency": { "value": {"float32_value": 800}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 7},
+                              "frequency": {"float32_value": 700},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 8},
+                              "frequency": {"float32_value": 800},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }

--- a/sdks/cpp/common/examples/use_structs/device.use_structs.json
+++ b/sdks/cpp/common/examples/use_structs/device.use_structs.json
@@ -56,24 +56,20 @@
         "struct_value": {
           "fields": {
             "latitude": {
-              "value": {
-                "struct_value": {
-                  "fields": {
-                    "degrees": { "value": { "int32_value": 1 } },
-                    "minutes": { "value": { "int32_value": 2 } },
-                    "seconds": { "value": { "float32_value": 3 } }
-                  }
+              "struct_value": {
+                "fields": {
+                  "degrees": {"int32_value": 1},
+                  "minutes": {"int32_value": 2},
+                  "seconds": {"float32_value": 3}
                 }
               }
             },
             "longitude": {
-              "value": {
-                "struct_value": {
-                  "fields": {
-                    "degrees": { "value": { "int32_value": 4 } },
-                    "minutes": { "value": { "int32_value": 5 } },
-                    "seconds": { "value": { "float32_value": 6 } }
-                  }
+              "struct_value": {
+                "fields": {
+                  "degrees": {"int32_value": 4},
+                  "minutes": {"int32_value": 5},
+                  "seconds": {"float32_value": 6}
                 }
               }
             }

--- a/sdks/cpp/common/examples/use_templates/device.use_templates.json
+++ b/sdks/cpp/common/examples/use_templates/device.use_templates.json
@@ -59,26 +59,10 @@
       "value": {
         "struct_value": {
           "fields": {
-            "city_name": {
-              "value": {
-                "string_value": "Ottawa"
-              }
-            },
-            "latitude": {
-              "value": {
-                "float32_value": 45.4215
-              }
-            },
-            "longitude": {
-              "value": {
-                "float32_value": -75.6972
-              }
-            },
-            "population": {
-              "value": {
-                "int32_value": 934243
-              }
-            }
+            "city_name": {"string_value": "Ottawa"},
+            "latitude": {"float32_value": 45.4215},
+            "longitude": {"float32_value": -75.6972},
+            "population": {"int32_value": 934243}
           }
         }
       }
@@ -94,26 +78,10 @@
       "value": {
         "struct_value": {
           "fields": {
-            "city_name": {
-              "value": {
-                "string_value": "Toronto"
-              }
-            },
-            "latitude": {
-              "value": {
-                "float32_value": 43.6511
-              }
-            },
-            "longitude": {
-              "value": {
-                "float32_value": -79.3470
-              }
-            },
-            "population": {
-              "value": {
-                "int32_value": 2731571
-              }
-            }
+            "city_name": {"string_value": "Toronto"},
+            "latitude": {"float32_value": 43.6511},
+            "longitude": {"float32_value": -79.3470},
+            "population": {"int32_value": 2731571}
           }
         }
       }

--- a/sdks/cpp/common/examples/use_variants/device.use_variants.json
+++ b/sdks/cpp/common/examples/use_variants/device.use_variants.json
@@ -45,21 +45,9 @@
       "value": {
         "struct_value": {
           "fields": {
-            "x": {
-              "value": {
-                "int32_value": 5
-              }
-            },
-            "y": {
-              "value": {
-                "int32_value": 10
-              }
-            },
-            "z": {
-              "value": {
-                "int32_value": 15
-              }
-            }
+            "x": {"int32_value": 5},
+            "y": {"int32_value": 10},
+            "z": {"int32_value": 15}
           }
         }
       }
@@ -129,21 +117,9 @@
               "value": {
                 "struct_value": {
                   "fields": {
-                    "x": {
-                      "value": {
-                        "int32_value": 1
-                      }
-                    },
-                    "y": {
-                      "value": {
-                        "int32_value": 2
-                      }
-                    },
-                    "z": {
-                      "value": {
-                        "int32_value": 3
-                      }
-                    }
+                    "x": {"int32_value": 1},
+                    "y": {"int32_value": 2},
+                    "z": {"int32_value": 3}
                   }
                 }
               }
@@ -153,21 +129,9 @@
               "value": {
                 "struct_value": {
                   "fields": {
-                    "rho": {
-                      "value": {
-                        "int32_value": 1
-                      }
-                    },
-                    "phi": {
-                      "value": {
-                        "int32_value": 90
-                      }
-                    },
-                    "z": {
-                      "value": {
-                        "int32_value": 3
-                      }
-                    }
+                    "rho": {"int32_value": 1},
+                    "phi": {"int32_value": 90},
+                    "z": {"int32_value": 3}
                   }
                 }
               }
@@ -177,21 +141,9 @@
               "value": {
                 "struct_value": {
                   "fields": {
-                    "r": {
-                      "value": {
-                        "int32_value": 1
-                      }
-                    },
-                    "theta": {
-                      "value": {
-                        "int32_value": 90
-                      }
-                    },
-                    "phi": {
-                      "value": {
-                        "int32_value": 180
-                      }
-                    }
+                    "r": {"int32_value": 1},
+                    "theta": {"int32_value": 90},
+                    "phi": {"int32_value": 180}
                   }
                 }
               }

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/constraints/param.constraint_examples.yaml
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/constraints/param.constraint_examples.yaml
@@ -42,15 +42,15 @@ params:
 value: 
   struct_value:
     fields:
-      int32_range: { value: { int32_value: 6 } }
-      int32_choice: { value: { int32_value: 1 } }
-      # int32_alarm: { value: { int32_value: 0 } }
-      float32_range: { value: { float32_value: 10.5 } }
-      string_choice: { value: { string_value: "a" } }
-      string_length: { value: { string_value: "Hello worl" } }
-      int_array_range: { value: { int32_array_values: { ints: [0, 2, 4, 6, 8, 10] } } }
-      int_array_choice: { value: { int32_array_values: { ints: [0, 1, 0, 0, 1] } } }
-      # int_array_alarm: { value: { int32_array_values: { ints: [0, 1, 2, 3, 4] } } }
-      float_array_range: { value: { float32_array_values: { floats: [11.5, 22.5, 33.5, 44.5] } } }
-      string_array_choice: { value: { string_array_values: { strings: [a, b, a] } } }
-      string_array_length: { value: { string_array_values: { strings: [a, b, c, d, e, f, g, h, i, j] } } }
+      int32_range: { int32_value: 6}
+      int32_choice: { int32_value: 1 }
+      # int32_alarm:{ int32_value: 0 }
+      float32_range: { float32_value: 10.5 }
+      string_choice: { string_value: "a" }
+      string_length: { string_value: "Hello worl" }
+      int_array_range: { int32_array_values: { ints: [0, 2, 4, 6, 8, 10] } }
+      int_array_choice: { int32_array_values: { ints: [0, 1, 0, 0, 1] } }
+      # int_array_alarm: { int32_array_values: { ints: [0, 1, 2, 3, 4] } }
+      float_array_range: { float32_array_values: { floats: [11.5, 22.5, 33.5, 44.5] } }
+      string_array_choice: { string_array_values: { strings: [a, b, a] } }
+      string_array_length: { string_array_values: { strings: [a, b, c, d, e, f, g, h, i, j] } }

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/device.one_of_everything.yaml
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/device.one_of_everything.yaml
@@ -6,17 +6,6 @@ access_scopes: ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"]
 default_scope: st2138:mon
 
 params:
-  test_struct:
-    type: STRUCT
-    value:
-      struct_value:
-        fields:
-          int_field: { value: { int32_value: 42 } }
-          float_field: { value: { float32_value: 3.14 } }
-          string_field: { value: { string_value: "Hello" } }
-      
-
-
   number_example: 
     type: INT32
     value: { int32_value: 0 }

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/params/param.struct_array.yaml
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/params/param.struct_array.yaml
@@ -11,16 +11,14 @@ value:
       - struct_value:
           fields:
             nested_struct:
-              value:
-                struct_value:
-                  fields:
-                    num_1: { value: { int32_value: 1 } }
-                    num_2: { value: { int32_value: 2 } }
+              struct_value:
+                fields:
+                  num_1: {int32_value: 1}
+                  num_2: {int32_value: 2}
       - struct_value:
           fields:
             nested_struct:
-              value:
-                struct_value:
-                  fields:
-                    num_1: { value: { int32_value: 3 } }
-                    num_2: { value: { int32_value: 4 } }
+              struct_value:
+                fields:
+                  num_1: {int32_value: 3}
+                  num_2: {int32_value: 4}

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/params/param.struct_example.yaml
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/params/param.struct_example.yaml
@@ -7,8 +7,7 @@ value:
   struct_value:
     fields:
       nested_struct:
-        value:
-          struct_value:
-            fields:
-              num_1: { value: { int32_value: 1 } }
-              num_2: { value: { int32_value: 2 } }
+        struct_value:
+          fields:
+            num_1: {int32_value: 1}
+            num_2: {int32_value: 2}

--- a/sdks/cpp/connections/REST/examples/structs_with_authz_REST/device.AudioDeck.yaml
+++ b/sdks/cpp/connections/REST/examples/structs_with_authz_REST/device.AudioDeck.yaml
@@ -1,4 +1,4 @@
-slot: 0
+slot: 1
 multi_set_enabled: true
 subscriptions: true
 detail_level: FULL
@@ -46,16 +46,16 @@ params:
             struct_values:
               - struct_value:
                   fields: 
-                    response: {value: {int32_value: 0}}
-                    frequency: {value: {float32_value: 0}}
-                    gain: {value: {float32_value: 0}}
-                    q_factor: {value: {float32_value: 0}}
+                    response: {int32_value: 0}
+                    frequency: {float32_value: 0}
+                    gain: {float32_value: 0}
+                    q_factor: {float32_value: 0}
               - struct_value: 
                   fields: 
-                    response: {value: {int32_value: 0}}
-                    frequency: {value: {float32_value: 0}}
-                    gain: {value: {float32_value: 0}}
-                    q_factor: {value: {float32_value: 0}}
+                    response: {int32_value: 0}
+                    frequency: {float32_value: 0}
+                    gain: {float32_value: 0}
+                    q_factor: {float32_value: 0}
 
   # Demonstrates array of structs that contain arrays (nested arrays)
   audio_deck: 
@@ -67,80 +67,76 @@ params:
         struct_values:
           - struct_value: 
               fields:
-                fader: {value: {float32_value: 0.0}}
+                fader: {float32_value: 0.0}
                 eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 1}}
-                              frequency: {value: {float32_value: 100}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 2}}
-                              frequency: {value: {float32_value: 200}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 1}
+                            frequency: {float32_value: 100}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 2}
+                            frequency: {float32_value: 200}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
           - struct_value: 
               fields: 
-                fader: {value: {float32_value: 0.1}}
-                eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 3}}
-                              frequency: {value: {float32_value: 300}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 4}}
-                              frequency: {value: {float32_value: 400}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                fader: {float32_value: 0.1}
+                eq_list:
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 3}
+                            frequency: {float32_value: 300}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 4}
+                            frequency: {float32_value: 400}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
           - struct_value: 
               fields: 
-                fader: {value: {float32_value: 0.2}}
-                eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 5}}
-                              frequency: {value: {float32_value: 500}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 6}}
-                              frequency: {value: {float32_value: 600}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                fader: {float32_value: 0.2}
+                eq_list:
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 5}
+                            frequency: {float32_value: 500}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 6}
+                            frequency: {float32_value: 600}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
           - struct_value: 
               fields: 
-                fader: {value: {float32_value: 0.3}}
-                eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 7}}
-                              frequency: {value: {float32_value: 700}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 8}}
-                              frequency: {value: {float32_value: 800}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                fader: {float32_value: 0.3}
+                eq_list:
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 7}
+                            frequency: {float32_value: 700}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 8}
+                            frequency: {float32_value: 800}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
 
   # Demonstrates basic variant of structs
   effect_settings:
@@ -173,8 +169,8 @@ params:
         value:
           struct_value:
             fields:
-              room_size: {value: {float32_value: 0.7}}
-              damping: {value: {float32_value: 0.3}}
+              room_size: {float32_value: 0.7}
+              damping: {float32_value: 0.3}
 
   # Demonstrates array of variants
   effect_chain:
@@ -188,14 +184,14 @@ params:
             value:
               struct_value:
                 fields:
-                  room_size: {value: {float32_value: 0.8}}
-                  damping: {value: {float32_value: 0.3}}
+                  room_size: {float32_value: 0.8}
+                  damping: {float32_value: 0.3}
           - struct_variant_type: "delay"
             value:
               struct_value:
                 fields:
-                  time: {value: {float32_value: 0.4}}
-                  feedback: {value: {float32_value: 0.6}}
+                  time: {float32_value: 0.4}
+                  feedback: {float32_value: 0.6}
 
 
   # Templates for structs that will be used by variants
@@ -235,12 +231,12 @@ params:
             struct_values:
               - struct_value:
                   fields:
-                    time: {value: {float32_value: 0.3}}
-                    feedback: {value: {float32_value: 0.5}}
+                    time: {float32_value: 0.3}
+                    feedback: {float32_value: 0.5}
               - struct_value:
                   fields:
-                    time: {value: {float32_value: 0.6}}
-                    feedback: {value: {float32_value: 0.4}}
+                    time: {float32_value: 0.6}
+                    feedback: {float32_value: 0.4}
 
 
                     

--- a/sdks/cpp/connections/REST/examples/use_menus_REST/params/param.product.json
+++ b/sdks/cpp/connections/REST/examples/use_menus_REST/params/param.product.json
@@ -1,44 +1,44 @@
 {
-    "type": "STRUCT",
-    "params": {
-        "name": {
-            "name": {"display_strings": { "en": "Name", "es": "Nombre", "fr": "Nom" } },
-            "type":"STRING"
-        },
-        "vendor": {
-            "name": { "display_strings": { "en": "Vendor", "es": "Vendedor", "fr": "Vendeur" }  },
-            "type":"STRING"
-        },
-        "version": {
-            "name": { "display_strings": { "en": "Version", "es": "Versión", "fr": "Version" } },
-            "type":"STRING"
-        },
-        "serial_number": {
-            "name": { "display_strings": {  "en": "Serial Number", "es": "Número de serie", "fr": "Numéro de série" } },
-            "type":"STRING"
-        },
-        "catena_sdk": {
-            "name": { "display_strings": { "en": "Catena SDK",  "es": "Catena SDK", "fr": "Catena SDK" } },
-            "type":"STRING"
-        },
-        "catena_sdk_version": {
-            "name": { "display_strings": { "en": "Catena SDK Version", "es": "Versión de Catena SDK",  "fr": "Version du SDK Catena" } },
-            "type":"STRING"
-        }
+  "type": "STRUCT",
+  "params": {
+    "name": {
+      "name": {"display_strings": { "en": "Name", "es": "Nombre", "fr": "Nom" } },
+      "type":"STRING"
     },
-    "access_scope": "monitor",
-    "read_only": true,
-    "name": { "display_strings": { "en": "Product Information", "es": "Información del producto", "fr": "Informations sur le produit" } },
-    "value": {
-        "struct_value": {
-            "fields": {
-                "name": { "value": {  "string_value": "Use Menus Example"  }  },
-                "vendor": { "value": {  "string_value": "Free, Open Source Software" } },
-                "version": { "value": {  "string_value": "1.0.0"  } },
-                "serial_number": { "value": {  "string_value": "Not serialized"  } },
-                "catena_sdk": { "value": { "string_value": "https://github.com/rossvideo/Catena/sdks/cpp" } },
-                "catena_sdk_version": { "value": { "string_value": "will be overwritten with correct version" }  }
-            }
-        }
+    "vendor": {
+      "name": { "display_strings": { "en": "Vendor", "es": "Vendedor", "fr": "Vendeur" }  },
+      "type":"STRING"
+    },
+    "version": {
+      "name": { "display_strings": { "en": "Version", "es": "Versión", "fr": "Version" } },
+      "type":"STRING"
+    },
+    "serial_number": {
+      "name": { "display_strings": {  "en": "Serial Number", "es": "Número de serie", "fr": "Numéro de série" } },
+      "type":"STRING"
+    },
+    "catena_sdk": {
+      "name": { "display_strings": { "en": "Catena SDK",  "es": "Catena SDK", "fr": "Catena SDK" } },
+      "type":"STRING"
+    },
+    "catena_sdk_version": {
+      "name": { "display_strings": { "en": "Catena SDK Version", "es": "Versión de Catena SDK",  "fr": "Version du SDK Catena" } },
+      "type":"STRING"
     }
+  },
+  "access_scope": "monitor",
+  "read_only": true,
+  "name": { "display_strings": { "en": "Product Information", "es": "Información del producto", "fr": "Informations sur le produit" } },
+  "value": {
+    "struct_value": {
+      "fields": {
+          "name": {  "string_value": "Use Menus Example"  } ,
+          "vendor": {  "string_value": "Free, Open Source Software" },
+          "version": {  "string_value": "1.0.0"  },
+          "serial_number": {  "string_value": "Not serialized"  },
+          "catena_sdk": { "string_value": "https://github.com/rossvideo/Catena/sdks/cpp" },
+          "catena_sdk_version": { "string_value": "will be overwritten with correct version" }
+      }
+    }
+  }
 }

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -135,7 +135,6 @@ void CatenaServiceImpl::run() {
             }
             // Writing to socket if there was an error.
             if (rc.status != catena::StatusCode::OK) {
-                std::cout<<"Error caught"<<std::endl;
                 // Try ensures that we don't fail to decrement active requests.
                 try {
                     SocketWriter writer(socket);

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/constraints/param.constraint_examples.yaml
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/constraints/param.constraint_examples.yaml
@@ -42,15 +42,15 @@ params:
 value: 
   struct_value:
     fields:
-      int32_range: { value: { int32_value: 6 } }
-      int32_choice: { value: { int32_value: 1 } }
-      # int32_alarm: { value: { int32_value: 0 } }
-      float32_range: { value: { float32_value: 10.5 } }
-      string_choice: { value: { string_value: "a" } }
-      string_length: { value: { string_value: "Hello worl" } }
-      int_array_range: { value: { int32_array_values: { ints: [0, 2, 4, 6, 8, 10] } } }
-      int_array_choice: { value: { int32_array_values: { ints: [0, 1, 0, 0, 1] } } }
-      # int_array_alarm: { value: { int32_array_values: { ints: [0, 1, 2, 3, 4] } } }
-      float_array_range: { value: { float32_array_values: { floats: [11.5, 22.5, 33.5, 44.5] } } }
-      string_array_choice: { value: { string_array_values: { strings: [a, b, a] } } }
-      string_array_length: { value: { string_array_values: { strings: [a, b, c, d, e, f, g, h, i, j] } } }
+      int32_range: { int32_value: 6}
+      int32_choice: { int32_value: 1 }
+      # int32_alarm:{ int32_value: 0 }
+      float32_range: { float32_value: 10.5 }
+      string_choice: { string_value: "a" }
+      string_length: { string_value: "Hello worl" }
+      int_array_range: { int32_array_values: { ints: [0, 2, 4, 6, 8, 10] } }
+      int_array_choice: { int32_array_values: { ints: [0, 1, 0, 0, 1] } }
+      # int_array_alarm: { int32_array_values: { ints: [0, 1, 2, 3, 4] } }
+      float_array_range: { float32_array_values: { floats: [11.5, 22.5, 33.5, 44.5] } }
+      string_array_choice: { string_array_values: { strings: [a, b, a] } }
+      string_array_length: { string_array_values: { strings: [a, b, c, d, e, f, g, h, i, j] } }

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/params/param.struct_array.yaml
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/params/param.struct_array.yaml
@@ -11,16 +11,14 @@ value:
       - struct_value:
           fields:
             nested_struct:
-              value:
-                struct_value:
-                  fields:
-                    num_1: { value: { int32_value: 1 } }
-                    num_2: { value: { int32_value: 2 } }
+              struct_value:
+                fields:
+                  num_1: {int32_value: 1}
+                  num_2: {int32_value: 2}
       - struct_value:
           fields:
             nested_struct:
-              value:
-                struct_value:
-                  fields:
-                    num_1: { value: { int32_value: 3 } }
-                    num_2: { value: { int32_value: 4 } }
+              struct_value:
+                fields:
+                  num_1: {int32_value: 3}
+                  num_2: {int32_value: 4}

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/params/param.struct_example.yaml
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/params/param.struct_example.yaml
@@ -7,8 +7,7 @@ value:
   struct_value:
     fields:
       nested_struct:
-        value:
-          struct_value:
-            fields:
-              num_1: { value: { int32_value: 1 } }
-              num_2: { value: { int32_value: 2 } }
+        struct_value:
+          fields:
+            num_1: {int32_value: 1}
+            num_2: {int32_value: 2}

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
@@ -51,20 +51,20 @@
                 {
                   "struct_value": {
                     "fields": {
-                      "response": { "value": {"int32_value": 0}},
-                      "frequency": { "value": {"float32_value": 0}},
-                      "gain": { "value": {"float32_value": 0}},
-                      "q_factor": { "value": {"float32_value": 0}}
+                      "response": {"int32_value": 0},
+                      "frequency": {"float32_value": 0},
+                      "gain": {"float32_value": 0},
+                      "q_factor": {"float32_value": 0}
                     }
                   }
                 },
                 {
                   "struct_value": {
                     "fields": {
-                      "response": { "value": {"int32_value": 0}},
-                      "frequency": { "value": {"float32_value": 0}},
-                      "gain": { "value": {"float32_value": 0}},
-                      "q_factor": { "value": {"float32_value": 0}}
+                      "response": {"int32_value": 0},
+                      "frequency": {"float32_value": 0},
+                      "gain": {"float32_value": 0},
+                      "q_factor": {"float32_value": 0}
                     }
                   }
                 }
@@ -84,33 +84,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.0}},
+                  "fader":{"float32_value": 0.0},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 1}},
-                                "frequency": { "value": {"float32_value": 100}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 2}},
-                                "frequency": { "value": {"float32_value": 200}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 1},
+                              "frequency": {"float32_value": 100},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 2},
+                              "frequency": {"float32_value": 200},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -119,33 +117,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.1}},
+                  "fader":{"float32_value": 0.1},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 3}},
-                                "frequency": { "value": {"float32_value": 300}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 4}},
-                                "frequency": { "value": {"float32_value": 400}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 3},
+                              "frequency": {"float32_value": 300},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 4},
+                              "frequency": {"float32_value": 400},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -154,33 +150,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.2}},
+                  "fader":{"float32_value": 0.2},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 5}},
-                                "frequency": { "value": {"float32_value": 500}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 6}},
-                                "frequency": { "value": {"float32_value": 600}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 5},
+                              "frequency": {"float32_value": 500},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 6},
+                              "frequency": {"float32_value": 600},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -189,33 +183,31 @@
             {
               "struct_value": {
                 "fields": {
-                  "fader":{"value": {"float32_value": 0.3}},
+                  "fader":{"float32_value": 0.3},
                   "eq_list": {
-                    "value": {
-                      "struct_array_values": {
-                        "struct_values": [
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 7}},
-                                "frequency": { "value": {"float32_value": 700}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
-                            }
-                          },
-                          {
-                            "struct_value": {
-                              "fields": {
-                                "response": { "value": {"int32_value": 8}},
-                                "frequency": { "value": {"float32_value": 800}},
-                                "gain": { "value": {"float32_value": 0}},
-                                "q_factor": { "value": {"float32_value": 0}}
-                              }
+                    "struct_array_values": {
+                      "struct_values": [
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 7},
+                              "frequency": {"float32_value": 700},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
                             }
                           }
-                        ]
-                      }
+                        },
+                        {
+                          "struct_value": {
+                            "fields": {
+                              "response": {"int32_value": 8},
+                              "frequency": {"float32_value": 800},
+                              "gain": {"float32_value": 0},
+                              "q_factor": {"float32_value": 0}
+                            }
+                          }
+                        }
+                      ]
                     }
                   }
                 }
@@ -264,8 +256,8 @@
           "value": {
             "struct_value": {
               "fields": {
-                "room_size": { "value": { "float32_value": 0.7 } },
-                "damping": { "value": { "float32_value": 0.3 } }
+                "room_size": { "float32_value": 0.7 },
+                "damping": { "float32_value": 0.3 }
               }
             }
           }
@@ -284,8 +276,8 @@
               "value": {
                 "struct_value": {
                   "fields": {
-                    "room_size": { "value": { "float32_value": 0.8 } },
-                    "damping": { "value": { "float32_value": 0.3 } }
+                    "room_size": { "float32_value": 0.8 },
+                    "damping": { "float32_value": 0.3 }
                   }
                 }
               }
@@ -295,8 +287,8 @@
               "value": {
                 "struct_value": {
                   "fields": {
-                    "time": { "value": { "float32_value": 0.4 } },
-                    "feedback": { "value": { "float32_value": 0.6 } }
+                    "time": { "float32_value": 0.4 },
+                    "feedback": { "float32_value": 0.6 }
                   }
                 }
               }
@@ -348,16 +340,16 @@
                 {
                   "struct_value": {
                     "fields": {
-                      "time": { "value": { "float32_value": 0.3 } },
-                      "feedback": { "value": { "float32_value": 0.5 } }
+                      "time": { "float32_value": 0.3 },
+                      "feedback": { "float32_value": 0.5 }
                     }
                   }
                 },
                 {
                   "struct_value": {
                     "fields": {
-                      "time": { "value": { "float32_value": 0.6 } },
-                      "feedback": { "value": { "float32_value": 0.4 } }
+                      "time": { "float32_value": 0.6 },
+                      "feedback": { "float32_value": 0.4 }
                     }
                   }
                 }

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/device.AudioDeck.yaml
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/device.AudioDeck.yaml
@@ -46,16 +46,16 @@ params:
             struct_values:
               - struct_value:
                   fields: 
-                    response: {value: {int32_value: 0}}
-                    frequency: {value: {float32_value: 0}}
-                    gain: {value: {float32_value: 0}}
-                    q_factor: {value: {float32_value: 0}}
+                    response: {int32_value: 0}
+                    frequency: {float32_value: 0}
+                    gain: {float32_value: 0}
+                    q_factor: {float32_value: 0}
               - struct_value: 
                   fields: 
-                    response: {value: {int32_value: 0}}
-                    frequency: {value: {float32_value: 0}}
-                    gain: {value: {float32_value: 0}}
-                    q_factor: {value: {float32_value: 0}}
+                    response: {int32_value: 0}
+                    frequency: {float32_value: 0}
+                    gain: {float32_value: 0}
+                    q_factor: {float32_value: 0}
 
   # Demonstrates array of structs that contain arrays (nested arrays)
   audio_deck: 
@@ -67,80 +67,76 @@ params:
         struct_values:
           - struct_value: 
               fields:
-                fader: {value: {float32_value: 0.0}}
+                fader: {float32_value: 0.0}
                 eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 1}}
-                              frequency: {value: {float32_value: 100}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 2}}
-                              frequency: {value: {float32_value: 200}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 1}
+                            frequency: {float32_value: 100}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 2}
+                            frequency: {float32_value: 200}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
           - struct_value: 
               fields: 
-                fader: {value: {float32_value: 0.1}}
-                eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 3}}
-                              frequency: {value: {float32_value: 300}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 4}}
-                              frequency: {value: {float32_value: 400}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                fader: {float32_value: 0.1}
+                eq_list:
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 3}
+                            frequency: {float32_value: 300}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 4}
+                            frequency: {float32_value: 400}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
           - struct_value: 
               fields: 
-                fader: {value: {float32_value: 0.2}}
-                eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 5}}
-                              frequency: {value: {float32_value: 500}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 6}}
-                              frequency: {value: {float32_value: 600}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                fader: {float32_value: 0.2}
+                eq_list:
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 5}
+                            frequency: {float32_value: 500}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 6}
+                            frequency: {float32_value: 600}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
           - struct_value: 
               fields: 
-                fader: {value: {float32_value: 0.3}}
-                eq_list: 
-                  value: 
-                    struct_array_values: 
-                      struct_values:
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 7}}
-                              frequency: {value: {float32_value: 700}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
-                        - struct_value: 
-                            fields: 
-                              response: {value: {int32_value: 8}}
-                              frequency: {value: {float32_value: 800}}
-                              gain: {value: {float32_value: 0}}
-                              q_factor: {value: {float32_value: 0}}
+                fader: {float32_value: 0.3}
+                eq_list:
+                  struct_array_values: 
+                    struct_values:
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 7}
+                            frequency: {float32_value: 700}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
+                      - struct_value: 
+                          fields: 
+                            response: {int32_value: 8}
+                            frequency: {float32_value: 800}
+                            gain: {float32_value: 0}
+                            q_factor: {float32_value: 0}
 
   # Demonstrates basic variant of structs
   effect_settings:
@@ -173,8 +169,8 @@ params:
         value:
           struct_value:
             fields:
-              room_size: {value: {float32_value: 0.7}}
-              damping: {value: {float32_value: 0.3}}
+              room_size: {float32_value: 0.7}
+              damping: {float32_value: 0.3}
 
   # Demonstrates array of variants
   effect_chain:
@@ -188,14 +184,14 @@ params:
             value:
               struct_value:
                 fields:
-                  room_size: {value: {float32_value: 0.8}}
-                  damping: {value: {float32_value: 0.3}}
+                  room_size: {float32_value: 0.8}
+                  damping: {float32_value: 0.3}
           - struct_variant_type: "delay"
             value:
               struct_value:
                 fields:
-                  time: {value: {float32_value: 0.4}}
-                  feedback: {value: {float32_value: 0.6}}
+                  time: {float32_value: 0.4}
+                  feedback: {float32_value: 0.6}
 
 
   # Templates for structs that will be used by variants
@@ -235,12 +231,12 @@ params:
             struct_values:
               - struct_value:
                   fields:
-                    time: {value: {float32_value: 0.3}}
-                    feedback: {value: {float32_value: 0.5}}
+                    time: {float32_value: 0.3}
+                    feedback: {float32_value: 0.5}
               - struct_value:
                   fields:
-                    time: {value: {float32_value: 0.6}}
-                    feedback: {value: {float32_value: 0.4}}
+                    time: {float32_value: 0.6}
+                    feedback: {float32_value: 0.4}
 
 
                     

--- a/sdks/cpp/connections/gRPC/examples/use_menus/params/param.product.json
+++ b/sdks/cpp/connections/gRPC/examples/use_menus/params/param.product.json
@@ -1,44 +1,44 @@
 {
-    "type": "STRUCT",
-    "params": {
-        "name": {
-            "name": {"display_strings": { "en": "Name", "es": "Nombre", "fr": "Nom" } },
-            "type":"STRING"
-        },
-        "vendor": {
-            "name": { "display_strings": { "en": "Vendor", "es": "Vendedor", "fr": "Vendeur" }  },
-            "type":"STRING"
-        },
-        "version": {
-            "name": { "display_strings": { "en": "Version", "es": "Versión", "fr": "Version" } },
-            "type":"STRING"
-        },
-        "serial_number": {
-            "name": { "display_strings": {  "en": "Serial Number", "es": "Número de serie", "fr": "Numéro de série" } },
-            "type":"STRING"
-        },
-        "catena_sdk": {
-            "name": { "display_strings": { "en": "Catena SDK",  "es": "Catena SDK", "fr": "Catena SDK" } },
-            "type":"STRING"
-        },
-        "catena_sdk_version": {
-            "name": { "display_strings": { "en": "Catena SDK Version", "es": "Versión de Catena SDK",  "fr": "Version du SDK Catena" } },
-            "type":"STRING"
-        }
+  "type": "STRUCT",
+  "params": {
+    "name": {
+      "name": {"display_strings": { "en": "Name", "es": "Nombre", "fr": "Nom" } },
+      "type":"STRING"
     },
-    "access_scope": "monitor",
-    "read_only": true,
-    "name": { "display_strings": { "en": "Product Information", "es": "Información del producto", "fr": "Informations sur le produit" } },
-    "value": {
-        "struct_value": {
-            "fields": {
-                "name": { "value": {  "string_value": "Use Menus Example"  }  },
-                "vendor": { "value": {  "string_value": "Free, Open Source Software" } },
-                "version": { "value": {  "string_value": "1.0.0"  } },
-                "serial_number": { "value": {  "string_value": "Not serialized"  } },
-                "catena_sdk": { "value": { "string_value": "https://github.com/rossvideo/Catena/sdks/cpp" } },
-                "catena_sdk_version": { "value": { "string_value": "will be overwritten with correct version" }  }
-            }
-        }
+    "vendor": {
+      "name": { "display_strings": { "en": "Vendor", "es": "Vendedor", "fr": "Vendeur" }  },
+      "type":"STRING"
+    },
+    "version": {
+      "name": { "display_strings": { "en": "Version", "es": "Versión", "fr": "Version" } },
+      "type":"STRING"
+    },
+    "serial_number": {
+      "name": { "display_strings": {  "en": "Serial Number", "es": "Número de serie", "fr": "Numéro de série" } },
+      "type":"STRING"
+    },
+    "catena_sdk": {
+      "name": { "display_strings": { "en": "Catena SDK",  "es": "Catena SDK", "fr": "Catena SDK" } },
+      "type":"STRING"
+    },
+    "catena_sdk_version": {
+      "name": { "display_strings": { "en": "Catena SDK Version", "es": "Versión de Catena SDK",  "fr": "Version du SDK Catena" } },
+      "type":"STRING"
     }
+  },
+  "access_scope": "monitor",
+  "read_only": true,
+  "name": { "display_strings": { "en": "Product Information", "es": "Información del producto", "fr": "Informations sur le produit" } },
+  "value": {
+    "struct_value": {
+      "fields": {
+          "name": {  "string_value": "Use Menus Example"  } ,
+          "vendor": {  "string_value": "Free, Open Source Software" },
+          "version": {  "string_value": "1.0.0"  },
+          "serial_number": {  "string_value": "Not serialized"  },
+          "catena_sdk": { "string_value": "https://github.com/rossvideo/Catena/sdks/cpp" },
+          "catena_sdk_version": { "string_value": "will be overwritten with correct version" }
+      }
+    }
+  }
 }

--- a/tools/codegen/cpp/param.js
+++ b/tools/codegen/cpp/param.js
@@ -420,7 +420,7 @@ class Param {
               throw new Error(`Subparam ${field} not found`);
             }
             let paramDef = subParam.template_param || subParam;
-            mappedFields.push(`.${field}${this.valueInitializer(typeValue.fields[field].value, subParam.type, paramDef)}`);
+            mappedFields.push(`.${field}${this.valueInitializer(typeValue.fields[field], subParam.type, paramDef)}`);
           }
         }
         return `${mappedFields.join(",")}`;


### PR DESCRIPTION
**Changlog:**
- Removed StructField from the param JSON schema.
- Removed deprecated "Value" parameter from Struct definition in the param JSON schema.
- Updated code gen and examples to reflect this change.

Essentially, whereas previously a struct param within a device model might look like this:
```yaml
struct_value:
    type: STRUCT
    fields:
        name: {type: STRING}
        id: {type: INT}
    value:
        struct_value:
            fields:
                name: {value: {string_value: "name"}}
                id: {value: {int32_value: 1}}
```
It will now look like:
```yaml
struct_value:
    type: STRUCT
    fields:
        name: {type: STRING}
        id: {type: INT}
    value:
        struct_value:
            fields:
                name: {string_value: "name"}
                id: {int32_value: 1}
```