### PR TITLE
re-enable unit tests

### DIFF
--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -248,10 +248,10 @@ install(
 # Build the documentation with Doxygen
 build_docs()
 
-if (UNIT_TESTING)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CATENA_UNITTESTS_DIR $ENV{HOME}/Catena/unittests)
 
   add_compile_definitions(CATENA_UNITTESTS_DIR="${CATENA_UNITTESTS_DIR}")
 
   add_subdirectory("${CATENA_UNITTESTS_DIR}/cpp/" $ENV{HOME}/Catena/$ENV{BUILD_TARGET}/unittests/)
-endif (UNIT_TESTING)
+endif (CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
the last unit test tweak accidently removed the unit tests from compilation with cmake. @NR-RV asked to just make the unit tests depend on `CMAKE_BUILD_TYPE STREQUALS "Debug"`.