### PR TITLE
learned some things about cleaning up coverage

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -49,9 +49,11 @@ if [ ! -d "coverage" ]; then
   mkdir -p coverage
 fi
 
+# clean the coverage directory before generating new reports
+rm -rf coverage/*
 # Conditionally generate HTML report
 if [ "$html_report" = true ]; then
-  gcovr --root ~/Catena --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' -e '(.+/)?examples/' --html=coverage/index.html --html-details --lcov=coverage/coverage.info --xml=coverage/coverage.xml
+  gcovr --root ~/Catena --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' -e '(.+/)?examples/' --delete --html=coverage/index.html --html-details --lcov=coverage/coverage.info --xml=coverage/coverage.xml
 else
-  gcovr --root ~/Catena --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' -e '(.+/)?examples/' --lcov=coverage/coverage.info --xml=coverage/coverage.xml
+  gcovr --root ~/Catena --filter sdks/cpp -e '(.+/)?build/' -e '(.+/)?tests/' -e '(.+/)?examples/' --delete --lcov=coverage/coverage.info --xml=coverage/coverage.xml
 fi


### PR DESCRIPTION
Learned that we can delete the .gcda files to reset branch counters. Also the `coverage/` dir seems to store counters so nuke that as well before counting new coverage