### PR TITLE
Fixed Client Disconnection Bug in gRPC

### DIFF
--- a/sdks/cpp/common/include/rpc/IConnect.h
+++ b/sdks/cpp/common/include/rpc/IConnect.h
@@ -72,15 +72,15 @@ class IConnect {
      */
     virtual bool operator<(const IConnect& otherConnection) const = 0;
     /**
+     * @brief Returns true if the call has been canceled.
+     */
+    virtual inline bool isCancelled() = 0;
+    /**
      * @brief Forcefully shuts down the connection.
      */
     virtual void shutdown() = 0;
   
   protected:
-    /**
-     * @brief Returns true if the call has been canceled.
-     */
-    virtual inline bool isCancelled() = 0;
     /**
      * @brief Updates the response message with parameter values and handles 
      * authorization checks.

--- a/sdks/cpp/connections/REST/include/controllers/Connect.h
+++ b/sdks/cpp/connections/REST/include/controllers/Connect.h
@@ -106,6 +106,10 @@ class Connect : public ICallData, public catena::common::Connect {
      * open connections to be shut down.
      */
     static vdk::signal<void()> shutdownSignal_;
+    /**
+     * @brief Returns true if the request was cancelled.
+     */
+    inline bool isCancelled() override;
     
   private:
     /**
@@ -119,10 +123,6 @@ class Connect : public ICallData, public catena::common::Connect {
                 << catena::common::timeNow() << " status: "
                 << static_cast<int>(status) <<", ok: "<< std::boolalpha << ok;
     }
-    /**
-     * @brief Returns true if the request was cancelled.
-     */
-    inline bool isCancelled() override { return !this->socket_.is_open(); }
 
     /**
      * @brief The socket to write the response stream to.

--- a/sdks/cpp/connections/REST/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/Connect.cpp
@@ -37,6 +37,7 @@ void catena::REST::Connect::proceed() {
     catena::exception_with_status rc{"", catena::StatusCode::OK};
     try {
         // Cancels all open connections if shutdown signal is sent.
+        // socket_.async_wait(tcp::socket::wait_error, [this](const boost::system::error_code& error){ shutdown(); });
         shutdownSignalId_ = shutdownSignal_.connect([this](){ shutdown(); });
         // Initialize variables and authz and add connection to the priority queue.
         detailLevel_ = context_.detailLevel();
@@ -112,4 +113,9 @@ void catena::REST::Connect::proceed() {
     // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());
     DEBUG_LOG << "Connect[" << objectId_ << "] finished";
+}
+
+// Returns true if the connection has been cancelled.
+bool catena::REST::Connect::isCancelled() {
+    return !this->socket_.is_open() || shutdown_ || (authz_ && authz_->isExpired());
 }

--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -198,5 +198,5 @@ void catena::gRPC::Connect::proceed(bool ok) {
 
 // Returns true if the connection has been cancelled.
 bool catena::gRPC::Connect::isCancelled() {
-    return context_.IsCancelled() || shutdown_;
+    return context_.IsCancelled() || shutdown_ || (authz_ && authz_->isExpired());
 }

--- a/unittests/cpp/REST/tests/Connect_test.cpp
+++ b/unittests/cpp/REST/tests/Connect_test.cpp
@@ -384,11 +384,6 @@ TEST_F(RESTConnectTest, Connect_AuthzExpired) {
         .WillRepeatedly(testing::ReturnRef(paramOid_));
     EXPECT_CALL(*param, getScope())
         .WillRepeatedly(testing::ReturnRef(Scopes().getForwardMap().at(Scopes_e::kMonitor)));
-    EXPECT_CALL(*param, toProto(testing::An<catena::Value&>(), testing::An<const IAuthorizer&>()))
-        .WillOnce(testing::Invoke([](catena::Value& value, const IAuthorizer&) {
-            value.set_string_value("test_value");
-            return catena::exception_with_status("", catena::StatusCode::OK);
-        }));
 
     std::string slotJson = buildSlotResponse();
 


### PR DESCRIPTION
Changelog:
- Added function to clear out any cancelled connections in ConnectionQueue
    - This is checked whenever a connection is added to make sure there are no disconnection clients who are lingering in the queue.
    
Boost::asio sucks so I haven't figured out REST as of yet.