### PR TITLE
[GO] Detailed Error Messages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
         "args": [],
         "env": {
           "CATENA_LOG_LEVEL": "DEBUG", // Set log level to DEBUG
-          "CATENA_ENV": "prod",
+          "CATENA_ENV": "dev",
         }
       },
       {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
         "args": [],
         "env": {
           "CATENA_LOG_LEVEL": "DEBUG", // Set log level to DEBUG
+          "CATENA_ENV": "prod",
         }
       },
       {

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -142,8 +142,8 @@ All variables use the same prefix (default: `CATENA`). Replace `{PREFIX}` with y
 
 ```go
 // Use the default CATENA prefix (no arguments needed)
-cfg, err := catena.InitSDK()  // reads CATENA_ENV, CATENA_PORT, etc.
+cfg, err := catena.InitOptions()  // reads CATENA_ENV, CATENA_PORT, etc.
 
 // Use a custom prefix for your application
-cfg, err := catena.InitSDK(catena.InitOptions{Prefix: "MYAPP", AppName: "my_app"})  // reads MYAPP_ENV, MYAPP_PORT, etc.
+cfg, err := catena.InitOptions(catena.Options{Prefix: "MYAPP", AppName: "my_app"})  // reads MYAPP_ENV, MYAPP_PORT, etc.
 ```

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -102,27 +102,51 @@ func (v Variant) Print() {
 }
 ```
 
-## Logging Config
+## SDK Configuration
 
-Config can be changed with env variables:
+The SDK uses a unified configuration system. All settings are loaded from environment variables with a configurable prefix.
+
+### Usage
+
+```go
+import "github.com/rossvideo/catena/sdks/go/pkg/catena"
+
+func main() {
+    // Parse config from environment variables (supports -v, -vv, -vvv flags)
+    cfg := catena.ParseConfigWithVerbosity("CATENA")
+    cfg.Logger.AppName = "my_service"
+
+    // Initialize SDK
+    if err := catena.Init(cfg); err != nil {
+        log.Fatal(err)
+    }
+    defer catena.Close()
+
+    // Use cfg.Port for server, catena.IsDev() for environment checks, etc.
+}
+```
+
+### Environment Variables
+
+All variables use the same prefix (default: `CATENA`). Replace `{PREFIX}` with your chosen prefix.
 
 | Variable | Description | Allowed values | Default |
 |---|---|---|---|
-| `CATENA_LOG_DIR` | Directory for log files | Path | `./logs` |
-| `CATENA_SILENT` | Suppress all output | `true` | — |
-| `CATENA_LOG_LEVEL` | Logging verbosity | `debug`, `info`, `warn`, `error` | `error` |
-| `CATENA_LOG_FILE` | Enable file logging | `true`, `false` | `true` |
-| `CATENA_LOG_CONSOLE` | Enable console logging | `true`, `false` | `true` |
-| `CATENA_LOG_JSON` | Output logs as JSON | `true` | — |
+| `{PREFIX}_ENV` | Environment mode | `dev`, `prod` | `prod` |
+| `{PREFIX}_PORT` | HTTP server port | Integer | `6254` |
+| `{PREFIX}_LOG_DIR` | Directory for log files | Path | `./logs` |
+| `{PREFIX}_SILENT` | Suppress all output | `true` | — |
+| `{PREFIX}_LOG_LEVEL` | Logging verbosity | `debug`, `info`, `warn`, `error` | `error` |
+| `{PREFIX}_LOG_FILE` | Enable file logging | `true`, `false` | `true` |
+| `{PREFIX}_LOG_CONSOLE` | Enable console logging | `true`, `false` | `true` |
+| `{PREFIX}_LOG_JSON` | Output logs as JSON | `true` | — |
 
 ### Custom Prefix
 
-By default, the logger uses `CATENA` as the environment variable prefix. If you want to use your own prefix, pass a custom prefix to `ParseFromEnv`:
-
 ```go
 // Use the default CATENA prefix
-cfg := logger.ParseFromEnv("")  // reads CATENA_LOG_LEVEL, CATENA_SILENT, etc.
+cfg := catena.ParseConfigWithVerbosity("")  // reads CATENA_ENV, CATENA_PORT, etc.
 
 // Use a custom prefix for your application
-cfg := logger.ParseFromEnv("MYAPP")  // reads MYAPP_LOG_LEVEL, MYAPP_SILENT, etc.
+cfg := catena.ParseConfigWithVerbosity("MYAPP")  // reads MYAPP_ENV, MYAPP_PORT, etc.
 ```

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -112,8 +112,8 @@ The SDK uses a unified configuration system. All settings are loaded from enviro
 import "github.com/rossvideo/catena/sdks/go/pkg/catena"
 
 func main() {
-    // Initialize SDK with prefix and app name (parses env vars, supports -v flags)
-    cfg, err := catena.InitSDK("CATENA", "my_service")
+    // Initialize SDK (parses env vars, supports -v flags)
+    cfg, err := catena.InitSDK(catena.InitOptions{AppName: "my_service"})
     if err != nil {
         log.Fatal(err)
     }
@@ -141,9 +141,9 @@ All variables use the same prefix (default: `CATENA`). Replace `{PREFIX}` with y
 ### Custom Prefix
 
 ```go
-// Use the default CATENA prefix
-cfg, err := catena.InitSDK("")  // reads CATENA_ENV, CATENA_PORT, etc.
+// Use the default CATENA prefix (no arguments needed)
+cfg, err := catena.InitSDK()  // reads CATENA_ENV, CATENA_PORT, etc.
 
 // Use a custom prefix for your application
-cfg, err := catena.InitSDK("MYAPP", "my_app")  // reads MYAPP_ENV, MYAPP_PORT, etc.
+cfg, err := catena.InitSDK(catena.InitOptions{Prefix: "MYAPP", AppName: "my_app"})  // reads MYAPP_ENV, MYAPP_PORT, etc.
 ```

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -112,12 +112,9 @@ The SDK uses a unified configuration system. All settings are loaded from enviro
 import "github.com/rossvideo/catena/sdks/go/pkg/catena"
 
 func main() {
-    // Parse config from environment variables (supports -v, -vv, -vvv flags)
-    cfg := catena.ParseConfigWithVerbosity("CATENA")
-    cfg.Logger.AppName = "my_service"
-
-    // Initialize SDK
-    if err := catena.Init(cfg); err != nil {
+    // Initialize SDK with prefix and app name (parses env vars, supports -v flags)
+    cfg, err := catena.InitSDK("CATENA", "my_service")
+    if err != nil {
         log.Fatal(err)
     }
     defer catena.Close()
@@ -145,8 +142,8 @@ All variables use the same prefix (default: `CATENA`). Replace `{PREFIX}` with y
 
 ```go
 // Use the default CATENA prefix
-cfg := catena.ParseConfigWithVerbosity("")  // reads CATENA_ENV, CATENA_PORT, etc.
+cfg, err := catena.InitSDK("")  // reads CATENA_ENV, CATENA_PORT, etc.
 
 // Use a custom prefix for your application
-cfg := catena.ParseConfigWithVerbosity("MYAPP")  // reads MYAPP_ENV, MYAPP_PORT, etc.
+cfg, err := catena.InitSDK("MYAPP", "my_app")  // reads MYAPP_ENV, MYAPP_PORT, etc.
 ```

--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -44,7 +44,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -118,15 +117,15 @@ func (c *CounterState) Increment() {
 }
 
 func main() {
-	// Parse config from environment variables with CATENA prefix
-	cfg := logger.ParseConfigWithVerbosity("CATENA")
-	cfg.AppName = "executeCommand_REST"
+	// Single unified config initialization with prefix
+	cfg := catena.ParseConfigWithVerbosity("CATENA")
+	cfg.Logger.AppName = "executeCommand_REST"
 
-	if err := logger.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize logger: %v\n", err)
+	if err := catena.Init(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
 		os.Exit(1)
 	}
-	defer logger.Close()
+	defer catena.Close()
 
 	// Handle signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -137,13 +136,8 @@ func main() {
 		close(shutdownChan) // closes the channel to signal the main goroutine to shut down
 	}()
 
-	// Get port from environment variables or use default 6254
-	portStr := envOr("CATENA_PORT", "6254")
-	port, err := strconv.Atoi(portStr) // converts the string to an integer
-	if err != nil {
-		logger.Error("invalid CATENA_PORT", "error", err)
-		os.Exit(1) // exits the program with a non-zero status code
-	}
+	// Port comes from the unified config
+	port := cfg.Port
 
 	// Initialize counter
 	counter := &CounterState{}
@@ -298,11 +292,4 @@ func main() {
 	// Wait for shutdown signal
 	<-shutdownChan
 	logger.Info("Server shutdown complete")
-}
-
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
 }

--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -118,7 +118,7 @@ func (c *CounterState) Increment() {
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "executeCommand_REST"})
+	cfg, err := catena.InitOptions(catena.Options{AppName: "executeCommand_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -118,7 +118,7 @@ func (c *CounterState) Increment() {
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK("CATENA", "executeCommand_REST")
+	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "executeCommand_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -117,12 +117,10 @@ func (c *CounterState) Increment() {
 }
 
 func main() {
-	// Single unified config initialization with prefix
-	cfg := catena.ParseConfigWithVerbosity("CATENA")
-	cfg.Logger.AppName = "executeCommand_REST"
-
-	if err := catena.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
+	// Initialize SDK with prefix and app name
+	cfg, err := catena.InitSDK("CATENA", "executeCommand_REST")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)
 	}
 	defer catena.Close()

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -77,7 +77,7 @@ var (
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK("CATENA", "asset_request_REST")
+	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "asset_request_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -76,12 +76,10 @@ var (
 )
 
 func main() {
-	// Single unified config initialization with prefix
-	cfg := catena.ParseConfigWithVerbosity("CATENA")
-	cfg.Logger.AppName = "asset_request_REST"
-
-	if err := catena.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
+	// Initialize SDK with prefix and app name
+	cfg, err := catena.InitSDK("CATENA", "asset_request_REST")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)
 	}
 	defer catena.Close()
@@ -242,4 +240,3 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map, ass
 		logger.Error("Error walking embedded directory", "root", root, "error", err)
 	}
 }
-

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -77,7 +77,7 @@ var (
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "asset_request_REST"})
+	cfg, err := catena.InitOptions(catena.Options{AppName: "asset_request_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -76,14 +76,15 @@ var (
 )
 
 func main() {
-	cfg := logger.ParseConfigWithVerbosity("CATENA")
-	cfg.AppName = "asset_request_REST"
+	// Single unified config initialization with prefix
+	cfg := catena.ParseConfigWithVerbosity("CATENA")
+	cfg.Logger.AppName = "asset_request_REST"
 
-	if err := logger.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize logger: %v\n", err)
+	if err := catena.Init(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
 		os.Exit(1)
 	}
-	defer logger.Close()
+	defer catena.Close()
 
 	// Handle signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -94,12 +95,8 @@ func main() {
 		close(shutdownChan)
 	}()
 
-	portStr := envOr("CATENA_PORT", "6254")
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		logger.Error("invalid CATENA_PORT", "error", err)
-		os.Exit(1)
-	}
+	// Port comes from the unified config (parsed from CATENA_PORT)
+	port := cfg.Port
 
 	// ==========================================================================
 	// Asset Storage
@@ -246,9 +243,3 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map, ass
 	}
 }
 
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -59,12 +59,10 @@ var (
 )
 
 func main() {
-	// Single unified config initialization with prefix
-	cfg := catena.ParseConfigWithVerbosity("CATENA")
-	cfg.Logger.AppName = "get_device_example"
-
-	if err := catena.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
+	// Initialize SDK with prefix and app name
+	cfg, err := catena.InitSDK("CATENA", "getDevice_REST")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)
 	}
 	defer catena.Close()

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -60,7 +60,7 @@ var (
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK("CATENA", "getDevice_REST")
+	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "getDevice_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -59,14 +59,15 @@ var (
 )
 
 func main() {
-	cfg := logger.ParseConfigWithVerbosity("CATENA")
-	cfg.AppName = "get_device_example"
+	// Single unified config initialization with prefix
+	cfg := catena.ParseConfigWithVerbosity("CATENA")
+	cfg.Logger.AppName = "get_device_example"
 
-	if err := logger.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize logger: %v\n", err)
+	if err := catena.Init(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
 		os.Exit(1)
 	}
-	defer logger.Close()
+	defer catena.Close()
 
 	// Handle signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -77,12 +78,8 @@ func main() {
 		close(shutdownChan)
 	}()
 
-	portStr := envOr("CATENA_PORT", "6254")
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		logger.Error("invalid CATENA_PORT", "error", err)
-		os.Exit(1)
-	}
+	// Port comes from the unified config (parsed from CATENA_PORT)
+	port := cfg.Port
 
 	// Define device metadata for multiple slots
 	devices := map[int]map[string]any{
@@ -197,11 +194,4 @@ func main() {
 	// Wait for shutdown signal
 	<-shutdownChan
 	logger.Info("Server shutdown complete")
-}
-
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
 }

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -60,7 +60,7 @@ var (
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "getDevice_REST"})
+	cfg, err := catena.InitOptions(catena.Options{AppName: "getDevice_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -124,12 +124,10 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 }
 
 func main() {
-	// Single unified config initialization with prefix
-	cfg := catena.ParseConfigWithVerbosity("CATENA")
-	cfg.Logger.AppName = "basic_device_bl"
-
-	if err := catena.Init(cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
+	// Initialize SDK with prefix and app name
+	cfg, err := catena.InitSDK("CATENA", "getSetValue_REST")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)
 	}
 	defer catena.Close()

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -124,17 +124,15 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 }
 
 func main() {
-	// Parse config from environment variables with CATENA prefix
-	// and apply CLI verbosity flags (-v, -vv) if specified
-	cfg := logger.ParseConfigWithVerbosity("CATENA")
-	cfg.AppName = "basic_device_bl"
+	// Single unified config initialization with prefix
+	cfg := catena.ParseConfigWithVerbosity("CATENA")
+	cfg.Logger.AppName = "basic_device_bl"
 
-	err := logger.Init(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize logger: %v\n", err)
+	if err := catena.Init(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize catena: %v\n", err)
 		os.Exit(1)
 	}
-	defer logger.Close()
+	defer catena.Close()
 
 	// Handle signals for graceful shutdown
 	sigChan := make(chan os.Signal, 1)
@@ -145,12 +143,8 @@ func main() {
 		close(shutdownChan)
 	}()
 
-	portStr := envOr("CATENA_PORT", "6254")
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		logger.Error("invalid CATENA_PORT", "error", err)
-		os.Exit(1)
-	}
+	// Port comes from the unified config (parsed from CATENA_PORT)
+	port := cfg.Port
 	logger.Info("Starting Dummy BaseServer", "port", port)
 
 	var params0 = &sync.Map{}
@@ -295,11 +289,4 @@ func main() {
 	// Wait for shutdown signal
 	<-shutdownChan
 	logger.Info("Server shutdown complete")
-}
-
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
 }

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -125,7 +125,7 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "getSetValue_REST"})
+	cfg, err := catena.InitOptions(catena.Options{AppName: "getSetValue_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -125,7 +125,7 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 
 func main() {
 	// Initialize SDK with prefix and app name
-	cfg, err := catena.InitSDK("CATENA", "getSetValue_REST")
+	cfg, err := catena.InitSDK(catena.InitOptions{AppName: "getSetValue_REST"})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize SDK: %v\n", err)
 		os.Exit(1)

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -93,7 +93,7 @@ func SetEnv(env Environment) {
 type Config struct {
 	Prefix string        // Environment variable prefix (e.g., "CATENA" or "MYAPP")
 	Env    Environment   // dev or prod (default: prod)
-	Logger logger.Config // Logger configuration
+	Logger logger.Settings // Logger configuration
 	Port   int           // HTTP server port (default: 6254)
 }
 
@@ -105,7 +105,7 @@ func DefaultConfig(prefix string) Config {
 	return Config{
 		Prefix: prefix,
 		Env:    EnvProd,
-		Logger: logger.DefaultConfig(),
+		Logger: logger.DefaultSettings(),
 		Port:   6254,
 	}
 }
@@ -144,7 +144,7 @@ func parseConfig(prefix string) Config {
 // parseConfigWithVerbosity parses config and applies CLI verbosity flags (-v, -vv, -vvv).
 func parseConfigWithVerbosity(prefix string) Config {
 	cfg := parseConfig(prefix)
-	cfg.Logger = logger.ParseConfigWithVerbosity(cfg.Prefix)
+	cfg.Logger = logger.ParseSettingsWithVerbosity(cfg.Prefix)
 	return cfg
 }
 

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -148,16 +148,16 @@ func parseConfigWithVerbosity(prefix string) Config {
 	return cfg
 }
 
-// InitOptions holds optional parameters for InitSDK.
-type InitOptions struct {
+// Options holds optional parameters for InitOptions.
+type Options struct {
 	Prefix  string // Environment variable prefix (default: "CATENA")
 	AppName string // Application name for logging
 }
 
-// InitSDK parses configuration from environment variables and initializes all Catena SDK systems.
-// Call with no arguments to use defaults, or pass InitOptions to customize.
-func InitSDK(opts ...InitOptions) (Config, error) {
-	var opt InitOptions
+// InitOptions parses configuration from environment variables and initializes all Catena SDK systems.
+// Call with no arguments to use defaults, or pass Options to customize.
+func InitOptions(opts ...Options) (Config, error) {
+	var opt Options
 	if len(opts) > 0 {
 		opt = opts[0]
 	}

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -110,8 +110,8 @@ func DefaultConfig(prefix string) Config {
 	}
 }
 
-// ParseConfig parses all configuration from environment variables using the given prefix.
-func ParseConfig(prefix string) Config {
+// parseConfig parses all configuration from environment variables using the given prefix.
+func parseConfig(prefix string) Config {
 	if prefix == "" {
 		prefix = "CATENA"
 	}
@@ -141,18 +141,24 @@ func ParseConfig(prefix string) Config {
 	return cfg
 }
 
-// ParseConfigWithVerbosity parses config and applies CLI verbosity flags (-v, -vv, -vvv).
-func ParseConfigWithVerbosity(prefix string) Config {
-	cfg := ParseConfig(prefix)
+// parseConfigWithVerbosity parses config and applies CLI verbosity flags (-v, -vv, -vvv).
+func parseConfigWithVerbosity(prefix string) Config {
+	cfg := parseConfig(prefix)
 	cfg.Logger = logger.ParseConfigWithVerbosity(cfg.Prefix)
 	return cfg
 }
 
-// Init initializes all Catena SDK systems with the given configuration.
-// Sets the global environment (accessible via IsDev/IsProd) and initializes the logger.
-func Init(cfg Config) error {
+// InitSDK parses configuration from environment variables and initializes all Catena SDK systems.
+func InitSDK(prefix string, appName ...string) (Config, error) {
+	cfg := parseConfigWithVerbosity(prefix)
+	if len(appName) > 0 && appName[0] != "" {
+		cfg.Logger.AppName = appName[0]
+	}
 	currentEnv = cfg.Env
-	return logger.Init(cfg.Logger)
+	if err := logger.Init(cfg.Logger); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
 }
 
 // Close cleans up all Catena SDK resources.

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -40,7 +40,10 @@ package catena
 
 import (
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 )
 
 // Environment represents dev or prod mode for the SDK.
@@ -53,14 +56,15 @@ const (
 
 var currentEnv Environment = EnvProd // default to prod
 
-func init() {
-	if v := os.Getenv("CATENA_ENV"); v != "" {
-		switch strings.ToLower(strings.TrimSpace(v)) {
-		case "dev", "development":
-			currentEnv = EnvDev
-		case "prod", "production":
-			currentEnv = EnvProd
-		}
+// parseEnvString parses an environment string to Environment type.
+func parseEnvString(s string) Environment {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "dev", "development":
+		return EnvDev
+	case "prod", "production":
+		return EnvProd
+	default:
+		return EnvProd
 	}
 }
 
@@ -82,4 +86,85 @@ func GetEnv() Environment {
 // SetEnv allows programmatic override of the environment.
 func SetEnv(env Environment) {
 	currentEnv = env
+}
+
+// Config holds all Catena SDK configuration.
+type Config struct {
+	Prefix string        // Environment variable prefix (e.g., "CATENA" or "MYAPP")
+	Env    Environment   // dev or prod (default: prod)
+	Logger logger.Config // Logger configuration
+	Port   int           // HTTP server port (default: 6254)
+}
+
+// DefaultConfig returns sensible defaults with the given prefix.
+func DefaultConfig(prefix string) Config {
+	if prefix == "" {
+		prefix = "CATENA"
+	}
+	return Config{
+		Prefix: prefix,
+		Env:    EnvProd,
+		Logger: logger.DefaultConfig(),
+		Port:   6254,
+	}
+}
+
+// ParseConfig parses all configuration from environment variables using the given prefix.
+func ParseConfig(prefix string) Config {
+	if prefix == "" {
+		prefix = "CATENA"
+	}
+
+	cfg := DefaultConfig(prefix)
+	cfg.Logger = logger.ParseFromEnv(prefix)
+
+	// Parse environment (dev/prod)
+	if v := os.Getenv(prefix + "_ENV"); v != "" {
+		cfg.Env = parseEnvString(v)
+	}
+
+	// Parse port
+	if v := os.Getenv(prefix + "_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil && port > 0 {
+			cfg.Port = port
+		}
+	}
+
+	return cfg
+}
+
+// ParseConfigWithVerbosity parses config and applies CLI verbosity flags (-v, -vv, -vvv).
+func ParseConfigWithVerbosity(prefix string) Config {
+	if prefix == "" {
+		prefix = "CATENA"
+	}
+
+	cfg := DefaultConfig(prefix)
+	cfg.Logger = logger.ParseConfigWithVerbosity(prefix)
+
+	// Parse environment (dev/prod)
+	if v := os.Getenv(prefix + "_ENV"); v != "" {
+		cfg.Env = parseEnvString(v)
+	}
+
+	// Parse port
+	if v := os.Getenv(prefix + "_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil && port > 0 {
+			cfg.Port = port
+		}
+	}
+
+	return cfg
+}
+
+// Init initializes all Catena SDK systems with the given configuration.
+// Sets the global environment (accessible via IsDev/IsProd) and initializes the logger.
+func Init(cfg Config) error {
+	currentEnv = cfg.Env
+	return logger.Init(cfg.Logger)
+}
+
+// Close cleans up all Catena SDK resources.
+func Close() {
+	logger.Close()
 }

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -148,11 +148,26 @@ func parseConfigWithVerbosity(prefix string) Config {
 	return cfg
 }
 
+// InitOptions holds optional parameters for InitSDK.
+type InitOptions struct {
+	Prefix  string // Environment variable prefix (default: "CATENA")
+	AppName string // Application name for logging
+}
+
 // InitSDK parses configuration from environment variables and initializes all Catena SDK systems.
-func InitSDK(prefix string, appName ...string) (Config, error) {
-	cfg := parseConfigWithVerbosity(prefix)
-	if len(appName) > 0 && appName[0] != "" {
-		cfg.Logger.AppName = appName[0]
+// Call with no arguments to use defaults, or pass InitOptions to customize.
+func InitSDK(opts ...InitOptions) (Config, error) {
+	var opt InitOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	if opt.Prefix == "" {
+		opt.Prefix = "CATENA"
+	}
+
+	cfg := parseConfigWithVerbosity(opt.Prefix)
+	if opt.AppName != "" {
+		cfg.Logger.AppName = opt.AppName
 	}
 	currentEnv = cfg.Env
 	if err := logger.Init(cfg.Logger); err != nil {

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -135,25 +135,8 @@ func ParseConfig(prefix string) Config {
 
 // ParseConfigWithVerbosity parses config and applies CLI verbosity flags (-v, -vv, -vvv).
 func ParseConfigWithVerbosity(prefix string) Config {
-	if prefix == "" {
-		prefix = "CATENA"
-	}
-
-	cfg := DefaultConfig(prefix)
-	cfg.Logger = logger.ParseConfigWithVerbosity(prefix)
-
-	// Parse environment (dev/prod)
-	if v := os.Getenv(prefix + "_ENV"); v != "" {
-		cfg.Env = parseEnvString(v)
-	}
-
-	// Parse port
-	if v := os.Getenv(prefix + "_PORT"); v != "" {
-		if port, err := strconv.Atoi(v); err == nil && port > 0 {
-			cfg.Port = port
-		}
-	}
-
+	cfg := ParseConfig(prefix)
+	cfg.Logger = logger.ParseConfigWithVerbosity(cfg.Prefix)
 	return cfg
 }
 

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * RE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Configuration for the Catena SDK.
+ * @file config.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-01-21
+ */
+
+package catena
+
+import (
+	"os"
+	"strings"
+)
+
+// Environment represents dev or prod mode for the SDK.
+type Environment string
+
+const (
+	EnvDev  Environment = "dev"  // development mode
+	EnvProd Environment = "prod" // production mode
+)
+
+var currentEnv Environment = EnvProd // default to prod
+
+func init() {
+	if v := os.Getenv("CATENA_ENV"); v != "" {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "dev", "development":
+			currentEnv = EnvDev
+		case "prod", "production":
+			currentEnv = EnvProd
+		}
+	}
+}
+
+// IsDev returns true if the SDK is running in development mode.
+func IsDev() bool {
+	return currentEnv == EnvDev
+}
+
+// IsProd returns true if the SDK is running in production mode.
+func IsProd() bool {
+	return currentEnv == EnvProd
+}
+
+// GetEnv returns the current environment (dev or prod).
+func GetEnv() Environment {
+	return currentEnv
+}
+
+// SetEnv allows programmatic override of the environment.
+func SetEnv(env Environment) {
+	currentEnv = env
+}

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -39,6 +39,7 @@
 package catena
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -125,9 +126,16 @@ func ParseConfig(prefix string) Config {
 
 	// Parse port
 	if v := os.Getenv(prefix + "_PORT"); v != "" {
-		if port, err := strconv.Atoi(v); err == nil && port > 0 {
-			cfg.Port = port
+		port, err := strconv.Atoi(v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid %s_PORT value %q: %v\n", prefix, v, err)
+			os.Exit(1)
 		}
+		if port <= 0 || port > 65535 {
+			fmt.Fprintf(os.Stderr, "Error: %s_PORT value %d is out of valid range (1-65535)\n", prefix, port)
+			os.Exit(1)
+		}
+		cfg.Port = port
 	}
 
 	return cfg

--- a/sdks/go/pkg/logger/logger.go
+++ b/sdks/go/pkg/logger/logger.go
@@ -59,13 +59,13 @@ var (
 
 // logger handles structured logging using slog
 type logger struct {
-	config Config
-	file   *os.File
+	settings Settings
+	file     *os.File
 }
 
 // Init initializes the global logger.
 // Returns ErrAlreadyInitialized if called more than once.
-func Init(cfg Config) error {
+func Init(stg Settings) error {
 	initMu.Lock()
 	defer initMu.Unlock()
 
@@ -73,7 +73,7 @@ func Init(cfg Config) error {
 		return ErrAlreadyInitialized
 	}
 
-	globalLogger = &logger{config: cfg}
+	globalLogger = &logger{settings: stg}
 	initErr := globalLogger.setup()
 	if initErr != nil {
 		// Nil out globalLogger on setup failure to avoid partially initialized state
@@ -86,7 +86,7 @@ func Init(cfg Config) error {
 
 // setup configures the slog handlers based on config and sets slog.SetDefault
 func (l *logger) setup() error {
-	if l.config.Silent {
+	if l.settings.Silent {
 		// Silent mode: discard all logs
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 		return nil
@@ -95,20 +95,20 @@ func (l *logger) setup() error {
 	var writers []io.Writer
 
 	// Setup console output
-	if l.config.WriteToConsole {
+	if l.settings.WriteToConsole {
 		writers = append(writers, os.Stderr)
 	}
 
 	// Setup file output
-	if l.config.WriteToFile {
-		if err := os.MkdirAll(l.config.LogDir, 0755); err != nil {
+	if l.settings.WriteToFile {
+		if err := os.MkdirAll(l.settings.LogDir, 0755); err != nil {
 			return fmt.Errorf("failed to create log directory: %w", err)
 		}
 
 		// Timestamped filename: YYYYMMDD_HHMMSS_appName.log
 		timestamp := time.Now().Format("20060102_150405")
-		filename := fmt.Sprintf("%s_%s.log", timestamp, l.config.AppName)
-		logPath := filepath.Join(l.config.LogDir, filename)
+		filename := fmt.Sprintf("%s_%s.log", timestamp, l.settings.AppName)
+		logPath := filepath.Join(l.settings.LogDir, filename)
 
 		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
@@ -130,12 +130,12 @@ func (l *logger) setup() error {
 
 	// Create handler options with configured level
 	opts := &slog.HandlerOptions{
-		Level: l.config.Level,
+		Level: l.settings.Level,
 	}
 
 	// Create handler based on format preference
 	var handler slog.Handler
-	if l.config.UseJSON {
+	if l.settings.UseJSON {
 		handler = slog.NewJSONHandler(output, opts)
 	} else {
 		handler = slog.NewTextHandler(output, opts)

--- a/sdks/go/pkg/logger/settings.go
+++ b/sdks/go/pkg/logger/settings.go
@@ -44,8 +44,8 @@ import (
 	"strings"
 )
 
-// Config holds logger configuration options
-type Config struct {
+// Settings holds logger configuration options
+type Settings struct {
 	// AppName is used in log file naming
 	AppName string
 
@@ -68,9 +68,9 @@ type Config struct {
 	UseJSON bool
 }
 
-// DefaultConfig returns sensible defaults for release mode
-func DefaultConfig() Config {
-	return Config{
+// DefaultSettings returns sensible defaults for release mode
+func DefaultSettings() Settings {
+	return Settings{
 		AppName:        "catena",
 		LogDir:         "./logs",
 		Silent:         false,
@@ -81,11 +81,11 @@ func DefaultConfig() Config {
 	}
 }
 
-// DebugConfig returns configuration for debug/development mode
-func DebugConfig() Config {
-	cfg := DefaultConfig()
-	cfg.Level = slog.LevelDebug
-	return cfg
+// DebugSettings returns configuration for debug/development mode
+func DebugSettings() Settings {
+	stg := DefaultSettings()
+	stg.Level = slog.LevelDebug
+	return stg
 }
 
 // ParseFromEnv creates a Config from environment variables.
@@ -97,38 +97,38 @@ func DebugConfig() Config {
 //   - {PREFIX}_LOG_FILE: "true"/"false" to enable file logging (default: "true")
 //   - {PREFIX}_LOG_CONSOLE: "true"/"false" to enable console logging (default: "true")
 //   - {PREFIX}_LOG_JSON: "true" to output JSON format
-func ParseFromEnv(prefix string) Config {
+func ParseFromEnv(prefix string) Settings {
 	if prefix == "" {
 		prefix = "CATENA"
 	}
 
-	cfg := DefaultConfig()
+	stg := DefaultSettings()
 
 	if v := os.Getenv(prefix + "_LOG_DIR"); v != "" {
-		cfg.LogDir = v
+		stg.LogDir = v
 	}
 
 	if parseBool(os.Getenv(prefix + "_SILENT")) {
-		cfg.Silent = true
+		stg.Silent = true
 	}
 
 	if v := os.Getenv(prefix + "_LOG_LEVEL"); v != "" {
-		cfg.Level = ParseLevel(v)
+		stg.Level = ParseLevel(v)
 	}
 
 	if v := os.Getenv(prefix + "_LOG_FILE"); v != "" {
-		cfg.WriteToFile = parseBool(v)
+		stg.WriteToFile = parseBool(v)
 	}
 
 	if v := os.Getenv(prefix + "_LOG_CONSOLE"); v != "" {
-		cfg.WriteToConsole = parseBool(v)
+		stg.WriteToConsole = parseBool(v)
 	}
 
 	if parseBool(os.Getenv(prefix + "_LOG_JSON")) {
-		cfg.UseJSON = true
+		stg.UseJSON = true
 	}
 
-	return cfg
+	return stg
 }
 
 // parseBool parses a string to a boolean value (case-insensitive)
@@ -195,13 +195,13 @@ func ParseVerbosityFromOS() slog.Level {
 	return ParseVerbosity(os.Args[1:])
 }
 
-// ParseConfigWithVerbosity parses config from environment variables and applies
+// ParseSettingsWithVerbosity parses settings from environment variables and applies
 // CLI verbosity flags (-v, -vv, -vvv). CLI flags override env level if more verbose.
-func ParseConfigWithVerbosity(prefix string) Config {
-	cfg := ParseFromEnv(prefix)
+func ParseSettingsWithVerbosity(prefix string) Settings {
+	stg := ParseFromEnv(prefix)
 	cliLevel := ParseVerbosityFromOS()
-	if cliLevel < cfg.Level {
-		cfg.Level = cliLevel
+	if cliLevel < stg.Level {
+		stg.Level = cliLevel
 	}
-	return cfg
+	return stg
 }

--- a/sdks/go/pkg/logger/settings.go
+++ b/sdks/go/pkg/logger/settings.go
@@ -30,7 +30,7 @@
 
 /**
  * @brief Config struct for logger.
- * @file config.go
+ * @file settings.go
  * @copyright Copyright © 2025 Ross Video Ltd
  * @author Nelson Daniels (nelson.daniels@rossvideo.com)
  * @date 2025-12-09

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -66,23 +66,28 @@ type Server struct {
 	fallbackHandler        FallbackHandler
 }
 
+func writeHTTPError(w http.ResponseWriter, result catena.StatusResult) {
+	httpStatus := result.Code.ToHTTPStatus()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+
+	// Only return detailed error messages in dev mode
+	if catena.IsDev() {
+		json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+	} else {
+		json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
+	}
+}
+
 // writeHTTPResult writes a CatenaValue and StatusResult to the HTTP response.
 func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result catena.StatusResult) {
-	httpStatus := result.Code.ToHTTPStatus()
-
-	// If there's an error message, write it as JSON
+	// If there's an error message, delegate to writeHTTPError
 	if result.Error != "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(httpStatus)
-
-		// Only return detailed error messages in dev mode
-		if catena.IsDev() {
-			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
-		} else {
-			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
-		}
+		writeHTTPError(w, result)
 		return
 	}
+
+	httpStatus := result.Code.ToHTTPStatus()
 
 	// If Value is nil, just write the status code
 	if value.Value == nil {

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -79,7 +79,7 @@ func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result cat
 		if catena.IsDev() {
 			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
 		} else {
-			json.NewEncoder(w).Encode(map[string]string{"error": "error"})
+			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
 		}
 		return
 	}

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -66,28 +66,21 @@ type Server struct {
 	fallbackHandler        FallbackHandler
 }
 
-func writeHTTPError(w http.ResponseWriter, result catena.StatusResult) {
+// writeHTTPResult writes a CatenaValue and StatusResult to the HTTP response.
+func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result catena.StatusResult) {
 	httpStatus := result.Code.ToHTTPStatus()
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
 
-	// Only return detailed error messages in dev mode
-	if catena.IsDev() {
-		json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
-	} else {
-		json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
-	}
-}
-
-// writeHTTPResult writes a CatenaValue and StatusResult to the HTTP response.
-func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result catena.StatusResult) {
-	// If there's an error message, delegate to writeHTTPError
 	if result.Error != "" {
-		writeHTTPError(w, result)
-		return
+		// Only return detailed error messages in dev mode
+		if catena.IsDev() {
+			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
+		}
 	}
-
-	httpStatus := result.Code.ToHTTPStatus()
 
 	// If Value is nil, just write the status code
 	if value.Value == nil {

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -66,7 +66,7 @@ type Server struct {
 	fallbackHandler        FallbackHandler
 }
 
-// writeHTTPResult writes a CatenaValue and StatusResult to the HTTP response
+// writeHTTPResult writes a CatenaValue and StatusResult to the HTTP response.
 func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result catena.StatusResult) {
 	httpStatus := result.Code.ToHTTPStatus()
 
@@ -74,7 +74,13 @@ func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result cat
 	if result.Error != "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(httpStatus)
-		json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+
+		// Only return detailed error messages in dev mode
+		if catena.IsDev() {
+			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"error": "error"})
+		}
 		return
 	}
 


### PR DESCRIPTION
## 📖 Description

### Error Message Behavior

Adds environment based error message handling to the Go SDK. 

`CATENA_ENV=prod` -> HTTP error responses return generic status text

`CATENA_ENV=dev`-> Detailed error messages are returned to aid debugging

### Unified Config

`catena.Config` struct centralizes all SDK configs including logging

### InitOptions Optional Arguments

`InitOptions` now uses the optional struct pattern, allowing it to be called with no arguments:

- `catena.InitOptions()` — uses all defaults (CATENA prefix)
- `catena.InitOptions(catena.Options{AppName: "myapp"})` — with app name
- `catena.InitOptions(catena.Options{Prefix: "MYAPP"})` — custom prefix
- `catena.InitOptions(catena.Options{Prefix: "MYAPP", AppName: "myapp"})` — both

---

## ✅ Definition of Done (DoD)

- [x] `config.go` reads `CATENA_ENV` at startup
- [x] new config file unifies logging and environment setup 
- [x] `server.go` uses the env var to determine what to return when `writeHTTPResult()` is called
- [x] `InitOptions` accepts optional `Options` struct (no empty string required)
- [x] All example files updated to use new `InitOptions` syntax
- [x] Documentation is updated

---

## 🛠️ Implementation Notes
- Added env var `CATENA_ENV` in `launch.json`
- Added env var `CATENA_PORT` -> default set to 6254
- Added `config.go` to read `CATENA_ENV` at startup
- Modified `server.go` to return detailed errors only in `dev` mode
- Added `Options` struct for optional `InitOptions` parameters
- Updated `getDevice_REST`, `getSetValue_REST`, `getAsset_REST`, `executeCommand_REST` examples

---

## 🔗 Related Issues / Links
[Detailed Error Messages](https://github.com/rossvideo/Catena/issues/1193)

Closes issue #1193 