### PR TITLE
missed updating launch.json with new example name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -245,7 +245,7 @@
         //"api_only", // unimplemented
         "asset_request_REST",
         "status_update_REST",
-        "status_update_REST_JSON",
+        "status_update_JSON_REST",
         "use_commands_REST",
         "use_menus_REST",
         "structs_with_authz_REST",


### PR DESCRIPTION
Missed renaming the `status_update_JSON_REST` example