### PR TITLE
Updated openAPI fqoid regex

### DIFF
--- a/interface/openapi/paths/Value.yaml
+++ b/interface/openapi/paths/Value.yaml
@@ -45,14 +45,14 @@ get:
     - name: slot
       in: path
       required: true
-      description: The slot of the device model containing the parameters to get info for
+      description: The slot of the device model containing the parameter to get the value of
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
    
     - name: fqoid
       in: path
       required: true
-      description: Fully qualified OID of the parameter to get info for
+      description: Fully qualified OID of the parameter to get the value of
       schema:
         $ref: "../../../schema/catena.param_schema.json#/$defs/fqoid"
       default: ""
@@ -112,14 +112,14 @@ put:
     - name: slot
       in: path
       required: true
-      description: The slot of the device model containing the parameters to get info for
+      description: The slot of the device model containing the parameters to set the value of
       schema:
         $ref: "../../../schema/catena.device_schema.json#/$defs/slot"
   
     - name: fqoid
       in: path
       required: true
-      description: Fully qualified OID of the parameter to get info for
+      description: Fully qualified OID of the parameter to set the value of
       schema:
         $ref: "../../../schema/catena.param_schema.json#/$defs/fqoid"
       default: ""

--- a/interface/openapi/paths/Values.yaml
+++ b/interface/openapi/paths/Values.yaml
@@ -75,7 +75,7 @@ put:
                 properties:
                   fqoid:
                     type: string
-                    description: Fully qualified OID of the parameter to get info for
+                    description: Fully qualified OID of the parameter to set the value of
                     schema: 
                       $ref: "../../../schema/catena.param_schema.json#/$defs/fqoid"
                   value:

--- a/schema/catena.param_schema.json
+++ b/schema/catena.param_schema.json
@@ -1087,7 +1087,7 @@
       "description": "The fully qualified object ID of a parameter, command, or external object.",
       "$comment": "The pattern is a series of segments starting with a solidus / and containing a valid oid, an array index or the one-past-the-end index.",
       "type": "string",
-      "pattern": "^([\\w]+([\\.]{1}[A-Za-z]+)?)$",
+      "pattern": "(?!.*\\.[^A-Za-z])(^[a-zA-Z][\\w\\.\\_\\-]{0,62}(?<!^stream)(\/(([a-zA-Z][\\w\\.\\_\\-]{0,62}(?<!\/stream))|((0|[1-9][\\d]{0,14}|[1-8][\\d]{0,15})))){0,30}($|\/\\-$)$)",
       "format": "json-pointer"
     },
     "float32": {


### PR DESCRIPTION
As the title suggests I updated the param schema fqoid pattern regex to allow for nested parameters, indices, and appends.

However, OpenAPI is a great service, so it has trouble linking to the fqoid json def unless you open the DeviceRequest endpoint first.

Also fixed a few slot/fqoid descriptions for get and set value.