### PR TITLE
Authorizer updates and cleanup

### DIFF
--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -43,13 +43,13 @@
  */
 
 // common
-#include <Path.h>
 #include <Enums.h>
 #include <IParam.h>
 #include <IParamDescriptor.h>
 #include <jwt-cpp/jwt.h>
 
 #include <functional>
+#include <set>
 
 /**
  * @brief top level namespace for Catena. Functionality at this scope includes
@@ -71,7 +71,7 @@ class Authorizer {
     /**
      * @brief The scopes of the object
      */
-    using Scopes = std::vector<std::string>;
+    using Scopes = std::set<std::string>;
   public:
     /**
      * @brief Special Authorizer object that disables authorization
@@ -115,43 +115,44 @@ class Authorizer {
     virtual ~Authorizer() = default;
 
     /**
-     * @brief Check if the client has the specified authorization
-     * @return true if the client has the specified authorization
-     */
-    bool hasAuthz(const std::string& scope) const;
-
-    /**
-     * @brief Check if the client has read authorization
+     * @brief Check if the client has read authorization for a param
+     * @param param The param to check for authorization
      * @return true if the client has read authorization
      */
     bool readAuthz(const IParam& param) const;
 
     /**
-     * @brief Check if the client has read authorization
+     * @brief Check if the client has read authorization for a param descriptor
+     * @param pd The param descriptor to check for authorization
      * @return true if the client has read authorization
      */
     bool readAuthz(const IParamDescriptor& pd) const;
 
     /**
-     * @brief Check if the client has read authorization
+     * @brief Check if the client has read authorization for a scope
+     * @param scope The scope to check for authorization
      * @return true if the client has read authorization
      */
     bool readAuthz(const std::string& scope) const;
 
     /**
-     * @brief Check if the client has write authorization
+     * @brief Check if the client has write authorization for a param
+     * @param param The param to check for authorization
      * @return true if the client has write authorization
      */
     bool writeAuthz(const IParam& param) const;
 
     /**
-     * @brief Check if the client has write authorization
+     * @brief Check if the client has write authorization for a param
+     * descriptor
+     * @param pd The param descriptor to check for authorization
      * @return true if the client has write authorization
      */
     bool writeAuthz(const IParamDescriptor& pd) const;
 
     /**
-     * @brief Check if the client has write authorization
+     * @brief Check if the client has write authorization for a scope
+     * @param scope The scope to check for authorization
      * @return true if the client has write authorization
      */
     bool writeAuthz(const std::string& scope) const;
@@ -162,6 +163,12 @@ class Authorizer {
      * @brief Constructor for kAuthzDisabled authorizer. 
      */
     Authorizer() : clientScopes_{{""}} {}
+    /**
+     * @brief Check if the client has the specified authorization
+     * @param scope The scope to check for authorization
+     * @return true if the client has the specified authorization
+     */
+    bool hasAuthz(const std::string& scope) const;
     /**
      * @brief Client scopes extracted from a valid JWS token.
      */

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -168,7 +168,7 @@ class Authorizer {
      * @param scope The scope to check for authorization
      * @return true if the client has the specified authorization
      */
-    bool hasAuthz(const std::string& scope) const;
+    bool hasAuthz_(const std::string& scope) const;
     /**
      * @brief Client scopes extracted from a valid JWS token.
      */

--- a/sdks/cpp/common/include/Authorization.h
+++ b/sdks/cpp/common/include/Authorization.h
@@ -71,7 +71,7 @@ class Authorizer {
     /**
      * @brief The scopes of the object
      */
-    using Scopes = std::set<std::string>;
+    using ClientScopes = std::set<std::string>;
   public:
     /**
      * @brief Special Authorizer object that disables authorization
@@ -136,6 +136,13 @@ class Authorizer {
     bool readAuthz(const std::string& scope) const;
 
     /**
+     * @brief Check if the client has read authorization for a scope
+     * @param scope The scope to check for authorization
+     * @return true if the client has read authorization
+     */
+    bool readAuthz(const Scopes_e& scope) const;
+
+    /**
      * @brief Check if the client has write authorization for a param
      * @param param The param to check for authorization
      * @return true if the client has write authorization
@@ -157,6 +164,13 @@ class Authorizer {
      */
     bool writeAuthz(const std::string& scope) const;
 
+    /**
+     * @brief Check if the client has read authorization for a scope
+     * @param scope The scope to check for authorization
+     * @return true if the client has read authorization
+     */
+    bool writeAuthz(const Scopes_e& scope) const;
+
 
   private:
 	  /**
@@ -172,7 +186,7 @@ class Authorizer {
     /**
      * @brief Client scopes extracted from a valid JWS token.
      */
-  	Scopes clientScopes_;
+  	ClientScopes clientScopes_;
 };
 
 } // namespace common

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -169,7 +169,7 @@ class Connect : public IConnect {
             if (isCancelled()){
                 hasUpdate_ = true;
                 cv_.notify_one();
-            } else if (authz_->readAuthz(Scopes().getForwardMap().at(Scopes_e::kMonitor))) {
+            } else if (authz_->readAuthz(Scopes_e::kMonitor)) {
                 // Updating res_'s device_component and pushing update.
                 res_.Clear();
                 res_.set_slot(slot);

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -169,19 +169,15 @@ class Connect : public IConnect {
             if (isCancelled()){
                 hasUpdate_ = true;
                 cv_.notify_one();
-                return;
+            } else if (authz_->readAuthz(Scopes().getForwardMap().at(Scopes_e::kMonitor))) {
+                // Updating res_'s device_component and pushing update.
+                res_.Clear();
+                res_.set_slot(slot);
+                auto pack = res_.mutable_device_component()->mutable_language_pack();
+                l->toProto(*pack->mutable_language_pack());
+                hasUpdate_ = true;
+                cv_.notify_one();
             }
-            // Returning if authorization is enabled and the client does not have monitor scope.
-            if (authz_ != &catena::common::Authorizer::kAuthzDisabled
-                && !authz_->hasAuthz(Scopes().getForwardMap().at(Scopes_e::kMonitor))) {
-                return;
-            }
-            // Updating res_'s device_component and pushing update.
-            res_.set_slot(slot);
-            auto pack = res_.mutable_device_component()->mutable_language_pack();
-            l->toProto(*pack->mutable_language_pack());
-            hasUpdate_ = true;
-            cv_.notify_one();
         } catch(catena::exception_with_status& why){
             // if an error is thrown, no update is pushed to the client
         }

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -68,6 +68,10 @@ bool Authorizer::writeAuthz(const std::string& scope) const {
     return hasAuthz_(scope + ":w");
 }
 
+bool Authorizer::writeAuthz(const Scopes_e& scope) const {
+    return writeAuthz(Scopes().getForwardMap().at(scope));
+}
+
 bool Authorizer::writeAuthz(const IParam& param) const {
     return !param.readOnly() && writeAuthz(param.getScope());
 }
@@ -81,6 +85,10 @@ bool Authorizer::writeAuthz(const IParamDescriptor& pd) const {
  */
 bool Authorizer::readAuthz(const std::string& scope) const {
     return hasAuthz_(scope) || writeAuthz(scope);
+}
+
+bool Authorizer::readAuthz(const Scopes_e& scope) const {
+    return readAuthz(Scopes().getForwardMap().at(scope));
 }
 
 bool Authorizer::readAuthz(const IParam& param) const {

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -56,7 +56,7 @@ Authorizer::Authorizer(const std::string& JWSToken) {
     }
 }
 
-bool Authorizer::hasAuthz(const std::string& scope) const {
+bool Authorizer::hasAuthz_(const std::string& scope) const {
     // no authorization required or scope found in client scopes.
     return this == &kAuthzDisabled || clientScopes_.contains(scope);
 }
@@ -65,7 +65,7 @@ bool Authorizer::hasAuthz(const std::string& scope) const {
  * Check if the client has write authorization
  */
 bool Authorizer::writeAuthz(const std::string& scope) const {
-    return hasAuthz(scope + ":w");
+    return hasAuthz_(scope + ":w");
 }
 
 bool Authorizer::writeAuthz(const IParam& param) const {
@@ -80,7 +80,7 @@ bool Authorizer::writeAuthz(const IParamDescriptor& pd) const {
  * Check if the client has read authorization
  */
 bool Authorizer::readAuthz(const std::string& scope) const {
-    return hasAuthz(scope) || writeAuthz(scope);
+    return hasAuthz_(scope) || writeAuthz(scope);
 }
 
 bool Authorizer::readAuthz(const IParam& param) const {

--- a/sdks/cpp/common/src/Authorization.cpp
+++ b/sdks/cpp/common/src/Authorization.cpp
@@ -46,7 +46,7 @@ Authorizer::Authorizer(const std::string& JWSToken) {
                 std::string scopeClaim = it->second.get<std::string>();
                 std::istringstream iss(scopeClaim);
                 while (std::getline(iss, scopeClaim, ' ')) {
-                    clientScopes_.push_back(scopeClaim);
+                    clientScopes_.insert(scopeClaim);
                 }
             }
         }
@@ -57,56 +57,36 @@ Authorizer::Authorizer(const std::string& JWSToken) {
 }
 
 bool Authorizer::hasAuthz(const std::string& scope) const {
-    if (this == &kAuthzDisabled) {
-        return true; // no authorization required
-    }
-
-    if (std::find(clientScopes_.begin(), clientScopes_.end(), scope) == clientScopes_.end()) {
-        return false;
-    }
-    return true;
+    // no authorization required or scope found in client scopes.
+    return this == &kAuthzDisabled || clientScopes_.contains(scope);
 }
 
 /**
- * @brief Check if the client has read authorization
- * @return true if the client has read authorization
+ * Check if the client has write authorization
  */
-bool Authorizer::readAuthz(const IParam& param) const {
-    const std::string& scope = param.getScope();
-    return hasAuthz(scope) || hasAuthz(scope + ":w");
+bool Authorizer::writeAuthz(const std::string& scope) const {
+    return hasAuthz(scope + ":w");
 }
 
-bool Authorizer::readAuthz(const IParamDescriptor& pd) const {
-    const std::string& scope = pd.getScope();
-    return hasAuthz(scope) || hasAuthz(scope + ":w");
-}
-
-bool Authorizer::readAuthz(const std::string& scope) const {
-    return hasAuthz(scope) || hasAuthz(scope + ":w");
-}
-
-/**
- * @brief Check if the client has write authorization
- * @return true if the client has write authorization
- */
 bool Authorizer::writeAuthz(const IParam& param) const {
-    if (param.readOnly()) {
-        return false;
-    }
-
-    const std::string scope = param.getScope() + ":w";
-    return hasAuthz(scope);
+    return !param.readOnly() && writeAuthz(param.getScope());
 }
 
 bool Authorizer::writeAuthz(const IParamDescriptor& pd) const {
-    if (pd.readOnly()) {
-        return false;
-    }
-
-    const std::string scope = pd.getScope() + ":w";
-    return hasAuthz(scope);
+    return !pd.readOnly() && writeAuthz(pd.getScope());
 }
 
-bool Authorizer::writeAuthz(const std::string& scope) const {
-    return hasAuthz(scope + ":w");
+/*
+ * Check if the client has read authorization
+ */
+bool Authorizer::readAuthz(const std::string& scope) const {
+    return hasAuthz(scope) || writeAuthz(scope);
+}
+
+bool Authorizer::readAuthz(const IParam& param) const {
+    return readAuthz(param.getScope());
+}
+
+bool Authorizer::readAuthz(const IParamDescriptor& pd) const {
+    return readAuthz(pd.getScope());
 }

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -206,7 +206,7 @@ catena::exception_with_status Device::addLanguage (catena::AddLanguagePayload& l
     auto& name = language.language_pack().name();
     auto& id = language.id();
     // Admin scope required.
-    if (!authz.hasAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin) + ":w")) {
+    if (!authz.writeAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin))) {
         ans = catena::exception_with_status("Not authorized to add language", catena::StatusCode::PERMISSION_DENIED);
     // Making sure LanguagePack is properly formatted.
     } else if (name.empty() || id.empty()) {
@@ -228,7 +228,7 @@ catena::exception_with_status Device::addLanguage (catena::AddLanguagePayload& l
 catena::exception_with_status Device::removeLanguage(const std::string& languageId, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     // Admin scope required.
-    if (!authz.hasAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin) + ":w")) {
+    if (!authz.writeAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin))) {
         ans = catena::exception_with_status("Not authorized to delete language", catena::StatusCode::PERMISSION_DENIED);
     // Cannot change shipped language packs.
     } else if (language_packs_.contains(languageId) && !added_packs_.contains(languageId)) {

--- a/sdks/cpp/common/src/Device.cpp
+++ b/sdks/cpp/common/src/Device.cpp
@@ -206,7 +206,7 @@ catena::exception_with_status Device::addLanguage (catena::AddLanguagePayload& l
     auto& name = language.language_pack().name();
     auto& id = language.id();
     // Admin scope required.
-    if (!authz.writeAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin))) {
+    if (!authz.writeAuthz(Scopes_e::kAdmin)) {
         ans = catena::exception_with_status("Not authorized to add language", catena::StatusCode::PERMISSION_DENIED);
     // Making sure LanguagePack is properly formatted.
     } else if (name.empty() || id.empty()) {
@@ -228,7 +228,7 @@ catena::exception_with_status Device::addLanguage (catena::AddLanguagePayload& l
 catena::exception_with_status Device::removeLanguage(const std::string& languageId, Authorizer& authz) {
     catena::exception_with_status ans{"", catena::StatusCode::OK};
     // Admin scope required.
-    if (!authz.writeAuthz(Scopes().getForwardMap().at(Scopes_e::kAdmin))) {
+    if (!authz.writeAuthz(Scopes_e::kAdmin)) {
         ans = catena::exception_with_status("Not authorized to delete language", catena::StatusCode::PERMISSION_DENIED);
     // Cannot change shipped language packs.
     } else if (language_packs_.contains(languageId) && !added_packs_.contains(languageId)) {

--- a/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
@@ -157,7 +157,7 @@ void AssetRequest::proceed() {
 
             //check for any read access
             //TODO: move to BL
-            if (!(authz->readAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kOperate)))) {   
+            if (!(authz->readAuthz(catena::common::Scopes_e::kOperate))) {   
                 //do something that indicates that the user is not authorized to download the asset
                 throw catena::exception_with_status("Not authorized to download asset", catena::StatusCode::PERMISSION_DENIED);
             }
@@ -239,9 +239,9 @@ void AssetRequest::proceed() {
             //Check if the user has write authorization in any scope other than monitoring
             //either authz have to be disabled or have write access to any scope other than monitor
             //TODO: move to BL
-            if (!(authz->writeAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kOperate))
-                    || authz->writeAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kConfig))
-                    || authz->writeAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kAdmin)))) {
+            if (!(authz->writeAuthz(catena::common::Scopes_e::kOperate)
+                    || authz->writeAuthz(catena::common::Scopes_e::kConfig)
+                    || authz->writeAuthz(catena::common::Scopes_e::kAdmin))) {
                 throw catena::exception_with_status("Not authorized to POST asset", catena::StatusCode::PERMISSION_DENIED);
             }
 
@@ -276,9 +276,9 @@ void AssetRequest::proceed() {
             //Check if the user has write authorization in any scope other than monitoring
             //either authz have to be disabled or have write access to any scope other than monitor
             //TODO: move to BL
-            if (!(authz->writeAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kOperate))
-                    || authz->writeAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kConfig))
-                    || authz->writeAuthz(catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kAdmin)))) {
+            if (!(authz->writeAuthz(catena::common::Scopes_e::kOperate)
+                    || authz->writeAuthz(catena::common::Scopes_e::kConfig)
+                    || authz->writeAuthz(catena::common::Scopes_e::kAdmin))) {
                 throw catena::exception_with_status("Not authorized to PUT asset", catena::StatusCode::PERMISSION_DENIED);
             }
 

--- a/unittests/cpp/common/tests/Authorization_test.cpp
+++ b/unittests/cpp/common/tests/Authorization_test.cpp
@@ -99,61 +99,52 @@ TEST_F(AuthorizationTest, Authz_createInvalid) {
 }
 
 /* 
- * TEST 3 - Testing hasAuthz().
- */
-TEST_F(AuthorizationTest, Authz_hasAuthz) {   
-    for (const auto& [currentScope, currentToken] : testTokens) {
-        Authorizer* authz = nullptr;
-        EXPECT_NO_THROW(authz = new Authorizer(currentToken));
-        // Testing hasAuthz.
-        for (std::string priviledge : {"", ":w"}) {
-            for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
-                if (scopeStr + priviledge == currentScope) {
-                    EXPECT_TRUE(authz->hasAuthz(scopeStr + priviledge));
-                } else {
-                    EXPECT_FALSE(authz->hasAuthz(scopeStr + priviledge));
-                }
-            }
-        }
-        if (authz) { delete authz; }
-    }
-}
-
-/* 
- * TEST 4 - Testing readAuthz().
+ * TEST 3 - Testing readAuthz().
  */
 TEST_F(AuthorizationTest, Authz_readAuthz) {
     MockParam param;
     MockParamDescriptor pd;
+    // Error messages.
+    std::string trueMsg  = "readAuthz should be true when the authorizer have the scope.";
+    std::string falseMsg = "readAuthz should be false when the authorizer does not have the scope.";
+    // Testing with tokens of each scope.
     for (const auto& [currentScope, currentToken] : testTokens) {
-        Authorizer* authz = nullptr;
-        EXPECT_NO_THROW(authz = new Authorizer(currentToken));
-        // Testing readAuthz(param).
+        std::unique_ptr<Authorizer> authz = nullptr;
+        EXPECT_NO_THROW(authz = std::make_unique<Authorizer>(currentToken));
+        // Testing readAuthz for each scope.
         for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
             EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
             EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
-            if (scopeStr == currentScope || scopeStr + ":w" == currentScope) {
-                EXPECT_TRUE(authz->readAuthz(param));
-                EXPECT_TRUE(authz->readAuthz(pd));
+            // Authz has either scope or scope:w.
+            if (currentScope.starts_with(scopeStr)) {
+                EXPECT_TRUE(authz->readAuthz(scopeStr))  << trueMsg;
+                EXPECT_TRUE(authz->readAuthz(param))     << trueMsg;
+                EXPECT_TRUE(authz->readAuthz(pd))        << trueMsg;
+            // Authz does not have scope or scope:w.
             } else {
-                EXPECT_FALSE(authz->readAuthz(param));
-                EXPECT_FALSE(authz->readAuthz(pd));
+                EXPECT_FALSE(authz->readAuthz(scopeStr)) << falseMsg;
+                EXPECT_FALSE(authz->readAuthz(param))    << falseMsg;
+                EXPECT_FALSE(authz->readAuthz(pd))       << falseMsg;
             }
         }
-        if (authz) { delete authz; }
     }
 }
 
 /* 
- * TEST 5 - Testing writeAuthz().
+ * TEST 4 - Testing writeAuthz().
  */
 TEST_F(AuthorizationTest, Authz_writeAuthz) {
     MockParam param;
     MockParamDescriptor pd;
+    // Error messages.
+    std::string trueMsg  = "writeAuthz should be true when the authorizer have the scope.";
+    std::string falseMsg = "writeAuthz should be false when the authorizer does not have the scope.";
+    std::string rOnlyMsg = "writeAuthz should be false when the param is readOnly";
+    // Testing with tokens of each scope.
     for (const auto& [currentScope, currentToken] : testTokens) {
-        Authorizer* authz = nullptr;
-        EXPECT_NO_THROW(authz = new Authorizer(currentToken));
-        // Testing writeAuthz(param).
+        std::unique_ptr<Authorizer> authz = nullptr;
+        EXPECT_NO_THROW(authz = std::make_unique<Authorizer>(currentToken));
+        // Testing writeAuthz for each scope.
         for (bool rOnly : {false, true}) {
             for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
                 EXPECT_CALL(param, readOnly()).Times(1).WillOnce(::testing::Return(rOnly));
@@ -162,40 +153,44 @@ TEST_F(AuthorizationTest, Authz_writeAuthz) {
                     EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
                     EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
                 }
-                if (scopeStr + ":w" == currentScope && !rOnly) {
-                    EXPECT_TRUE(authz->writeAuthz(param));
-                    EXPECT_TRUE(authz->writeAuthz(pd));
+                // Authz has either scope:w, depends on whether rOnly == true.
+                if (scopeStr + ":w" == currentScope) {
+                    EXPECT_TRUE(authz->writeAuthz(scopeStr))    << trueMsg;
+                    EXPECT_EQ(!rOnly, authz->writeAuthz(param)) << (rOnly ? rOnlyMsg: trueMsg);
+                    EXPECT_EQ(!rOnly, authz->writeAuthz(pd))    << (rOnly ? rOnlyMsg: trueMsg);
+                // Authz does not have scope:w.
                 } else {
-                    EXPECT_FALSE(authz->writeAuthz(param));
-                    EXPECT_FALSE(authz->writeAuthz(pd));
+                    EXPECT_FALSE(authz->writeAuthz(scopeStr))   << falseMsg;
+                    EXPECT_FALSE(authz->writeAuthz(param))      << falseMsg;
+                    EXPECT_FALSE(authz->writeAuthz(pd))         << falseMsg;
                 }
             }
         }
-        if (authz) { delete authz; }
     }
 }
 
 /* 
- * TEST 6 - Testing authorizer with no scope.
+ * TEST 5 - Testing authorizer with no scope.
  */
 TEST_F(AuthorizationTest, Authz_scopeNone) {
     std::string noScope = getJwsToken("");
-    Authorizer* authz = nullptr;
-    EXPECT_NO_THROW(authz = new Authorizer(noScope));
+    // Error message.
+    std::string errMsg = "Authz should return false if the client does not have the specified scope.";
+    std::unique_ptr<Authorizer> authz = nullptr;
+    EXPECT_NO_THROW(authz = std::make_unique<Authorizer>(noScope));
     MockParam param;
     MockParamDescriptor pd;
-    // hasAuthz should always return false if client has no scopes.
-    for (std::string priviledge : {"", ":w"}) {
-        for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
-            EXPECT_FALSE(authz->hasAuthz(scopeStr + priviledge));
-        }
+    // readAuthz() and writeAuthz() should always return false if client has no scopes.
+    for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
+        EXPECT_FALSE(authz->writeAuthz(scopeStr)) << errMsg;
     }
     // readAuthz() should always return false if client has no scopes.
     for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
         EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
         EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
-        EXPECT_FALSE(authz->readAuthz(param));
-        EXPECT_FALSE(authz->readAuthz(pd));
+        EXPECT_FALSE(authz->readAuthz(scopeStr)) << errMsg;
+        EXPECT_FALSE(authz->readAuthz(param))    << errMsg;
+        EXPECT_FALSE(authz->readAuthz(pd))       << errMsg;
     }
     // writeAuthz() should always return false if client has no scopes.
     for (bool rOnly : {false, true}) {
@@ -206,29 +201,28 @@ TEST_F(AuthorizationTest, Authz_scopeNone) {
                 EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
                 EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
             }
-            EXPECT_FALSE(authz->writeAuthz(param));
-            EXPECT_FALSE(authz->writeAuthz(pd));
+            EXPECT_FALSE(authz->writeAuthz(scopeStr)) << errMsg;
+            EXPECT_FALSE(authz->writeAuthz(param))    << errMsg;
+            EXPECT_FALSE(authz->writeAuthz(pd))       << errMsg;
         }
     }
 }
 
 /* 
- * TEST 7 - Testing kAuthzDisabled.
+ * TEST 6 - Testing kAuthzDisabled.
  */
 TEST_F(AuthorizationTest, Authz_disabled) {
     Authorizer* authz = &Authorizer::kAuthzDisabled;
     MockParam param;
     MockParamDescriptor pd;
-    // hasAuthz should always return true.
-    for (std::string priviledge : {"", ":w"}) {
-        for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
-            EXPECT_TRUE(authz->hasAuthz(scopeStr + priviledge));
-        }
-    }
+    // Error messages.
+    std::string trueMsg  = "Authz should always return true if disabled.";
+    std::string rOnlyMsg = "writeAuthz should be false when the param is readOnly";
     // readAuthz() should always return true.
     for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
         EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
         EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
+        EXPECT_TRUE(authz->readAuthz(scopeStr))  << "Authz should always return true if disabled.";
         EXPECT_TRUE(authz->readAuthz(param));
         EXPECT_TRUE(authz->readAuthz(pd));
     }
@@ -238,50 +232,45 @@ TEST_F(AuthorizationTest, Authz_disabled) {
             EXPECT_CALL(param, readOnly()).Times(1).WillOnce(::testing::Return(rOnly));
             EXPECT_CALL(pd, readOnly()).Times(1).WillOnce(::testing::Return(rOnly));
             if (rOnly) {
-                EXPECT_FALSE(authz->writeAuthz(param));
-                EXPECT_FALSE(authz->writeAuthz(pd));
+                EXPECT_FALSE(authz->writeAuthz(param)) << rOnlyMsg;
+                EXPECT_FALSE(authz->writeAuthz(pd))    << rOnlyMsg;
             } else {
                 EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
                 EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
-                EXPECT_TRUE(authz->writeAuthz(param));
-                EXPECT_TRUE(authz->writeAuthz(pd));
+                EXPECT_TRUE(authz->writeAuthz(param)) << trueMsg;
+                EXPECT_TRUE(authz->writeAuthz(pd))    << trueMsg;
             }
+            EXPECT_TRUE(authz->writeAuthz(scopeStr))  << trueMsg;
         }
     }
 }
 
 /* 
- * TEST 8 - Testing authorizer with multiple scopes.
+ * TEST 7 - Testing authorizer with multiple scopes.
  */
 TEST_F(AuthorizationTest, Authz_scopeMulti) {
     // This token has st2138:mon and st2138:op:w scopes.
     std::string multiScopes = getJwsToken("st2138:mon st2138:op:w");
-    Authorizer* authz = nullptr;
-    EXPECT_NO_THROW(authz = new Authorizer(multiScopes));
+    std::unique_ptr<Authorizer> authz = nullptr;
+    EXPECT_NO_THROW(authz = std::make_unique<Authorizer>(multiScopes));
     MockParam param;
     MockParamDescriptor pd;
-    // hasAuthz should return true if it has the correct scope.
-    for (std::string priviledge : {"", ":w"}) {
-        for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
-            if (scopeStr + priviledge == Scopes().getForwardMap().at(Scopes_e::kMonitor)
-                || scopeStr + priviledge == Scopes().getForwardMap().at(Scopes_e::kOperate) + ":w") {
-                EXPECT_TRUE(authz->hasAuthz(scopeStr + priviledge));
-            } else {
-                EXPECT_FALSE(authz->hasAuthz(scopeStr + priviledge));
-            }
-        }
-    }
+    // Error messages.
+    std::string trueMsg  = "writeAuthz should be true when the authorizer have the scope.";
+    std::string falseMsg = "writeAuthz should be false when the authorizer does not have the scope.";
+    std::string rOnlyMsg = "writeAuthz should be false when the param is readOnly";
     // readAuthz() should return true if the scope is op or mon.
     for (auto& [scopeEnum, scopeStr]: Scopes().getForwardMap()) {
         EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
         EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
-        if (scopeStr == Scopes().getForwardMap().at(Scopes_e::kMonitor)
-            || scopeStr == Scopes().getForwardMap().at(Scopes_e::kOperate)) {
-            EXPECT_TRUE(authz->readAuthz(param));
-            EXPECT_TRUE(authz->readAuthz(pd));
+        if (scopeStr == Scopes().getForwardMap().at(Scopes_e::kMonitor) || scopeStr == Scopes().getForwardMap().at(Scopes_e::kOperate)) {
+            EXPECT_TRUE(authz->readAuthz(param))     << trueMsg;
+            EXPECT_TRUE(authz->readAuthz(pd))        << trueMsg;
+            EXPECT_TRUE(authz->readAuthz(scopeStr))  << trueMsg;
         } else {
-            EXPECT_FALSE(authz->readAuthz(param));
-            EXPECT_FALSE(authz->readAuthz(pd));
+            EXPECT_FALSE(authz->readAuthz(param))    << falseMsg;
+            EXPECT_FALSE(authz->readAuthz(pd))       << falseMsg;
+            EXPECT_FALSE(authz->readAuthz(scopeStr)) << falseMsg;
         }
     }
     // writeAuthz() should return true if the scope is op and param is not read-only.
@@ -293,12 +282,14 @@ TEST_F(AuthorizationTest, Authz_scopeMulti) {
                 EXPECT_CALL(param, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
                 EXPECT_CALL(pd, getScope()).Times(1).WillOnce(::testing::ReturnRef(scopeStr));
             }
-            if (scopeStr == Scopes().getForwardMap().at(Scopes_e::kOperate) && !rOnly) {
-                EXPECT_TRUE(authz->writeAuthz(param));
-                EXPECT_TRUE(authz->writeAuthz(pd));
+            if (scopeStr == Scopes().getForwardMap().at(Scopes_e::kOperate)) {
+                EXPECT_TRUE(authz->writeAuthz(scopeStr))    << trueMsg;
+                EXPECT_EQ(!rOnly, authz->writeAuthz(param)) << (rOnly ? rOnlyMsg: trueMsg);
+                EXPECT_EQ(!rOnly, authz->writeAuthz(pd))    << (rOnly ? rOnlyMsg: trueMsg);
             } else {
-                EXPECT_FALSE(authz->writeAuthz(param));
-                EXPECT_FALSE(authz->writeAuthz(pd));
+                EXPECT_FALSE(authz->writeAuthz(scopeStr))   << falseMsg;
+                EXPECT_FALSE(authz->writeAuthz(param))      << falseMsg;
+                EXPECT_FALSE(authz->writeAuthz(pd))         << falseMsg;
             }
         }
     }


### PR DESCRIPTION
**Changelog:**
- Switched Authorizer::Scopes from vector to set to allow for use of .contains() function.
- Cleaned up Authorizer functions.
- Added readAuthz(scope_e) and writeAuthz(scope_e) for convenience.
    - Kept the string impl too in case clients have custom scopes to implement in business logic 
- Made hasAuthz(scope) private so use of readAuthz() and writeAuthz() is forced (hard to mess up).
- Updated Authorizer unit test accordingly. Also made it more memory safe (I was NOT deallocating memory before my bad)
