### PR TITLE
Added unary support to commands

### DIFF
--- a/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/REST/include/controllers/ExecuteCommand.h
@@ -42,9 +42,13 @@
 #include <SocketWriter.h>
 #include "interface/ICallData.h"
 
+// Protobuf
+#include <google/protobuf/util/json_util.h>
+
 // common
 #include <Device.h>
 #include <IParam.h>
+#include <Status.h>
 #include <rpc/TimeNow.h>
 
 // boost
@@ -63,6 +67,7 @@ class ExecuteCommand : public ICallData {
     using IDevice = catena::common::IDevice;
     using IParam = catena::common::IParam;
     using SlotMap = catena::common::SlotMap;
+    using CommandResponder = catena::common::IParamDescriptor::ICommandResponder;
 
     /**
      * @brief Constructor for the ExecuteCommand controller.
@@ -120,7 +125,7 @@ class ExecuteCommand : public ICallData {
     /**
      * @brief The SocketWriter object for writing to socket_.
      */
-    SSEWriter writer_;
+    std::unique_ptr<ISocketWriter> writer_ = nullptr;
     /**
      * @brief The ISocketReader object.
      */

--- a/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ExecuteCommand.cpp
@@ -1,19 +1,20 @@
 // connections/REST
 #include <controllers/ExecuteCommand.h>
-#include <Status.h>
-#include <google/protobuf/util/json_util.h>
-#include <iostream>
 
 using catena::REST::ExecuteCommand;
-using catena::common::IParam;
-using catena::common::IParamDescriptor;
 
 // Initializes the object counter for ExecuteCommand to 0.
 int ExecuteCommand::objectCounter_ = 0;
 
 ExecuteCommand::ExecuteCommand(tcp::socket& socket, ISocketReader& context, SlotMap& dms) :
-    socket_{socket}, writer_{socket, context.origin()}, context_{context}, dms_{dms} {
+    socket_{socket}, context_{context}, dms_{dms} {
     objectId_ = objectCounter_++;
+    // Initializing the writer depending on if the response is stream or unary.
+    if (context.stream()) {
+        writer_ = std::make_unique<catena::REST::SSEWriter>(socket, context.origin());
+    } else {
+        writer_ = std::make_unique<catena::REST::SocketWriter>(socket, context.origin(), true);
+    }
     writeConsole_(CallStatus::kCreate, socket_.is_open());
 }
 
@@ -57,7 +58,7 @@ void ExecuteCommand::proceed() {
             // If the command is not found, return an error
             if (command != nullptr) {
                 // Execute the command and write response if respond = true.
-                std::unique_ptr<IParamDescriptor::ICommandResponder> responder = command->executeCommand(val);
+                std::unique_ptr<CommandResponder> responder = command->executeCommand(val);
                 if (!responder) {
                     rc = catena::exception_with_status("Illegal state", catena::StatusCode::INTERNAL);
                 } else {
@@ -65,7 +66,7 @@ void ExecuteCommand::proceed() {
                         writeConsole_(CallStatus::kWrite, socket_.is_open());
                         catena::CommandResponse res = responder->getNext();
                         if (respond) {
-                            writer_.sendResponse(rc, res);
+                            writer_->sendResponse(rc, res);
                         }
                     }
                 }
@@ -76,10 +77,8 @@ void ExecuteCommand::proceed() {
     } catch (...) {
         rc = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
     }
-    // Writing final code if respond = false or an error occurred.
-    if (rc.status != catena::StatusCode::OK || !respond) {
-        writer_.sendResponse(rc);
-    }
+    // empty msg signals unary to send response. Does nothing for stream.
+    writer_->sendResponse(rc);
 }
 
 void ExecuteCommand::finish() {

--- a/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/REST/tests/ExecuteCommand_test.cpp
@@ -112,7 +112,12 @@ class RESTExecuteCommandTests : public RESTEndpointTest {
                 ASSERT_TRUE(status.ok()) << "Failed to convert expected value to JSON";
             }
         }
-        EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
+        // Response format based on stream or unary.
+        if (stream_) {
+            EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
+        } else {
+            EXPECT_EQ(readResponse(), expectedResponse(expRc_, jsonBodies));
+        }
     }
 
     // in variables
@@ -265,7 +270,139 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_RespondFalse) {
 }
 
 /*
- * TEST 7 - ExecuteCommand returns a CommandResponse no response with authz
+ * TEST 7 - ExecuteCommand returns two CommandResponse responses.
+ */
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_StreamResponse) {
+    initPayload(0, "test_command", "test_value", true);
+    expResponse("test_response_1");
+    expResponse("test_response_2");
+    // Remaking with stream enabled.
+    stream_ = true;
+    endpoint_.reset(makeOne());
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(fqoid_, testing::_, testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
+        }));
+    EXPECT_CALL(*mockCommand_, executeCommand(testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.SerializeAsString(), inVal_.SerializeAsString());
+            return std::move(mockResponder_);
+        }));
+    EXPECT_CALL(*mockResponder_, getNext()).Times(2)
+        .WillOnce(testing::Return(expVals_[0]))
+        .WillOnce(testing::Return(expVals_[1]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(3)
+        .WillOnce(testing::Return(true))
+        .WillOnce(testing::Return(true))
+        .WillOnce(testing::Return(false));
+    // Calling proceed and testing the output
+    testCall();
+}
+
+/*
+ * TEST 8 - ExecuteCommand returns a CommandResponse no response.
+ */
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_StreamNoResponse) {
+    initPayload(0, "test_command", "test_value", true);
+    expNoResponse();
+    // Remaking with stream enabled.
+    stream_ = true;
+    endpoint_.reset(makeOne());
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(fqoid_, testing::_, testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
+        }));
+    EXPECT_CALL(*mockCommand_, executeCommand(testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.SerializeAsString(), inVal_.SerializeAsString());
+            return std::move(mockResponder_);
+        }));
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1).WillOnce(testing::Return(expVals_[0]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(2)
+        .WillOnce(testing::Return(true))
+        .WillOnce(testing::Return(false));
+    // Calling proceed and testing the output
+    testCall();
+}
+
+/*
+ * TEST 9 - ExecuteCommand returns a CommandResponse exception.
+ */
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_StreamException) {
+    initPayload(0, "test_command", "test_value", true);
+    expException("test_exception_type", "test_exception_details");
+    // Remaking with stream enabled.
+    stream_ = true;
+    endpoint_.reset(makeOne());
+    // Setting expectations
+    EXPECT_CALL(dm0_, getCommand(fqoid_, testing::_, testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
+        }));
+    EXPECT_CALL(*mockCommand_, executeCommand(testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.SerializeAsString(), inVal_.SerializeAsString());
+            return std::move(mockResponder_);
+        }));
+    EXPECT_CALL(*mockResponder_, getNext()).Times(1).WillOnce(testing::Return(expVals_[0]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(2)
+        .WillOnce(testing::Return(true))
+        .WillOnce(testing::Return(false));
+    // Calling proceed and testing the output
+    testCall();
+}
+
+/*
+ * TEST 10 - ExecuteCommand returns no response (respond = false).
+ */
+TEST_F(RESTExecuteCommandTests, ExecuteCommand_StreamRespondFalse) {
+    initPayload(0, "test_command", "test_value", false);
+    expResponse("test_response_1");
+    expResponse("test_response_2");
+    // Remaking with stream enabled.
+    stream_ = true;
+    endpoint_.reset(makeOne());
+    // Mocking kProcess functions
+    EXPECT_CALL(dm0_, getCommand(fqoid_, testing::_, testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const std::string& oid, catena::exception_with_status& status, Authorizer& authz) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(!authzEnabled_, &authz == &catena::common::Authorizer::kAuthzDisabled);
+            status = catena::exception_with_status(expRc_.what(), expRc_.status);
+            return std::move(mockCommand_);
+        }));
+    EXPECT_CALL(*mockCommand_, executeCommand(testing::_)).Times(1)
+        .WillOnce(testing::Invoke([this](const catena::Value& value) {
+            // Making sure the correct values were passed in.
+            EXPECT_EQ(value.SerializeAsString(), inVal_.SerializeAsString());
+            return std::move(mockResponder_);
+        }));
+    EXPECT_CALL(*mockResponder_, getNext()).Times(2)
+        .WillOnce(testing::Return(expVals_[0]))
+        .WillOnce(testing::Return(expVals_[1]));
+    EXPECT_CALL(*mockResponder_, hasMore()).Times(3)
+        .WillOnce(testing::Return(true))
+        .WillOnce(testing::Return(true))
+        .WillOnce(testing::Return(false));
+    // Calling proceed and testing the output
+    testCall();
+}
+
+/*
+ * TEST 11 - ExecuteCommand returns a CommandResponse no response with authz
  *          enabled.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
@@ -306,7 +443,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzValid) {
 }
 
 /*
- * TEST 8 - ExecuteCommand fails from invalid JWS token.
+ * TEST 12 - ExecuteCommand fails from invalid JWS token.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) { 
     expRc_ = catena::exception_with_status("Invalid JWS Token", catena::StatusCode::UNAUTHENTICATED);
@@ -320,7 +457,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_AuthzInvalid) {
 }
 
 /*
- * TEST 9 - No device in the specified slot.
+ * TEST 13 - No device in the specified slot.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ErrInvalidSlot) {
     initPayload(dms_.size(), "test_command", "test_value", true);
@@ -333,7 +470,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ErrInvalidSlot) {
 }
 
 /*
- * TEST 10 - ExecuteCommand fails to parse the json body.
+ * TEST 14 - ExecuteCommand fails to parse the json body.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
     expRc_ = catena::exception_with_status("Failed to parse JSON body", catena::StatusCode::INVALID_ARGUMENT);
@@ -345,7 +482,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_InvalidJsonBody) {
 }
 
 /*
- * TEST 11 - getCommand does not find a command.
+ * TEST 15 - getCommand does not find a command.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
     expRc_ = catena::exception_with_status("Command not found", catena::StatusCode::INVALID_ARGUMENT);
@@ -360,7 +497,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandReturnError) {
 }
 
 /*
- * TEST 12 - getCommand throws a catena::exception_with_status.
+ * TEST 16 - getCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -375,7 +512,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowCatena) {
 }
 
 /*
- * TEST 13 - getCommand throws an std::runtime error.
+ * TEST 17 - getCommand throws an std::runtime error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -387,7 +524,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetCommandThrowUnknown) {
 }
 
 /*
- * TEST 14 - executeCommand returns a nullptr.
+ * TEST 18 - executeCommand returns a nullptr.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
     expRc_ = catena::exception_with_status("Illegal state", catena::StatusCode::INTERNAL);
@@ -406,7 +543,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandReturnError) {
 }
 
 /*
- * TEST 15 - executeCommand throws a catena::exception_with_status.
+ * TEST 19 - executeCommand throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -426,7 +563,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowCatena) {
 }
 
 /*
- * TEST 16 - executeCommand returns an std::runtime_error.
+ * TEST 20 - executeCommand returns an std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);
@@ -443,7 +580,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_ExecuteCommandThrowUnknown) {
 }
 
 /*
- * TEST 17 - getNext throws a catena::exception_with_status.
+ * TEST 21 - getNext throws a catena::exception_with_status.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
     expRc_ = catena::exception_with_status("Threw error", catena::StatusCode::INVALID_ARGUMENT);
@@ -469,7 +606,7 @@ TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowCatena) {
 }
 
 /*
- * TEST 18 - getNext throws a std::runtime_error.
+ * TEST 22 - getNext throws a std::runtime_error.
  */
 TEST_F(RESTExecuteCommandTests, ExecuteCommand_GetNextThrowUnknown) {
     expRc_ = catena::exception_with_status("Unknown error", catena::StatusCode::UNKNOWN);


### PR DESCRIPTION
**Changelog:**
- Added unary support to the ExecuteCommand REST endpoint
- Updated REST/ExecuteCommand_test.cpp to cover unary and stream responses. 