### PR TITLE
fixed shutting down hanging

### DIFF
--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -157,6 +157,11 @@ void catena::gRPC::Connect::proceed(bool ok) {
                 }
             }
             connect_lock.unlock();
+            if (shutdown_ && context_.IsCancelled()) {
+                // in the case when we are shutting down AND the connection was already terminated by the client
+                // we need to manually call proceed to move to the finish state. The completion queue won't do it for us.
+                proceed(false);
+            }
             break;
         /**
          * kFinish: Ends the connection.


### PR DESCRIPTION
When we did: https://github.com/rossvideo/Catena/pull/1032, we were unsure about the break at the end of the `kWrite` falling through to `kFinish` status. Turns out it was intentional that the switch falls through to the finish during shutdown. This modifies things slightly to simply call `proceed` manually instead of falling through the switch.