### PR TITLE
THE Connect Update Part 1 (gRPC)

### DIFF
--- a/sdks/cpp/common/include/SharedFlags.h
+++ b/sdks/cpp/common/include/SharedFlags.h
@@ -100,3 +100,9 @@ extern absl::Flag<uint32_t> FLAGS_default_max_array_size;
  * @brief the default total length for string array params, default is 1024.
  */
 extern absl::Flag<uint32_t> FLAGS_default_total_array_size;
+
+/**
+ * @brief the maximum number of connections that can be made concurrently to a
+ * service.
+ */
+extern absl::Flag<uint32_t> FLAGS_max_connections;

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -81,7 +81,7 @@ class Connect : public IConnect {
     /**
      * @brief Returns true if this has less prioirty than otherConnection.
      */
-    bool operator<(const IConnect& otherConnection) override {
+    bool operator<(const IConnect& otherConnection) const override {
         return priority_ < otherConnection.priority() ||
                (priority_ == otherConnection.priority() && age_ >= otherConnection.age());
     }

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -52,7 +52,6 @@
 
 #include <string>
 #include <condition_variable>
-#include <chrono>
 
 namespace catena {
 namespace common {
@@ -75,15 +74,15 @@ class Connect : public IConnect {
      */
     uint32_t priority() const override { return priority_; }
     /**
-     * @brief Returns the creation time.
+     * @brief Returns the object Id.
      */
-    const system_clock::time_point& age() const override { return age_; }
+    uint32_t objectId() const override { return objectId_; }
     /**
      * @brief Returns true if this has less prioirty than otherConnection.
      */
     bool operator<(const IConnect& otherConnection) const override {
         return priority_ < otherConnection.priority() ||
-               (priority_ == otherConnection.priority() && age_ >= otherConnection.age());
+               (priority_ == otherConnection.priority() && objectId_ >= otherConnection.objectId());
     }
     /**
      * @brief Forcefully shuts down the connection.
@@ -109,8 +108,7 @@ class Connect : public IConnect {
     Connect(SlotMap& dms, ISubscriptionManager& subscriptionManager) : 
         dms_{dms}, 
         subscriptionManager_{subscriptionManager},
-        detailLevel_{catena::Device_DetailLevel_UNSET},
-        age_{std::chrono::system_clock::now()} {}
+        detailLevel_{catena::Device_DetailLevel_UNSET} {}
     /**
      * @brief Connect does not have copy semantics
      */
@@ -252,10 +250,6 @@ class Connect : public IConnect {
      */
     uint32_t priority_ = 0;
     /**
-     * @brief The connection's time of creation.
-     */
-    system_clock::time_point age_;
-    /**
      * @brief Shared ptr to maintain ownership of authorizer.
      */
     std::shared_ptr<catena::common::Authorizer> sharedAuthz_;
@@ -307,6 +301,10 @@ class Connect : public IConnect {
      * @brief Flag indicating whether to shut down the connection.
      */
     bool shutdown_ = false;
+    /**
+     * @brief ID of the Connect object
+     */
+    uint32_t objectId_ = 0;
 };
 
 }; // common

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -72,13 +72,8 @@ class Connect : public IConnect {
     const system_clock::time_point& age() const override {  }
 
     bool operator<(const IConnect& otherConnection) override {
-        bool isLess = false;
-        if (priority_ != otherConnection.priority()) {
-            isLess = priority_ < otherConnection.priority();
-        } else if (age_ != otherConnection.age()) {
-            isLess = age_ < otherConnection.age();
-        }
-        return isLess;
+        return priority_ < otherConnection.priority() ||
+               (priority_ == otherConnection.priority() && age_ < otherConnection.age());
     }
 
   protected:

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -69,7 +69,7 @@ class Connect : public IConnect {
     
     uint8_t priority() const override { return priority_; }
 
-    const system_clock::time_point& age() const override {  }
+    const system_clock::time_point& age() const override { return age_; }
 
     bool operator<(const IConnect& otherConnection) override {
         return priority_ < otherConnection.priority() ||

--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -64,9 +64,9 @@ class IConnect {
      */
     virtual uint32_t priority() const = 0;
     /**
-     * @brief Returns the creation time.
+     * @brief Returns the object Id.
      */
-    virtual const system_clock::time_point& age() const = 0;
+    virtual uint32_t objectId() const = 0;
     /**
      * @brief Returns true if this has less prioirty than otherConnection.
      */

--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -55,26 +55,32 @@ namespace common {
  */
 class IConnect {
   public:
-    
-    virtual uint8_t priority() const = 0;
-
+    /**
+     * @brief Descructor
+     */
+    virtual ~IConnect() = default;
+    /**
+     * @brief Returns the connection's priority.
+     */
+    virtual uint32_t priority() const = 0;
+    /**
+     * @brief Returns the creation time.
+     */
     virtual const system_clock::time_point& age() const = 0;
-
+    /**
+     * @brief Returns true if this has less prioirty than otherConnection.
+     */
     virtual bool operator<(const IConnect& otherConnection) = 0;
+    /**
+     * @brief Forcefully shuts down the connection.
+     */
+    virtual void shutdown() = 0;
   
   protected:
-    IConnect() = default;
-    IConnect(const IConnect&) = default;
-    IConnect& operator=(const IConnect&) = default;
-    IConnect(IConnect&&) = default;
-    IConnect& operator=(IConnect&&) = default;
-    virtual ~IConnect() = default;
-
     /**
      * @brief Returns true if the call has been canceled.
      */
     virtual inline bool isCancelled() = 0;
-
     /**
      * @brief Updates the response message with parameter values and handles 
      * authorization checks.
@@ -83,7 +89,6 @@ class IConnect {
      * @param p - The parameter to update
      */
     virtual void updateResponse_(const std::string& oid, const IParam* p, uint32_t slot) = 0;
-    
     /**
      * @brief Updates the response message with a ILanguagePack and
      * handles authorization checks.
@@ -91,7 +96,6 @@ class IConnect {
      * @param l The added ILanguagePack emitted by device.
      */
     virtual void updateResponse_(const ILanguagePack* l, uint32_t slot) = 0;
-    
     /**
      * @brief Sets up the authorizer object with the jwsToken.
      * @param jwsToken The jwsToken to use for authorization.

--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -70,7 +70,7 @@ class IConnect {
     /**
      * @brief Returns true if this has less prioirty than otherConnection.
      */
-    virtual bool operator<(const IConnect& otherConnection) = 0;
+    virtual bool operator<(const IConnect& otherConnection) const = 0;
     /**
      * @brief Forcefully shuts down the connection.
      */

--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -43,6 +43,9 @@
 #include <interface/device.pb.h>
 // Std
 #include <string>
+#include <chrono>
+
+using std::chrono::system_clock;
 
 namespace catena {
 namespace common {
@@ -51,6 +54,14 @@ namespace common {
  * @brief Interface class for Connect RPCs
  */
 class IConnect {
+  public:
+    
+    virtual uint8_t priority() const = 0;
+
+    virtual const system_clock::time_point& age() const = 0;
+
+    virtual bool operator<(const IConnect& otherConnection) = 0;
+  
   protected:
     IConnect() = default;
     IConnect(const IConnect&) = default;

--- a/sdks/cpp/common/include/rpc/TimeNow.h
+++ b/sdks/cpp/common/include/rpc/TimeNow.h
@@ -40,6 +40,7 @@
 // std
 #include <string>
 #include <iostream>
+#include <chrono>
 
 namespace catena {
 namespace common {

--- a/sdks/cpp/common/src/SharedFlags.cpp
+++ b/sdks/cpp/common/src/SharedFlags.cpp
@@ -14,3 +14,4 @@ ABSL_FLAG(bool, authz, false, "use OAuth token authorization");
 ABSL_FLAG(std::string, static_root, getenv("HOME"), "Specify the directory to search for external objects");
 ABSL_FLAG(uint32_t, default_max_array_size, catena::common::kDefaultMaxArrayLength, "use this to define the default max length for array and string params.");
 ABSL_FLAG(uint32_t, default_total_array_size, catena::common::kDefaultMaxArrayLength, "use this to define the default total length for string array params.");
+ABSL_FLAG(uint32_t, max_connections, 16, "use this to define the total number of concurrent connections that can be made to a service.");

--- a/sdks/cpp/connections/gRPC/examples/external_object_request/external_object_request.cpp
+++ b/sdks/cpp/connections/gRPC/examples/external_object_request/external_object_request.cpp
@@ -104,7 +104,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         // Updating device's default max array length.
         dm.set_default_max_length(absl::GetFlag(FLAGS_default_max_array_size));

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
@@ -304,7 +304,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         // Updating device's default max array length.
         dm.set_default_max_length(absl::GetFlag(FLAGS_default_max_array_size));

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -187,7 +187,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         // Updating device's default max array length.
         dm.set_default_max_length(absl::GetFlag(FLAGS_default_max_array_size));

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/structs_with_authz.cpp
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/structs_with_authz.cpp
@@ -117,7 +117,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/structs_with_authz_yaml.cpp
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/structs_with_authz_yaml.cpp
@@ -114,7 +114,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
@@ -100,7 +100,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
@@ -128,7 +128,8 @@ void RunRPCServer(std::string addr)
         std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz);
+        uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
+        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -89,6 +89,7 @@ using grpc::ServerCompletionQueue;
 
 using catena::common::IDevice;
 using catena::common::IParam;
+using catena::common::IConnect;
 
 namespace catena {
 namespace gRPC {
@@ -197,9 +198,14 @@ class CatenaServiceImpl : public ICatenaServiceImpl {
      */
     catena::common::SubscriptionManager subscriptionManager_;
     /**
+     * @brief Mutex to protect the connectionQueue 
+     */
+    std::mutex connectionMutex_;
+    /**
      * @brief The priority queue for Connect CallData objects.
      * 
-     * Vector for the time being.
+     * Not an actual priority queue object since individual access is required
+     * for deregistering old connections.
      */
     std::vector<catena::common::IConnect*> connectionQueue_;
     /**

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -104,8 +104,9 @@ class CatenaServiceImpl : public ICatenaServiceImpl {
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param EOPath The path to the external object.
      * @param authz Flag to enable authorization.
+     * @param maxConnections The maximum number of connections allowed to the service.
      */
-    CatenaServiceImpl(ServerCompletionQueue* cq, std::vector<IDevice*> dms, std::string& EOPath, bool authz);  
+    CatenaServiceImpl(ServerCompletionQueue* cq, std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint32_t maxConnections);  
     /**
      * @brief Creates the CallData objects for each gRPC command.
      */
@@ -135,6 +136,17 @@ class CatenaServiceImpl : public ICatenaServiceImpl {
      * @brief Returns the EOPath.
      */
     const std::string& EOPath() override { return EOPath_; }
+    /**
+     * @brief Regesters a Connect CallData object into the Connection priority queue.
+     * @param cd The Connect CallData object to register.
+     * @return TRUE if successfully registered, FALSE otherwise
+     */
+    bool registerConnection(catena::common::IConnect* cd) override;
+    /**
+     * @brief Deregisters a Connect CallData object into the Connection priority queue.
+     * @param cd The Connect CallData object to deregister.
+     */
+    void deregisterConnection(catena::common::IConnect* cd) override;
     /**
      * @brief Returns the size of the registry.
      */
@@ -184,6 +196,16 @@ class CatenaServiceImpl : public ICatenaServiceImpl {
      * @brief The subscription manager for handling parameter subscriptions
      */
     catena::common::SubscriptionManager subscriptionManager_;
+    /**
+     * @brief The priority queue for Connect CallData objects.
+     * 
+     * Vector for the time being.
+     */
+    std::vector<catena::common::IConnect*> connectionQueue_;
+    /**
+     * @brief The maximum number of connections allowed to the service.
+     */
+    uint32_t maxConnections_;
 };
 
 }; // namespace gRPC

--- a/sdks/cpp/connections/gRPC/include/controllers/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/Connect.h
@@ -55,8 +55,8 @@ namespace catena {
 namespace gRPC {
 
 /**
-* @brief CallData class for the Connect RPC
-*/
+ * @brief CallData class for the Connect RPC
+ */
 class Connect : public CallData, public catena::common::Connect {
   public:
     /**
@@ -77,7 +77,6 @@ class Connect : public CallData, public catena::common::Connect {
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;
-
     /**
      * @brief Returns true if the connection has been cancelled.
      * 

--- a/sdks/cpp/connections/gRPC/include/controllers/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/Connect.h
@@ -102,10 +102,6 @@ class Connect : public CallData, public catena::common::Connect {
      */
     std::mutex mtx_;
     /**
-     * @brief ID of the Connect object
-     */
-    int objectId_;
-    /**
      * @brief The total # of Connect objects.
      */
     static int objectCounter_;

--- a/sdks/cpp/connections/gRPC/include/interface/IServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/interface/IServiceImpl.h
@@ -39,6 +39,7 @@
 
 // common
 #include <SubscriptionManager.h>
+#include <rpc/IConnect.h>
 
 // gRPC/interface
 #include "ICallData.h"
@@ -88,6 +89,17 @@ class ICatenaServiceImpl : public catena::CatenaService::AsyncService {
      * @brief Returns the EOPath.
      */
     virtual const std::string& EOPath() = 0;
+    /**
+     * @brief Regesters a Connect CallData object into the Connection priority queue.
+     * @param cd The Connect CallData object to register.
+     * @return TRUE if successfully registered, FALSE otherwise.
+     */
+    virtual bool registerConnection(catena::common::IConnect* cd) = 0;
+    /**
+     * @brief Deregisters a Connect CallData object into the Connection priority queue.
+     * @param cd The Connect CallData object to deregister.
+     */
+    virtual void deregisterConnection(catena::common::IConnect* cd) = 0;
     /**
      * @brief Returns the size of the registry.
      */

--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -93,6 +93,7 @@ void catena::gRPC::Connect::proceed(bool ok) {
             try {
                 // Initialize authz and add connection to the priority queue.
                 detailLevel_ = req_.detail_level();
+                forceConnection_ = req_.force_connection();
                 initAuthz_(jwsToken_(), service_->authorizationEnabled());
                 if (service_->registerConnection(this)) {
                     // Connecting to each device in dms_.

--- a/unittests/cpp/common/mocks/MockConnect.h
+++ b/unittests/cpp/common/mocks/MockConnect.h
@@ -47,7 +47,7 @@ namespace common {
 class MockConnect : public IConnect {
   public:
     MOCK_METHOD(uint32_t, priority, (), (const, override));
-    MOCK_METHOD(const system_clock::time_point&, age, (), (const, override));
+    MOCK_METHOD(uint32_t, objectId, (), (const, override));
     MOCK_METHOD(void, shutdown, (), (override));
     MOCK_METHOD(bool, isCancelled, (), (override));
     MOCK_METHOD(void, updateResponse_, (const std::string& oid, const IParam* p, uint32_t slot), (override));

--- a/unittests/cpp/common/mocks/MockConnect.h
+++ b/unittests/cpp/common/mocks/MockConnect.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Mock implementation for the IConnect class.
+ * @author benjamin.whitten@rossvideo.com
+ * @date 25/06/26
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "rpc/IConnect.h"
+
+namespace catena {
+namespace common {
+
+// Mock implementation for the IConnect class.
+class MockConnect : public IConnect {
+  public:
+    MOCK_METHOD(uint32_t, priority, (), (const, override));
+    MOCK_METHOD(const system_clock::time_point&, age, (), (const, override));
+    MOCK_METHOD(void, shutdown, (), (override));
+    MOCK_METHOD(bool, isCancelled, (), (override));
+    MOCK_METHOD(void, updateResponse_, (const std::string& oid, const IParam* p, uint32_t slot), (override));
+    MOCK_METHOD(void, updateResponse_, (const ILanguagePack* l, uint32_t slot), (override));
+    MOCK_METHOD(void, initAuthz_, (const std::string& jwsToken, bool authz), (override));
+
+    MOCK_METHOD(bool, lessThan, (const IConnect& otherConnection), (const));
+    bool operator<(const IConnect& otherConnection) const override {
+        return lessThan(otherConnection);
+    }
+};
+
+} // namespace common
+} // namespace catena

--- a/unittests/cpp/common/tests/Connect_test.cpp
+++ b/unittests/cpp/common/tests/Connect_test.cpp
@@ -48,6 +48,7 @@ class TestConnect : public Connect {
     
     bool isCancelled() override { return shutdown_; }
     void forceConnection(bool forceConnection) { forceConnection_ = forceConnection; }
+    void objectId(uint32_t id) { objectId_ = id; }
 
     // Expose protected methods for testing
     using Connect::updateResponse_;
@@ -315,7 +316,9 @@ TEST_F(CommonConnectTest, PriorityAuthzOn) {
 // Test 1.9: Testing connection comparison based on priority and age
 TEST_F(CommonConnectTest, Compare) {
     // Creating a second connect obj for comparison.
+    connect->objectId(0);
     TestConnect otherConnect(dms_, subscriptionManager);
+    otherConnect.objectId(1);  // Set a different object ID for comparison
     // Higher priority connection should be greater than lower priority connection
     connect->initAuthz_(getJwsToken(Scopes().getForwardMap().at(Scopes_e::kMonitor)), true);
     otherConnect.initAuthz_(getJwsToken(Scopes().getForwardMap().at(Scopes_e::kOperate)), true);

--- a/unittests/cpp/common/tests/Connect_test.cpp
+++ b/unittests/cpp/common/tests/Connect_test.cpp
@@ -46,8 +46,8 @@ class TestConnect : public Connect {
     TestConnect(SlotMap& dms, ISubscriptionManager& subscriptionManager) 
         : Connect(dms, subscriptionManager) {}
     
-    bool isCancelled() override { return cancelled_; }
-    void setCancelled(bool cancelled) { cancelled_ = cancelled; }
+    bool isCancelled() override { return shutdown_; }
+    void forceConnection(bool forceConnection) { forceConnection_ = forceConnection; }
 
     // Expose protected methods for testing
     using Connect::updateResponse_;
@@ -57,9 +57,6 @@ class TestConnect : public Connect {
     // Expose state for verification
     bool hasUpdate() const { return hasUpdate_; }
     const catena::PushUpdates& getResponse() const { return res_; }
-
-  private:
-    bool cancelled_ = false;
 };
 
 // Fixture
@@ -285,6 +282,48 @@ TEST_F(CommonConnectTest, updateResponseLanguagePackAuthzOnSucceeds) {
     EXPECT_TRUE(connect->hasUpdate());
 }
 
+// Test 1.7: EXPECT EQ - Priority should be 0 if authz is off.
+TEST_F(CommonConnectTest, PriorityAuthzOff) {
+    // Test authorization disabled - priority should be 0
+    connect->initAuthz_(monitorToken, false);
+    EXPECT_EQ(connect->priority(), 0);
+}
+
+// Test 1.8: EXPECT EQ - Priority should not be 0 if authz is on.
+TEST_F(CommonConnectTest, PriorityAuthzOn) {
+    // No scopes
+    connect->initAuthz_(getJwsToken(""), true);
+    EXPECT_EQ(connect->priority(), 0);
+    // Read/write scopes w and without force connection
+    for (uint32_t i = 1; i <= static_cast<uint32_t>(Scopes_e::kAdmin); i += 1) {
+        for (bool fc : {false, true}) {
+            connect->forceConnection(fc);
+            // Read scope
+            connect->initAuthz_(getJwsToken(Scopes().getForwardMap().at(static_cast<Scopes_e>(i))), true);
+            EXPECT_EQ(connect->priority(), 2 * i);
+            // Write scope
+            connect->initAuthz_(getJwsToken(Scopes().getForwardMap().at(static_cast<Scopes_e>(i)) + ":w"), true);
+            if (!fc || static_cast<Scopes_e>(i) != Scopes_e::kAdmin) {
+                EXPECT_EQ(connect->priority(), 2 * i + 1);
+            } else {
+                EXPECT_EQ(connect->priority(), 2 * i + 2);  // Admin with force connection gets highest priority
+            }
+        }
+    }
+}
+
+// Test 1.9: Testing connection comparison based on priority and age
+TEST_F(CommonConnectTest, Compare) {
+    // Creating a second connect obj for comparison.
+    TestConnect otherConnect(dms_, subscriptionManager);
+    // Higher priority connection should be greater than lower priority connection
+    connect->initAuthz_(getJwsToken(Scopes().getForwardMap().at(Scopes_e::kMonitor)), true);
+    otherConnect.initAuthz_(getJwsToken(Scopes().getForwardMap().at(Scopes_e::kOperate)), true);
+    EXPECT_TRUE(*connect < otherConnect) << "Connect with Monitor scope should be less than Connection with Operate scope";
+    // If scopes are the same, older connection should be larger than newer connection
+    otherConnect.initAuthz_(getJwsToken(Scopes().getForwardMap().at(Scopes_e::kMonitor)), true);
+    EXPECT_FALSE(*connect < otherConnect) << "Older connection should have higher priority than newer connection";
+}
 
 // == 2. Cancellation Tests ==
 
@@ -296,8 +335,8 @@ TEST_F(CommonConnectTest, updateResponseCancelled) {
     setupCommonExpectations(param, descriptor);
     setupMockParam(param, testOid, descriptor);
 
-    // Set cancelled to true
-    connect->setCancelled(true);
+    // Set shutdown to true
+    connect->shutdown();
 
     // Setup param toProto to succeed (but it shouldn't be called)
     EXPECT_CALL(param, toProto(::testing::An<catena::Value&>(), ::testing::An<catena::common::Authorizer&>()))
@@ -312,8 +351,8 @@ TEST_F(CommonConnectTest, updateResponseLanguagePackCancelled) {
     // Setup test data
     auto languagePack = setupLanguagePack();
     
-    // Set cancelled to true
-    connect->setCancelled(true);
+    // Set shutdown to true
+    connect->shutdown();
     
     connect->updateResponse_(languagePack.get(), 0);
     EXPECT_TRUE(connect->hasUpdate());  // Should be true even though we didn't set language pack data

--- a/unittests/cpp/gRPC/mocks/MockServiceImpl.h
+++ b/unittests/cpp/gRPC/mocks/MockServiceImpl.h
@@ -55,6 +55,8 @@ class MockServiceImpl : public ICatenaServiceImpl {
     MOCK_METHOD(ISubscriptionManager&, getSubscriptionManager, (), (override));
     MOCK_METHOD(grpc::ServerCompletionQueue*, cq, (), (override));
     MOCK_METHOD(const std::string&, EOPath, (), (override));
+    MOCK_METHOD(bool, registerConnection, (catena::common::IConnect* cd), (override));
+    MOCK_METHOD(void, deregisterConnection, (catena::common::IConnect* cd), (override));
     MOCK_METHOD(uint32_t, registrySize, (), (const, override));
     MOCK_METHOD(void, registerItem, (ICallData* cd), (override));
     MOCK_METHOD(void, deregisterItem, (ICallData* cd), (override));

--- a/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
+++ b/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
@@ -43,6 +43,7 @@
 #include <string>
 
 #include "MockDevice.h"
+#include "MockConnect.h"
 #include "MockServiceImpl.h"
 
 // protobuf
@@ -82,7 +83,7 @@ class gRPCServiceImplTests : public testing::Test {
         // Creating the gRPC server.
         builder_.AddListeningPort(serverAddr_, grpc::InsecureServerCredentials());
         cq_ = builder_.AddCompletionQueue();
-        service_.reset(new CatenaServiceImpl(cq_.get(), {&dm_}, EOPath_, authzEnabled_, 16));
+        service_.reset(new CatenaServiceImpl(cq_.get(), {&dm_}, EOPath_, authzEnabled_, 1));
         builder_.RegisterService(service_.get());
         server_ = builder_.BuildAndStart();
         service_->init();
@@ -148,7 +149,31 @@ TEST_F(gRPCServiceImplTests, ServiceImpl_CreateDestroy) {
 }
 
 /*
- * TEST 2 - Creating a REST CatenaServiceImpl.
+ * TEST 2 - Test serviceImpl's ability to register and derigister connections.
+ */
+TEST_F(gRPCServiceImplTests, ServiceImpl_ManageConnections) {
+    // Mocking 2 connecitons with A < B.
+    MockConnect connectionA, connectionB;
+    bool shutdownA = false;
+    bool shutdownB = false;
+    EXPECT_CALL(connectionA, shutdown()).WillRepeatedly(testing::Invoke([&shutdownA]() { shutdownA = true; }));
+    EXPECT_CALL(connectionA, lessThan(testing::_)).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(connectionB, shutdown()).WillRepeatedly(testing::Invoke([&shutdownB]() { shutdownB = true; }));
+    EXPECT_CALL(connectionB, lessThan(testing::_)).WillRepeatedly(testing::Return(false));
+    // Registering connection A.
+    EXPECT_TRUE(service_->registerConnection(&connectionA)) << "Service should be able to register a connection.";
+    // Setting connection B to higher prioirity and registering.
+    EXPECT_TRUE(service_->registerConnection(&connectionB)) << "Service should be able to register a higher priority connection.";
+    EXPECT_TRUE(shutdownA) << "Lower priority connections should be shutdown when a higher priority connection is registered.";
+    service_->deregisterConnection(&connectionA);
+    // Trying to re-add connection A should fail.
+    EXPECT_FALSE(service_->registerConnection(&connectionA)) << "Service should not be able to register a lower priority connection";
+    EXPECT_FALSE(shutdownB) << "Higher priority connection should not be shutdown when a lower priority connection tries to connect.";
+    service_->deregisterConnection(&connectionB);
+}
+
+/*
+ * TEST 3 - Creating a REST CatenaServiceImpl.
  *
  * This is not under the fixture because setting up a gRPC server is time
  * consuming and not needed.

--- a/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
+++ b/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
@@ -82,7 +82,7 @@ class gRPCServiceImplTests : public testing::Test {
         // Creating the gRPC server.
         builder_.AddListeningPort(serverAddr_, grpc::InsecureServerCredentials());
         cq_ = builder_.AddCompletionQueue();
-        service_.reset(new CatenaServiceImpl(cq_.get(), {&dm_}, EOPath_, authzEnabled_));
+        service_.reset(new CatenaServiceImpl(cq_.get(), {&dm_}, EOPath_, authzEnabled_, 16));
         builder_.RegisterService(service_.get());
         server_ = builder_.BuildAndStart();
         service_->init();
@@ -159,6 +159,6 @@ TEST(gRPCServiceImplTests_NoFixture, ServiceImpl_CreateDuplicateSlot) {
     EXPECT_CALL(dm1, slot()).WillRepeatedly(testing::Return(0));
     EXPECT_CALL(dm2, slot()).WillRepeatedly(testing::Return(0));
     // Creating a service with a duplicate slot.
-    EXPECT_THROW(CatenaServiceImpl(nullptr, {&dm1, &dm2}, EOPath, false), std::runtime_error)
+    EXPECT_THROW(CatenaServiceImpl(nullptr, {&dm1, &dm2}, EOPath, false, 16), std::runtime_error)
         << "Creating a service with two devices sharing a slot should throw an error.";
 }


### PR DESCRIPTION
The Fellowship of gRPC

**Changelog:**
- Added 4 new functions to the virtual common::Connect class.
    - priority() returns the connection's priority value, calculated as = scope * 2 + write + (adm:w AND forceConnection)
    - objectId() returns the object's id. This will be lower based on creation time.
    - The < operator returns true based on the object's priority. If priorities are equal, then it instead returns true based on which object has the lower objectId (and is thus older).
    - shutdown() forcefully shuts down the connection.
- Added maxConnections input variable to the gRPC::ServiceImpl class.
- Added 2 new functions to the gRPC::ServiceImpl class.
    - RegisterConnection() registers a connection to the connectionQueue. If maxConnections has been reached, it forcefully shuts down the lowest priority connection in the queue.
        - ConnectionQueue is actually just a vector with the connections sorted by priority... Was going to use an actual priority queue but that doesn't allow for direct access to objects, which is required when deregistering connections.
    - DeregisterConnection() deregister's a connection from the ConnectionQueue.
- Refactored gRPC::Connect and updated to now use register and deregister connection.
    - Refactor changes are based on various things learned from developing tests for gRPC::Connect
- Added maxConnections flag.
- Created MockConnect object
- Updated relevant unit tests.