### PR TITLE
install extension with devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,15 @@
             "path": "/bin/bash"
           }
         }
-      }
+      },
+      "extensions": [
+        "redhat.vscode-yaml",
+        "ms-vscode.cpptools",
+        "mhutchie.git-graph",
+        "github.vscode-pull-request-github",
+        "ms-vscode.cmake-tools",
+        "ryanluker.vscode-coverage-gutters"
+      ]
     }
   },
   "mounts": [


### PR DESCRIPTION
tired of manually installing extensions from the recommended list.
We tested with Nelson's cursor and it doesn't kill cursor anymore to have the cpp extension auto install so now we can just have it! :D