### PR TITLE
Added EQ graphs to audio deck UI

### DIFF
--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
@@ -39,7 +39,7 @@
           "access_scope": "st2138:op",
           "constraint": {
             "type": "FLOAT_RANGE",
-            "float_range": {"min_value":0,  "max_value": 10.0, "step": 0.1}
+            "float_range": {"min_value":20, "display_min": 20,  "max_value": 20000, "display_max": 20000, "step": 1.0}
           },
           "widget": "wheel"
         },

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/device.AudioDeck.json
@@ -131,9 +131,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 10},
-                              "frequency": {"float32_value": 1},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 0.8},
+                              "gain": {"float32_value": 2.5},
+                              "q_factor": {"float32_value": 8.4}
                             }
                           }
                         },
@@ -141,9 +141,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 20},
-                              "frequency": {"float32_value": 2},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 4.7},
+                              "gain": {"float32_value": 3.7},
+                              "q_factor": {"float32_value": 5.6}
                             }
                           }
                         }
@@ -164,9 +164,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 30},
-                              "frequency": {"float32_value": 3},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 0.8},
+                              "gain": {"float32_value": 2.5},
+                              "q_factor": {"float32_value": 9.3}
                             }
                           }
                         },
@@ -174,9 +174,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 40},
-                              "frequency": {"float32_value": 4},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 1.9},
+                              "gain": {"float32_value": 0.5},
+                              "q_factor": {"float32_value": 1.2}
                             }
                           }
                         }
@@ -197,9 +197,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 50},
-                              "frequency": {"float32_value": 5},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 1.1},
+                              "gain": {"float32_value": 3.8},
+                              "q_factor": {"float32_value": 0.9}
                             }
                           }
                         },
@@ -207,9 +207,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 60},
-                              "frequency": {"float32_value": 6},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 4.2},
+                              "gain": {"float32_value": 4.6},
+                              "q_factor": {"float32_value": 0.3}
                             }
                           }
                         }
@@ -230,9 +230,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 70},
-                              "frequency": {"float32_value": 7},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 1.4},
+                              "gain": {"float32_value": 4.5},
+                              "q_factor": {"float32_value": 0.1}
                             }
                           }
                         },
@@ -240,9 +240,9 @@
                           "struct_value": {
                             "fields": {
                               "response": {"int32_value": 80},
-                              "frequency": {"float32_value": 8},
-                              "gain": {"float32_value": 0},
-                              "q_factor": {"float32_value": 0}
+                              "frequency": {"float32_value": 6.1},
+                              "gain": {"float32_value": 4.8},
+                              "q_factor": {"float32_value": 9.9}
                             }
                           }
                         }
@@ -255,6 +255,154 @@
           ]
         }
       }
+    },
+    "eq_graph_0":{
+      "type": "STRING",
+      "name": { "display_strings": { "en": "EQ Graph 0"}},
+      "widget": "eq_graph",
+      "constraint": {
+        "type": "STRING_STRING_CHOICE",
+        "string_string_choice": {
+          "choices": [
+            {
+              "name": { "display_strings": { "en": "audio_deck.0.eq_list.0.frequency" }},
+              "value": "1.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.0.eq_list.0.gain" }},
+              "value": "1.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.0.eq_list.0.q_factor" }},
+              "value": "1.q"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.0.eq_list.1.frequency" }},
+              "value": "2.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.0.eq_list.1.gain" }},
+              "value": "2.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.0.eq_list.1.q_factor" }},
+              "value": "2.q"
+            }
+          ]
+        }
+      },
+      "value": { "string_value": "" }
+    },
+    "eq_graph_1":{
+      "type": "STRING",
+      "name": { "display_strings": { "en": "EQ Graph 1"}},
+      "widget": "eq_graph",
+      "constraint": {
+        "type": "STRING_STRING_CHOICE",
+        "string_string_choice": {
+          "choices": [
+            {
+              "name": { "display_strings": { "en": "audio_deck.1.eq_list.0.frequency" }},
+              "value": "1.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.1.eq_list.0.gain" }},
+              "value": "1.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.1.eq_list.0.q_factor" }},
+              "value": "1.q"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.1.eq_list.1.frequency" }},
+              "value": "2.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.1.eq_list.1.gain" }},
+              "value": "2.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.1.eq_list.1.q_factor" }},
+              "value": "2.q"
+            }
+          ]
+        }
+      },
+      "value": { "string_value": "" }
+    },
+    "eq_graph_2": {
+      "type": "STRING",
+      "name": { "display_strings": { "en": "EQ Graph 2"}},
+      "widget": "eq_graph",
+      "constraint": {
+        "type": "STRING_STRING_CHOICE",
+        "string_string_choice": {
+          "choices": [
+            {
+              "name": { "display_strings": { "en": "audio_deck.2.eq_list.0.frequency" }},
+              "value": "1.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.2.eq_list.0.gain" }},
+              "value": "1.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.2.eq_list.0.q_factor" }},
+              "value": "1.q"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.2.eq_list.1.frequency" }},
+              "value": "2.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.2.eq_list.1.gain" }},
+              "value": "2.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.2.eq_list.1.q_factor" }},
+              "value": "2.q"
+            }
+          ]
+        }
+      },
+      "value": { "string_value": "" }
+    },
+    "eq_graph_3": {
+      "type": "STRING",
+      "name": { "display_strings": { "en": "EQ Graph 3"}},
+      "widget": "eq_graph",
+      "constraint": {
+        "type": "STRING_STRING_CHOICE",
+        "string_string_choice": {
+          "choices": [
+            {
+              "name": { "display_strings": { "en": "audio_deck.3.eq_list.0.frequency" }},
+              "value": "1.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.3.eq_list.0.gain" }},
+              "value": "1.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.3.eq_list.0.q_factor" }},
+              "value": "1.q"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.3.eq_list.1.frequency" }},
+              "value": "2.f"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.3.eq_list.1.gain" }},
+              "value": "2.g"
+            },
+            {
+              "name": { "display_strings": { "en": "audio_deck.3.eq_list.1.q_factor" }},
+              "value": "2.q"
+            }
+          ]
+        }
+      },
+      "value": { "string_value": "" }
     },
     "effect_settings": {
       "type": "STRUCT_VARIANT",

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/static/AudioDeck.grid
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/static/AudioDeck.grid
@@ -206,7 +206,21 @@
          </table>
       </tr>
       <tr>
-         <label colspan="4" fill="both" name="" rowspan="1" style="bg-u:eo://catena_logo.png;" weightx="1.0" weighty="10"/>
+         <tab colspan="4" fill="both" name="" rowspan="1" style="bg-u:eo://catena_logo.png;" weightx="1.0" weighty="2">
+            <abs id="tab1" name="Tab 1" fill="both" style="bg-u:eo://catena_logo.png;"/>
+            <table id="tab2" name="Tab 2" bottom="0" fill="both" left="0" right="0" top="0" weightx="1.0" weighty="1.0">
+               <tr>
+                  <table colspan="1" fill="both" rowspan="1" weightx="1.0" weighty="1.0">
+                     <tr>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_0" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_1" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_2" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_3" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
+                     </tr>
+                  </table>
+               </tr>
+            </table>
+         </tab>
       </tr>
    </table>
 </abs>

--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz/static/AudioDeck.grid
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz/static/AudioDeck.grid
@@ -212,10 +212,22 @@
                <tr>
                   <table colspan="1" fill="both" rowspan="1" weightx="1.0" weighty="1.0">
                      <tr>
-                        <param colspan="1" expand="true" fill="both" oid="eq_graph_0" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
-                        <param colspan="1" expand="true" fill="both" oid="eq_graph_1" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
-                        <param colspan="1" expand="true" fill="both" oid="eq_graph_2" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
-                        <param colspan="1" expand="true" fill="both" oid="eq_graph_3" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0"/>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_0" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0">
+                           <config key="w.xaxisentries">20, 50, 100, 200, 500, 1000, 2000, 5000, 10000</config>
+                           <config key="w.frequencyshift">18</config>
+                        </param>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_1" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0">
+                           <config key="w.xaxisentries">20, 50, 100, 200, 500, 1000, 2000, 5000, 10000</config>
+                           <config key="w.frequencyshift">18</config>
+                        </param>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_2" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0">
+                           <config key="w.xaxisentries">20, 50, 100, 200, 500, 1000, 2000, 5000, 10000</config>
+                           <config key="w.frequencyshift">18</config>
+                        </param>
+                        <param colspan="1" expand="true" fill="both" oid="eq_graph_3" rowspan="1" showlabel="false" weightx="1.0" weighty="1.0">
+                           <config key="w.xaxisentries">20, 50, 100, 200, 500, 1000, 2000, 5000, 10000</config>
+                           <config key="w.frequencyshift">18</config>
+                        </param>
                      </tr>
                   </table>
                </tr>


### PR DESCRIPTION
Had some free time so I decided to experiment with adding EQ graphs to the Audio Deck UI. You guys are welcome to rework this if you want it to look different, but this is a good starting point of how it can be implemented.

<img width="1609" height="956" alt="image" src="https://github.com/user-attachments/assets/d9f27926-352c-43ed-a3a8-98bab109959e" />
