### PR TITLE
another connect finish deadlock

### DIFF
--- a/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/Connect.cpp
@@ -156,10 +156,12 @@ void catena::gRPC::Connect::proceed(bool ok) {
                     writer_.Write(res_, this);
                 }
             }
+            // unlock before potentially finishing
             connect_lock.unlock();
-            if (shutdown_ && context_.IsCancelled()) {
-                // in the case when we are shutting down AND the connection was already terminated by the client
-                // we need to manually call proceed to move to the finish state. The completion queue won't do it for us.
+            if (context_.IsCancelled()) {
+                // in the case where the connection is cancelled by the client,
+                // we need to manually call proceed to move to the finish state.
+                // The completion queue won't do it for us.
                 proceed(false);
             }
             break;


### PR DESCRIPTION
Went back and examined the original fall through logic and modified the kWrite to match it. Don't know how we messed it up last time.

For posterity, we verified that when the *client* cancels the connection, there is no final `Connect::proceed` from the completion queue, so we must call it manually. This is what the old logic used falling through the to the next case in the switch.
When the service is shutdown, `writer_->Finish` causes a final call to `Connect::proceed` through the completion queue. So the Connect cleans itself up.