### PR TITLE
add ssh for real this time

### DIFF
--- a/.devcontainer/cpp/toolchain.dockerfile
+++ b/.devcontainer/cpp/toolchain.dockerfile
@@ -18,6 +18,7 @@ RUN . /root/toolchain.env \
     sudo \
     cmake=$CMAKE_VERSION \
     git \
+    openssh-client \
     libssl-dev=$OPENSSL_VERSION \
     doxygen=$DOXYGEN_VERSION \
     graphviz=$GRAPHVIZ_VERSION \

--- a/.devcontainer/cpp/toolchain.dockerfile
+++ b/.devcontainer/cpp/toolchain.dockerfile
@@ -18,7 +18,6 @@ RUN . /root/toolchain.env \
     sudo \
     cmake=$CMAKE_VERSION \
     git \
-    openssh-client \
     libssl-dev=$OPENSSL_VERSION \
     doxygen=$DOXYGEN_VERSION \
     graphviz=$GRAPHVIZ_VERSION \

--- a/.devcontainer/go/toolchain.dockerfile
+++ b/.devcontainer/go/toolchain.dockerfile
@@ -17,6 +17,7 @@ RUN . /root/toolchain.env \
     build-essential \
     sudo \
     git \
+    openssh-client \
     libssl-dev=$OPENSSL_VERSION \
     doxygen=$DOXYGEN_VERSION \
     valgrind=$VALGRIND_VERSION \


### PR DESCRIPTION
can't figure out how the cpp toolchain is getting ssh installed, but whatever, just do it manually for the go toolchain. Not tying it to a specific version, because like git, it's just a dev utility, not something we're compiling against.