### PR TITLE
Ut #777 zs

### DIFF
--- a/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
@@ -79,7 +79,7 @@ void ParamInfoRequest::proceed(bool ok) {
                 }
                 // Making sure the device exists.
                 if (!dm) {
-                    rc = catena::exception_with_status("device not found in slot " + std::to_string(req_.slot()), catena::StatusCode::NOT_FOUND);
+                    rc = catena::exception_with_status("Device not found in slot " + std::to_string(req_.slot()), catena::StatusCode::NOT_FOUND);
                 } else {
                     if (service_->authorizationEnabled()) {
                         sharedAuthz = std::make_shared<Authorizer>(jwsToken_());

--- a/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
@@ -196,9 +196,15 @@ void ParamInfoRequest::proceed(bool ok) {
                 grpc::Status errorStatus(static_cast<grpc::StatusCode>(err.status), err.what());
                 writer_.Finish(errorStatus, this);
                 break;
+            } catch (const std::exception& e) {
+                status_ = CallStatus::kFinish;
+                grpc::Status errorStatus(grpc::StatusCode::UNKNOWN, 
+                    "Failed due to unknown error in ParamInfoRequest: " + std::string(e.what()));
+                writer_.Finish(errorStatus, this);
+                break;
             } catch (...) {
                 status_ = CallStatus::kFinish;
-                grpc::Status errorStatus(grpc::StatusCode::INTERNAL, 
+                grpc::Status errorStatus(grpc::StatusCode::UNKNOWN, 
                     "Failed due to unknown error in ParamInfoRequest");
                 writer_.Finish(errorStatus, this);
                 break;

--- a/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ParamInfoRequest.cpp
@@ -119,6 +119,10 @@ void ParamInfoRequest::proceed(bool ok) {
                         writer_.Write(responses_[0], this);  //Write the first response
                         writer_lock_.unlock();
                         break;  
+                    } else if (rc.status != catena::StatusCode::OK) {
+                        throw catena::exception_with_status(rc.what(), rc.status);
+                    } else {
+                        throw catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
                     }
 
                 // Mode 2: Get a specific parameter and its children
@@ -155,8 +159,10 @@ void ParamInfoRequest::proceed(bool ok) {
                         writer_.Write(responses_[0], this); //Write the first response
                         writer_lock_.unlock();
                         break;
-                    } else {
+                    } else if (rc.status != catena::StatusCode::OK) {
                         throw catena::exception_with_status(rc.what(), rc.status);
+                    } else {
+                        throw catena::exception_with_status("Parameter not found: " + req_.oid_prefix(), catena::StatusCode::NOT_FOUND);
                     }
 
                 // Mode 3: Get ALL parameters recursively
@@ -194,8 +200,10 @@ void ParamInfoRequest::proceed(bool ok) {
                         writer_.Write(responses_[0], this);  //Write the first response
                         writer_lock_.unlock();
                         break;  
-                    } else {
+                    } else if (rc.status != catena::StatusCode::OK) {
                         throw catena::exception_with_status(rc.what(), rc.status);
+                    } else {
+                        throw catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
                     }
                 }
 

--- a/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
@@ -568,26 +568,7 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithRecursio
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
 }
 
-// Test 2.4: Get top-level parameters with error status from getTopLevelParams
-TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithErrorStatus) {
-    expRc_ = catena::exception_with_status("Error getting parameters", catena::StatusCode::INTERNAL);
-
-    // Setup mock expectations
-    EXPECT_CALL(context_, hasField("recursive")).WillOnce(testing::Return(true));
-    EXPECT_CALL(context_, stream()).WillRepeatedly(testing::Return(true));
-    EXPECT_CALL(dm0_, getTopLevelParams(testing::_, testing::_))
-        .WillOnce(testing::Invoke([](catena::exception_with_status& status, Authorizer&) {
-            status = catena::exception_with_status("Error getting parameters", catena::StatusCode::INTERNAL);
-            return std::vector<std::unique_ptr<IParam>>();
-        }));
-
-    endpoint_->proceed();
-
-    // Match expected and actual responses
-    EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_));
-}
-
-// Test 2.5: Get top-level parameters with empty list and recursion
+// Test 2.4: Get top-level parameters with empty list and recursion
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsWithEmptyListAndRecursion) {
     expRc_ = catena::exception_with_status("No top-level parameters found", catena::StatusCode::NOT_FOUND);
 

--- a/unittests/cpp/gRPC/CMakeLists.txt
+++ b/unittests/cpp/gRPC/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     tests/LanguagePackRequest_test.cpp
     tests/ListLanguages_test.cpp
     tests/MultiSetValue_test.cpp
+    tests/ParamInfoRequest_test.cpp
     tests/SetValue_test.cpp
     tests/ServiceImpl_test.cpp
 )	

--- a/unittests/cpp/gRPC/GRPCTestHelpers.h
+++ b/unittests/cpp/gRPC/GRPCTestHelpers.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Helper functions for gRPC API tests
+ * @author Zuhayr Sarker (zuhayr.sarker@rossvideo.com)
+ * @date 2025-07-24
+ * @copyright Copyright © 2025 Ross Video Ltd
+ */
+
+#pragma once
+
+#include <interface/device.pb.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <string>
+#include <vector>
+
+#include "MockParamDescriptor.h"
+#include "MockParam.h"
+
+namespace catena {
+namespace gRPC {
+namespace test {
+
+/*
+ * ============================================================================
+ *                        ParamInfoRequest Helpers
+ * ============================================================================
+ */
+
+struct ParamInfo {
+    std::string oid;
+    catena::ParamType type;
+    uint32_t array_length = 0;
+    catena::StatusCode status = catena::StatusCode::OK;  // Default to OK
+};
+
+/**
+ * @brief Creates or populates a ParamInfoResponse with the specified parameters
+ */
+inline void setupParamInfo(catena::ParamInfoResponse& response, const ParamInfo& info) {
+    response.mutable_info()->set_oid(info.oid);
+    response.mutable_info()->set_type(info.type);
+    if (info.array_length > 0) {
+        // Note: set_array_length might not exist in the protobuf, so we'll skip this for now
+        // response.set_array_length(info.array_length);
+    }
+}
+
+/**
+ * @brief Sets up a mock parameter to return a ParamInfoResponse
+ *        Also sets up getDescriptor, isArrayType, and size for array types.
+ */
+inline void setupMockParam(catena::common::MockParam& mockParam, const ParamInfo& info, const catena::common::MockParamDescriptor& descriptor) {
+    EXPECT_CALL(mockParam, getOid())
+        .WillRepeatedly(::testing::ReturnRef(info.oid));
+
+    // Set up getDescriptor
+    EXPECT_CALL(mockParam, getDescriptor())
+        .WillRepeatedly(::testing::ReturnRef(descriptor));
+
+    // Set up getScope for authorization checks (default to monitor scope)
+    static const std::string scope = catena::common::Scopes().getForwardMap().at(catena::common::Scopes_e::kMonitor);
+    EXPECT_CALL(mockParam, getScope())
+        .WillRepeatedly(::testing::ReturnRef(scope));
+
+    // Set up isArrayType and size if array_length > 0
+    if (info.array_length > 0) {
+        EXPECT_CALL(mockParam, isArrayType())
+            .WillRepeatedly(::testing::Return(true));
+        EXPECT_CALL(mockParam, size())
+            .WillRepeatedly(::testing::Return(info.array_length));
+    } else {
+        EXPECT_CALL(mockParam, isArrayType())
+            .WillRepeatedly(::testing::Return(false));
+    }
+
+    // Set up toProto for successful status
+    if (info.status == catena::StatusCode::OK) {
+        EXPECT_CALL(mockParam, toProto(::testing::An<catena::ParamInfoResponse&>(), ::testing::_))
+            .WillRepeatedly(::testing::Invoke([info](catena::ParamInfoResponse& response, catena::common::Authorizer&) {
+                setupParamInfo(response, info);
+                return catena::exception_with_status("", catena::StatusCode::OK);
+            }));
+    }
+}
+
+/**
+ * @brief Creates a ParamInfoResponse with the specified parameters
+ * @return The ParamInfoResponse object
+ */
+inline catena::ParamInfoResponse createParamInfoResponse(const ParamInfo& info) {
+    catena::ParamInfoResponse response;
+    setupParamInfo(response, info);
+    return response;
+}
+
+/**
+ * @brief Creates a vector of ParamInfoResponse objects from a vector of ParamInfo structs
+ * @return The vector of ParamInfoResponse objects
+ */
+inline std::vector<catena::ParamInfoResponse> createParamInfoResponses(const std::vector<ParamInfo>& infos) {
+    std::vector<catena::ParamInfoResponse> responses;
+    responses.reserve(infos.size());
+    
+    for (const auto& info : infos) {
+        responses.emplace_back(createParamInfoResponse(info));
+    }
+    
+    return responses;
+}
+
+} // namespace test
+} // namespace gRPC
+} // namespace catena 

--- a/unittests/cpp/gRPC/GRPCTestHelpers.h
+++ b/unittests/cpp/gRPC/GRPCTestHelpers.h
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief Helper functions for gRPC API tests
+ * @brief Helper functions for gRPC tests
  * @author Zuhayr Sarker (zuhayr.sarker@rossvideo.com)
  * @date 2025-07-24
  * @copyright Copyright © 2025 Ross Video Ltd
@@ -70,8 +70,7 @@ inline void setupParamInfo(catena::ParamInfoResponse& response, const ParamInfo&
     response.mutable_info()->set_oid(info.oid);
     response.mutable_info()->set_type(info.type);
     if (info.array_length > 0) {
-        // Note: set_array_length might not exist in the protobuf, so we'll skip this for now
-        // response.set_array_length(info.array_length);
+        response.set_array_length(info.array_length);
     }
 }
 

--- a/unittests/cpp/gRPC/GRPCTestHelpers.h
+++ b/unittests/cpp/gRPC/GRPCTestHelpers.h
@@ -153,7 +153,7 @@ inline void setupParamInfo(catena::ParamInfoResponse& response, const ParamInfo&
  * @brief Sets up a mock parameter to return a ParamInfoResponse
  *        Also sets up getDescriptor, isArrayType, and size for array types.
  */
-inline void setupMockParam(catena::common::MockParam& mockParam, const ParamInfo& info, const catena::common::MockParamDescriptor& descriptor) {
+inline void setupMockParamInfo(catena::common::MockParam& mockParam, const ParamInfo& info, const catena::common::MockParamDescriptor& descriptor) {
     EXPECT_CALL(mockParam, getOid())
         .WillRepeatedly(::testing::ReturnRef(info.oid));
 

--- a/unittests/cpp/gRPC/tests/Connect_test.cpp
+++ b/unittests/cpp/gRPC/tests/Connect_test.cpp
@@ -41,6 +41,7 @@
 #include "MockLanguagePack.h"
 #include "MockConnectionQueue.h"
 #include "GRPCTest.h"
+#include "GRPCTestHelpers.h"
 
 // gRPC
 #include "controllers/Connect.h"
@@ -104,60 +105,8 @@ class gRPCConnectTests : public GRPCTest {
      * This is a test class which makes an async RPC to the MockServer on
      * construction and compares the streamed-back response.
      */
-    class StreamReader : public grpc::ClientReadReactor<catena::PushUpdates> {
-      public:
-        StreamReader(std::vector<catena::PushUpdates>* outVals_, grpc::Status* outRc_, uint32_t reads = 1)
-            : outVals_(outVals_), outRc_(outRc_), reads_(reads) {}
-        /*
-         * This function makes an async RPC to the MockServer.
-         */
-        void MakeCall(catena::CatenaService::Stub* client, grpc::ClientContext* clientContext, const catena::ConnectPayload* inVal) {
-            // Sending async RPC.
-            client->async()->Connect(clientContext, inVal, this);
-            StartRead(&outVal_);
-            StartCall();
-        }
-        /*
-        * Triggers when a read is done_ and adds output to outVals_.
-        */
-        void OnReadDone(bool ok) override {
-            if (ok) {
-                outVals_->emplace_back(outVal_);
-                done_ = true;
-                cv_.notify_one();
-                StartRead(&outVal_);
-            }
-        }
-        /*
-         * Triggers when the RPC is finished and notifies Await().
-         */
-        void OnDone(const grpc::Status& status) override {
-            *outRc_ = status;
-            done_ = true;
-            cv_.notify_one();
-        }
-        /*
-         * Blocks until a call to OnReadDone or OnDOne has been made. 
-         */
-        inline void Await() {
-            cv_.wait(lock_, [this] { return done_; });
-            done_ = false;
-        }
-        
-      private:
-        // Pointers to the output variables.
-        grpc::Status* outRc_;
-        std::vector<catena::PushUpdates>* outVals_;
-
-        uint32_t reads_;
-        uint32_t current_ = 0;
-
-        catena::PushUpdates outVal_;
-        bool done_ = false;
-        std::condition_variable cv_;
-        std::mutex cv_mtx_;
-        std::unique_lock<std::mutex> lock_{cv_mtx_};
-    };
+    using StreamReader = catena::gRPC::test::StreamReader<catena::PushUpdates, catena::ConnectPayload, 
+        std::function<void(grpc::ClientContext*, const catena::ConnectPayload*, grpc::ClientReadReactor<catena::PushUpdates>*)>>;
 
     /*
      * Streamlines the creation of executeCommandPayloads. 
@@ -261,8 +210,10 @@ TEST_F(gRPCConnectTests, Connect_ConnectDisconnect) {
     // Once for main call, once for the async call.
     EXPECT_CALL(connectionQueue_, deregisterConnection(testing::_)).Times(2).WillOnce(testing::Return());
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     testRPC();
 }
@@ -290,8 +241,10 @@ TEST_F(gRPCConnectTests, Connect_ValueSetByClient) {
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     dm0_.getValueSetByClient().emit("oid0", &param0);
     streamReader_->Await();
@@ -325,8 +278,10 @@ TEST_F(gRPCConnectTests, Connect_ValueSetByServer) {
             return catena::exception_with_status("", catena::StatusCode::OK);
         }));
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     dm0_.getValueSetByServer().emit("oid0", &param0);
     streamReader_->Await();
@@ -354,8 +309,10 @@ TEST_F(gRPCConnectTests, Connect_LanguageAddedPushUpdate) {
             (*pack.mutable_words())["key1"] = "value1";
         }));
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     dm0_.getLanguageAddedPushUpdate().emit(&languagePack0);
     streamReader_->Await();
@@ -403,8 +360,10 @@ TEST_F(gRPCConnectTests, Connect_AuthzValid) {
             (*pack.mutable_words())["key0"] = "value0";
         }));
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     dm0_.getValueSetByClient().emit("oid0", &param0);
     streamReader_->Await();
@@ -423,8 +382,10 @@ TEST_F(gRPCConnectTests, Connect_AuthzInvalid) {
     authzEnabled_ = true;
     clientContext_.AddMetadata("authorization", "Bearer THIS SHOULD NOT PARSE");
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     streamReader_.reset(nullptr);
 }
@@ -437,8 +398,10 @@ TEST_F(gRPCConnectTests, Connect_AuthzJWSNotFound) {
     authzEnabled_ = true;
     clientContext_.AddMetadata("authorization", "NOT A BEARER TOKEN");
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     streamReader_.reset(nullptr);
 }
@@ -451,8 +414,10 @@ TEST_F(gRPCConnectTests, Connect_RegisterConnectionFailure) {
     // Setting expectations
     EXPECT_CALL(connectionQueue_, registerConnection(testing::_)).WillOnce(testing::Return(false));
     // Making call
-    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_);
-    streamReader_->MakeCall(client_.get(), &clientContext_, &inVal_);
+    streamReader_ = std::make_unique<StreamReader>(&outVals_, &outRc_, true);
+    streamReader_->MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+        client_->async()->Connect(ctx, payload, reactor);
+    });
     streamReader_->Await();
     streamReader_.reset(nullptr);
 }

--- a/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/DeviceRequest_test.cpp
@@ -37,6 +37,7 @@
 
 // Test helpers
 #include "GRPCTest.h"
+#include "GRPCTestHelpers.h"
 #include "CommonTestHelpers.h"
 
 // gRPC
@@ -68,52 +69,8 @@ class gRPCDeviceRequestTests : public GRPCTest {
      * This is a test class which makes an async RPC to the MockServer on
      * construction and returns the streamed-back response.
      */
-    class StreamReader : public grpc::ClientReadReactor<catena::DeviceComponent> {
-        public:
-            StreamReader(std::vector<catena::DeviceComponent>* outVals, grpc::Status* outRc_)
-                : outVals_(outVals), outRc_(outRc_) {}
-            /*
-             * This function makes an async RPC to the MockServer.
-             */
-            void MakeCall(catena::CatenaService::Stub* client, grpc::ClientContext* clientContext_, const catena::DeviceRequestPayload* inVal_) {
-                // Sending async RPC.
-                client->async()->DeviceRequest(clientContext_, inVal_, this);
-                StartRead(&outVal_);
-                StartCall();
-            }
-            /*
-             * Triggers when a read is done_ and adds output to outVals_.
-             */
-            void OnReadDone(bool ok) override {
-                if (ok) {
-                    outVals_->emplace_back(outVal_);
-                    StartRead(&outVal_);
-                }
-            }
-            /*
-             * Triggers when the RPC is finished and notifies Await().
-             */
-            void OnDone(const grpc::Status& status) override {
-                *outRc_ = status;
-                done_ = true;
-                cv_.notify_one();
-            }
-            /*
-             * Blocks until the RPC is finished. 
-             */
-            inline void Await() { cv_.wait(lock_, [this] { return done_; }); }
-        
-          private:
-            // Pointers to the output variables.
-            grpc::Status* outRc_;
-            std::vector<catena::DeviceComponent>* outVals_;
-
-            catena::DeviceComponent outVal_;
-            bool done_ = false;
-            std::condition_variable cv_;
-            std::mutex cv_mtx_;
-            std::unique_lock<std::mutex> lock_{cv_mtx_};
-    };
+    using StreamReader = catena::gRPC::test::StreamReader<catena::DeviceComponent, catena::DeviceRequestPayload, 
+        std::function<void(grpc::ClientContext*, const catena::DeviceRequestPayload*, grpc::ClientReadReactor<catena::DeviceComponent>*)>>;
 
     /*
      * Helper function which initializes an DeviceRequestPayload object.
@@ -160,7 +117,9 @@ class gRPCDeviceRequestTests : public GRPCTest {
     void testRPC() {
         // Sending async RPC.
         StreamReader streamReader(&outVals_, &outRc_);
-        streamReader.MakeCall(client_.get(), &clientContext_, &inVal_);
+        streamReader.MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+            client_->async()->DeviceRequest(ctx, payload, reactor);
+        });
         streamReader.Await();
         // Comparing the results.
         ASSERT_EQ(outVals_.size(), expVals_.size()) << "Output missing >= 1 DeviceComponents";

--- a/unittests/cpp/gRPC/tests/ExecuteCommand_test.cpp
+++ b/unittests/cpp/gRPC/tests/ExecuteCommand_test.cpp
@@ -39,6 +39,7 @@
 #include "MockParam.h"
 #include "MockCommandResponder.h"
 #include "GRPCTest.h"
+#include "GRPCTestHelpers.h"
 #include "CommonTestHelpers.h"
 
 // gRPC
@@ -68,52 +69,8 @@ class gRPCExecuteCommandTests : public GRPCTest {
      * This is a test class which makes an async RPC to the MockServer on
      * construction and compares the streamed-back response.
      */
-    class StreamReader : public grpc::ClientReadReactor<catena::CommandResponse> {
-      public:
-        StreamReader(std::vector<catena::CommandResponse>* outVals_, grpc::Status* outRc_)
-            : outVals_(outVals_), outRc_(outRc_) {}
-        /*
-         * This function makes an async RPC to the MockServer.
-         */
-        void MakeCall(catena::CatenaService::Stub* client, grpc::ClientContext* clientContext_, const catena::ExecuteCommandPayload* inVal_) {
-            // Sending async RPC.
-            client->async()->ExecuteCommand(clientContext_, inVal_, this);
-            StartRead(&outVal_);
-            StartCall();
-        }
-        /*
-        * Triggers when a read is done_ and adds output to outVals_.
-        */
-        void OnReadDone(bool ok) override {
-            if (ok) {
-                outVals_->emplace_back(outVal_);
-                StartRead(&outVal_);
-            }
-        }
-        /*
-         * Triggers when the RPC is finished and notifies Await().
-         */
-        void OnDone(const grpc::Status& status) override {
-            *outRc_ = status;
-            done_ = true;
-            cv_.notify_one();
-        }
-        /*
-         * Blocks until the RPC is finished. 
-         */
-        inline void Await() { cv_.wait(lock_, [this] { return done_; }); }
-    
-      private:
-        // Pointers to the output variables.
-        grpc::Status* outRc_;
-        std::vector<catena::CommandResponse>* outVals_;
-
-        catena::CommandResponse outVal_;
-        bool done_ = false;
-        std::condition_variable cv_;
-        std::mutex cv_mtx_;
-        std::unique_lock<std::mutex> lock_{cv_mtx_};
-    };
+    using StreamReader = catena::gRPC::test::StreamReader<catena::CommandResponse, catena::ExecuteCommandPayload, 
+        std::function<void(grpc::ClientContext*, const catena::ExecuteCommandPayload*, grpc::ClientReadReactor<catena::CommandResponse>*)>>;
 
     /*
      * Streamlines the creation of executeCommandPayloads. 
@@ -156,7 +113,9 @@ class gRPCExecuteCommandTests : public GRPCTest {
     void testRPC() {
         // Sending async RPC.
         StreamReader streamReader(&outVals_, &outRc_);
-        streamReader.MakeCall(client_.get(), &clientContext_, &inVal_);
+        streamReader.MakeCall(&clientContext_, &inVal_, [this](auto ctx, auto payload, auto reactor) {
+            client_->async()->ExecuteCommand(ctx, payload, reactor);
+        });
         streamReader.Await();
         // Comparing the results.
         if (respond_) {


### PR DESCRIPTION
# 📃 Intro
- This was a bit of a weird test because I had to change parts of the base class to handle errors better and more closely match the REST implementation - it looks like I did a lot of changing, but I mostly moved things around (a lot of the moving is literally just centered around me switching mode 2 and 3 to match the orientation in REST)
- File has 100% coverage and was mostly a simple match from REST implementation, but when it came to error handling I was fighting to figure out how to reach certain blocks of code, only to realize the error handling needed to be improved
- I also made a few changes to the helpers

# ✨ Main Additions/Changes

### Unit Test Legend
| |  |
| ------------- | ------------- |
| ✅ | Expects eq/true |
| ☑️ | Expects false/null/no-eq/etc., but for a success case |
| ⭕ | Expects eq/true, but covers an error/failure case |
| 🔴 | Expects false |

For ✅/☑️ expect a default status of Catena Status OK 

Note: I am going to abbreviate ParamInfoRequest as PIR

## 🟢 (NEW) ParamInfoRequest_test.cpp

### Fixtures/Helpers
- A lot of this was just shamelessly copied from Ben's setup, however, I refactored StreamReader to be a template inside GRPCTestHelpers.h
- makeOne - creates PIR handler object
- initPayload - initializes PIR payload
- testRPC - makes an async RPC call, waits for a response, and then compares output
- Members for input values, output values and expected values

Literally everything in this uses testRPC() which tests EQ/TRUE, so I won't bother specifying for every test.

### Section 0 Tests: Basic Setup
- ✅ **0.0**: TRUE create a PIR object
- ✅ **0.1**: Authorization test with valid token
- ⭕ **0.2**: Authorization test with invalid token
  - Expects Catena `Invalid JWS Token (UNAUTHENTICATED)`
- ⭕ **0.3**: Authorization test with invalid slot
  - Expects Catena `Device not found in slot (NOT_FOUND)`

### Mode 1 Tests: Get all top-level params without recursion
- ✅ **1.1**: Get all top-level params without recursion
- ✅ **1.2**: Get top-level params with array type
- ⭕ **1.3**: Get top-level params with empty list returned from getTopLevelParams 
  - Expects Catena `No top-level parameters found (NOT_FOUND)`
- ⭕ **1.4**: Get Top-level params with error status in returned params
  - Expects Catena `Error processing parameter (INTERNAL)`
- ⭕ **1.5**: Get Top-level param with exception during param processing
  - Expects Catena `Error getting top-level parameters (INTERNAL)`

### Mode 2 Tests:  Get all top-level params WITH recursion
- ✅ **2.1**: Get top-level params with recursion and deep nesting
- ✅ **2.2**: Get top-level params with recursion and arrays
- ⭕ **2.3**: Get top-level params with recursion and error in child processing
  - Expects Catena `Error processing child parameter (INTERNAL)`
- ⭕ **2.4**: Get top-level params with empty list and recursion
  - Expects Catena `No top-level parameters found (INTERNAL)`

### Mode 3 Tests: Get a specific parameter and its children if recursive
- ✅ **3.1**: Get specific parameter without recursion
- ✅ **3.2**: Get specific parameter WITH recursion
- ⭕ **3.3**: Parameter not found
  - Expects Catena `Parameter not found: missing_param (NOT_FOUND)`
- ⭕ **3.4**: Catena exception in getParam
  - Expects Catena `Error processing parameter (INTERNAL)`

### Section 4 Tests: Additional error cases at end of proceed()
- ⭕ **4.1**: Catena exception in proceed()
  - Expects Catena `Test catena exception (INTERNAL)
- ⭕ **4.2**: Std exception in proceed()
  - After throwing an std exception, expects Catena `Failed due to unknown error in ParamInfoRequest: Test std exception (UNKNOWN)`
- ⭕ **4.3**: Unknown exception in proceed()
  - After throwing an int, expects Catena `Failed due to unknown error in ParamInfoRequest (UNKNOWN)`

## 🟡 ParamInfoRequest.cpp
- Removed every single throw in the kProcess step and instead switched to assigning return code variable, which is more testable and matches other implementations
  - Note the rc scope brackets
- Removed redundant error testing in kWrite stage as any errors would be caught beforehand during process 
  - For example, if we had null/no responses, this would be caught beforehand
- Added more detailed error handling per-mode and removed vague "no more responses" error code
  - Old implementation was incredibly unclear on the specific error and would often resort to this old basic error code without detailing what the exact error was.
- Add default case to gcov exclude, impossible to reach
- Switched modes 2 and 3 to match orientation in REST
  - Does not change any kind of functionality, just looks cleaner (one of the modes was added afterwards hence the orientation weirdness)

# 🛠️ Other changes
- Renamed setupMockParam to setupMockParamInfo to avoid confusion
- Refactored StreamReader helper as a single template in GRPCTestHelpers to be used in all the relevant gRPC streaming unit tests
- Got rid of redundant test on REST-side, checked for 100% coverage
 
