### PR TITLE
953 code gen readonly bug

### DIFF
--- a/sdks/cpp/connections/gRPC/examples/use_commands/device.video_player.json
+++ b/sdks/cpp/connections/gRPC/examples/use_commands/device.video_player.json
@@ -18,7 +18,6 @@
       "type": "STRING",
       "read_only": true,
       "minimal_set": true,
-      "widget": "text-display",
       "name": { "display_strings": {
         "en": "State",
         "fr": "État",

--- a/tools/codegen/cpp/param.js
+++ b/tools/codegen/cpp/param.js
@@ -123,7 +123,7 @@ class Descriptor {
         return `"${desc.access_scope || ""}"`;
       },
       read_only: () => {
-        return !!desc.readonly;
+        return !!desc.read_only;
       },
       oid: () => {
         return `"${oid}"`;


### PR DESCRIPTION
there was a typo in param.js `readonly` instead of `read_only`

also removed the widget hint from the device model since its no longer needed

closes #953