### PR TITLE
1138 param_value_string bug fix

### DIFF
--- a/sdks/cpp/common/src/utils.cpp
+++ b/sdks/cpp/common/src/utils.cpp
@@ -186,8 +186,8 @@ std::string catena::param_value_string(const st2138::Value& value) {
             return "[undefined value]";
         case st2138::Value::KIND_NOT_SET:
             return "[kind not set]";
-        default: //GCOVR_EXCL_START
+        default: // GCOVR_EXCL_START
             return "[no value]";
-            //GCOVR_EXCL_END
+            // GCOVR_EXCL_STOP
     }
 }

--- a/sdks/cpp/common/src/utils.cpp
+++ b/sdks/cpp/common/src/utils.cpp
@@ -186,7 +186,8 @@ std::string catena::param_value_string(const st2138::Value& value) {
             return "[undefined value]";
         case st2138::Value::KIND_NOT_SET:
             return "[kind not set]";
-        default:
+        default: //GCOVR_EXCL_START
             return "[no value]";
+            //GCOVR_EXCL_END
     }
 }

--- a/sdks/cpp/common/src/utils.cpp
+++ b/sdks/cpp/common/src/utils.cpp
@@ -180,6 +180,12 @@ std::string catena::param_value_string(const st2138::Value& value) {
             return "[struct variant value]";
         case st2138::Value::kStructVariantArrayValues:
             return "[struct variant array values]";
+        case st2138::Value::kStructArrayValues:
+            return "[struct array values]";
+        case st2138::Value::kUndefinedValue:
+            return "[undefined value]";
+        case st2138::Value::KIND_NOT_SET:
+            return "[kind not set]";
         default:
             return "[no value]";
     }

--- a/unittests/cpp/common/tests/utils_test.cpp
+++ b/unittests/cpp/common/tests/utils_test.cpp
@@ -136,10 +136,11 @@ TEST(UtilsTest, Fmt_NoArgs) {
     EXPECT_EQ(result, "Hello, World!");
 }
 
+// PARAM_VALUE_STRING TESTS
+
 TEST(UtilsTest, Value_Param_Empty) {
     st2138::Value value;
-    st2138::Empty* emptyValue = new st2138::Empty();
-    value.set_allocated_empty_value(emptyValue);
+    value.mutable_empty_value();
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "");
 }
@@ -160,14 +161,15 @@ TEST(UtilsTest, Value_Param_Float32) {
 
 TEST(UtilsTest, Value_Param_String) {
     st2138::Value value;
-    value.set_string_value("test string");
+    auto str = value.mutable_string_value();
+    str->assign("test string");
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "test string");
 }
 
 TEST(UtilsTest, Value_Param_Struct) {
     st2138::Value value;
-    value.set_allocated_struct_value(new st2138::StructValue());
+    value.mutable_struct_value();
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "[struct value]");
 }
@@ -204,30 +206,29 @@ TEST(UtilsTest, Value_Param_StringArray) {
 
 TEST(UtilsTest, Value_Param_DataPayload) {
     st2138::Value value;
-    st2138::DataPayload* dataPayload = new st2138::DataPayload();
-    dataPayload->set_payload("binarydata");
-    value.set_allocated_data_payload(dataPayload);
+    auto datapayload = value.mutable_data_payload();
+    datapayload->set_payload("binarydata");
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "binarydata");
 }
 
 TEST(UtilsTest, Value_Param_StructVariantValue) {
     st2138::Value value;
-    value.set_allocated_struct_variant_value(new st2138::StructVariantValue());
+    value.mutable_struct_variant_value();
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "[struct variant value]");
 }
 
 TEST(UtilsTest, Value_Param_StructVariantArrayValues) {
     st2138::Value value;
-    value.set_allocated_struct_variant_array_values(new st2138::StructVariantList());
+    value.mutable_struct_variant_array_values();
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "[struct variant array values]");
 }
 
 TEST(UtilsTest, Value_Param_StructArrayValues) {
     st2138::Value value;
-    value.set_allocated_struct_array_values(new st2138::StructList());
+    value.mutable_struct_array_values();
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "[struct array values]");
 }

--- a/unittests/cpp/common/tests/utils_test.cpp
+++ b/unittests/cpp/common/tests/utils_test.cpp
@@ -161,8 +161,7 @@ TEST(UtilsTest, Value_Param_Float32) {
 
 TEST(UtilsTest, Value_Param_String) {
     st2138::Value value;
-    auto str = value.mutable_string_value();
-    str->assign("test string");
+    value.set_string_value("test string");
     std::string result = catena::param_value_string(value);
     EXPECT_EQ(result, "test string");
 }

--- a/unittests/cpp/common/tests/utils_test.cpp
+++ b/unittests/cpp/common/tests/utils_test.cpp
@@ -225,8 +225,22 @@ TEST(UtilsTest, Value_Param_StructVariantArrayValues) {
     EXPECT_EQ(result, "[struct variant array values]");
 }
 
-TEST(UtilsTest, Value_Param_DefaultCase) {
+TEST(UtilsTest, Value_Param_StructArrayValues) {
+    st2138::Value value;
+    value.set_allocated_struct_array_values(new st2138::StructList());
+    std::string result = catena::param_value_string(value);
+    EXPECT_EQ(result, "[struct array values]");
+}
+
+TEST(UtilsTest, Value_Param_UndefinedValue) {
+    st2138::Value value;
+    value.set_undefined_value(st2138::UNDEFINED_VALUE);
+    std::string result = catena::param_value_string(value);
+    EXPECT_EQ(result, "[undefined value]");
+}
+
+TEST(UtilsTest, Value_Param_KIND_NOT_SET) {
     st2138::Value value; // No kind set
     std::string result = catena::param_value_string(value);
-    EXPECT_EQ(result, "[no value]");
+    EXPECT_EQ(result, "[kind not set]");
 }


### PR DESCRIPTION

## 📖 Description
<!-- A clear and concise explanation of what this pull request is about and what it accomplishes. -->
Addresses issue #1138 by modifying `catena::param_value_string`  in `utils.cpp` to handle the following value types: `kStructArrayValues`, `kUndefinedValue`, `KIND_NOT_SET`.

---

## ✅ Definition of Done (DoD)
- [x] Bug is fixed and feature works as expected
- [x] Edge cases are handled
- [x] Tests are added or updated (if applicable)
- [x] Documentation is updated (if needed)
- [x] Code is reviewed and approved

---

## 🛠️ Implementation Notes
<!-- List of changes made:
- Added file.cpp to src
- Added function to file2.cpp
- Deleted file3.cpp-->
Added tests to `utils_test.cpp`.

---

## 🔗 Related Issues / Links
<!-- Links to the relevant issues  -->
[Issue #1138](https://github.com/rossvideo/Catena/issues/1138)
<!--
---
## 📝 Additional Context
(Optional) Any extra information, screenshots, or background.


---

## 🚧 Risks / Open Questions
(Optional) Anything unclear or potentially risky. 

---

## ✨ Updates
(Optional) List summarizing changes made when editing the pull request
-->
