### PR TITLE
Fixed Issue With Generating Struct Arrays Without Templatated Element

### DIFF
--- a/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/device.AudioDeck.yaml
+++ b/sdks/cpp/connections/gRPC/examples/structs_with_authz_yaml/device.AudioDeck.yaml
@@ -5,29 +5,7 @@ detail_level: FULL
 access_scopes: ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"]
 default_scope: st2138:mon
 language_packs: {}
-params: 
-  # Basic struct template used by arrays
-  eq: 
-    type: STRUCT
-    name: {display_strings: {en: EQ}}
-    params: 
-      response: 
-        type: INT32
-        name: {display_strings: {en: Response}}
-        access_scope: st2138:mon
-      frequency: 
-        type: FLOAT32
-        name: {display_strings: {en: Frequency}}
-        access_scope: st2138:op
-      gain: 
-        type: FLOAT32
-        name: {display_strings: {en: Gain}}
-        access_scope: st2138:cfg
-      q_factor: 
-        type: FLOAT32
-        name: {display_strings: {en: Q Factor}}
-        access_scope: st2138:adm
-
+params:
   # Template struct containing an array (STRUCT containing STRUCT_ARRAY)
   audio_channel: 
     type: STRUCT
@@ -40,7 +18,23 @@ params:
       eq_list: 
         type: STRUCT_ARRAY
         name: {display_strings: {en: EQ List}}
-        template_oid: /eq
+        params:
+          response: 
+            type: INT32
+            name: {display_strings: {en: Response}}
+            access_scope: st2138:mon
+          frequency: 
+            type: FLOAT32
+            name: {display_strings: {en: Frequency}}
+            access_scope: st2138:op
+          gain: 
+            type: FLOAT32
+            name: {display_strings: {en: Gain}}
+            access_scope: st2138:cfg
+          q_factor: 
+            type: FLOAT32
+            name: {display_strings: {en: Q Factor}}
+            access_scope: st2138:adm
         value: 
           struct_array_values: 
             struct_values:

--- a/tools/codegen/cpp/cppgen.js
+++ b/tools/codegen/cpp/cppgen.js
@@ -300,9 +300,10 @@ class CppGen {
       hloc(`};`, --hindent);
 
       // add StructInfo specialization to the buffer
+      let paramNamespace = param.isArrayType() ? param.elementNamespaceType() : param.objectNamespaceType();
       ploc(`template<>`);
-      ploc(`struct catena::common::StructInfo<${param.objectNamespaceType()}> {`, pindent++);
-      ploc(`using ${param.objectType()} = ${param.objectNamespaceType()};`, pindent);
+      ploc(`struct catena::common::StructInfo<${paramNamespace}> {`, pindent++);
+      ploc(`using ${param.objectType()} = ${paramNamespace};`, pindent);
       ploc(`using Type = std::tuple<${param.getFieldInfoTypes()}>;`, pindent);
       ploc(`static constexpr Type fields = {${param.getFieldInfoInit()}};`, pindent);
       ploc(`};`, --pindent);

--- a/tools/codegen/cpp/param.js
+++ b/tools/codegen/cpp/param.js
@@ -307,18 +307,19 @@ class Param {
    * 
    * @returns the c++ type of the param's value as a string
    */
-  objectType() {
+  objectType() { // <----- Here This 
     if (!this.hasTypeInfo()) {
       return typeArg(this.type);
     }
-    if (this.isTemplated()) {
-      if (this.isArrayType() && !this.template_param.isArrayType()) {
-        return `${initialCap(this.oid)}`;
-      } else {
-        return this.template_param.objectType();
-      }
-    } else {
+    // Not templated returns param
+    if (!this.isTemplated()) {
       return `${initialCap(this.oid)}`;
+    // Non-array template also returns param
+    } else if (this.isArrayType() && !this.template_param.isArrayType()) {
+      return `${initialCap(this.oid)}`;
+    // Array template returns template_param
+    } else {
+      return this.template_param.objectType();
     }
   }
 
@@ -330,14 +331,15 @@ class Param {
     if (!this.hasTypeInfo()) {
       return typeArg(this.type);
     }
-    if (this.isTemplated()) {
-      if (this.isArrayType() && !this.template_param.isArrayType()) {
-        return `${this.namespace}::${initialCap(this.oid)}`;
-      } else {
-        return this.template_param.objectNamespaceType();
-      }
-    } else {
+    // Not templated returns namespace::param
+    if (!this.isTemplated()) {
       return `${this.namespace}::${initialCap(this.oid)}`;
+    // Non-array template also returns namespace::param
+    } else if (this.isArrayType() && !this.template_param.isArrayType()) {
+      return `${this.namespace}::${initialCap(this.oid)}`;
+    // Array template returns namespace::template_param
+    } else {
+      return this.template_param.objectNamespaceType();
     }
   }
 
@@ -350,13 +352,36 @@ class Param {
     if (!this.isArrayType()) {
       throw new Error(`${this.type} type does not have an element type`);
     }
-
+    // Not templated returns param_elem
     if (!this.isTemplated()) {
       return `${this.objectType()}_elem`;
-    } else if (!this.template_param.isArrayType()) {
-      return `${this.template_param.objectNamespaceType()}`;
-    } else {
+    // Array template returns template_param_elem
+    } else if (this.template_param.isArrayType()) {
       return this.template_param.elementType();
+    // Non-array template returns template_param
+    } else {
+      return `${this.template_param.objectNamespaceType()}`;
+    }
+  }
+
+  /**
+   * @returns the c++ type of an element of an array type param with its full
+   * namespace as a string
+   * @throws if the param is not an array type
+   */
+  elementNamespaceType() {
+    if (!this.isArrayType()) {
+      throw new Error(`${this.type} type does not have an element type`);
+    }
+    // Not templated returns namespace::param_elem
+    if (!this.isTemplated()) {
+      return `${this.namespace}::${this.elementType()}`;
+    // Array template also returns namespace::param_elem
+    } else if (this.template_param.isArrayType()) {
+      return `${this.namespace}::${this.elementType()}`;
+    // Non-array template returns namespace::template_param
+    } else {
+      return this.template_param.objectNamespaceType();
     }
   }
 
@@ -503,7 +528,7 @@ class Param {
   getFieldInfoTypes() {
     let subParamArr = Object.values(this.subParams);
     let mappedArr = subParamArr.map((subParam) => {
-      return `FieldInfo<${subParam.objectNamespaceType()}, ${this.objectType()}>`;
+      return `FieldInfo<${subParam.objectNamespaceType()}, ${this.objectType()}>`; // <-- Here
     });
     return mappedArr.join(", ");
   }

--- a/tools/codegen/cpp/param.js
+++ b/tools/codegen/cpp/param.js
@@ -307,7 +307,7 @@ class Param {
    * 
    * @returns the c++ type of the param's value as a string
    */
-  objectType() { // <----- Here This 
+  objectType() {
     if (!this.hasTypeInfo()) {
       return typeArg(this.type);
     }
@@ -528,7 +528,7 @@ class Param {
   getFieldInfoTypes() {
     let subParamArr = Object.values(this.subParams);
     let mappedArr = subParamArr.map((subParam) => {
-      return `FieldInfo<${subParam.objectNamespaceType()}, ${this.objectType()}>`; // <-- Here
+      return `FieldInfo<${subParam.objectNamespaceType()}, ${this.objectType()}>`;
     });
     return mappedArr.join(", ");
   }


### PR DESCRIPTION
Changelog:
- Fixed issue with generating Struct Arrays without templated elements
- Added new function ElementNamespace() to param.js which is the array element equivalent of ObjectNamespace().
- Refactored Element and Object functions to remove nested if-statements.