### PR TITLE
Fix Mismatching File/Class Names Across the C++ SDK

### DIFF
--- a/sdks/cpp/common/CMakeLists.txt
+++ b/sdks/cpp/common/CMakeLists.txt
@@ -28,7 +28,7 @@ set(sources
     "src/utils.cpp" 
     "src/vdk/signals.cpp" 
     "src/Path.cpp"
-    "src/Authorization.cpp"
+    "src/Authorizer.cpp"
     "src/Device.cpp"
     "src/ParamDescriptor.cpp"
     "src/StructInfo.cpp"

--- a/sdks/cpp/common/include/Authorizer.h
+++ b/sdks/cpp/common/include/Authorizer.h
@@ -31,7 +31,7 @@
  */
 
 /**
- * @file Authorization.h
+ * @file Authorizer.h
  * @brief Class for handling authorization information
  * @author John R. Naylor john.naylor@rossvideo.com
  * @author John Danen

--- a/sdks/cpp/common/include/Device.h
+++ b/sdks/cpp/common/include/Device.h
@@ -44,7 +44,7 @@
  */
 
 // common
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Path.h>
 #include <Enums.h>
 #include <IParam.h>

--- a/sdks/cpp/common/include/IDevice.h
+++ b/sdks/cpp/common/include/IDevice.h
@@ -38,7 +38,7 @@
  */
 
 // common
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Path.h>
 #include <IParam.h>
 #include <ILanguagePack.h>

--- a/sdks/cpp/common/include/ISubscriptionManager.h
+++ b/sdks/cpp/common/include/ISubscriptionManager.h
@@ -42,7 +42,7 @@
 #include <string>
 #include <IDevice.h>
 #include <IParam.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 
 namespace catena {
 namespace common {

--- a/sdks/cpp/common/include/ParamDescriptor.h
+++ b/sdks/cpp/common/include/ParamDescriptor.h
@@ -44,7 +44,7 @@
 #include <PolyglotText.h>
 #include <IParamDescriptor.h>
 #include <IDevice.h>
-#include <Authorization.h>  
+#include <Authorizer.h>  
 
 #include <vector>
 #include <string>

--- a/sdks/cpp/common/include/ParamWithValue.h
+++ b/sdks/cpp/common/include/ParamWithValue.h
@@ -47,7 +47,7 @@
 #include <IDevice.h>
 #include <StructInfo.h>
 #include <PolyglotText.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 
 // protobuf interface
 #include <interface/param.pb.h>

--- a/sdks/cpp/common/include/StructInfo.h
+++ b/sdks/cpp/common/include/StructInfo.h
@@ -42,7 +42,7 @@
 #include <meta/Typelist.h>
 #include <meta/IsVector.h>
 #include <meta/Variant.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 
 // protobuf interface
 #include <interface/param.pb.h>

--- a/sdks/cpp/common/include/SubscriptionManager.h
+++ b/sdks/cpp/common/include/SubscriptionManager.h
@@ -45,7 +45,7 @@
 #include <IParam.h>
 #include <ParamVisitor.h>
 #include <ISubscriptionManager.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 
 // std
 #include <set>

--- a/sdks/cpp/common/include/rpc/Connect.h
+++ b/sdks/cpp/common/include/rpc/Connect.h
@@ -44,7 +44,7 @@
 #include <vdk/signals.h>
 #include <IParam.h>
 #include <IDevice.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <ISubscriptionManager.h>
 #include "IConnect.h"
 #include <Logger.h>

--- a/sdks/cpp/common/src/Authorizer.cpp
+++ b/sdks/cpp/common/src/Authorizer.cpp
@@ -28,7 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <Authorization.h>
+#include <Authorizer.h>
 
 using catena::common::Authorizer;
 

--- a/sdks/cpp/connections/REST/examples/asset_request_REST/asset_request_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/asset_request_REST/asset_request_REST.cpp
@@ -62,11 +62,11 @@
 #include <signal.h>
 #include <functional>
 #include <Logger.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 
 using namespace catena::common;
 
-catena::REST::CatenaServiceImpl *globalApi = nullptr;
+catena::REST::ServiceImpl *globalApi = nullptr;
 
 // handle SIGINT
 void handle_signal(int sig) {
@@ -172,7 +172,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
         
         // Creating and running the REST service.
-        catena::REST::CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        catena::REST::ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/one_of_everything_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/one_of_everything_REST.cpp
@@ -64,12 +64,12 @@
 #include <Logger.h>
 
 
-using catena::REST::CatenaServiceImpl;
+using catena::REST::ServiceImpl;
 
 using namespace catena::common;
 
 
-CatenaServiceImpl *globalApi = nullptr;
+ServiceImpl *globalApi = nullptr;
 std::atomic<bool> fibLoop = false;
 std::unique_ptr<std::thread> fibThread = nullptr;
 std::atomic<bool> counterLoop = true;
@@ -295,7 +295,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
 
         // Creating and running the REST service.
-        CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST/status_update_REST.cpp
@@ -67,7 +67,7 @@
 
 using namespace catena::common;
 
-catena::REST::CatenaServiceImpl *globalApi = nullptr;
+catena::REST::ServiceImpl *globalApi = nullptr;
 std::atomic<bool> globalLoop = true;
 
 // handle SIGINT
@@ -170,7 +170,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
         
         // Creating and running the REST service.
-        catena::REST::CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        catena::REST::ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
+++ b/sdks/cpp/connections/REST/examples/status_update_REST_JSON/status_update_REST_JSON.cpp
@@ -67,7 +67,7 @@
 
 using namespace catena::common;
 
-catena::REST::CatenaServiceImpl *globalApi = nullptr;
+catena::REST::ServiceImpl *globalApi = nullptr;
 std::atomic<bool> globalLoop = true;
 
 // handle SIGINT
@@ -170,7 +170,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
         
         // Creating and running the REST service.
-        catena::REST::CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        catena::REST::ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/examples/structs_with_authz_REST/structs_with_authz_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/structs_with_authz_REST/structs_with_authz_REST.cpp
@@ -66,7 +66,7 @@
 
 using namespace catena::common;
 
-catena::REST::CatenaServiceImpl *globalApi = nullptr;
+catena::REST::ServiceImpl *globalApi = nullptr;
 std::atomic<bool> globalLoop = true;
 
 // handle SIGINT
@@ -110,7 +110,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
         
         // Creating and running the REST service.
-        catena::REST::CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        catena::REST::ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_commands_REST/use_commands_REST.cpp
@@ -67,7 +67,7 @@
 
 using namespace catena::common;
 
-catena::REST::CatenaServiceImpl *globalApi = nullptr;
+catena::REST::ServiceImpl *globalApi = nullptr;
 std::atomic<bool> globalLoop = true;
 
 // handle SIGINT
@@ -97,7 +97,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
         
         // Creating and running the REST service.
-        catena::REST::CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        catena::REST::ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/examples/use_menus_REST/use_menus_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/use_menus_REST/use_menus_REST.cpp
@@ -67,7 +67,7 @@
 
 using namespace catena::common;
 
-catena::REST::CatenaServiceImpl *globalApi = nullptr;
+catena::REST::ServiceImpl *globalApi = nullptr;
 std::atomic<bool> globalLoop = true;
 
 // handle SIGINT
@@ -128,7 +128,7 @@ void RunRESTServer() {
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
         
         // Creating and running the REST service.
-        catena::REST::CatenaServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
+        catena::REST::ServiceImpl api({&dm}, EOPath, authorization, port, maxConnections);
         globalApi = &api;
         DEBUG_LOG << "API Version: " << api.version();
         DEBUG_LOG << "REST on 0.0.0.0:" << port;

--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -43,7 +43,7 @@
 #include <vdk/signals.h>
 #include <patterns/GenericFactory.h>
 #include <IParam.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 #include <SubscriptionManager.h>
 #include <SharedFlags.h>
@@ -80,7 +80,7 @@ namespace REST {
 /**
  * @brief Implements Catena REST API request handlers.
  */
-class CatenaServiceImpl : public catena::REST::ICatenaServiceImpl {
+class ServiceImpl : public catena::REST::IServiceImpl {
   public:
     /**
      * @brief Constructor for the REST API.
@@ -91,7 +91,7 @@ class CatenaServiceImpl : public catena::REST::ICatenaServiceImpl {
      * @param port The port to listen on. Default is 443.
      * @param maxConnections The maximum # of connections the service allows.
      */
-    explicit CatenaServiceImpl(std::vector<IDevice*> dms, std::string& EOPath, bool authz = false, uint16_t port = 443, uint32_t maxConnections = 16);
+    explicit ServiceImpl(std::vector<IDevice*> dms, std::string& EOPath, bool authz = false, uint16_t port = 443, uint32_t maxConnections = 16);
     /**
      * @brief Returns the API's version.
      */

--- a/sdks/cpp/connections/REST/include/SocketReader.h
+++ b/sdks/cpp/connections/REST/include/SocketReader.h
@@ -80,9 +80,9 @@ class SocketReader : public ISocketReader {
   public:
     /**
      * @brief Constructor for the SocketReader class.
-     * @param service Pointer to the CatenaServiceImpl.
+     * @param service Pointer to the ServiceImpl.
      */
-    SocketReader(ICatenaServiceImpl* service) : service_(service) {};
+    SocketReader(IServiceImpl* service) : service_(service) {};
     /**
      * @brief Populates variables using information read from the inputted
      * socket.
@@ -148,9 +148,9 @@ class SocketReader : public ISocketReader {
     bool stream() const override { return stream_; } 
 
     /**
-     * @brief Returns a pointer to the CatenaServiceImpl
+     * @brief Returns a pointer to the ServiceImpl
      */
-    ICatenaServiceImpl* service() override { return service_; }
+    IServiceImpl* service() override { return service_; }
     /**
      * @brief Returns true if authorization is enabled.
      */
@@ -216,9 +216,9 @@ class SocketReader : public ISocketReader {
      */
     std::string fieldNotFound = "";
     /**
-     * @brief Pointer to the CatenaServiceImpl
+     * @brief Pointer to the ServiceImpl
      */
-    ICatenaServiceImpl* service_ = nullptr;
+    IServiceImpl* service_ = nullptr;
 };
 
 }; // Namespace REST

--- a/sdks/cpp/connections/REST/include/controllers/AssetRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/AssetRequest.h
@@ -47,7 +47,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -49,7 +49,7 @@
 #include <IDevice.h>
 #include <ILanguagePack.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <SubscriptionManager.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/REST/include/controllers/DeviceRequest.h
@@ -48,7 +48,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 
 // Connections/REST
 #include "interface/ISocketReader.h"

--- a/sdks/cpp/connections/REST/include/controllers/GetParam.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetParam.h
@@ -47,7 +47,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetPopulatedSlots.h
@@ -47,7 +47,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/GetValue.h
@@ -47,7 +47,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/LanguagePack.h
+++ b/sdks/cpp/connections/REST/include/controllers/LanguagePack.h
@@ -46,7 +46,7 @@
 #include <Status.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/Languages.h
+++ b/sdks/cpp/connections/REST/include/controllers/Languages.h
@@ -46,7 +46,7 @@
 #include <Status.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/REST/include/controllers/MultiSetValue.h
@@ -47,7 +47,7 @@
 #include <IParam.h>
 #include <IDevice.h>
 #include <utils.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <Enums.h>
 
 // Connections/REST

--- a/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/interface/IServiceImpl.h
@@ -61,16 +61,16 @@ namespace catena {
 namespace REST {
 
 /**
- * @brief Interface for the REST::CatenaServiceImpl class
+ * @brief Interface for the REST::ServiceImpl class
  */
-class ICatenaServiceImpl {
+class IServiceImpl {
   public:
-    ICatenaServiceImpl() = default;
-    ICatenaServiceImpl(const ICatenaServiceImpl&) = delete;
-    ICatenaServiceImpl& operator=(const ICatenaServiceImpl&) = delete;
-    ICatenaServiceImpl(ICatenaServiceImpl&&) = delete;
-    ICatenaServiceImpl& operator=(ICatenaServiceImpl&&) = delete;
-    virtual ~ICatenaServiceImpl() = default;
+    IServiceImpl() = default;
+    IServiceImpl(const IServiceImpl&) = delete;
+    IServiceImpl& operator=(const IServiceImpl&) = delete;
+    IServiceImpl(IServiceImpl&&) = delete;
+    IServiceImpl& operator=(IServiceImpl&&) = delete;
+    virtual ~IServiceImpl() = default;
 
     /**
      * @brief Returns the API's version.

--- a/sdks/cpp/connections/REST/include/interface/ISocketReader.h
+++ b/sdks/cpp/connections/REST/include/interface/ISocketReader.h
@@ -132,9 +132,9 @@ class ISocketReader {
     virtual bool stream() const = 0;
 
     /**
-     * @brief Returns a pointer to the CatenaServiceImpl
+     * @brief Returns a pointer to the ServiceImpl
      */
-    virtual ICatenaServiceImpl* service() = 0;
+    virtual IServiceImpl* service() = 0;
     /**
      * @brief Returns true if authorization is enabled.
      */

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -1,6 +1,6 @@
 // connections/REST
 #include <ServiceImpl.h>
-using catena::REST::CatenaServiceImpl;
+using catena::REST::ServiceImpl;
 
 // REST controllers
 #include <controllers/Connect.h>
@@ -35,7 +35,7 @@ void expandEnvVariables(std::string &str) {
 }
 // GCOVR_EXCL_STOP
 
-CatenaServiceImpl::CatenaServiceImpl(std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint16_t port, uint32_t maxConnections)
+ServiceImpl::ServiceImpl(std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint16_t port, uint32_t maxConnections)
     : version_{"v1"},
       EOPath_{EOPath},
       port_{port},
@@ -82,7 +82,7 @@ CatenaServiceImpl::CatenaServiceImpl(std::vector<IDevice*> dms, std::string& EOP
 // Initializing the shutdown signal for all open connections.
 vdk::signal<void()> catena::REST::Connect::shutdownSignal_;
 
-void CatenaServiceImpl::run() {
+void ServiceImpl::run() {
     // TLS handled by Envoyproxy
     shutdown_ = false;
 
@@ -163,7 +163,7 @@ void CatenaServiceImpl::run() {
     acceptor_.close();
 }
 
-void CatenaServiceImpl::Shutdown() {
+void ServiceImpl::Shutdown() {
     shutdown_ = true;
     // Sending dummy connection to run() loop.
     tcp::socket dummySocket(io_context_);
@@ -172,7 +172,7 @@ void CatenaServiceImpl::Shutdown() {
 
 // (UNUSED)
 // GCOVR_EXCL_START
-bool CatenaServiceImpl::is_port_in_use_() const {
+bool ServiceImpl::is_port_in_use_() const {
     try {
         boost::asio::io_context io_context;
         tcp::acceptor acceptor(io_context, tcp::endpoint(tcp::v4(), port_));

--- a/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/AssetRequest.cpp
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <zlib.h>
 #include <sys/stat.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 using catena::REST::AssetRequest;
 
 // Initializes the object counter for GetParam to 0.

--- a/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
@@ -34,7 +34,7 @@ using catena::REST::ParamInfoRequest;
 
 // common
 #include <Tags.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <ParamVisitor.h>
 
 // type aliases

--- a/sdks/cpp/connections/gRPC/examples/external_object_request/external_object_request.cpp
+++ b/sdks/cpp/connections/gRPC/examples/external_object_request/external_object_request.cpp
@@ -63,7 +63,7 @@
 #include <Logger.h>
 
 using grpc::Server;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 using namespace catena::common;
 
@@ -105,7 +105,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         // Updating device's default max array length.
         dm.set_default_max_length(absl::GetFlag(FLAGS_default_max_array_size));

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/one_of_everything.cpp
@@ -71,7 +71,7 @@
 #include <Logger.h>
 
 using grpc::Server;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 using namespace catena::common;
 
@@ -305,7 +305,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         // Updating device's default max array length.
         dm.set_default_max_length(absl::GetFlag(FLAGS_default_max_array_size));

--- a/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
+++ b/sdks/cpp/connections/gRPC/examples/status_update/status_update.cpp
@@ -71,7 +71,7 @@
 #include <Logger.h>
 
 using grpc::Server;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 using namespace catena::common;
 
@@ -188,7 +188,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         // Updating device's default max array length.
         dm.set_default_max_length(absl::GetFlag(FLAGS_default_max_array_size));

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/structs_with_authz.cpp
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/structs_with_authz.cpp
@@ -55,7 +55,7 @@
 #include <Logger.h>
 
 using grpc::Server;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 using namespace catena::common;
 
@@ -118,7 +118,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/structs_with_authz_yaml.cpp
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/structs_with_authz_yaml.cpp
@@ -57,7 +57,7 @@
 using grpc::Server;
 
 using namespace catena::common;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 Server *globalServer = nullptr;
 std::atomic<bool> globalLoop = true;
@@ -115,7 +115,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/use_commands.cpp
@@ -57,7 +57,7 @@
 #include <Logger.h>
 
 using grpc::Server;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 using namespace catena::common;
 
@@ -101,7 +101,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
+++ b/sdks/cpp/connections/gRPC/examples/use_menus/use_menus.cpp
@@ -58,7 +58,7 @@
 #include <Logger.h>
 
 using grpc::Server;
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 using namespace catena::common;
 
@@ -129,7 +129,7 @@ void RunRPCServer(std::string addr)
         std::string EOPath = absl::GetFlag(FLAGS_static_root);
         bool authz = absl::GetFlag(FLAGS_authz);
         uint32_t maxConnections = absl::GetFlag(FLAGS_max_connections);
-        CatenaServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
+        ServiceImpl service(cq.get(), {&dm}, EOPath, authz, maxConnections);
 
         builder.RegisterService(&service);
 

--- a/sdks/cpp/connections/gRPC/include/CallData.h
+++ b/sdks/cpp/connections/gRPC/include/CallData.h
@@ -73,7 +73,7 @@ class CallData : public ICallData {
     /**
      * @brief CallData constructor which initializes service_.
      */
-    CallData(ICatenaServiceImpl *service): service_(service) {}
+    CallData(IServiceImpl *service): service_(service) {}
     /**
      * @brief Extracts the JWS Bearer token from the server context's
      * client metadata.
@@ -107,9 +107,9 @@ class CallData : public ICallData {
      */
     ServerContext context_;
     /**
-     * @brief Pointer to CatenaServiceImpl
+     * @brief Pointer to ServiceImpl
      */
-    ICatenaServiceImpl* service_;
+    IServiceImpl* service_;
 };
 
 };

--- a/sdks/cpp/connections/gRPC/include/ServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/ServiceImpl.h
@@ -64,7 +64,7 @@
 #include <vdk/signals.h>
 #include <IParam.h>
 #include <IDevice.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <SharedFlags.h>
 #include <SubscriptionManager.h>
 #include <rpc/ConnectionQueue.h>
@@ -98,17 +98,17 @@ namespace gRPC {
 /**
  * @brief Implements Catena gRPC request handlers.
  */
-class CatenaServiceImpl : public ICatenaServiceImpl {
+class ServiceImpl : public IServiceImpl {
   public:
     /**
-     * @brief Constructor for the CatenaServiceImpl class.
+     * @brief Constructor for the ServiceImpl class.
      * @param cq The completion queue for the server.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param EOPath The path to the external object.
      * @param authz Flag to enable authorization.
      * @param maxConnections The maximum number of connections allowed to the service.
      */
-    CatenaServiceImpl(ServerCompletionQueue* cq, std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint32_t maxConnections);  
+    ServiceImpl(ServerCompletionQueue* cq, std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint32_t maxConnections);  
     /**
      * @brief Creates the CallData objects for each gRPC command.
      */

--- a/sdks/cpp/connections/gRPC/include/controllers/AddLanguage.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/AddLanguage.h
@@ -53,16 +53,16 @@ class AddLanguage : public CallData {
      * @brief Constructor for the CallData class of the AddLanguage gRPC.
      * Calls proceed() once initialized.
      *
-     * @param service Pointer to the parent CatenaServiceImpl.
+     * @param service Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok Flag to check if the command was successfully executed.
      */ 
-    AddLanguage(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    AddLanguage(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages the steps of the AddLanguage gRPC commands through
      * the state variable status.
      *
-     * @param service Pointer to the parent CatenaServiceImpl.
+     * @param service Pointer to the parent ServiceImpl.
      * @param ok Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/Connect.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/Connect.h
@@ -63,17 +63,17 @@ class Connect : public CallData, public catena::common::Connect {
      * @brief Constructor for the CallData class of the Connect gRPC.
      * Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    Connect(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    Connect(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages the steps of the Connect gRPC command
      * through the state variable status. Returns the value of the
      * parameter specified by the user.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/DeviceRequest.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/DeviceRequest.h
@@ -61,7 +61,7 @@ class DeviceRequest : public CallData {
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok flag to check if request is successful 
      */
-    DeviceRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    DeviceRequest(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages gRPC request through a state machine
      *

--- a/sdks/cpp/connections/gRPC/include/controllers/ExecuteCommand.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/ExecuteCommand.h
@@ -58,7 +58,7 @@ class ExecuteCommand : public CallData {
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok flag to check if command was successfully executed 
      */
-    ExecuteCommand(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    ExecuteCommand(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages gRPC command execution through a state machine
      *

--- a/sdks/cpp/connections/gRPC/include/controllers/ExternalObjectRequest.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/ExternalObjectRequest.h
@@ -58,7 +58,7 @@ class ExternalObjectRequest : public CallData {
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok flag to check if request is successful 
      */
-    ExternalObjectRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    ExternalObjectRequest(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Destrutor for ExternalObjectRequest, although it isn't used.
      */

--- a/sdks/cpp/connections/gRPC/include/controllers/GetParam.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/GetParam.h
@@ -56,18 +56,18 @@ class GetParam : public CallData {
      * @brief Constructor for the CallData class of the GetParam
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    GetParam(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    GetParam(IServiceImpl *service, SlotMap& dms, bool ok);
 
     /**
      * @brief Manages the steps of the GetParam gRPC command
      * through the state variable status. Returns the value of the
      * parameter specified by the user.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/GetPopulatedSlots.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/GetPopulatedSlots.h
@@ -55,17 +55,17 @@ class GetPopulatedSlots : public CallData{
      * @brief Constructor for the CallData class of the GetPopulatedSlots
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    GetPopulatedSlots(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    GetPopulatedSlots(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
     * @brief Manages the steps of the GetPopulatedSlots gRPC command
     * through the state variable status. Returns the number of populated
     * slots to the client.
     *
-    * @param service - Pointer to the parent CatenaServiceImpl.
+    * @param service - Pointer to the parent ServiceImpl.
     * @param ok - Flag to check if the command was successfully executed.
     */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/GetValue.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/GetValue.h
@@ -55,17 +55,17 @@ class GetValue : public CallData{
      * @brief Constructor for the CallData class of the GetValue
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    GetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    GetValue(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages the steps of the GetValue gRPC command
      * through the state variable status. Returns the value of the
      * parameter specified by the user.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/LanguagePackRequest.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/LanguagePackRequest.h
@@ -53,16 +53,16 @@ class LanguagePackRequest : public CallData {
      * @brief Constructor for the CallData class of the LanguagePackRequest
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    LanguagePackRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    LanguagePackRequest(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages the steps of the LanguagePackRequest command through
      * the state variable status.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/ListLanguages.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/ListLanguages.h
@@ -53,16 +53,16 @@ class ListLanguages : public CallData {
      * @brief Constructor for the CallData class of the ListLanguages gRPC.
      * Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    ListLanguages(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    ListLanguages(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages the steps of the ListLanguages gRPC command through
      * the state variable status.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/MultiSetValue.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/MultiSetValue.h
@@ -57,16 +57,16 @@ class MultiSetValue : public CallData {
      * @brief Constructor for the CallData class of the MultiSetValue
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    MultiSetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    MultiSetValue(IServiceImpl *service, SlotMap& dms, bool ok);
     /**
      * @brief Manages the steps of the SetValue and MultiSetValue gRPC
      * commands through the state variable status.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;
@@ -76,12 +76,12 @@ class MultiSetValue : public CallData {
      *   
      * Helper function to allow reuse of proceed().
      *
-     * @param service Pointer to the parent CatenaServiceImpl.
+     * @param service Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok Flag to check if the command was successfully executed.
      * @param objectId objectCounter_ + 1
      */ 
-    MultiSetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok, int objectId);
+    MultiSetValue(IServiceImpl *service, SlotMap& dms, bool ok, int objectId);
     /**
      * @brief Requests Multi Set Value from the system and sets the
      * request to the MultiSetValuePayload.

--- a/sdks/cpp/connections/gRPC/include/controllers/ParamInfoRequest.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/ParamInfoRequest.h
@@ -64,18 +64,18 @@ class ParamInfoRequest : public CallData {
      * @brief Constructor for the CallData class of the ParamInfoRequest
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    ParamInfoRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    ParamInfoRequest(IServiceImpl *service, SlotMap& dms, bool ok);
 
     /**
      * @brief Manages the steps of the ParamInfoRequest gRPC command
      * through the state variable status. Returns the value of the
      * parameter specified by the user.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param ok - Flag to check if the command was successfully executed.
      */
     void proceed(bool ok) override;

--- a/sdks/cpp/connections/gRPC/include/controllers/SetValue.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/SetValue.h
@@ -54,11 +54,11 @@ class SetValue : public MultiSetValue {
      * @brief Constructor for the CallData class of the SetValue
      * gRPC. Calls proceed() once initialized.
      *
-     * @param service - Pointer to the parent CatenaServiceImpl.
+     * @param service - Pointer to the parent ServiceImpl.
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok - Flag to check if the command was successfully executed.
      */ 
-    SetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    SetValue(IServiceImpl *service, SlotMap& dms, bool ok);
   private:
     /**
      * @brief Requests Set Value from the system and adds the request to

--- a/sdks/cpp/connections/gRPC/include/controllers/UpdateSubscriptions.h
+++ b/sdks/cpp/connections/gRPC/include/controllers/UpdateSubscriptions.h
@@ -56,11 +56,11 @@ class UpdateSubscriptions : public CallData {
     /**
      * @brief Constructor for the CallData class of the UpdateSubscriptions RPC
      * gRPC. Calls proceed() once initialized.
-     * @param service The CatenaServiceImpl instance
+     * @param service The ServiceImpl instance
      * @param dms A map of slots to ptrs to their corresponding device.
      * @param ok Flag indicating if initialization was successful
      */
-    UpdateSubscriptions(ICatenaServiceImpl *service, SlotMap& dms, bool ok);
+    UpdateSubscriptions(IServiceImpl *service, SlotMap& dms, bool ok);
 
     /**
      * @brief Manages the steps of the UpdateSubscriptions gRPC command

--- a/sdks/cpp/connections/gRPC/include/interface/IServiceImpl.h
+++ b/sdks/cpp/connections/gRPC/include/interface/IServiceImpl.h
@@ -58,7 +58,7 @@ namespace gRPC {
 /**
  * @brief Interface class for the gRPC API Implementation.
  */
-class ICatenaServiceImpl : public catena::CatenaService::AsyncService {
+class IServiceImpl : public catena::CatenaService::AsyncService {
   public:
     /**
      * @brief Creates the CallData objects for each gRPC command.

--- a/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/gRPC/src/ServiceImpl.cpp
@@ -31,12 +31,12 @@
 // connections/gRPC
 #include <ServiceImpl.h>
 #include <Logger.h>
-using catena::gRPC::CatenaServiceImpl;
+using catena::gRPC::ServiceImpl;
 
 // Defining the port flag from SharedFlags.h
 ABSL_FLAG(uint16_t, port, 6254, "Catena gRPC service port");
 
-CatenaServiceImpl::CatenaServiceImpl(ServerCompletionQueue *cq, std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint32_t maxConnections)
+ServiceImpl::ServiceImpl(ServerCompletionQueue *cq, std::vector<IDevice*> dms, std::string& EOPath, bool authz, uint32_t maxConnections)
     : cq_{cq},
       EOPath_{EOPath}, 
       authorizationEnabled_{authz},
@@ -54,7 +54,7 @@ CatenaServiceImpl::CatenaServiceImpl(ServerCompletionQueue *cq, std::vector<IDev
 /**
  * Creates the CallData objects for each gRPC command.
  */
-void CatenaServiceImpl::init() {
+void ServiceImpl::init() {
     new catena::gRPC::GetPopulatedSlots(this, dms_, true);
     new catena::gRPC::GetValue(this, dms_, true);
     new catena::gRPC::SetValue(this, dms_, true);
@@ -75,7 +75,7 @@ void CatenaServiceImpl::init() {
 vdk::signal<void()> catena::gRPC::Connect::shutdownSignal_;
 
 // Processes events in the server's completion queue.
-void CatenaServiceImpl::processEvents() {
+void ServiceImpl::processEvents() {
     void *tag;
     bool ok;
     DEBUG_LOG << "Start processing events\n";
@@ -99,13 +99,13 @@ void CatenaServiceImpl::processEvents() {
 }
 
 //Registers current CallData object into the registry
-void CatenaServiceImpl::registerItem(ICallData *cd) {
+void ServiceImpl::registerItem(ICallData *cd) {
     std::lock_guard<std::mutex> lock(registryMutex_);
     this->registry_.push_back(RegistryItem(cd));
 }
 
 //Deregisters current CallData object from the registry
-void CatenaServiceImpl::deregisterItem(ICallData *cd) {
+void ServiceImpl::deregisterItem(ICallData *cd) {
     std::lock_guard<std::mutex> lock(registryMutex_);
     auto it = std::find_if(registry_.begin(), registry_.end(),
                             [cd](const RegistryItem &i) { return i.get() == cd; });

--- a/sdks/cpp/connections/gRPC/src/controllers/AddLanguage.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/AddLanguage.cpp
@@ -36,7 +36,7 @@ using catena::gRPC::AddLanguage;
 // Initializes the object counter for AddLanguage to 0.
 int AddLanguage::objectCounter_ = 0;
 
-AddLanguage::AddLanguage(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+AddLanguage::AddLanguage(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, responder_(&context_), status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     objectId_ = objectCounter_++;
     service_->registerItem(this);
@@ -116,7 +116,7 @@ void AddLanguage::proceed(bool ok) {
             break;
         /**
          * kFinish: Final step of gRPC is the deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << "AddLanguage[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -41,7 +41,7 @@ int catena::gRPC::Connect::objectCounter_ = 0;
  * Constructor which initializes and registers the current Connect object, 
  * then starts the process.
  */
-catena::gRPC::Connect::Connect(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+catena::gRPC::Connect::Connect(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish}, 
         catena::common::Connect(dms, service->getSubscriptionManager()) {

--- a/sdks/cpp/connections/gRPC/src/controllers/DeviceRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/DeviceRequest.cpp
@@ -40,7 +40,7 @@ int DeviceRequest::objectCounter_ = 0;
  * Constructor which initializes and registers the current DeviceRequest
  * object, then starts the process
  */
-DeviceRequest::DeviceRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+DeviceRequest::DeviceRequest(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service_->registerItem(this);

--- a/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExecuteCommand.cpp
@@ -40,7 +40,7 @@ int ExecuteCommand::objectCounter_ = 0;
  * Constructor which initializes and registers the current ExecuteCommand
  * object, then starts the process
  */
-ExecuteCommand::ExecuteCommand(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+ExecuteCommand::ExecuteCommand(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, writer_(&context_),
       status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service_->registerItem(this);

--- a/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
@@ -54,7 +54,7 @@ int ExternalObjectRequest::objectCounter_ = 0;
  * Constructor which initializes and registers the current
  * ExternalObjectRequest object, then starts the process
  */
-ExternalObjectRequest::ExternalObjectRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+ExternalObjectRequest::ExternalObjectRequest(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, writer_(&context_),
     status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service_->registerItem(this);

--- a/sdks/cpp/connections/gRPC/src/controllers/GetParam.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetParam.cpp
@@ -40,7 +40,7 @@ int GetParam::objectCounter_ = 0;
  * then starts the process.
  */
 
-GetParam::GetParam(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+GetParam::GetParam(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service_->registerItem(this);
@@ -134,7 +134,7 @@ void GetParam::proceed( bool ok) {
 
         /*
          * kFinish: Final step of gRPC is to deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << "GetParam[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/GetPopulatedSlots.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetPopulatedSlots.cpp
@@ -40,7 +40,7 @@ int GetPopulatedSlots::objectCounter_ = 0;
  * Constructor which initializes and registers the current GetPopulatedSlots
  * object, then starts the process.
  */
-GetPopulatedSlots::GetPopulatedSlots(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+GetPopulatedSlots::GetPopulatedSlots(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, responder_(&context_), status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     objectId_ = objectCounter_++;
     service_->registerItem(this);
@@ -90,7 +90,7 @@ void GetPopulatedSlots::proceed( bool ok) {
         break;
         /**
          * kFinish: Final step of gRPC is the deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << "GetPopulatedSlots[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/GetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/GetValue.cpp
@@ -40,7 +40,7 @@ int GetValue::objectCounter_ = 0;
  * Constructor which initializes and registers the current GetValue object, 
  * then starts the process.
  */
-GetValue::GetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok) : CallData(service), dms_{dms}, responder_(&context_), 
+GetValue::GetValue(IServiceImpl *service, SlotMap& dms, bool ok) : CallData(service), dms_{dms}, responder_(&context_), 
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     objectId_ = objectCounter_++;
     service_->registerItem(this);
@@ -128,7 +128,7 @@ void GetValue::proceed( bool ok) {
         break;
         /**
          * kFinish: Final step of gRPC is to deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << "GetValue[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/LanguagePackRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/LanguagePackRequest.cpp
@@ -36,7 +36,7 @@ using catena::gRPC::LanguagePackRequest;
 // Initializes the object counter for LanguagePackRequest to 0.
 int LanguagePackRequest::objectCounter_ = 0;
 
-LanguagePackRequest::LanguagePackRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+LanguagePackRequest::LanguagePackRequest(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, responder_(&context_), status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     objectId_ = objectCounter_++;
     service_->registerItem(this);
@@ -105,7 +105,7 @@ void LanguagePackRequest::proceed(bool ok) {
             break;
         /**
          * kFinish: Final step of gRPC is the deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << "LanguagePackRequest[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/ListLanguages.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ListLanguages.cpp
@@ -36,7 +36,7 @@ using catena::gRPC::ListLanguages;
 // Initializes the object counter for SetValue to 0.
 int ListLanguages::objectCounter_ = 0;
 
-ListLanguages::ListLanguages(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+ListLanguages::ListLanguages(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, responder_(&context_), status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     objectId_ = objectCounter_++;
     service_->registerItem(this);
@@ -101,7 +101,7 @@ void ListLanguages::proceed(bool ok) {
             break;
         /**
          * kFinish: Final step of gRPC is the deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << "ListLanguages[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/MultiSetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/MultiSetValue.cpp
@@ -36,14 +36,14 @@ using catena::gRPC::MultiSetValue;
 // Initializes the object counter for SetValue to 0.
 int MultiSetValue::objectCounter_ = 0;
 
-MultiSetValue::MultiSetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+MultiSetValue::MultiSetValue(IServiceImpl *service, SlotMap& dms, bool ok)
     : MultiSetValue(service, dms, ok, objectCounter_++) {
     typeName = "MultiSetValue";
     service_->registerItem(this);
     proceed(ok);
 }
 
-MultiSetValue::MultiSetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok, int objectId)
+MultiSetValue::MultiSetValue(IServiceImpl *service, SlotMap& dms, bool ok, int objectId)
     : CallData(service), dms_{dms}, objectId_(objectId), responder_(&context_),
     status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {}
 
@@ -134,7 +134,7 @@ void MultiSetValue::proceed(bool ok) {
             break;
         /**
          * kFinish: Final step of gRPC is the deregister the item from
-         * CatenaServiceImpl.
+         * ServiceImpl.
          */
         case CallStatus::kFinish:
             DEBUG_LOG << typeName << "[" << objectId_ << "] finished";

--- a/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
@@ -35,7 +35,7 @@ using catena::gRPC::ParamInfoRequest;
 
 int ParamInfoRequest::objectCounter_ = 0;
 
-ParamInfoRequest::ParamInfoRequest(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+ParamInfoRequest::ParamInfoRequest(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service_->registerItem(this);

--- a/sdks/cpp/connections/gRPC/src/controllers/SetValue.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/SetValue.cpp
@@ -35,7 +35,7 @@ using catena::gRPC::SetValue;
 // Initializes the object counter for SetValue to 0.
 int SetValue::objectCounter_ = 0;
 
-SetValue::SetValue(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+SetValue::SetValue(IServiceImpl *service, SlotMap& dms, bool ok)
     : MultiSetValue(service, dms, ok, objectCounter_++) {
     typeName = "SetValue";
     service_->registerItem(this);

--- a/sdks/cpp/connections/gRPC/src/controllers/UpdateSubscriptions.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/UpdateSubscriptions.cpp
@@ -35,7 +35,7 @@ using catena::gRPC::UpdateSubscriptions;
 
 int UpdateSubscriptions::objectCounter_ = 0;
 
-UpdateSubscriptions::UpdateSubscriptions(ICatenaServiceImpl *service, SlotMap& dms, bool ok)
+UpdateSubscriptions::UpdateSubscriptions(IServiceImpl *service, SlotMap& dms, bool ok)
     : CallData(service), dms_{dms}, writer_(&context_),
         status_{ok ? CallStatus::kCreate : CallStatus::kFinish} {
     service_->registerItem(this);

--- a/unittests/cpp/REST/mocks/MockServiceImpl.h
+++ b/unittests/cpp/REST/mocks/MockServiceImpl.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief Mock implementation for the REST ICatenaServiceImpl class.
+ * @brief Mock implementation for the REST IServiceImpl class.
  * @author benjamin.whitten@rossvideo.com
  * @date 25/07/22
  * @copyright Copyright © 2025 Ross Video Ltd
@@ -45,8 +45,8 @@ using namespace catena::common;
 namespace catena {
 namespace REST {
 
-// Mock implementation for the REST ICatenaServiceImpl class.
-class MockServiceImpl : public ICatenaServiceImpl {
+// Mock implementation for the REST IServiceImpl class.
+class MockServiceImpl : public IServiceImpl {
   public:
     MOCK_METHOD(const std::string&, version, (), (const, override));
     MOCK_METHOD(void, run, (), (override));

--- a/unittests/cpp/REST/mocks/MockSocketReader.h
+++ b/unittests/cpp/REST/mocks/MockSocketReader.h
@@ -58,7 +58,7 @@ class MockSocketReader : public ISocketReader {
     MOCK_METHOD(catena::Device_DetailLevel, detailLevel, (), (const, override));
     MOCK_METHOD(const std::string&, jsonBody, (), (const, override));
     MOCK_METHOD(bool, stream, (), (const, override));
-    MOCK_METHOD(ICatenaServiceImpl*, service, (), (override));
+    MOCK_METHOD(IServiceImpl*, service, (), (override));
     MOCK_METHOD(IConnectionQueue&, connectionQueue, (), (override));
     MOCK_METHOD(bool, authorizationEnabled, (), (const, override));
     MOCK_METHOD(const std::string&, EOPath, (), (const, override));

--- a/unittests/cpp/REST/tests/ServiceImpl_test.cpp
+++ b/unittests/cpp/REST/tests/ServiceImpl_test.cpp
@@ -69,7 +69,7 @@ class RESTServiceImplTests : public testing::Test {
     void SetUp() override {
         oldCout_ = std::cout.rdbuf(MockConsole_.rdbuf());
         EXPECT_CALL(dm_, slot()).WillRepeatedly(testing::Return(0));
-        service_.reset(new CatenaServiceImpl({&dm_}, EOPath_, authzEnabled_, port_, 1));
+        service_.reset(new ServiceImpl({&dm_}, EOPath_, authzEnabled_, port_, 1));
     }
 
     /*
@@ -100,7 +100,7 @@ class RESTServiceImplTests : public testing::Test {
         return std::string(std::istreambuf_iterator<char>(response_stream), std::istreambuf_iterator<char>());
     }
 
-    std::unique_ptr<CatenaServiceImpl> service_ = nullptr;
+    std::unique_ptr<ServiceImpl> service_ = nullptr;
 
     // Cout variables
     std::stringstream MockConsole_;
@@ -115,7 +115,7 @@ class RESTServiceImplTests : public testing::Test {
 };
 
 /*
- * TEST 1 - Creating a REST CatenaServiceImpl.
+ * TEST 1 - Creating a REST ServiceImpl.
  */
 TEST_F(RESTServiceImplTests, ServiceImpl_Create) {
     ASSERT_TRUE(service_);
@@ -126,18 +126,18 @@ TEST_F(RESTServiceImplTests, ServiceImpl_Create) {
 }
 
 /*
- * TEST 2 - Creating a REST CatenaServiceImpl.
+ * TEST 2 - Creating a REST ServiceImpl.
  */
 TEST_F(RESTServiceImplTests, ServiceImpl_CreateDuplicateSlot) {
     MockDevice dm2;
     EXPECT_CALL(dm2, slot()).WillRepeatedly(testing::Return(0));
     // Creating a service with a duplicate slot.
-    EXPECT_THROW(CatenaServiceImpl({&dm_, &dm2}, EOPath_, authzEnabled_, port_ + 2, 1), std::runtime_error)
+    EXPECT_THROW(ServiceImpl({&dm_, &dm2}, EOPath_, authzEnabled_, port_ + 2, 1), std::runtime_error)
         << "Creating a service with two devices sharing a slot should throw an error.";
 }
 
 /*
- * TEST 3 - Running and shutting down the REST CatenaServiceImpl.
+ * TEST 3 - Running and shutting down the REST ServiceImpl.
  */
 TEST_F(RESTServiceImplTests, ServiceImpl_RunAndShutdown) {
     // Starting the service.

--- a/unittests/cpp/common/CMakeLists.txt
+++ b/unittests/cpp/common/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SOURCES
     tests/utils_test.cpp
     tests/SubscriptionManager_test.cpp
     tests/ParamVisitor_test.cpp
-    tests/Authorization_test.cpp
+    tests/Authorizer_test.cpp
     tests/Connect_test.cpp
     tests/MenuGroup_test.cpp
     tests/Menu_test.cpp

--- a/unittests/cpp/common/tests/Authorizer_test.cpp
+++ b/unittests/cpp/common/tests/Authorizer_test.cpp
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief This file is for testing the Authorization.cpp file.
+ * @brief This file is for testing the Authorizer.cpp file.
  * @author benjamin.whitten@rossvideo.com
  * @date 25/05/20
  * @copyright Copyright © 2025 Ross Video Ltd
@@ -37,7 +37,7 @@
 
 #include "MockParam.h"
 #include "MockParamDescriptor.h"
-#include "Authorization.h"
+#include "Authorizer.h"
 #include "Enums.h"
 #include "CommonTestHelpers.h"
 #include <Logger.h>

--- a/unittests/cpp/common/tests/ParamVisitor_test.cpp
+++ b/unittests/cpp/common/tests/ParamVisitor_test.cpp
@@ -44,7 +44,7 @@
 #include <IDevice.h>
 #include <IParam.h>
 #include <Status.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <ParamVisitor.h>
 #include <Logger.h>
 

--- a/unittests/cpp/common/tests/SubscriptionManager_test.cpp
+++ b/unittests/cpp/common/tests/SubscriptionManager_test.cpp
@@ -43,7 +43,7 @@
 #include <IDevice.h>
 #include <IParam.h>
 #include <Status.h>
-#include <Authorization.h>
+#include <Authorizer.h>
 #include <SubscriptionManager.h>
 #include <Logger.h>
 

--- a/unittests/cpp/gRPC/mocks/MockServiceImpl.h
+++ b/unittests/cpp/gRPC/mocks/MockServiceImpl.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief Mock implementation for the gRPC ICatenaServiceImpl class.
+ * @brief Mock implementation for the gRPC IServiceImpl class.
  * @author benjamin.whitten@rossvideo.com
  * @date 25/06/26
  * @copyright Copyright © 2025 Ross Video Ltd
@@ -45,8 +45,8 @@ using namespace catena::common;
 namespace catena {
 namespace gRPC {
 
-// Mock implementation for the gRPC ICatenaServiceImpl class.
-class MockServiceImpl : public ICatenaServiceImpl {
+// Mock implementation for the gRPC IServiceImpl class.
+class MockServiceImpl : public IServiceImpl {
   public:
     MOCK_METHOD(void, init, (), (override));
     MOCK_METHOD(void, processEvents, (), (override));

--- a/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
+++ b/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
@@ -83,7 +83,7 @@ class gRPCServiceImplTests : public testing::Test {
         // Creating the gRPC server.
         builder_.AddListeningPort(serverAddr_, grpc::InsecureServerCredentials());
         cq_ = builder_.AddCompletionQueue();
-        service_.reset(new CatenaServiceImpl(cq_.get(), {&dm_}, EOPath_, authzEnabled_, 1));
+        service_.reset(new ServiceImpl(cq_.get(), {&dm_}, EOPath_, authzEnabled_, 1));
         builder_.RegisterService(service_.get());
         server_ = builder_.BuildAndStart();
         service_->init();
@@ -118,7 +118,7 @@ class gRPCServiceImplTests : public testing::Test {
     // Server and service variables.
     grpc::ServerBuilder builder_;
     std::unique_ptr<grpc::Server> server_ = nullptr;
-    std::unique_ptr<CatenaServiceImpl> service_ = nullptr;
+    std::unique_ptr<ServiceImpl> service_ = nullptr;
     MockDevice dm_;
     // Completion queue variables.
     std::unique_ptr<grpc::ServerCompletionQueue> cq_ = nullptr;
@@ -151,7 +151,7 @@ TEST_F(gRPCServiceImplTests, ServiceImpl_CreateDestroy) {
 }
 
 /*
- * TEST 2 - Creating a REST CatenaServiceImpl.
+ * TEST 2 - Creating a REST ServiceImpl.
  *
  * This is not under the fixture because setting up a gRPC server is time
  * consuming and not needed.
@@ -162,6 +162,6 @@ TEST(gRPCServiceImplTests_NoFixture, ServiceImpl_CreateDuplicateSlot) {
     EXPECT_CALL(dm1, slot()).WillRepeatedly(testing::Return(0));
     EXPECT_CALL(dm2, slot()).WillRepeatedly(testing::Return(0));
     // Creating a service with a duplicate slot.
-    EXPECT_THROW(CatenaServiceImpl(nullptr, {&dm1, &dm2}, EOPath, false, 16), std::runtime_error)
+    EXPECT_THROW(ServiceImpl(nullptr, {&dm1, &dm2}, EOPath, false, 16), std::runtime_error)
         << "Creating a service with two devices sharing a slot should throw an error.";
 }


### PR DESCRIPTION
**Changelog:**
- Renamed Authorization.h/cpp to Authorizer.h/cpp
- Renamed gRPC and REST ICatenaServiceImpl and CatenaServiceImpl to IServiceImpl and ServiceImpl respectively.

This PR is just a find-replace job. All unittests passed afterwards and example devices worked fine.