### PR TITLE
gtest discovery

### DIFF
--- a/.devcontainer/cpp/devcontainer.json
+++ b/.devcontainer/cpp/devcontainer.json
@@ -19,7 +19,8 @@
   "postCreateCommand": {
     "dockerInit": "sudo groupdel docker || true && DOCKER_GID=$(stat -c '%g' /var/run/docker.sock) && sudo groupadd -forg $DOCKER_GID docker && sudo usermod -aG docker ${USER_NAME}",
     "initSubmodules": "git submodule update --init --recursive",
-    "cmake": "sudo chown ${USER_NAME}:${USER_NAME} ~/Catena/${BUILD_TARGET} && ${CMAKE_COMMAND} && echo 'Docker setup complete, please restart the dev container!'"
+    "cmake": "sudo chown ${USER_NAME}:${USER_NAME} ~/Catena/${BUILD_TARGET} && ${CMAKE_COMMAND} && echo 'Docker setup complete, please restart the dev container!'",
+    "ctestAlias": "echo 'alias ctest=\"ctest --progress --output-on-failure\"' >> ~/.bash_aliases"
   },
   "runArgs": [
     "--env-file",

--- a/.github/workflows/cpp-pull-request.yml
+++ b/.github/workflows/cpp-pull-request.yml
@@ -88,9 +88,9 @@ jobs:
 
       - name: Run Tests
         run: |
-          ctest --test-dir ${BUILD_TARGET} -R '^common\.' --output-junit /common_test_results.xml
-          ctest --test-dir ${BUILD_TARGET} -R '^gRPC\.' --output-junit /grpc_test_results.xml
-          ctest --test-dir ${BUILD_TARGET} -R '^REST\.' --output-junit /rest_test_results.xml
+          ctest --output-on-failure --test-dir ${BUILD_TARGET} -R '^common\.' --output-junit /common_test_results.xml
+          ctest --output-on-failure --test-dir ${BUILD_TARGET} -R '^gRPC\.' --output-junit /grpc_test_results.xml
+          ctest --output-on-failure --test-dir ${BUILD_TARGET} -R '^REST\.' --output-junit /rest_test_results.xml
 
       - name: Copy files
         if: always()

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status
+set -e
+
 cd ~/Catena/${BUILD_TARGET}
 echo ~/Catena/${BUILD_TARGET}
 clean=false
@@ -52,11 +55,12 @@ for arg in "$@"; do
   fi
 done
 
+CTEST_FLAGS="--progress --output-on-failure"
 # Run tests with verbose output if -V flag is present
 if [ "$verbose" = true ]; then
-  ctest --output-on-failure -V || ctest --rerun-failed --output-on-failure -V
+  ctest $CTEST_FLAGS -V || ctest $CTEST_FLAGS --rerun-failed -V
 else
-  ctest --output-on-failure || ctest --rerun-failed --output-on-failure
+  ctest $CTEST_FLAGS || ctest $CTEST_FLAGS --rerun-failed
 fi
 
 cd ~/Catena/

--- a/unittests/cpp/REST/CMakeLists.txt
+++ b/unittests/cpp/REST/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 find_package(GTest REQUIRED)
+include(GoogleTest)
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(${CATENA_CPP_ROOT_DIR}/common/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -45,5 +46,5 @@ foreach(test_file ${REST_TEST_FILES})
         GTest::gmock
         GTest::gmock_main
     )
-    add_test(NAME REST.${test_name} COMMAND REST_${test_name})
+    gtest_discover_tests(REST_${test_name} TEST_PREFIX "REST." DISCOVERY_MODE PRE_TEST)
 endforeach()

--- a/unittests/cpp/common/CMakeLists.txt
+++ b/unittests/cpp/common/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 find_package(GTest REQUIRED)
+include(GoogleTest)
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CATENA_UNITTESTS_DIR}/cpp/REST/mocks)
@@ -59,7 +60,7 @@ foreach(test_file ${TEST_FILES})
         GTest::gmock_main
         ${common_lib}
     )
-    add_test(NAME common.${test_name} COMMAND common_${test_name})
+    gtest_discover_tests(common_${test_name} TEST_PREFIX "common." DISCOVERY_MODE PRE_TEST)
 endforeach()
 
 #special avahi linking for NmosNode_test
@@ -99,4 +100,4 @@ target_link_libraries(common_ParamWithValue PRIVATE
     ${common_lib}
 )
 
-add_test(NAME common.ParamWithValue COMMAND common_ParamWithValue)
+gtest_discover_tests(common_ParamWithValue TEST_PREFIX "common.ParamWithValue." DISCOVERY_MODE PRE_TEST)

--- a/unittests/cpp/gRPC/CMakeLists.txt
+++ b/unittests/cpp/gRPC/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 find_package(GTest REQUIRED)
+include(GoogleTest)
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(mocks)
@@ -45,5 +46,5 @@ foreach(test_file ${GRPC_TEST_FILES})
         GTest::gmock
         GTest::gmock_main
     )
-    add_test(NAME gRPC.${test_name} COMMAND gRPC_${test_name})
+    gtest_discover_tests(gRPC_${test_name} TEST_PREFIX "gRPC." DISCOVERY_MODE PRE_TEST)
 endforeach()


### PR DESCRIPTION
<!-- please continue to update this as work is being done to add context, links, scope creep, and any other useful info -->

## 📖 Description
<!-- A clear and concise explanation of what this pull request is about and what it accomplishes. -->
This is the first of many PR's to break up #1100 
Improving ctest to discovery each gtest test function individually. So now we have almost 1000 tests instead of ~50

---

## ✅ Definition of Done (DoD)
- [x] Feature is implemented and works as expected
- [x] Edge cases are handled
- ~[ ] Tests are added or updated (if applicable)~
- ~[ ] Documentation is updated (if needed)~
- [x] Code is reviewed and approved

---

## 🛠️ Implementation Notes
- Update `CMakeLists.txt` to use ctest's `gtest_discover_tests` function which runs the test exe with a flag to get it to report all of the test functions
- Important note was to make them run `PRE_TEST` so that it will pick up new tests (default is to run with the $CMAKE_COMMAND)
- Added alias for ctest
  - now that there's 1000 tests, the --progress flag makes it update a single line like ninja does. Instead of barfing out all the junk.
  - --output-on-failure should be the default behaviour imo, make ctest output the failed test if there's a failure.
- also added --output-on-failure to the PR workflow ctest
- added --progress and --output-on-failure to run_coverage.sh
---

## 🔗 Related Issues / Links
<!-- Links to the relevant issues  -->


---
## 📝 Additional Context
<!-- (Optional) Any extra information, screenshots, or background. -->


---

## 🚧 Risks / Open Questions
<!-- (Optional) Anything unclear or potentially risky. -->

---
## ✨ Updates
<!-- (Optional) List summarizing changes made when editing the pull request>
 