### PR TITLE
doxygen shouldn't run on PRs

### DIFF
--- a/.github/workflows/doxygenate.yml
+++ b/.github/workflows/doxygenate.yml
@@ -3,8 +3,6 @@ name: "Doxygen and Markdown GitHub Pages Deploy Action"
 on:
     push:
       branches: [ "develop", "main", "doxygen" ]
-    pull_request:
-      branches: [ "develop", "main" ]
     schedule:
       - cron: '25 16 * * 2'
 


### PR DESCRIPTION
Doxygen shouldn't run on PRs. That means that it runs with *proposed* changes that haven't been approved yet. So the docs may have in-development updates.