### PR TITLE
add ssl to the go toolchain

### DIFF
--- a/.devcontainer/go/toolchain.dockerfile
+++ b/.devcontainer/go/toolchain.dockerfile
@@ -17,6 +17,7 @@ RUN . /root/toolchain.env \
     build-essential \
     sudo \
     git \
+    libssl-dev=$OPENSSL_VERSION \
     doxygen=$DOXYGEN_VERSION \
     valgrind=$VALGRIND_VERSION \
     curl=$CURL_VERSION \

--- a/.devcontainer/go/toolchain.env
+++ b/.devcontainer/go/toolchain.env
@@ -7,6 +7,7 @@ IMAGE_VENDOR="Rossvideo"
 # Tool versions used across build system
 DOXYGEN_VERSION=1.9.8+ds-2build5
 NODEJS_VERSION=22
+OPENSSL_VERSION=3.0.13-0ubuntu3.6
 UBUNTU_VERSION=24.04
 VALGRIND_VERSION=1:3.22.0-0ubuntu3
 CURL_VERSION=8.5.0-2ubuntu10.6


### PR DESCRIPTION
I need ssl in the go dev container because I checked out with the ssh url instead of https.