### PR TITLE
Security fixes

### DIFF
--- a/.devcontainer/toolchain-cpp.dockerfile
+++ b/.devcontainer/toolchain-cpp.dockerfile
@@ -83,7 +83,7 @@ RUN . /root/toolchain.env \
     && chmod a+r /etc/apt/keyrings/docker.asc \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update \
-    && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    && apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin
 
 COPY .devcontainer/toolchain-cpp.requirements.txt /root/requirements.txt
 

--- a/.devcontainer/toolchain-cpp.requirements.txt
+++ b/.devcontainer/toolchain-cpp.requirements.txt
@@ -1,1 +1,2 @@
 gcovr==8.4
+setuptools>=80.0.0


### PR DESCRIPTION
Addessing:
- CVE-2024-6345 (HIGH)
- CVE-2025-47273 (HIGH)
- CVE-2025-22870 (MEDIUM)
- CVE-2025-22872 (MEDIUM)
- CVE-2025-22870 (MEDIUM)
- CVE-2025-22872 (MEDIUM)

Fixes
Updated setuptools to >=80.0.0
removed docker-ce from toolchain (only need the cli)