### PR TITLE
Fix clangd (and in effect Cursor)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,9 @@
             "url": "./schema/catena.param_schema.json"
         }
     ],
+    "clangd.arguments": [
+        "--compile-commands-dir=${workspaceFolder}/${env:BUILD_TARGET}"
+    ],
     "yaml.schemas": {
         "./schema/catena.device_schema.json" : [
             "/example_device_models/device.*.yaml",


### PR DESCRIPTION
If you use the clangd language server with Cursor on our dev container, you can now get back a bunch of the IDE features like go to definition.