### PR TITLE
Fixed logging folder creation

### DIFF
--- a/sdks/cpp/CMakeLists.txt
+++ b/sdks/cpp/CMakeLists.txt
@@ -56,7 +56,6 @@ add_compile_options(--coverage)
 add_link_options(--coverage)
 
 option(UNIT_TESTING "Build the unit tests" ON)
-add_compile_definitions(UNIT_TESTING="${UNIT_TESTING}")
 
 # enable testing
 enable_testing()


### PR DESCRIPTION
CMake now checks for the logging folder on build
if not present it is created
UNIT_TESTING macro exposed to entire codebase