### PR TITLE
Catena Go types

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -192,13 +192,12 @@
       "description": "Select Go program to debug",
       "type": "pickString",
       "options": [
-        "basic_device_v2",
         "getDevice_REST",
         "executeCommand_REST",
         "getAsset_REST",
         "getSetValue_REST"
       ],
-      "default": "basic_device_bl"
+      "default": "getSetValue_REST"
     },
     {
       "id": "pickDeviceModel",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -192,7 +192,6 @@
       "description": "Select Go program to debug",
       "type": "pickString",
       "options": [
-        "basic_device_bl",
         "basic_device_v2",
         "getDevice_REST",
         "executeCommand_REST",

--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -178,12 +178,12 @@ func main() {
 			if counter.IsRunning() {
 				logger.Info("Start command - already running")
 				val, _ := catena.ToCatenaValue(buildResponse())
-				return catena.ReplyOK(val)
+				return catena.Reply(val)
 			}
 			counter.Start()
 			logger.Info("Counter started", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.ReplyOK(val)
+			return catena.Reply(val)
 		},
 
 		// Stop command
@@ -191,12 +191,12 @@ func main() {
 			if !counter.IsRunning() {
 				logger.Info("Stop command - already stopped")
 				val, _ := catena.ToCatenaValue(buildResponse())
-				return catena.ReplyOK(val)
+				return catena.Reply(val)
 			}
 			counter.Stop()
 			logger.Info("Counter stopped", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.ReplyOK(val)
+			return catena.Reply(val)
 		},
 
 		// Add10 command
@@ -204,7 +204,7 @@ func main() {
 			counter.Add(10)
 			logger.Info("Added 10 to counter", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.ReplyOK(val)
+			return catena.Reply(val)
 		},
 
 		// Reset command
@@ -212,7 +212,7 @@ func main() {
 			counter.Reset()
 			logger.Info("Counter reset", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.ReplyOK(val)
+			return catena.Reply(val)
 		},
 	}
 
@@ -226,9 +226,9 @@ func main() {
 	srv.RegisterGetValueHandler(0, func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
 		if fqoid == "counter" {
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.ReplyOK(val)
+			return catena.Reply(val)
 		}
-		return catena.ReplyNotFound("parameter not found: " + fqoid)
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"parameter not found: " + fqoid)
 	})
 
 	// Register ExecuteCommand handler
@@ -245,7 +245,7 @@ func main() {
 				},
 			}
 			val, _ := catena.ToCatenaValue(exception)
-			return catena.ReplyOK(val)
+			return catena.Reply(val)
 		}
 
 		return handler(payload)
@@ -257,13 +257,13 @@ func main() {
 		if r.URL.Path == "/" {
 			data, err := staticFS.ReadFile("static/index.htm")
 			if err != nil {
-				return catena.ReplyNotFound("index.html not found")
+				return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"index.html not found")
 			}
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.Write(data)
-			return catena.ReplyOK(catena.CatenaValue{})
+			return catena.Reply(catena.CatenaValue{})
 		}
-		return catena.ReplyNotFound("endpoint not found: " + r.URL.Path)
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"endpoint not found: " + r.URL.Path)
 	})
 
 	// ==========================================================================

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -39,6 +39,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -47,7 +48,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -59,13 +59,6 @@ import (
 
 //go:embed static/*
 var staticFS embed.FS
-
-// Asset represents a binary asset with metadata
-type Asset struct {
-	ContentType string
-	Data        []byte
-	Filename    string
-}
 
 // Global state for graceful shutdown
 var (
@@ -124,33 +117,21 @@ func main() {
 		val, ok := assets.Load(fqoid)
 		if !ok {
 			logger.Warning("Asset not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyAssetNotFound("asset not found: " + fqoid)
+			return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND,"asset not found: " + fqoid)
 		}
 
-		asset := val.(Asset)
-
-		// Create DataPayload in business logic
-		payload := catena.DataPayload{
-			Data:        asset.Data,
-			ContentType: asset.ContentType,
-			Cachable:    true,
-		}
-
-		// Add filename to content-disposition if available
-		if asset.Filename != "" {
-			payload.ContentDisposition = fmt.Sprintf("attachment; filename=%q", asset.Filename)
-		}
+		payload := val.(catena.DataPayload)
 
 		// Convert DataPayload to CatenaAsset when returning
-		catenaAsset := payload.ToCatenaAsset()
+		catenaAsset := payload.ToCatenaAsset(true)
 
-		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(asset.Data))
-		return catena.ReplyAsset(catenaAsset)
+		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(payload.Payload))
+		return catena.Reply(catenaAsset)
 	})
 
 	// Not found handler
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
-		return catena.ReplyNotFound("endpoint not found")
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"endpoint not found")
 	})
 
 	// ==========================================================================
@@ -217,13 +198,23 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map) {
 		// Normalize path separators for URL use
 		assetID := strings.ReplaceAll(relPath, string(filepath.Separator), "/")
 
-		asset := Asset{
-			ContentType: contentType,
-			Data:        data,
-			Filename:    filepath.Base(path),
+		// Build metadata
+		metadata := map[string]string{
+			"content-type":        contentType,
+			"content-disposition": fmt.Sprintf("attachment; filename=%q", filepath.Base(path)),
 		}
 
-		assets.Store(assetID, asset)
+		// Calculate SHA-256 digest
+		hash := sha256.Sum256(data)
+
+		// Store as DataPayload directly
+		payload := catena.DataPayload{
+			Payload:  data,
+			Metadata: metadata,
+			Digest:   hash[:],
+		}
+
+		assets.Store(assetID, payload)
 		logger.Info("Loaded asset", "id", assetID, "size", len(data), "type", contentType)
 
 		return nil

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -117,13 +117,17 @@ func main() {
 		val, ok := assets.Load(fqoid)
 		if !ok {
 			logger.Warning("Asset not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND,"asset not found: " + fqoid)
+			return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "asset not found: "+fqoid)
 		}
 
 		payload := val.(catena.DataPayload)
 
 		// Convert DataPayload to CatenaAsset when returning
-		catenaAsset := payload.ToCatenaAsset(true)
+		catenaAsset, err := catena.ToCatenaAsset(payload, true)
+		if err != nil {
+			logger.Error("Failed to convert payload to asset", "slot", slot, "fqoid", fqoid, "error", err)
+			return catena.ReplyError[catena.CatenaAsset](catena.INTERNAL, "failed to convert asset: "+err.Error())
+		}
 
 		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(payload.Payload))
 		return catena.Reply(catenaAsset)
@@ -131,7 +135,7 @@ func main() {
 
 	// Not found handler
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
-		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"endpoint not found")
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
 	})
 
 	// ==========================================================================
@@ -200,8 +204,8 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map) {
 
 		// Build metadata
 		metadata := map[string]string{
-			"content-type":        contentType,
-			"content-disposition": fmt.Sprintf("attachment; filename=%q", filepath.Base(path)),
+			"content-type": contentType,
+			"file-name":    filepath.Base(path),
 		}
 
 		// Calculate SHA-256 digest

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -98,16 +98,17 @@ func main() {
 	// Asset Storage
 	// ==========================================================================
 	assets := &sync.Map{}
-	assetsList := &sync.Map{}
 
 	// Load assets from embedded static directory
-	loadAssetsFromEmbedded(staticFS, "static", assets, assetsList)
+	loadAssetsFromEmbedded(staticFS, "static", assets)
 
-	// Build assets list for logging
-	var assetNames []string
-	assetsList.Range(func(key, value any) bool {
-		assetNames = append(assetNames, key.(string))
-		return true
+	// Collect asset names for example curl command
+	var firstAssetName string
+	assets.Range(func(key, _ any) bool {
+		if firstAssetName == "" {
+			firstAssetName = key.(string)
+		}
+		return firstAssetName == "" // Stop after finding first asset
 	})
 
 	// ==========================================================================
@@ -128,13 +129,20 @@ func main() {
 
 		asset := val.(Asset)
 
-		// Create CatenaAsset with the data and content type
-		catenaAsset := catena.NewCatenaAsset(asset.Data, asset.ContentType)
-
-		// Add filename if available
-		if asset.Filename != "" {
-			catenaAsset = catenaAsset.WithFilename(asset.Filename)
+		// Create DataPayload in business logic
+		payload := catena.DataPayload{
+			Data:        asset.Data,
+			ContentType: asset.ContentType,
+			Cachable:    true,
 		}
+
+		// Add filename to content-disposition if available
+		if asset.Filename != "" {
+			payload.ContentDisposition = fmt.Sprintf("attachment; filename=%q", asset.Filename)
+		}
+
+		// Convert DataPayload to CatenaAsset when returning
+		catenaAsset := payload.ToCatenaAsset()
 
 		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(asset.Data))
 		return catena.ReplyAsset(catenaAsset)
@@ -156,15 +164,9 @@ func main() {
 	logger.Info("Available endpoint:")
 	logger.Info("  GET  /st2138-api/v1/0/asset/{oid}  - GetAsset")
 	logger.Info("")
-	logger.Info("Loaded assets:")
-	assetsList.Range(func(key, value any) bool {
-		logger.Info("  ", "asset", key)
-		return true
-	})
-	logger.Info("")
-	logger.Info("Example curl:")
-	if len(assetNames) > 0 {
-		logger.Info(fmt.Sprintf("  curl http://localhost:%d/st2138-api/v1/0/asset/%s", port, assetNames[0]))
+	if firstAssetName != "" {
+		logger.Info("Example curl:")
+		logger.Info(fmt.Sprintf("  curl http://localhost:%d/st2138-api/v1/0/asset/%s", port, firstAssetName))
 	}
 	logger.Info("=======================================================")
 
@@ -182,7 +184,7 @@ func main() {
 }
 
 // loadAssetsFromEmbedded loads all files from the embedded filesystem into the asset store
-func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map, assetsList *sync.Map) {
+func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map) {
 	err := fs.WalkDir(embedFS, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			logger.Warning("Error accessing path", "path", path, "error", err)
@@ -222,7 +224,6 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map, ass
 		}
 
 		assets.Store(assetID, asset)
-		assetsList.Store(assetID, true)
 		logger.Info("Loaded asset", "id", assetID, "size", len(data), "type", contentType)
 
 		return nil

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -39,10 +39,8 @@
 package main
 
 import (
-	"bytes"
 	"embed"
 	"fmt"
-	"io"
 	"io/fs"
 	"mime"
 	"net/http"
@@ -119,36 +117,30 @@ func main() {
 	srv = rest.NewServer(slotList)
 
 	// Register GetAsset handler
-	srv.RegisterGetAssetHandler(0, func(w http.ResponseWriter, r *http.Request, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterGetAssetHandler(0, func(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
 		logger.Info("Asset download request", "slot", slot, "fqoid", fqoid)
 
 		val, ok := assets.Load(fqoid)
 		if !ok {
 			logger.Warning("Asset not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyNotFound("asset not found: " + fqoid)
+			return catena.ReplyAssetNotFound("asset not found: " + fqoid)
 		}
 
 		asset := val.(Asset)
 
-		// Set appropriate headers for binary content
-		w.Header().Set("Content-Type", asset.ContentType)
-		w.Header().Set("Content-Length", strconv.Itoa(len(asset.Data)))
+		// Create CatenaAsset with the data and content type
+		catenaAsset := catena.NewCatenaAsset(asset.Data, asset.ContentType)
+
+		// Add filename if available
 		if asset.Filename != "" {
-			w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", asset.Filename))
+			catenaAsset = catenaAsset.WithFilename(asset.Filename)
 		}
 
-		// Stream the content
-		reader := bytes.NewReader(asset.Data)
-		if _, err := io.Copy(w, reader); err != nil {
-			logger.Error("Asset streaming error", "slot", slot, "fqoid", fqoid, "error", err)
-			return catena.ReplyInternalError("failed to stream asset")
-		}
-
-		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid)
-		return catena.ReplyOK(catena.CatenaValue{})
+		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(asset.Data))
+		return catena.ReplyAsset(catenaAsset)
 	})
 
-	// Fallback handler
+	// Not found handler
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
 		return catena.ReplyNotFound("endpoint not found")
 	})

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -80,8 +80,8 @@ func main() {
 	// Define device metadata for multiple slots
 	devices := map[int]map[string]any{
 		0: {
-			"slot":         uint32(0),
-			"detail_level": catena.DetailLevelFull,
+			"slot":              uint32(0),
+			"detail_level":      catena.DetailLevelFull,
 			"multi_set_enabled": true,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
@@ -93,7 +93,7 @@ func main() {
 							"en": "Brightness",
 						},
 					},
-					"type": int32(4), // INT32
+					"type": catena.ParamTypeInt32,
 					"constraint": map[string]any{
 						"ref_oid": "brightness_range",
 					},
@@ -106,7 +106,7 @@ func main() {
 							"en": "Contrast",
 						},
 					},
-					"type": int32(4), // INT32
+					"type": catena.ParamTypeInt32,
 					"constraint": map[string]any{
 						"ref_oid": "brightness_range",
 					},
@@ -120,7 +120,7 @@ func main() {
 							"fr": "Source d'entrée",
 						},
 					},
-					"type": int32(7), // STRING
+					"type": catena.ParamTypeString,
 					"constraint": map[string]any{
 						"ref_oid": "input_source_choice",
 					},
@@ -193,7 +193,7 @@ func main() {
 							"fr": "Redémarrer l'appareil",
 						},
 					},
-					"type": int32(1), // EMPTY (command with no args)
+					"type": catena.ParamTypeEmpty, // command with no args
 				},
 				"reset": map[string]any{
 					"name": map[string]any{
@@ -202,7 +202,7 @@ func main() {
 							"fr": "Réinitialiser aux valeurs par défaut",
 						},
 					},
-					"type": int32(1), // EMPTY
+					"type": catena.ParamTypeEmpty,
 				},
 			},
 			"language_packs": map[string]any{
@@ -236,8 +236,8 @@ func main() {
 			},
 		},
 		1: {
-			"slot":         uint32(1),
-			"detail_level": catena.DetailLevelFull,
+			"slot":              uint32(1),
+			"detail_level":      catena.DetailLevelFull,
 			"multi_set_enabled": false,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op"},
@@ -263,7 +263,7 @@ func main() {
 							"en": "Master Gain",
 						},
 					},
-					"type": int32(6), // FLOAT32
+					"type": catena.ParamTypeFloat32,
 					"constraint": map[string]any{
 						"ref_oid": "gain_range",
 					},
@@ -276,7 +276,7 @@ func main() {
 							"en": "Input 1 Gain",
 						},
 					},
-					"type": int32(6), // FLOAT32
+					"type": catena.ParamTypeFloat32,
 					"constraint": map[string]any{
 						"ref_oid": "gain_range",
 					},
@@ -289,7 +289,7 @@ func main() {
 							"en": "Mute",
 						},
 					},
-					"type":      int32(4), // INT32 (treating boolean as int32)
+					"type":      catena.ParamTypeInt32, // treating boolean as int32
 					"widget":    "CHECKBOX",
 					"read_only": false,
 				},
@@ -324,7 +324,7 @@ func main() {
 							"en": "Reset Peak Meters",
 						},
 					},
-					"type": int32(1), // EMPTY
+					"type": catena.ParamTypeEmpty,
 				},
 			},
 			"language_packs": map[string]any{
@@ -344,8 +344,8 @@ func main() {
 			},
 		},
 		2: {
-			"slot":         uint32(2),
-			"detail_level": catena.DetailLevelFull,
+			"slot":              uint32(2),
+			"detail_level":      catena.DetailLevelFull,
 			"multi_set_enabled": true,
 			"subscriptions":     false,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg"},
@@ -371,7 +371,7 @@ func main() {
 							"en": "Output 1 Source",
 						},
 					},
-					"type": int32(4), // INT32
+					"type": catena.ParamTypeInt32,
 					"constraint": map[string]any{
 						"ref_oid": "input_choice",
 					},
@@ -384,7 +384,7 @@ func main() {
 							"en": "Lock Enabled",
 						},
 					},
-					"type":      int32(4), // INT32 (treating boolean as int32)
+					"type":      catena.ParamTypeInt32, // treating boolean as int32
 					"widget":    "CHECKBOX",
 					"read_only": false,
 				},
@@ -427,7 +427,7 @@ func main() {
 							"en": "Take (Execute Salvo)",
 						},
 					},
-					"type": int32(1), // EMPTY
+					"type": catena.ParamTypeEmpty,
 				},
 				"clear_locks": map[string]any{
 					"name": map[string]any{
@@ -435,7 +435,7 @@ func main() {
 							"en": "Clear All Locks",
 						},
 					},
-					"type": int32(1), // EMPTY
+					"type": catena.ParamTypeEmpty,
 				},
 			},
 			"language_packs": map[string]any{

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -44,7 +44,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
@@ -137,20 +136,7 @@ func main() {
 
 	// Register GetDevice handler for each slot
 	for _, slot := range slotList {
-		srv.RegisterGetDeviceHandler(slot, func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
-			// Parse slot from URL path: /st2138-api/v1/{slot}
-			parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-			if len(parts) < 3 {
-				logger.Error("GetDevice invalid path", "path", r.URL.Path)
-				return catena.ReplyBadRequest("invalid path")
-			}
-			slotStr := parts[2]
-			slot, err := strconv.Atoi(slotStr)
-			if err != nil {
-				logger.Error("GetDevice invalid slot", "slot", slotStr, "error", err)
-				return catena.ReplyBadRequest("invalid slot")
-			}
-
+		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaValue, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
 			_, ok := devices[slot]
 			if !ok {
@@ -165,8 +151,8 @@ func main() {
 
 	// Register fallback handler
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
-		logger.Warning("Endpoint not found", "method", r.Method, "path", r.URL.Path)
-		return catena.ReplyNotFound("endpoint not found: " + r.URL.Path)
+		logger.Warning("Endpoint not found")
+		return catena.ReplyNotFound("endpoint not found")
 	})
 
 	// Logger info about the example

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -80,8 +80,8 @@ func main() {
 	// Define device metadata for multiple slots
 	devices := map[int]map[string]any{
 		0: {
-			"slot":              uint32(0),
-			"detail_level":      int32(0), // FULL
+			"slot":         uint32(0),
+			"detail_level": catena.DetailLevelFull,
 			"multi_set_enabled": true,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
@@ -236,8 +236,8 @@ func main() {
 			},
 		},
 		1: {
-			"slot":              uint32(1),
-			"detail_level":      int32(0), // FULL
+			"slot":         uint32(1),
+			"detail_level": catena.DetailLevelFull,
 			"multi_set_enabled": false,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op"},
@@ -344,8 +344,8 @@ func main() {
 			},
 		},
 		2: {
-			"slot":              uint32(2),
-			"detail_level":      int32(0), // FULL
+			"slot":         uint32(2),
+			"detail_level": catena.DetailLevelFull,
 			"multi_set_enabled": true,
 			"subscriptions":     false,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg"},

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -43,7 +43,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
@@ -82,6 +81,7 @@ func main() {
 	devices := map[int]map[string]any{
 		0: {
 			"slot":              uint32(0),
+			"detail_level":      int32(0), // FULL
 			"multi_set_enabled": true,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
@@ -237,6 +237,7 @@ func main() {
 		},
 		1: {
 			"slot":              uint32(1),
+			"detail_level":      int32(0), // FULL
 			"multi_set_enabled": false,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op"},
@@ -344,6 +345,7 @@ func main() {
 		},
 		2: {
 			"slot":              uint32(2),
+			"detail_level":      int32(0), // FULL
 			"multi_set_enabled": true,
 			"subscriptions":     false,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg"},
@@ -466,23 +468,23 @@ func main() {
 			_, ok := devices[slot]
 			if !ok {
 				logger.Error("GetDevice device not found", "slot", slot)
-				return catena.ReplyDeviceNotFound("device not found")
+				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
 			}
 
 			device, err := catena.ToCatenaDevice(devices[slot])
 			if err != nil {
 				logger.Error("failed to convert device", "slot", slot, "error", err)
-				return catena.ReplyDeviceInternalError("failed to convert device")
+				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL, "failed to convert device")
 			}
 
-			return catena.ReplyDevice(device)
+			return catena.Reply(device)
 		})
 	}
 
 	// Register fallback handler
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
 		logger.Warning("Endpoint not found")
-		return catena.ReplyNotFound("endpoint not found")
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
 	})
 
 	// Logger info about the example

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -460,6 +460,7 @@ func main() {
 
 	// Register GetDevice handler for each slot
 	for _, slot := range slotList {
+		slot := slot
 		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaDevice, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
 			_, ok := devices[slot]

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -81,52 +81,376 @@ func main() {
 	// Define device metadata for multiple slots
 	devices := map[int]map[string]any{
 		0: {
-			"slot":              0,
-			"name":              "Primary Video Processor",
-			"product":           "VP-2000",
-			"version":           "1.2.3",
+			"slot":              uint32(0),
 			"multi_set_enabled": true,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
 			"default_scope":     "st2138:op",
-			"capabilities": map[string]any{
-				"max_channels":   8,
-				"supports_4k":    true,
-				"supports_hdr":   true,
-				"input_formats":  []string{"SDI", "HDMI", "IP"},
-				"output_formats": []string{"SDI", "HDMI"},
+			"params": map[string]any{
+				"brightness": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Brightness",
+						},
+					},
+					"type": int32(4), // INT32
+					"constraint": map[string]any{
+						"ref_oid": "brightness_range",
+					},
+					"read_only": false,
+					"widget":    "SLIDER",
+				},
+				"contrast": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Contrast",
+						},
+					},
+					"type": int32(4), // INT32
+					"constraint": map[string]any{
+						"ref_oid": "brightness_range",
+					},
+					"read_only": false,
+					"widget":    "SLIDER",
+				},
+				"input_source": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Input Source",
+							"fr": "Source d'entrée",
+						},
+					},
+					"type": int32(7), // STRING
+					"constraint": map[string]any{
+						"ref_oid": "input_source_choice",
+					},
+					"read_only": false,
+					"widget":    "DROPDOWN",
+				},
+			},
+			"constraints": map[string]any{
+				"brightness_range": map[string]any{
+					"int32_range": map[string]any{
+						"min_value": int32(0),
+						"max_value": int32(100),
+					},
+				},
+				"input_source_choice": map[string]any{
+					"string_choice": map[string]any{
+						"choices": []string{"SDI", "HDMI", "IP"},
+					},
+				},
+			},
+			"menu_groups": map[string]any{
+				"video": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Video Settings",
+						},
+					},
+					"menus": map[string]any{
+						"basic": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Basic",
+								},
+							},
+							"param_oids": []string{"brightness", "contrast"},
+						},
+						"input": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Input Configuration",
+								},
+							},
+							"param_oids": []string{"input_source"},
+						},
+					},
+				},
+				"system": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "System",
+						},
+					},
+					"menus": map[string]any{
+						"info": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Device Info",
+								},
+							},
+							"param_oids": []string{},
+						},
+					},
+				},
+			},
+			"commands": map[string]any{
+				"reboot": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Reboot Device",
+							"fr": "Redémarrer l'appareil",
+						},
+					},
+					"type": int32(1), // EMPTY (command with no args)
+				},
+				"reset": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Reset to Defaults",
+							"fr": "Réinitialiser aux valeurs par défaut",
+						},
+					},
+					"type": int32(1), // EMPTY
+				},
+			},
+			"language_packs": map[string]any{
+				"packs": map[string]any{
+					"en": map[string]any{
+						"name": "English",
+						"words": map[string]string{
+							"brightness":   "Brightness",
+							"contrast":     "Contrast",
+							"input_source": "Input Source",
+							"video":        "Video Settings",
+							"basic":        "Basic",
+							"input":        "Input Configuration",
+							"system":       "System",
+							"info":         "Device Info",
+							"reboot":       "Reboot Device",
+							"reset":        "Reset to Defaults",
+						},
+					},
+					"fr": map[string]any{
+						"name": "Français",
+						"words": map[string]string{
+							"brightness":   "Luminosité",
+							"contrast":     "Contraste",
+							"input_source": "Source d'entrée",
+							"reboot":       "Redémarrer l'appareil",
+							"reset":        "Réinitialiser aux valeurs par défaut",
+						},
+					},
+				},
 			},
 		},
 		1: {
-			"slot":              1,
-			"name":              "Audio Mixer",
-			"product":           "AM-500",
-			"version":           "2.0.1",
+			"slot":              uint32(1),
 			"multi_set_enabled": false,
 			"subscriptions":     true,
 			"access_scopes":     []string{"st2138:mon", "st2138:op"},
 			"default_scope":     "st2138:mon",
-			"capabilities": map[string]any{
-				"max_inputs":    16,
-				"max_outputs":   8,
-				"sample_rates":  []int{44100, 48000, 96000},
-				"bit_depths":    []int{16, 24, 32},
-				"supports_aes3": true,
+			"constraints": map[string]any{
+				"gain_range": map[string]any{
+					"float_range": map[string]any{
+						"min_value": float32(-60.0),
+						"max_value": float32(12.0),
+					},
+				},
+				"channel_count": map[string]any{
+					"int32_range": map[string]any{
+						"min_value": int32(1),
+						"max_value": int32(16),
+					},
+				},
+			},
+			"params": map[string]any{
+				"master_gain": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Master Gain",
+						},
+					},
+					"type": int32(6), // FLOAT32
+					"constraint": map[string]any{
+						"ref_oid": "gain_range",
+					},
+					"widget":    "SLIDER",
+					"read_only": false,
+				},
+				"input_1_gain": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Input 1 Gain",
+						},
+					},
+					"type": int32(6), // FLOAT32
+					"constraint": map[string]any{
+						"ref_oid": "gain_range",
+					},
+					"widget":    "SLIDER",
+					"read_only": false,
+				},
+				"mute": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Mute",
+						},
+					},
+					"type":      int32(4), // INT32 (treating boolean as int32)
+					"widget":    "CHECKBOX",
+					"read_only": false,
+				},
+			},
+			"menu_groups": map[string]any{
+				"audio": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Audio Settings",
+						},
+					},
+					"menus": map[string]any{
+						"levels": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Levels",
+								},
+							},
+							"param_oids": []string{
+								"master_gain",
+								"input_1_gain",
+								"mute",
+							},
+						},
+					},
+				},
+			},
+			"commands": map[string]any{
+				"reset_meters": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Reset Peak Meters",
+						},
+					},
+					"type": int32(1), // EMPTY
+				},
+			},
+			"language_packs": map[string]any{
+				"packs": map[string]any{
+					"en": map[string]any{
+						"name": "English",
+						"words": map[string]string{
+							"master_gain":  "Master Gain",
+							"input_1_gain": "Input 1 Gain",
+							"mute":         "Mute",
+							"reset_meters": "Reset Peak Meters",
+							"audio":        "Audio Settings",
+							"levels":       "Levels",
+						},
+					},
+				},
 			},
 		},
 		2: {
-			"slot":              2,
-			"name":              "Router Controller",
-			"product":           "RC-100",
-			"version":           "3.1.0",
+			"slot":              uint32(2),
 			"multi_set_enabled": true,
 			"subscriptions":     false,
 			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg"},
 			"default_scope":     "st2138:op",
-			"capabilities": map[string]any{
-				"matrix_size":    "32x32",
-				"supports_locks": true,
-				"supports_salvo": true,
+			"constraints": map[string]any{
+				"input_choice": map[string]any{
+					"int32_range": map[string]any{
+						"min_value": int32(1),
+						"max_value": int32(32),
+					},
+				},
+				"output_choice": map[string]any{
+					"int32_range": map[string]any{
+						"min_value": int32(1),
+						"max_value": int32(32),
+					},
+				},
+			},
+			"params": map[string]any{
+				"output_1_source": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Output 1 Source",
+						},
+					},
+					"type": int32(4), // INT32
+					"constraint": map[string]any{
+						"ref_oid": "input_choice",
+					},
+					"widget":    "DROPDOWN",
+					"read_only": false,
+				},
+				"lock_enabled": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Lock Enabled",
+						},
+					},
+					"type":      int32(4), // INT32 (treating boolean as int32)
+					"widget":    "CHECKBOX",
+					"read_only": false,
+				},
+			},
+			"menu_groups": map[string]any{
+				"routing": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Routing",
+						},
+					},
+					"menus": map[string]any{
+						"outputs": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Output Configuration",
+								},
+							},
+							"param_oids": []string{
+								"output_1_source",
+							},
+						},
+						"settings": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Settings",
+								},
+							},
+							"param_oids": []string{
+								"lock_enabled",
+							},
+						},
+					},
+				},
+			},
+			"commands": map[string]any{
+				"take": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Take (Execute Salvo)",
+						},
+					},
+					"type": int32(1), // EMPTY
+				},
+				"clear_locks": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Clear All Locks",
+						},
+					},
+					"type": int32(1), // EMPTY
+				},
+			},
+			"language_packs": map[string]any{
+				"packs": map[string]any{
+					"en": map[string]any{
+						"name": "English",
+						"words": map[string]string{
+							"output_1_source": "Output 1 Source",
+							"lock_enabled":    "Lock Enabled",
+							"take":            "Take (Execute Salvo)",
+							"clear_locks":     "Clear All Locks",
+							"routing":         "Routing",
+							"outputs":         "Output Configuration",
+							"settings":        "Settings",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -136,16 +460,21 @@ func main() {
 
 	// Register GetDevice handler for each slot
 	for _, slot := range slotList {
-		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaValue, catena.StatusResult) {
+		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaDevice, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
 			_, ok := devices[slot]
 			if !ok {
 				logger.Error("GetDevice device not found", "slot", slot)
-				return catena.ReplyNotFound("device not found")
+				return catena.ReplyDeviceNotFound("device not found")
 			}
 
-			//will be catenadevice later
-			return catena.ReplyOK(catena.CatenaValue{})
+			device, err := catena.ToCatenaDevice(devices[slot])
+			if err != nil {
+				logger.Error("failed to convert device", "slot", slot, "error", err)
+				return catena.ReplyDeviceInternalError("failed to convert device")
+			}
+
+			return catena.ReplyDevice(device)
 		})
 	}
 

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -58,14 +58,14 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 		val, ok := params.Load(fqoid)
 		if !ok {
 			logger.Error("SetParam param not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyNotFound("param not found")
+			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
 		}
 		if reflect.TypeOf(val) != reflect.TypeOf(value) {
 			logger.Error("SetParam type mismatch", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyBadRequest("type mismatch")
+			return catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT,"type mismatch")
 		}
 		params.Store(fqoid, value)
-		return catena.ReplyNoContent()
+		return catena.ReplyError[catena.CatenaValue](catena.NO_CONTENT, "")
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
@@ -73,14 +73,14 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 		v, ok := params.Load(fqoid)
 		if !ok {
 			logger.Error("GetParam param not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyNotFound("param not found")
+			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
 		}
 		catenaVal, err := catena.ToCatenaValue(v)
 		if err != nil {
 			logger.Error("GetParam failed to convert value", "slot", slot, "fqoid", fqoid, "error", err)
-			return catena.ReplyInternalError("failed to convert value")
+			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to convert value")
 		}
-		return catena.ReplyOK(catenaVal)
+		return catena.Reply(catenaVal)
 	})
 }
 
@@ -88,38 +88,38 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid string, slot int) {
 	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid_ string) (catena.CatenaValue, catena.StatusResult) {
 		if fqoid_ != fqoid {
-			return catena.ReplyNotImplemented("no handler for fqoid " + fqoid_)
+			return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED,"no handler for fqoid " + fqoid_)
 		}
 		logger.Info("SetSpecificParam", "slot", slot, "fqoid", fqoid_)
 		val, ok := params.Load(fqoid_)
 		if !ok {
 			logger.Error("SetSpecificParam param not found", "slot", slot, "fqoid", fqoid_)
-			return catena.ReplyNotFound("param not found")
+			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
 		}
 		if reflect.TypeOf(val) != reflect.TypeOf(value) {
 			logger.Error("SetSpecificParam type mismatch", "slot", slot, "fqoid", fqoid_)
-			return catena.ReplyBadRequest("type mismatch")
+			return catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT,"type mismatch")
 		}
 		params.Store(fqoid_, value)
-		return catena.ReplyNoContent()
+		return catena.ReplyError[catena.CatenaValue](catena.NO_CONTENT, "")
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid_ string) (catena.CatenaValue, catena.StatusResult) {
 		if fqoid_ != fqoid {
-			return catena.ReplyNotImplemented("no handler for fqoid " + fqoid_)
+			return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED,"no handler for fqoid " + fqoid_)
 		}
 		logger.Info("GetSpecificParam", "slot", slot, "fqoid", fqoid_)
 		v, ok := params.Load(fqoid_)
 		if !ok {
 			logger.Error("GetSpecificParam param not found", "slot", slot, "fqoid", fqoid_)
-			return catena.ReplyNotFound("param not found")
+			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
 		}
 		catenaVal, err := catena.ToCatenaValue(v)
 		if err != nil {
 			logger.Error("GetSpecificParam failed to convert value", "slot", slot, "fqoid", fqoid_, "error", err)
-			return catena.ReplyInternalError("failed to convert value")
+			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to convert value")
 		}
-		return catena.ReplyOK(catenaVal)
+		return catena.Reply(catenaVal)
 	})
 }
 
@@ -203,9 +203,9 @@ func main() {
 		// A real implementation would keep the connection open and push updates
 		catenaVal, err := catena.ToCatenaValue("connected")
 		if err != nil {
-			return catena.ReplyInternalError("failed to create response")
+			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to create response")
 		}
-		return catena.ReplyOK(catenaVal)
+		return catena.Reply(catenaVal)
 	})
 
 	// Register command handlers for each slot
@@ -222,9 +222,9 @@ func main() {
 			}
 			catenaVal, err := catena.ToCatenaValue(response)
 			if err != nil {
-				return catena.ReplyInternalError("failed to create command response")
+				return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to create command response")
 			}
-			return catena.ReplyOK(catenaVal)
+			return catena.Reply(catenaVal)
 		})
 	}
 
@@ -261,16 +261,16 @@ func main() {
 			logger.Info("GetDevice", "slot", slot)
 			device, err := catena.ToCatenaDevice(deviceInfo)
 			if err != nil {
-				return catena.ReplyDeviceInternalError("failed to create device info")
+				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL,"failed to create device info")
 			}
-			return catena.ReplyDevice(device)
+			return catena.Reply(device)
 		})
 	}
 
 	// Register handler for non-existent endpoints
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
 		logger.Error("Endpoint not found")
-		return catena.ReplyNotFound("endpoint not found")
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"endpoint not found")
 	})
 
 	addr := ":" + strconv.Itoa(port)

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -257,7 +257,7 @@ func main() {
 	for slot, deviceInfo := range devices {
 		slot := slot             // capture loop variable
 		deviceInfo := deviceInfo // capture loop variable
-		srv.RegisterGetDeviceHandler(slot, func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
+		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaValue, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
 			catenaVal, err := catena.ToCatenaValue(deviceInfo)
 			if err != nil {

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -257,13 +257,13 @@ func main() {
 	for slot, deviceInfo := range devices {
 		slot := slot             // capture loop variable
 		deviceInfo := deviceInfo // capture loop variable
-		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaValue, catena.StatusResult) {
+		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaDevice, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
-			catenaVal, err := catena.ToCatenaValue(deviceInfo)
+			device, err := catena.ToCatenaDevice(deviceInfo)
 			if err != nil {
-				return catena.ReplyInternalError("failed to create device info")
+				return catena.ReplyDeviceInternalError("failed to create device info")
 			}
-			return catena.ReplyOK(catenaVal)
+			return catena.ReplyDevice(device)
 		})
 	}
 

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -1,277 +1,140 @@
 package catena
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/rossvideo/catena/build/go/protos"
 )
 
-// DataPayload is a Go-friendly representation of asset data.
-// Use this in business logic to build assets before converting to CatenaAsset.
-type DataPayload struct {
-	// Either Data or URL must be set, not both
-	Data []byte // Embedded binary data
-	URL  string // External URL reference
-
-	// Metadata
-	ContentType        string            // MIME type
-	ContentDisposition string            // How to display/download the file
-	CustomHeaders      map[string]string // Additional HTTP headers
-	Digest             []byte            // Checksum/hash of the data
-
-	// Options
-	Cachable        bool   // Whether the asset can be cached
-	PayloadEncoding string // "gzip", "deflate", or "" (uncompressed)
+// CatenaAsset wraps protos.ExternalObjectPayload for asset handling
+type CatenaAsset struct {
+	asset    *protos.ExternalObjectPayload
+	jsonData []byte // Cached JSON representation
 }
 
-// ToCatenaAsset converts a DataPayload to CatenaAsset
+// DataPayload is a helper type for business logic to create assets
+// It provides a convenient way to construct ExternalObjectPayload
+type DataPayload struct {
+	Data               []byte
+	ContentType        string
+	ContentDisposition string
+	Cachable           bool
+	CustomHeaders      map[string]string
+	PayloadEncoding    int32 // 0=UNCOMPRESSED, 1=GZIP, 2=DEFLATE
+}
+
+// ToCatenaAsset converts DataPayload to CatenaAsset
 func (dp DataPayload) ToCatenaAsset() CatenaAsset {
 	// Build metadata map
 	metadata := make(map[string]string)
+
+	// Add standard headers
 	if dp.ContentType != "" {
 		metadata["content-type"] = dp.ContentType
 	}
 	if dp.ContentDisposition != "" {
 		metadata["content-disposition"] = dp.ContentDisposition
 	}
-	for k, v := range dp.CustomHeaders {
-		metadata[k] = v
+
+	// Add custom headers
+	for key, value := range dp.CustomHeaders {
+		metadata[key] = value
 	}
 
-	// Determine payload encoding
-	var encoding protos.DataPayload_PayloadEncoding
-	switch dp.PayloadEncoding {
-	case "gzip":
-		encoding = protos.DataPayload_GZIP
-	case "deflate":
-		encoding = protos.DataPayload_DEFLATE
-	default:
-		encoding = protos.DataPayload_UNCOMPRESSED
-	}
-
-	// Create the protobuf DataPayload with appropriate Kind
-	protoPayload := &protos.DataPayload{
-		Metadata:        metadata,
-		Digest:          dp.Digest,
-		PayloadEncoding: encoding,
-	}
-
-	if dp.URL != "" {
-		// URL-based asset
-		protoPayload.Kind = &protos.DataPayload_Url{Url: dp.URL}
-	} else {
-		// Embedded data asset
-		protoPayload.Kind = &protos.DataPayload_Payload{Payload: dp.Data}
-	}
-
-	return CatenaAsset{
-		ExternalObject: &protos.ExternalObjectPayload{
-			Cachable: dp.Cachable,
-			Payload:  protoPayload,
+	// Create the map structure for ExternalObjectPayload
+	assetMap := map[string]any{
+		"cachable": dp.Cachable,
+		"payload": map[string]any{
+			"payload":          dp.Data,
+			"metadata":         metadata,
+			"payload_encoding": dp.PayloadEncoding,
 		},
 	}
+
+	// Convert to CatenaAsset
+	catenaAsset, err := ToCatenaAsset(assetMap)
+	if err != nil {
+		// In case of error, return an empty CatenaAsset
+		// The error will be logged by the caller
+		return CatenaAsset{asset: nil, jsonData: nil}
+	}
+
+	return catenaAsset
 }
 
-// CatenaAsset wraps protos.ExternalObjectPayload for asset handling
-type CatenaAsset struct {
-	ExternalObject *protos.ExternalObjectPayload
+// NewCatenaAsset creates a CatenaAsset from a protos.ExternalObjectPayload
+func NewCatenaAsset(asset *protos.ExternalObjectPayload) CatenaAsset {
+	return CatenaAsset{asset: asset}
 }
 
-// NewCatenaAsset creates a CatenaAsset from binary data and content type
-func NewCatenaAsset(data []byte, contentType string) CatenaAsset {
-	return DataPayload{
-		Data:        data,
-		ContentType: contentType,
-		Cachable:    true,
-	}.ToCatenaAsset()
+// ToCatenaAsset converts a Go map/struct to CatenaAsset
+// This allows developers to work with native Go types and convert to the protobuf format
+func ToCatenaAsset(m map[string]any) (CatenaAsset, error) {
+	asset, jsonData, err := toProtoAsset(m)
+	if err != nil {
+		return CatenaAsset{asset: nil, jsonData: nil}, fmt.Errorf("ToCatenaAsset: %w", err)
+	}
+	return CatenaAsset{asset: asset, jsonData: jsonData}, nil
 }
 
-// NewCatenaAssetFromURL creates a CatenaAsset that references an external URL
-func NewCatenaAssetFromURL(url string, contentType string) CatenaAsset {
-	return DataPayload{
-		URL:         url,
-		ContentType: contentType,
-		Cachable:    true,
-	}.ToCatenaAsset()
-}
+// toProtoAsset converts native Go types to protos.ExternalObjectPayload
+// For complex nested types, uses JSON marshaling to leverage protojson's
+// automatic conversion and validation
+// Returns the asset, cached JSON data, and any error
+func toProtoAsset(m map[string]any) (*protos.ExternalObjectPayload, []byte, error) {
+	// For complex types, use JSON marshaling to handle nested structures
+	jsonData, err := json.Marshal(m)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal map to JSON: %w", err)
+	}
 
-// NewCatenaAssetFromProto creates a CatenaAsset from a protos.ExternalObjectPayload
-func NewCatenaAssetFromProto(eop *protos.ExternalObjectPayload) CatenaAsset {
-	return CatenaAsset{ExternalObject: eop}
-}
+	asset := &protos.ExternalObjectPayload{}
+	if err := protojson.Unmarshal(jsonData, asset); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal JSON to ExternalObjectPayload proto: %w", err)
+	}
 
-// NewCatenaAssetFromDataPayload creates a CatenaAsset from a protos.DataPayload
-func NewCatenaAssetFromDataPayload(dp *protos.DataPayload) CatenaAsset {
-	return CatenaAsset{
-		ExternalObject: &protos.ExternalObjectPayload{
-			Cachable: true,
-			Payload:  dp,
-		},
-	}
-}
-
-// isValid checks if the asset has valid structure
-func (ca CatenaAsset) isValid() bool {
-	return ca.ExternalObject != nil && ca.ExternalObject.Payload != nil
-}
-
-// WithFilename sets the Content-Disposition header for download
-func (ca CatenaAsset) WithFilename(filename string) CatenaAsset {
-	if !ca.isValid() {
-		return ca
-	}
-	if ca.ExternalObject.Payload.Metadata == nil {
-		ca.ExternalObject.Payload.Metadata = make(map[string]string)
-	}
-	ca.ExternalObject.Payload.Metadata["content-disposition"] = fmt.Sprintf("attachment; filename=\"%s\"", filename)
-	return ca
-}
-
-// WithInlineFilename sets the Content-Disposition header for inline display
-func (ca CatenaAsset) WithInlineFilename(filename string) CatenaAsset {
-	if !ca.isValid() {
-		return ca
-	}
-	if ca.ExternalObject.Payload.Metadata == nil {
-		ca.ExternalObject.Payload.Metadata = make(map[string]string)
-	}
-	ca.ExternalObject.Payload.Metadata["content-disposition"] = fmt.Sprintf("inline; filename=\"%s\"", filename)
-	return ca
-}
-
-// WithCustomHeader adds a custom HTTP header
-func (ca CatenaAsset) WithCustomHeader(key, value string) CatenaAsset {
-	if !ca.isValid() {
-		return ca
-	}
-	if ca.ExternalObject.Payload.Metadata == nil {
-		ca.ExternalObject.Payload.Metadata = make(map[string]string)
-	}
-	ca.ExternalObject.Payload.Metadata[key] = value
-	return ca
-}
-
-// WithCompression sets the payload encoding
-func (ca CatenaAsset) WithCompression(encoding string) CatenaAsset {
-	if !ca.isValid() {
-		return ca
-	}
-	switch encoding {
-	case "gzip":
-		ca.ExternalObject.Payload.PayloadEncoding = protos.DataPayload_GZIP
-	case "deflate":
-		ca.ExternalObject.Payload.PayloadEncoding = protos.DataPayload_DEFLATE
-	default:
-		ca.ExternalObject.Payload.PayloadEncoding = protos.DataPayload_UNCOMPRESSED
-	}
-	return ca
-}
-
-// WithDigest sets the digest/checksum for the payload
-func (ca CatenaAsset) WithDigest(digest []byte) CatenaAsset {
-	if !ca.isValid() {
-		return ca
-	}
-	ca.ExternalObject.Payload.Digest = digest
-	return ca
-}
-
-// WithMetadata adds metadata to the payload
-func (ca CatenaAsset) WithMetadata(key, value string) CatenaAsset {
-	if !ca.isValid() {
-		return ca
-	}
-	if ca.ExternalObject.Payload.Metadata == nil {
-		ca.ExternalObject.Payload.Metadata = make(map[string]string)
-	}
-	ca.ExternalObject.Payload.Metadata[key] = value
-	return ca
-}
-
-// SetCachable sets whether the asset should be cached
-func (ca CatenaAsset) SetCachable(cachable bool) CatenaAsset {
-	if ca.ExternalObject == nil {
-		return ca
-	}
-	ca.ExternalObject.Cachable = cachable
-	return ca
-}
-
-// IsURL returns true if this asset is a URL reference
-func (ca CatenaAsset) IsURL() bool {
-	if !ca.isValid() {
-		return false
-	}
-	_, ok := ca.ExternalObject.Payload.Kind.(*protos.DataPayload_Url)
-	return ok
-}
-
-// GetData returns the embedded payload data (nil if URL-based)
-func (ca CatenaAsset) GetData() []byte {
-	if !ca.isValid() {
-		return nil
-	}
-	if payload, ok := ca.ExternalObject.Payload.Kind.(*protos.DataPayload_Payload); ok {
-		return payload.Payload
-	}
-	return nil
-}
-
-// GetURL returns the URL (empty string if embedded data)
-func (ca CatenaAsset) GetURL() string {
-	if !ca.isValid() {
-		return ""
-	}
-	if url, ok := ca.ExternalObject.Payload.Kind.(*protos.DataPayload_Url); ok {
-		return url.Url
-	}
-	return ""
-}
-
-// ContentLength returns the size of the payload (0 for URL-based assets)
-func (ca CatenaAsset) ContentLength() int64 {
-	data := ca.GetData()
-	if data != nil {
-		return int64(len(data))
-	}
-	return 0
-}
-
-// GetContentType returns the content-type from metadata
-func (ca CatenaAsset) GetContentType() string {
-	if !ca.isValid() || ca.ExternalObject.Payload.Metadata == nil {
-		return ""
-	}
-	return ca.ExternalObject.Payload.Metadata["content-type"]
-}
-
-// GetContentDisposition returns the content-disposition from metadata
-func (ca CatenaAsset) GetContentDisposition() string {
-	if !ca.isValid() || ca.ExternalObject.Payload.Metadata == nil {
-		return ""
-	}
-	return ca.ExternalObject.Payload.Metadata["content-disposition"]
-}
-
-// GetMetadata returns a specific metadata value
-func (ca CatenaAsset) GetMetadata(key string) string {
-	if !ca.isValid() || ca.ExternalObject.Payload.Metadata == nil {
-		return ""
-	}
-	return ca.ExternalObject.Payload.Metadata[key]
-}
-
-// GetAllMetadata returns all metadata
-func (ca CatenaAsset) GetAllMetadata() map[string]string {
-	if !ca.isValid() {
-		return nil
-	}
-	return ca.ExternalObject.Payload.Metadata
+	return asset, jsonData, nil
 }
 
 // IsCachable returns whether the asset is cachable
 func (ca CatenaAsset) IsCachable() bool {
-	if ca.ExternalObject == nil {
+	if ca.asset == nil {
 		return false
 	}
-	return ca.ExternalObject.Cachable
+	return ca.asset.Cachable
+}
+
+// GetPayload returns the asset's data payload
+func (ca CatenaAsset) GetPayload() *protos.DataPayload {
+	if ca.asset == nil {
+		return nil
+	}
+	return ca.asset.Payload
+}
+
+// GetProtoAsset returns the underlying protos.ExternalObjectPayload
+func (ca CatenaAsset) GetProtoAsset() *protos.ExternalObjectPayload {
+	return ca.asset
+}
+
+// ToJSON converts CatenaAsset to JSON bytes using protojson
+// Uses cached JSON if available, otherwise generates new JSON
+func (ca CatenaAsset) ToJSON() ([]byte, error) {
+	if ca.asset == nil {
+		return nil, nil
+	}
+
+	// Return cached JSON if available
+	if ca.jsonData != nil {
+		return ca.jsonData, nil
+	}
+
+	// Generate JSON from protobuf if not cached
+	return (protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}).Marshal(ca.asset)
 }

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -1,9 +1,6 @@
 package catena
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/rossvideo/catena/build/go/protos"
@@ -11,8 +8,7 @@ import (
 
 // CatenaAsset wraps protos.ExternalObjectPayload for asset handling
 type CatenaAsset struct {
-	asset    *protos.ExternalObjectPayload
-	jsonData []byte // Cached JSON representation
+	asset *protos.ExternalObjectPayload
 }
 
 // DataPayload is a helper type for business logic to create assets
@@ -25,74 +21,29 @@ type DataPayload struct {
 	Url             string            // URL to external resource (use this OR Payload, not both)
 }
 
-// ToCatenaAsset converts DataPayload to CatenaAsset
-func (dp DataPayload) ToCatenaAsset(cachable bool) CatenaAsset {
-	// Build the payload map for DataPayload
-	payloadMap := map[string]any{
-		"payload_encoding": dp.PayloadEncoding,
+// ToCatenaAsset converts DataPayload to CatenaAsset by building the proto directly
+func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, error) {
+	// Build the proto DataPayload directly
+	protoPayload := &protos.DataPayload{
+		Metadata:        dp.Metadata,
+		Digest:          dp.Digest,
+		PayloadEncoding: protos.DataPayload_PayloadEncoding(dp.PayloadEncoding),
 	}
 
-	// Add metadata if present
-	if len(dp.Metadata) > 0 {
-		payloadMap["metadata"] = dp.Metadata
-	}
-
-	// Add digest if present
-	if len(dp.Digest) > 0 {
-		payloadMap["digest"] = dp.Digest
-	}
-
-	// Add either payload or url (oneof in proto)
+	// Handle oneof: either url or payload (not both)
 	if dp.Url != "" {
-		payloadMap["url"] = dp.Url
+		protoPayload.Kind = &protos.DataPayload_Url{Url: dp.Url}
 	} else if len(dp.Payload) > 0 {
-		payloadMap["payload"] = dp.Payload
+		protoPayload.Kind = &protos.DataPayload_Payload{Payload: dp.Payload}
 	}
 
-	// Create the map structure for ExternalObjectPayload
-	assetMap := map[string]any{
-		"cachable": cachable,
-		"payload":  payloadMap,
+	// Build the ExternalObjectPayload
+	asset := &protos.ExternalObjectPayload{
+		Cachable: cachable,
+		Payload:  protoPayload,
 	}
 
-	// Convert to CatenaAsset
-	catenaAsset, err := ToCatenaAsset(assetMap)
-	if err != nil {
-		// In case of error, return an empty CatenaAsset
-		// The error will be logged by the caller
-		return CatenaAsset{asset: nil, jsonData: nil}
-	}
-
-	return catenaAsset
-}
-
-// ToCatenaAsset converts a Go map/struct to CatenaAsset
-// This allows developers to work with native Go types and convert to the protobuf format
-func ToCatenaAsset(m map[string]any) (CatenaAsset, error) {
-	asset, jsonData, err := toProtoAsset(m)
-	if err != nil {
-		return CatenaAsset{asset: nil, jsonData: nil}, fmt.Errorf("ToCatenaAsset: %w", err)
-	}
-	return CatenaAsset{asset: asset, jsonData: jsonData}, nil
-}
-
-// toProtoAsset converts native Go types to protos.ExternalObjectPayload
-// For complex nested types, uses JSON marshaling to leverage protojson's
-// automatic conversion and validation
-// Returns the asset, cached JSON data, and any error
-func toProtoAsset(m map[string]any) (*protos.ExternalObjectPayload, []byte, error) {
-	// For complex types, use JSON marshaling to handle nested structures
-	jsonData, err := json.Marshal(m)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to marshal map to JSON: %w", err)
-	}
-
-	asset := &protos.ExternalObjectPayload{}
-	if err := protojson.Unmarshal(jsonData, asset); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal JSON to ExternalObjectPayload proto: %w", err)
-	}
-
-	return asset, jsonData, nil
+	return CatenaAsset{asset: asset}, nil
 }
 
 // GetProtoAsset returns the underlying protos.ExternalObjectPayload
@@ -101,18 +52,11 @@ func (ca CatenaAsset) GetProtoAsset() *protos.ExternalObjectPayload {
 }
 
 // ToJSON converts CatenaAsset to JSON bytes using protojson
-// Uses cached JSON if available, otherwise generates new JSON
 func (ca CatenaAsset) ToJSON() ([]byte, error) {
 	if ca.asset == nil {
 		return nil, nil
 	}
 
-	// Return cached JSON if available
-	if ca.jsonData != nil {
-		return ca.jsonData, nil
-	}
-
-	// Generate JSON from protobuf if not cached
 	return (protojson.MarshalOptions{
 		UseProtoNames:   true,
 		EmitUnpopulated: false,

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -16,42 +16,43 @@ type CatenaAsset struct {
 }
 
 // DataPayload is a helper type for business logic to create assets
-// It provides a convenient way to construct ExternalObjectPayload
+// It mirrors protos.DataPayload structure for convenient construction
 type DataPayload struct {
-	Data               []byte
-	ContentType        string
-	ContentDisposition string
-	Cachable           bool
-	CustomHeaders      map[string]string
-	PayloadEncoding    int32 // 0=UNCOMPRESSED, 1=GZIP, 2=DEFLATE
+	Metadata        map[string]string // Information about the payload (e.g. content-type, filename)
+	Digest          []byte            // SHA-256 digest of the payload
+	PayloadEncoding int32             // 0=UNCOMPRESSED, 1=GZIP, 2=DEFLATE
+	Payload         []byte            // Embedded binary data (use this OR Url, not both)
+	Url             string            // URL to external resource (use this OR Payload, not both)
 }
 
 // ToCatenaAsset converts DataPayload to CatenaAsset
-func (dp DataPayload) ToCatenaAsset() CatenaAsset {
-	// Build metadata map
-	metadata := make(map[string]string)
-
-	// Add standard headers
-	if dp.ContentType != "" {
-		metadata["content-type"] = dp.ContentType
-	}
-	if dp.ContentDisposition != "" {
-		metadata["content-disposition"] = dp.ContentDisposition
+func (dp DataPayload) ToCatenaAsset(cachable bool) CatenaAsset {
+	// Build the payload map for DataPayload
+	payloadMap := map[string]any{
+		"payload_encoding": dp.PayloadEncoding,
 	}
 
-	// Add custom headers
-	for key, value := range dp.CustomHeaders {
-		metadata[key] = value
+	// Add metadata if present
+	if len(dp.Metadata) > 0 {
+		payloadMap["metadata"] = dp.Metadata
+	}
+
+	// Add digest if present
+	if len(dp.Digest) > 0 {
+		payloadMap["digest"] = dp.Digest
+	}
+
+	// Add either payload or url (oneof in proto)
+	if dp.Url != "" {
+		payloadMap["url"] = dp.Url
+	} else if len(dp.Payload) > 0 {
+		payloadMap["payload"] = dp.Payload
 	}
 
 	// Create the map structure for ExternalObjectPayload
 	assetMap := map[string]any{
-		"cachable": dp.Cachable,
-		"payload": map[string]any{
-			"payload":          dp.Data,
-			"metadata":         metadata,
-			"payload_encoding": dp.PayloadEncoding,
-		},
+		"cachable": cachable,
+		"payload":  payloadMap,
 	}
 
 	// Convert to CatenaAsset
@@ -63,11 +64,6 @@ func (dp DataPayload) ToCatenaAsset() CatenaAsset {
 	}
 
 	return catenaAsset
-}
-
-// NewCatenaAsset creates a CatenaAsset from a protos.ExternalObjectPayload
-func NewCatenaAsset(asset *protos.ExternalObjectPayload) CatenaAsset {
-	return CatenaAsset{asset: asset}
 }
 
 // ToCatenaAsset converts a Go map/struct to CatenaAsset
@@ -97,22 +93,6 @@ func toProtoAsset(m map[string]any) (*protos.ExternalObjectPayload, []byte, erro
 	}
 
 	return asset, jsonData, nil
-}
-
-// IsCachable returns whether the asset is cachable
-func (ca CatenaAsset) IsCachable() bool {
-	if ca.asset == nil {
-		return false
-	}
-	return ca.asset.Cachable
-}
-
-// GetPayload returns the asset's data payload
-func (ca CatenaAsset) GetPayload() *protos.DataPayload {
-	if ca.asset == nil {
-		return nil
-	}
-	return ca.asset.Payload
 }
 
 // GetProtoAsset returns the underlying protos.ExternalObjectPayload

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -1,0 +1,277 @@
+package catena
+
+import (
+	"fmt"
+	"github.com/rossvideo/catena/build/go/protos"
+)
+
+// DataPayload is a Go-friendly representation of asset data.
+// Use this in business logic to build assets before converting to CatenaAsset.
+type DataPayload struct {
+	// Either Data or URL must be set, not both
+	Data []byte // Embedded binary data
+	URL  string // External URL reference
+
+	// Metadata
+	ContentType        string            // MIME type
+	ContentDisposition string            // How to display/download the file
+	CustomHeaders      map[string]string // Additional HTTP headers
+	Digest             []byte            // Checksum/hash of the data
+
+	// Options
+	Cachable        bool   // Whether the asset can be cached
+	PayloadEncoding string // "gzip", "deflate", or "" (uncompressed)
+}
+
+// ToCatenaAsset converts a DataPayload to CatenaAsset
+func (dp DataPayload) ToCatenaAsset() CatenaAsset {
+	// Build metadata map
+	metadata := make(map[string]string)
+	if dp.ContentType != "" {
+		metadata["content-type"] = dp.ContentType
+	}
+	if dp.ContentDisposition != "" {
+		metadata["content-disposition"] = dp.ContentDisposition
+	}
+	for k, v := range dp.CustomHeaders {
+		metadata[k] = v
+	}
+
+	// Determine payload encoding
+	var encoding protos.DataPayload_PayloadEncoding
+	switch dp.PayloadEncoding {
+	case "gzip":
+		encoding = protos.DataPayload_GZIP
+	case "deflate":
+		encoding = protos.DataPayload_DEFLATE
+	default:
+		encoding = protos.DataPayload_UNCOMPRESSED
+	}
+
+	// Create the protobuf DataPayload with appropriate Kind
+	protoPayload := &protos.DataPayload{
+		Metadata:        metadata,
+		Digest:          dp.Digest,
+		PayloadEncoding: encoding,
+	}
+
+	if dp.URL != "" {
+		// URL-based asset
+		protoPayload.Kind = &protos.DataPayload_Url{Url: dp.URL}
+	} else {
+		// Embedded data asset
+		protoPayload.Kind = &protos.DataPayload_Payload{Payload: dp.Data}
+	}
+
+	return CatenaAsset{
+		ExternalObject: &protos.ExternalObjectPayload{
+			Cachable: dp.Cachable,
+			Payload:  protoPayload,
+		},
+	}
+}
+
+// CatenaAsset wraps protos.ExternalObjectPayload for asset handling
+type CatenaAsset struct {
+	ExternalObject *protos.ExternalObjectPayload
+}
+
+// NewCatenaAsset creates a CatenaAsset from binary data and content type
+func NewCatenaAsset(data []byte, contentType string) CatenaAsset {
+	return DataPayload{
+		Data:        data,
+		ContentType: contentType,
+		Cachable:    true,
+	}.ToCatenaAsset()
+}
+
+// NewCatenaAssetFromURL creates a CatenaAsset that references an external URL
+func NewCatenaAssetFromURL(url string, contentType string) CatenaAsset {
+	return DataPayload{
+		URL:         url,
+		ContentType: contentType,
+		Cachable:    true,
+	}.ToCatenaAsset()
+}
+
+// NewCatenaAssetFromProto creates a CatenaAsset from a protos.ExternalObjectPayload
+func NewCatenaAssetFromProto(eop *protos.ExternalObjectPayload) CatenaAsset {
+	return CatenaAsset{ExternalObject: eop}
+}
+
+// NewCatenaAssetFromDataPayload creates a CatenaAsset from a protos.DataPayload
+func NewCatenaAssetFromDataPayload(dp *protos.DataPayload) CatenaAsset {
+	return CatenaAsset{
+		ExternalObject: &protos.ExternalObjectPayload{
+			Cachable: true,
+			Payload:  dp,
+		},
+	}
+}
+
+// isValid checks if the asset has valid structure
+func (ca CatenaAsset) isValid() bool {
+	return ca.ExternalObject != nil && ca.ExternalObject.Payload != nil
+}
+
+// WithFilename sets the Content-Disposition header for download
+func (ca CatenaAsset) WithFilename(filename string) CatenaAsset {
+	if !ca.isValid() {
+		return ca
+	}
+	if ca.ExternalObject.Payload.Metadata == nil {
+		ca.ExternalObject.Payload.Metadata = make(map[string]string)
+	}
+	ca.ExternalObject.Payload.Metadata["content-disposition"] = fmt.Sprintf("attachment; filename=\"%s\"", filename)
+	return ca
+}
+
+// WithInlineFilename sets the Content-Disposition header for inline display
+func (ca CatenaAsset) WithInlineFilename(filename string) CatenaAsset {
+	if !ca.isValid() {
+		return ca
+	}
+	if ca.ExternalObject.Payload.Metadata == nil {
+		ca.ExternalObject.Payload.Metadata = make(map[string]string)
+	}
+	ca.ExternalObject.Payload.Metadata["content-disposition"] = fmt.Sprintf("inline; filename=\"%s\"", filename)
+	return ca
+}
+
+// WithCustomHeader adds a custom HTTP header
+func (ca CatenaAsset) WithCustomHeader(key, value string) CatenaAsset {
+	if !ca.isValid() {
+		return ca
+	}
+	if ca.ExternalObject.Payload.Metadata == nil {
+		ca.ExternalObject.Payload.Metadata = make(map[string]string)
+	}
+	ca.ExternalObject.Payload.Metadata[key] = value
+	return ca
+}
+
+// WithCompression sets the payload encoding
+func (ca CatenaAsset) WithCompression(encoding string) CatenaAsset {
+	if !ca.isValid() {
+		return ca
+	}
+	switch encoding {
+	case "gzip":
+		ca.ExternalObject.Payload.PayloadEncoding = protos.DataPayload_GZIP
+	case "deflate":
+		ca.ExternalObject.Payload.PayloadEncoding = protos.DataPayload_DEFLATE
+	default:
+		ca.ExternalObject.Payload.PayloadEncoding = protos.DataPayload_UNCOMPRESSED
+	}
+	return ca
+}
+
+// WithDigest sets the digest/checksum for the payload
+func (ca CatenaAsset) WithDigest(digest []byte) CatenaAsset {
+	if !ca.isValid() {
+		return ca
+	}
+	ca.ExternalObject.Payload.Digest = digest
+	return ca
+}
+
+// WithMetadata adds metadata to the payload
+func (ca CatenaAsset) WithMetadata(key, value string) CatenaAsset {
+	if !ca.isValid() {
+		return ca
+	}
+	if ca.ExternalObject.Payload.Metadata == nil {
+		ca.ExternalObject.Payload.Metadata = make(map[string]string)
+	}
+	ca.ExternalObject.Payload.Metadata[key] = value
+	return ca
+}
+
+// SetCachable sets whether the asset should be cached
+func (ca CatenaAsset) SetCachable(cachable bool) CatenaAsset {
+	if ca.ExternalObject == nil {
+		return ca
+	}
+	ca.ExternalObject.Cachable = cachable
+	return ca
+}
+
+// IsURL returns true if this asset is a URL reference
+func (ca CatenaAsset) IsURL() bool {
+	if !ca.isValid() {
+		return false
+	}
+	_, ok := ca.ExternalObject.Payload.Kind.(*protos.DataPayload_Url)
+	return ok
+}
+
+// GetData returns the embedded payload data (nil if URL-based)
+func (ca CatenaAsset) GetData() []byte {
+	if !ca.isValid() {
+		return nil
+	}
+	if payload, ok := ca.ExternalObject.Payload.Kind.(*protos.DataPayload_Payload); ok {
+		return payload.Payload
+	}
+	return nil
+}
+
+// GetURL returns the URL (empty string if embedded data)
+func (ca CatenaAsset) GetURL() string {
+	if !ca.isValid() {
+		return ""
+	}
+	if url, ok := ca.ExternalObject.Payload.Kind.(*protos.DataPayload_Url); ok {
+		return url.Url
+	}
+	return ""
+}
+
+// ContentLength returns the size of the payload (0 for URL-based assets)
+func (ca CatenaAsset) ContentLength() int64 {
+	data := ca.GetData()
+	if data != nil {
+		return int64(len(data))
+	}
+	return 0
+}
+
+// GetContentType returns the content-type from metadata
+func (ca CatenaAsset) GetContentType() string {
+	if !ca.isValid() || ca.ExternalObject.Payload.Metadata == nil {
+		return ""
+	}
+	return ca.ExternalObject.Payload.Metadata["content-type"]
+}
+
+// GetContentDisposition returns the content-disposition from metadata
+func (ca CatenaAsset) GetContentDisposition() string {
+	if !ca.isValid() || ca.ExternalObject.Payload.Metadata == nil {
+		return ""
+	}
+	return ca.ExternalObject.Payload.Metadata["content-disposition"]
+}
+
+// GetMetadata returns a specific metadata value
+func (ca CatenaAsset) GetMetadata(key string) string {
+	if !ca.isValid() || ca.ExternalObject.Payload.Metadata == nil {
+		return ""
+	}
+	return ca.ExternalObject.Payload.Metadata[key]
+}
+
+// GetAllMetadata returns all metadata
+func (ca CatenaAsset) GetAllMetadata() map[string]string {
+	if !ca.isValid() {
+		return nil
+	}
+	return ca.ExternalObject.Payload.Metadata
+}
+
+// IsCachable returns whether the asset is cachable
+func (ca CatenaAsset) IsCachable() bool {
+	if ca.ExternalObject == nil {
+		return false
+	}
+	return ca.ExternalObject.Cachable
+}

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -1,6 +1,8 @@
 package catena
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/rossvideo/catena/build/go/protos"
@@ -31,10 +33,12 @@ func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, error) {
 	}
 
 	// Handle oneof: either url or payload (not both)
-	if dp.Url != "" {
+	if dp.Url != "" && len(dp.Payload) == 0 {
 		protoPayload.Kind = &protos.DataPayload_Url{Url: dp.Url}
-	} else if len(dp.Payload) > 0 {
+	} else if len(dp.Payload) > 0 && dp.Url == "" {
 		protoPayload.Kind = &protos.DataPayload_Payload{Payload: dp.Payload}
+	} else {
+		return CatenaAsset{asset: nil}, fmt.Errorf("either payload or url must be provided in DataPayload, but not both")
 	}
 
 	// Build the ExternalObjectPayload

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -39,15 +39,24 @@ import (
 	"github.com/rossvideo/catena/build/go/protos"
 )
 
+// DetailLevel represents how much of the device model to deliver
+// Mirrors protos.Device_DetailLevel for convenience
+type DetailLevel = protos.Device_DetailLevel
+
+// DetailLevel constants matching the proto enum
+const (
+	DetailLevelFull          DetailLevel = protos.Device_FULL
+	DetailLevelSubscriptions DetailLevel = protos.Device_SUBSCRIPTIONS
+	DetailLevelMinimal       DetailLevel = protos.Device_MINIMAL
+	DetailLevelCommands      DetailLevel = protos.Device_COMMANDS
+	DetailLevelNone          DetailLevel = protos.Device_NONE
+	DetailLevelUnset         DetailLevel = protos.Device_UNSET
+)
+
 // CatenaDevice wraps protos.Device for device model handling
 type CatenaDevice struct {
 	device   *protos.Device
 	jsonData []byte // Cached JSON representation
-}
-
-// NewCatenaDevice creates a CatenaDevice from a protos.Device
-func NewCatenaDevice(newDevice *protos.Device) CatenaDevice {
-	return CatenaDevice{device: newDevice}
 }
 
 // ToCatenaDevice converts a Go map/struct to CatenaDevice
@@ -82,54 +91,6 @@ func toProtoDevice(m map[string]any) (*protos.Device, []byte, error) {
 // GetProtoDevice returns the underlying protos.Device
 func (cd CatenaDevice) GetProtoDevice() *protos.Device {
 	return cd.device
-}
-
-// GetSlot returns the device slot
-func (cd CatenaDevice) GetSlot() uint32 {
-	if cd.device == nil {
-		return 0
-	}
-	return cd.device.Slot
-}
-
-// GetDetailLevel returns the detail level
-func (cd CatenaDevice) GetDetailLevel() protos.Device_DetailLevel {
-	if cd.device == nil {
-		return protos.Device_UNSET
-	}
-	return cd.device.DetailLevel
-}
-
-// IsMultiSetEnabled returns whether multi-set is enabled
-func (cd CatenaDevice) IsMultiSetEnabled() bool {
-	if cd.device == nil {
-		return false
-	}
-	return cd.device.MultiSetEnabled
-}
-
-// SupportsSubscriptions returns whether subscriptions are supported
-func (cd CatenaDevice) SupportsSubscriptions() bool {
-	if cd.device == nil {
-		return false
-	}
-	return cd.device.Subscriptions
-}
-
-// GetAccessScopes returns the device access scopes
-func (cd CatenaDevice) GetAccessScopes() []string {
-	if cd.device == nil {
-		return nil
-	}
-	return cd.device.AccessScopes
-}
-
-// GetDefaultScope returns the default access scope
-func (cd CatenaDevice) GetDefaultScope() string {
-	if cd.device == nil {
-		return ""
-	}
-	return cd.device.DefaultScope
 }
 
 // ToJSON converts CatenaDevice to JSON bytes using protojson

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -31,85 +31,122 @@
 package catena
 
 import (
-	"context"
-	"errors"
-	"io"
-	"os"
-	"sync"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/rossvideo/catena/build/go/protos"
 )
 
-type Value struct {
-	String string `json:"string,omitempty"`
-	// Extend with numeric, boolean, etc.
+// CatenaDevice wraps protos.Device for device model handling
+type CatenaDevice struct {
+	device   *protos.Device
+	jsonData []byte // Cached JSON representation
 }
 
-type DeviceDescriptor struct {
-	Id      string `json:"id"`
-	Vendor  string `json:"vendor"`
-	Product string `json:"product"`
-	// plus menus, commands, params, etc.
+// NewCatenaDevice creates a CatenaDevice from a protos.Device
+func NewCatenaDevice(newDevice *protos.Device) CatenaDevice {
+	return CatenaDevice{device: newDevice}
 }
 
-// Device is what your business-logic implements.
-// This is the "lite" device model from Catena’s perspective.
-type Device interface {
-	Describe(ctx context.Context) (*DeviceDescriptor, error)
-	GetParam(ctx context.Context, path string) (Value, error)
-	SetParam(ctx context.Context, path string, v Value) error
-	GetAsset(ctx context.Context, id string) (io.ReadCloser, error)
-}
-
-// Simple in-memory implementation for an example device.
-type simpleDevice struct {
-	mu     sync.RWMutex
-	status string
-	// imagine a map of assetID -> path
-	assetRoot string
-}
-
-func NewSimpleDevice(assetRoot string) Device {
-	return &simpleDevice{
-		status:    "OK",
-		assetRoot: assetRoot,
-	}
-}
-
-func (d *simpleDevice) Describe(ctx context.Context) (*DeviceDescriptor, error) {
-	return &DeviceDescriptor{
-		Id:      "catena-go-example",
-		Vendor:  "Ross Video",
-		Product: "Catena Go REST Example",
-	}, nil
-}
-
-func (d *simpleDevice) GetParam(ctx context.Context, path string) (Value, error) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	switch path {
-	case "status":
-		return Value{String: d.status}, nil
-	default:
-		return Value{}, errors.New("param not found")
-	}
-}
-
-func (d *simpleDevice) SetParam(ctx context.Context, path string, v Value) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	switch path {
-	case "status":
-		d.status = v.String
-		return nil
-	default:
-		return errors.New("param not found")
-	}
-}
-
-func (d *simpleDevice) GetAsset(ctx context.Context, id string) (io.ReadCloser, error) {
-	// In real Catena, you'd respect the asset model; here we just map id -> file
-	f, err := os.Open(d.assetRoot + "/" + id)
+// ToCatenaDevice converts a Go map/struct to CatenaDevice
+// This allows developers to work with native Go types and convert to the protobuf format
+func ToCatenaDevice(m map[string]any) (CatenaDevice, error) {
+	device, jsonData, err := toProtoDevice(m)
 	if err != nil {
-		return nil, err
+		return CatenaDevice{jsonData: nil}, fmt.Errorf("ToCatenaDevice: %w", err)
 	}
-	return f, nil
+	return CatenaDevice{device: device, jsonData: jsonData}, nil
+}
+
+// toProtoDevice converts native Go types to protos.Device
+// For complex nested types (params, constraints, etc.), uses JSON marshaling
+// to leverage protojson's automatic conversion and validation
+// Returns the device, cached JSON data, and any error
+func toProtoDevice(m map[string]any) (*protos.Device, []byte, error) {
+	// For complex types, use JSON marshaling to handle nested structures
+	jsonData, err := json.Marshal(m)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal map to JSON: %w", err)
+	}
+
+	device := &protos.Device{}
+	if err := protojson.Unmarshal(jsonData, device); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal JSON to Device proto: %w", err)
+	}
+
+	return device, jsonData, nil
+}
+
+// GetProtoDevice returns the underlying protos.Device
+func (cd CatenaDevice) GetProtoDevice() *protos.Device {
+	return cd.device
+}
+
+// GetSlot returns the device slot
+func (cd CatenaDevice) GetSlot() uint32 {
+	if cd.device == nil {
+		return 0
+	}
+	return cd.device.Slot
+}
+
+// GetDetailLevel returns the detail level
+func (cd CatenaDevice) GetDetailLevel() protos.Device_DetailLevel {
+	if cd.device == nil {
+		return protos.Device_UNSET
+	}
+	return cd.device.DetailLevel
+}
+
+// IsMultiSetEnabled returns whether multi-set is enabled
+func (cd CatenaDevice) IsMultiSetEnabled() bool {
+	if cd.device == nil {
+		return false
+	}
+	return cd.device.MultiSetEnabled
+}
+
+// SupportsSubscriptions returns whether subscriptions are supported
+func (cd CatenaDevice) SupportsSubscriptions() bool {
+	if cd.device == nil {
+		return false
+	}
+	return cd.device.Subscriptions
+}
+
+// GetAccessScopes returns the device access scopes
+func (cd CatenaDevice) GetAccessScopes() []string {
+	if cd.device == nil {
+		return nil
+	}
+	return cd.device.AccessScopes
+}
+
+// GetDefaultScope returns the default access scope
+func (cd CatenaDevice) GetDefaultScope() string {
+	if cd.device == nil {
+		return ""
+	}
+	return cd.device.DefaultScope
+}
+
+// ToJSON converts CatenaDevice to JSON bytes using protojson
+// Uses cached JSON if available, otherwise generates new JSON
+func (cd CatenaDevice) ToJSON() ([]byte, error) {
+	if cd.device == nil {
+		return nil, nil
+	}
+
+	// Return cached JSON if available
+	if cd.jsonData != nil {
+		return cd.jsonData, nil
+	}
+
+	// Generate JSON from protobuf if not cached
+	return (protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}).Marshal(cd.device)
 }

--- a/sdks/go/pkg/catena/device_v2.go
+++ b/sdks/go/pkg/catena/device_v2.go
@@ -1,0 +1,85 @@
+package catena
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+)
+
+type Value struct {
+	String string `json:"string,omitempty"`
+	// Extend with numeric, boolean, etc.
+}
+
+type DeviceDescriptor struct {
+	Id      string `json:"id"`
+	Vendor  string `json:"vendor"`
+	Product string `json:"product"`
+	// plus menus, commands, params, etc.
+}
+
+// Device is what your business-logic implements.
+// This is the "lite" device model from Catena’s perspective.
+type Device interface {
+	Describe(ctx context.Context) (*DeviceDescriptor, error)
+	GetParam(ctx context.Context, path string) (Value, error)
+	SetParam(ctx context.Context, path string, v Value) error
+	GetAsset(ctx context.Context, id string) (io.ReadCloser, error)
+}
+
+// Simple in-memory implementation for an example device.
+type simpleDevice struct {
+	mu     sync.RWMutex
+	status string
+	// imagine a map of assetID -> path
+	assetRoot string
+}
+
+func NewSimpleDevice(assetRoot string) Device {
+	return &simpleDevice{
+		status:    "OK",
+		assetRoot: assetRoot,
+	}
+}
+
+func (d *simpleDevice) Describe(ctx context.Context) (*DeviceDescriptor, error) {
+	return &DeviceDescriptor{
+		Id:      "catena-go-example",
+		Vendor:  "Ross Video",
+		Product: "Catena Go REST Example",
+	}, nil
+}
+
+func (d *simpleDevice) GetParam(ctx context.Context, path string) (Value, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	switch path {
+	case "status":
+		return Value{String: d.status}, nil
+	default:
+		return Value{}, errors.New("param not found")
+	}
+}
+
+func (d *simpleDevice) SetParam(ctx context.Context, path string, v Value) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	switch path {
+	case "status":
+		d.status = v.String
+		return nil
+	default:
+		return errors.New("param not found")
+	}
+}
+
+func (d *simpleDevice) GetAsset(ctx context.Context, id string) (io.ReadCloser, error) {
+	// In real Catena, you'd respect the asset model; here we just map id -> file
+	f, err := os.Open(d.assetRoot + "/" + id)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -306,47 +306,102 @@ func ReplyAsset(asset CatenaAsset) (CatenaAsset, StatusResult) {
 // ReplyAssetNotFound returns a 404 Not Found error for asset requests.
 func ReplyAssetNotFound(msg string) (CatenaAsset, StatusResult) {
 	if msg == "" {
-		return CatenaAsset{}, StatusResult{Code: NOT_FOUND}
+		return CatenaAsset{asset: nil}, StatusResult{Code: NOT_FOUND}
 	}
-	return CatenaAsset{}, StatusResult{Code: NOT_FOUND, Error: msg}
+	return CatenaAsset{asset: nil}, StatusResult{Code: NOT_FOUND, Error: msg}
 }
 
 // ReplyAssetBadRequest returns a 400 Bad Request error for asset requests.
 func ReplyAssetBadRequest(msg string) (CatenaAsset, StatusResult) {
 	if msg == "" {
-		return CatenaAsset{}, StatusResult{Code: INVALID_ARGUMENT}
+		return CatenaAsset{asset: nil}, StatusResult{Code: INVALID_ARGUMENT}
 	}
-	return CatenaAsset{}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
+	return CatenaAsset{asset: nil}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
 }
 
 // ReplyAssetUnauthorized returns a 401 Unauthorized error for asset requests.
 func ReplyAssetUnauthorized(msg string) (CatenaAsset, StatusResult) {
 	if msg == "" {
-		return CatenaAsset{}, StatusResult{Code: UNAUTHENTICATED}
+		return CatenaAsset{asset: nil}, StatusResult{Code: UNAUTHENTICATED}
 	}
-	return CatenaAsset{}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
+	return CatenaAsset{asset: nil}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
 }
 
 // ReplyAssetForbidden returns a 403 Forbidden error for asset requests.
 func ReplyAssetForbidden(msg string) (CatenaAsset, StatusResult) {
 	if msg == "" {
-		return CatenaAsset{}, StatusResult{Code: PERMISSION_DENIED}
+		return CatenaAsset{asset: nil}, StatusResult{Code: PERMISSION_DENIED}
 	}
-	return CatenaAsset{}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
+	return CatenaAsset{asset: nil}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
 }
 
 // ReplyAssetInternalError returns a 500 Internal Server Error for asset requests.
 func ReplyAssetInternalError(msg string) (CatenaAsset, StatusResult) {
 	if msg == "" {
-		return CatenaAsset{}, StatusResult{Code: INTERNAL}
+		return CatenaAsset{asset: nil}, StatusResult{Code: INTERNAL}
 	}
-	return CatenaAsset{}, StatusResult{Code: INTERNAL, Error: msg}
+	return CatenaAsset{asset: nil}, StatusResult{Code: INTERNAL, Error: msg}
 }
 
 // ReplyAssetUnavailable returns a 503 Service Unavailable error for asset requests.
 func ReplyAssetUnavailable(msg string) (CatenaAsset, StatusResult) {
 	if msg == "" {
-		return CatenaAsset{}, StatusResult{Code: UNAVAILABLE}
+		return CatenaAsset{asset: nil}, StatusResult{Code: UNAVAILABLE}
 	}
-	return CatenaAsset{}, StatusResult{Code: UNAVAILABLE, Error: msg}
+	return CatenaAsset{asset: nil}, StatusResult{Code: UNAVAILABLE, Error: msg}
+}
+
+// Device reply helper functions that return (CatenaDevice, StatusResult)
+
+// ReplyDevice returns a successful device response with the given device data.
+func ReplyDevice(device CatenaDevice) (CatenaDevice, StatusResult) {
+	return device, StatusResult{Code: OK}
+}
+
+// ReplyDeviceNotFound returns a 404 Not Found error for device requests.
+func ReplyDeviceNotFound(msg string) (CatenaDevice, StatusResult) {
+	if msg == "" {
+		return CatenaDevice{device: nil}, StatusResult{Code: NOT_FOUND}
+	}
+	return CatenaDevice{device: nil}, StatusResult{Code: NOT_FOUND, Error: msg}
+}
+
+// ReplyDeviceBadRequest returns a 400 Bad Request error for device requests.
+func ReplyDeviceBadRequest(msg string) (CatenaDevice, StatusResult) {
+	if msg == "" {
+		return CatenaDevice{device: nil}, StatusResult{Code: INVALID_ARGUMENT}
+	}
+	return CatenaDevice{device: nil}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
+}
+
+// ReplyDeviceUnauthorized returns a 401 Unauthorized error for device requests.
+func ReplyDeviceUnauthorized(msg string) (CatenaDevice, StatusResult) {
+	if msg == "" {
+		return CatenaDevice{device: nil}, StatusResult{Code: UNAUTHENTICATED}
+	}
+	return CatenaDevice{device: nil}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
+}
+
+// ReplyDeviceForbidden returns a 403 Forbidden error for device requests.
+func ReplyDeviceForbidden(msg string) (CatenaDevice, StatusResult) {
+	if msg == "" {
+		return CatenaDevice{device: nil}, StatusResult{Code: PERMISSION_DENIED}
+	}
+	return CatenaDevice{device: nil}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
+}
+
+// ReplyDeviceInternalError returns a 500 Internal Server Error for device requests.
+func ReplyDeviceInternalError(msg string) (CatenaDevice, StatusResult) {
+	if msg == "" {
+		return CatenaDevice{device: nil}, StatusResult{Code: INTERNAL}
+	}
+	return CatenaDevice{device: nil}, StatusResult{Code: INTERNAL, Error: msg}
+}
+
+// ReplyDeviceUnavailable returns a 503 Service Unavailable error for device requests.
+func ReplyDeviceUnavailable(msg string) (CatenaDevice, StatusResult) {
+	if msg == "" {
+		return CatenaDevice{device: nil}, StatusResult{Code: UNAVAILABLE}
+	}
+	return CatenaDevice{device: nil}, StatusResult{Code: UNAVAILABLE, Error: msg}
 }

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -295,3 +295,58 @@ func ReplyWithCode(code StatusCode, msg string) (CatenaValue, StatusResult) {
 	}
 	return CatenaValue{Value: nil}, StatusResult{Code: code, Error: msg}
 }
+
+// Asset reply helper functions that return (CatenaAsset, StatusResult)
+
+// ReplyAsset returns a successful asset response with the given asset data.
+func ReplyAsset(asset CatenaAsset) (CatenaAsset, StatusResult) {
+	return asset, StatusResult{Code: OK}
+}
+
+// ReplyAssetNotFound returns a 404 Not Found error for asset requests.
+func ReplyAssetNotFound(msg string) (CatenaAsset, StatusResult) {
+	if msg == "" {
+		return CatenaAsset{}, StatusResult{Code: NOT_FOUND}
+	}
+	return CatenaAsset{}, StatusResult{Code: NOT_FOUND, Error: msg}
+}
+
+// ReplyAssetBadRequest returns a 400 Bad Request error for asset requests.
+func ReplyAssetBadRequest(msg string) (CatenaAsset, StatusResult) {
+	if msg == "" {
+		return CatenaAsset{}, StatusResult{Code: INVALID_ARGUMENT}
+	}
+	return CatenaAsset{}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
+}
+
+// ReplyAssetUnauthorized returns a 401 Unauthorized error for asset requests.
+func ReplyAssetUnauthorized(msg string) (CatenaAsset, StatusResult) {
+	if msg == "" {
+		return CatenaAsset{}, StatusResult{Code: UNAUTHENTICATED}
+	}
+	return CatenaAsset{}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
+}
+
+// ReplyAssetForbidden returns a 403 Forbidden error for asset requests.
+func ReplyAssetForbidden(msg string) (CatenaAsset, StatusResult) {
+	if msg == "" {
+		return CatenaAsset{}, StatusResult{Code: PERMISSION_DENIED}
+	}
+	return CatenaAsset{}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
+}
+
+// ReplyAssetInternalError returns a 500 Internal Server Error for asset requests.
+func ReplyAssetInternalError(msg string) (CatenaAsset, StatusResult) {
+	if msg == "" {
+		return CatenaAsset{}, StatusResult{Code: INTERNAL}
+	}
+	return CatenaAsset{}, StatusResult{Code: INTERNAL, Error: msg}
+}
+
+// ReplyAssetUnavailable returns a 503 Service Unavailable error for asset requests.
+func ReplyAssetUnavailable(msg string) (CatenaAsset, StatusResult) {
+	if msg == "" {
+		return CatenaAsset{}, StatusResult{Code: UNAVAILABLE}
+	}
+	return CatenaAsset{}, StatusResult{Code: UNAVAILABLE, Error: msg}
+}

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -184,224 +184,27 @@ func (s StatusCode) ToHTTPStatus() int {
 	}
 }
 
-// Reply helper functions that return (CatenaValue, StatusResult)
-// CatenaValue is returned by value (never nil), but its internal *protos.Value can be nil.
+// ResponseType is a constraint for types that can be returned from handlers
+type ResponseType interface {
+	CatenaValue | CatenaAsset | CatenaDevice
+}
 
-// ReplyOK returns a successful response with the given value.
-func ReplyOK(value CatenaValue) (CatenaValue, StatusResult) {
+// Reply returns a successful response (OK) with the given value.
+// Usage: catena.Reply(value), catena.Reply(asset), catena.Reply(device)
+func Reply[T ResponseType](value T) (T, StatusResult) {
 	return value, StatusResult{Code: OK}
 }
 
-// ReplyCreated returns a 201 Created response with the given value.
-func ReplyCreated(value CatenaValue) (CatenaValue, StatusResult) {
-	return value, StatusResult{Code: CREATED}
+// ReplyWithCode returns a response with the given value and status code.
+// Usage: catena.ReplyWithCode(value, catena.CREATED)
+func ReplyWithCode[T ResponseType](value T, code StatusCode) (T, StatusResult) {
+	return value, StatusResult{Code: code}
 }
 
-// ReplyAccepted returns a 202 Accepted response with the given value.
-func ReplyAccepted(value CatenaValue) (CatenaValue, StatusResult) {
-	return value, StatusResult{Code: ACCEPTED}
-}
-
-// ReplyNoContent returns a 204 No Content response with no payload.
-func ReplyNoContent() (CatenaValue, StatusResult) {
-	return CatenaValue{Value: nil}, StatusResult{Code: NO_CONTENT}
-}
-
-// ReplyBadRequest returns a 400 Bad Request error with an optional message.
-func ReplyBadRequest(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: INVALID_ARGUMENT}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
-}
-
-// ReplyNotFound returns a 404 Not Found error with an optional message.
-func ReplyNotFound(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: NOT_FOUND}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: NOT_FOUND, Error: msg}
-}
-
-// ReplyMethodNotAllowed returns a 405 Method Not Allowed error with an optional message.
-func ReplyMethodNotAllowed(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: METHOD_NOT_ALLOWED}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: METHOD_NOT_ALLOWED, Error: msg}
-}
-
-// ReplyConflict returns a 409 Conflict error with an optional message.
-func ReplyConflict(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: CONFLICT}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: CONFLICT, Error: msg}
-}
-
-// ReplyUnprocessableEntity returns a 422 Unprocessable Entity error with an optional message.
-func ReplyUnprocessableEntity(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: UNPROCESSABLE_ENTITY}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: UNPROCESSABLE_ENTITY, Error: msg}
-}
-
-// ReplyNotImplemented returns a 501 Not Implemented error with an optional message.
-func ReplyNotImplemented(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: UNIMPLEMENTED}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: UNIMPLEMENTED, Error: msg}
-}
-
-// ReplyInternalError returns a 500 Internal Server Error with an optional message.
-func ReplyInternalError(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: INTERNAL}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: INTERNAL, Error: msg}
-}
-
-// ReplyUnavailable returns a 503 Service Unavailable error with an optional message.
-func ReplyUnavailable(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: UNAVAILABLE}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: UNAVAILABLE, Error: msg}
-}
-
-// ReplyUnauthenticated returns a 401 Unauthorized error with an optional message.
-func ReplyUnauthenticated(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: UNAUTHENTICATED}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
-}
-
-// ReplyPermissionDenied returns a 403 Forbidden error with an optional message.
-func ReplyPermissionDenied(msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: PERMISSION_DENIED}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
-}
-
-// ReplyWithCode returns a response with the given StatusCode and optional message.
-// This is a generic helper for cases not covered by specific Reply* functions.
-func ReplyWithCode(code StatusCode, msg string) (CatenaValue, StatusResult) {
-	if msg == "" {
-		return CatenaValue{Value: nil}, StatusResult{Code: code}
-	}
-	return CatenaValue{Value: nil}, StatusResult{Code: code, Error: msg}
-}
-
-// Asset reply helper functions that return (CatenaAsset, StatusResult)
-
-// ReplyAsset returns a successful asset response with the given asset data.
-func ReplyAsset(asset CatenaAsset) (CatenaAsset, StatusResult) {
-	return asset, StatusResult{Code: OK}
-}
-
-// ReplyAssetNotFound returns a 404 Not Found error for asset requests.
-func ReplyAssetNotFound(msg string) (CatenaAsset, StatusResult) {
-	if msg == "" {
-		return CatenaAsset{asset: nil}, StatusResult{Code: NOT_FOUND}
-	}
-	return CatenaAsset{asset: nil}, StatusResult{Code: NOT_FOUND, Error: msg}
-}
-
-// ReplyAssetBadRequest returns a 400 Bad Request error for asset requests.
-func ReplyAssetBadRequest(msg string) (CatenaAsset, StatusResult) {
-	if msg == "" {
-		return CatenaAsset{asset: nil}, StatusResult{Code: INVALID_ARGUMENT}
-	}
-	return CatenaAsset{asset: nil}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
-}
-
-// ReplyAssetUnauthorized returns a 401 Unauthorized error for asset requests.
-func ReplyAssetUnauthorized(msg string) (CatenaAsset, StatusResult) {
-	if msg == "" {
-		return CatenaAsset{asset: nil}, StatusResult{Code: UNAUTHENTICATED}
-	}
-	return CatenaAsset{asset: nil}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
-}
-
-// ReplyAssetForbidden returns a 403 Forbidden error for asset requests.
-func ReplyAssetForbidden(msg string) (CatenaAsset, StatusResult) {
-	if msg == "" {
-		return CatenaAsset{asset: nil}, StatusResult{Code: PERMISSION_DENIED}
-	}
-	return CatenaAsset{asset: nil}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
-}
-
-// ReplyAssetInternalError returns a 500 Internal Server Error for asset requests.
-func ReplyAssetInternalError(msg string) (CatenaAsset, StatusResult) {
-	if msg == "" {
-		return CatenaAsset{asset: nil}, StatusResult{Code: INTERNAL}
-	}
-	return CatenaAsset{asset: nil}, StatusResult{Code: INTERNAL, Error: msg}
-}
-
-// ReplyAssetUnavailable returns a 503 Service Unavailable error for asset requests.
-func ReplyAssetUnavailable(msg string) (CatenaAsset, StatusResult) {
-	if msg == "" {
-		return CatenaAsset{asset: nil}, StatusResult{Code: UNAVAILABLE}
-	}
-	return CatenaAsset{asset: nil}, StatusResult{Code: UNAVAILABLE, Error: msg}
-}
-
-// Device reply helper functions that return (CatenaDevice, StatusResult)
-
-// ReplyDevice returns a successful device response with the given device data.
-func ReplyDevice(device CatenaDevice) (CatenaDevice, StatusResult) {
-	return device, StatusResult{Code: OK}
-}
-
-// ReplyDeviceNotFound returns a 404 Not Found error for device requests.
-func ReplyDeviceNotFound(msg string) (CatenaDevice, StatusResult) {
-	if msg == "" {
-		return CatenaDevice{device: nil}, StatusResult{Code: NOT_FOUND}
-	}
-	return CatenaDevice{device: nil}, StatusResult{Code: NOT_FOUND, Error: msg}
-}
-
-// ReplyDeviceBadRequest returns a 400 Bad Request error for device requests.
-func ReplyDeviceBadRequest(msg string) (CatenaDevice, StatusResult) {
-	if msg == "" {
-		return CatenaDevice{device: nil}, StatusResult{Code: INVALID_ARGUMENT}
-	}
-	return CatenaDevice{device: nil}, StatusResult{Code: INVALID_ARGUMENT, Error: msg}
-}
-
-// ReplyDeviceUnauthorized returns a 401 Unauthorized error for device requests.
-func ReplyDeviceUnauthorized(msg string) (CatenaDevice, StatusResult) {
-	if msg == "" {
-		return CatenaDevice{device: nil}, StatusResult{Code: UNAUTHENTICATED}
-	}
-	return CatenaDevice{device: nil}, StatusResult{Code: UNAUTHENTICATED, Error: msg}
-}
-
-// ReplyDeviceForbidden returns a 403 Forbidden error for device requests.
-func ReplyDeviceForbidden(msg string) (CatenaDevice, StatusResult) {
-	if msg == "" {
-		return CatenaDevice{device: nil}, StatusResult{Code: PERMISSION_DENIED}
-	}
-	return CatenaDevice{device: nil}, StatusResult{Code: PERMISSION_DENIED, Error: msg}
-}
-
-// ReplyDeviceInternalError returns a 500 Internal Server Error for device requests.
-func ReplyDeviceInternalError(msg string) (CatenaDevice, StatusResult) {
-	if msg == "" {
-		return CatenaDevice{device: nil}, StatusResult{Code: INTERNAL}
-	}
-	return CatenaDevice{device: nil}, StatusResult{Code: INTERNAL, Error: msg}
-}
-
-// ReplyDeviceUnavailable returns a 503 Service Unavailable error for device requests.
-func ReplyDeviceUnavailable(msg string) (CatenaDevice, StatusResult) {
-	if msg == "" {
-		return CatenaDevice{device: nil}, StatusResult{Code: UNAVAILABLE}
-	}
-	return CatenaDevice{device: nil}, StatusResult{Code: UNAVAILABLE, Error: msg}
+// ReplyError returns an error response with the given status code and message.
+// The value returned is the zero value of T.
+// Usage: catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "not found")
+func ReplyError[T ResponseType](code StatusCode, msg string) (T, StatusResult) {
+	var zero T
+	return zero, StatusResult{Code: code, Error: msg}
 }

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -49,6 +49,28 @@ type EmptyValue struct{}
 
 type UndefinedValue int32
 
+// ParamType represents the type of a parameter value
+// Mirrors protos.ParamType for convenience
+type ParamType = protos.ParamType
+
+// ParamType constants matching the proto enum
+const (
+	ParamTypeUndefined          ParamType = protos.ParamType_UNDEFINED
+	ParamTypeEmpty              ParamType = protos.ParamType_EMPTY
+	ParamTypeInt32              ParamType = protos.ParamType_INT32
+	ParamTypeFloat32            ParamType = protos.ParamType_FLOAT32
+	ParamTypeString             ParamType = protos.ParamType_STRING
+	ParamTypeStruct             ParamType = protos.ParamType_STRUCT
+	ParamTypeStructVariant      ParamType = protos.ParamType_STRUCT_VARIANT
+	ParamTypeInt32Array         ParamType = protos.ParamType_INT32_ARRAY
+	ParamTypeFloat32Array       ParamType = protos.ParamType_FLOAT32_ARRAY
+	ParamTypeStringArray        ParamType = protos.ParamType_STRING_ARRAY
+	ParamTypeBinary             ParamType = protos.ParamType_BINARY
+	ParamTypeStructArray        ParamType = protos.ParamType_STRUCT_ARRAY
+	ParamTypeStructVariantArray ParamType = protos.ParamType_STRUCT_VARIANT_ARRAY
+	ParamTypeData               ParamType = protos.ParamType_DATA
+)
+
 func ToCatenaValue(v any) (CatenaValue, error) {
 	val, err := ToProto(v)
 	if err != nil {
@@ -62,7 +84,7 @@ func ToProto(v any) (*protos.Value, error) {
 	switch val := v.(type) {
 	case *protos.DataPayload:
 		// Pass through DataPayload directly
-		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: val}}, nil
+		return nil, fmt.Errorf("DataPayload is not supported in ToProto")
 	case UndefinedValue:
 		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, nil
 	case EmptyValue:
@@ -133,37 +155,41 @@ func ToProto(v any) (*protos.Value, error) {
 }
 
 // FromProto converts protos.Value to native Go types
-func FromProto(pv *protos.Value) any {
+func FromProto(pv *protos.Value) (any, error) {
 	if pv == nil {
-		return nil
+		return nil, fmt.Errorf("nil Value")
 	}
 	switch pv.GetKind().(type) {
 	case *protos.Value_DataPayload:
 		// Return the raw DataPayload proto
-		return pv.GetDataPayload()
+		return nil, fmt.Errorf("DataPayload is not supported in FromProto")
 	case *protos.Value_UndefinedValue:
-		return UndefinedValue(pv.GetUndefinedValue())
+		return UndefinedValue(pv.GetUndefinedValue()), nil
 	case *protos.Value_EmptyValue:
-		return EmptyValue{}
+		return EmptyValue{}, nil
 	case *protos.Value_Int32Value:
-		return pv.GetInt32Value()
+		return pv.GetInt32Value(), nil
 	case *protos.Value_Float32Value:
-		return pv.GetFloat32Value()
+		return pv.GetFloat32Value(), nil
 	case *protos.Value_StringValue:
-		return pv.GetStringValue()
+		return pv.GetStringValue(), nil
 	case *protos.Value_Int32ArrayValues:
-		return pv.GetInt32ArrayValues().GetInts()
+		return pv.GetInt32ArrayValues().GetInts(), nil
 	case *protos.Value_Float32ArrayValues:
-		return pv.GetFloat32ArrayValues().GetFloats()
+		return pv.GetFloat32ArrayValues().GetFloats(), nil
 	case *protos.Value_StringArrayValues:
-		return pv.GetStringArrayValues().GetStrings()
+		return pv.GetStringArrayValues().GetStrings(), nil
 	case *protos.Value_StructValue:
 		fields := pv.GetStructValue().GetFields()
 		m := make(map[string]any, len(fields))
 		for k, v := range fields {
-			m[k] = FromProto(v)
+			val, err := FromProto(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert struct field %s: %w", k, err)
+			}
+			m[k] = val
 		}
-		return m
+		return m, nil
 	case *protos.Value_StructArrayValues:
 		list := pv.GetStructArrayValues().GetStructValues()
 		arr := make([]map[string]any, len(list))
@@ -171,28 +197,40 @@ func FromProto(pv *protos.Value) any {
 			fields := sv.GetFields()
 			m := make(map[string]any, len(fields))
 			for k, v := range fields {
-				m[k] = FromProto(v)
+				val, err := FromProto(v)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert struct field %s: %w", k, err)
+				}
+				m[k] = val
 			}
 			arr[i] = m
 		}
-		return arr
+		return arr, nil
 	case *protos.Value_StructVariantValue:
 		sv := pv.GetStructVariantValue()
+		val, err := FromProto(sv.GetValue())
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert struct variant value: %w", err)
+		}
 		return StructVariantValue{
 			StructVariantType: sv.GetStructVariantType(),
-			Value:             FromProto(sv.GetValue()),
-		}
+			Value:             val,
+		}, nil
 	case *protos.Value_StructVariantArrayValues:
 		list := pv.GetStructVariantArrayValues().GetStructVariants()
 		arr := make([]StructVariantValue, 0, len(list))
 		for _, sv := range list {
+			val, err := FromProto(sv.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert struct variant value: %w", err)
+			}
 			arr = append(arr, StructVariantValue{
 				StructVariantType: sv.GetStructVariantType(),
-				Value:             FromProto(sv.GetValue()),
+				Value:             val,
 			})
 		}
-		return arr
+		return arr, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported Value type: %T", pv.GetKind())
 	}
 }

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -40,14 +40,6 @@ type CatenaValue struct {
 	Value *protos.Value
 }
 
-// CatenaAsset represents a binary asset with HTTP headers for GetAsset responses
-type CatenaAsset struct {
-	ContentType        string
-	ContentDisposition string
-	Payload            DataPayload       // Use DataPayload instead of raw bytes
-	CustomHeaders      map[string]string // Additional headers if needed
-}
-
 type StructVariantValue struct {
 	StructVariantType string `json:"struct_variant_type"`
 	Value             any    `json:"value"`
@@ -57,14 +49,6 @@ type EmptyValue struct{}
 
 type UndefinedValue int32
 
-type DataPayload struct {
-	Metadata        map[string]string `json:"metadata,omitempty"`
-	Digest          []byte            `json:"digest,omitempty"`
-	PayloadEncoding string            `json:"payload_encoding,omitempty"` // "uncompressed", "gzip", or "deflate"
-	URL             string            `json:"url,omitempty"`
-	Payload         []byte            `json:"payload,omitempty"`
-}
-
 func ToCatenaValue(v any) (CatenaValue, error) {
 	val, err := ToProto(v)
 	if err != nil {
@@ -73,104 +57,12 @@ func ToCatenaValue(v any) (CatenaValue, error) {
 	return CatenaValue{Value: val}, nil
 }
 
-// NewCatenaAsset creates a CatenaAsset from binary data and metadata
-func NewCatenaAsset(data []byte, contentType string) CatenaAsset {
-	return CatenaAsset{
-		ContentType: contentType,
-		Payload: DataPayload{
-			Payload:         data,
-			PayloadEncoding: "uncompressed",
-		},
-	}
-}
-
-// NewCatenaAssetFromURL creates a CatenaAsset that references an external URL
-func NewCatenaAssetFromURL(url string, contentType string) CatenaAsset {
-	return CatenaAsset{
-		ContentType: contentType,
-		Payload: DataPayload{
-			URL:             url,
-			PayloadEncoding: "uncompressed",
-		},
-	}
-}
-
-// NewCatenaAssetFromPayload creates a CatenaAsset from an existing DataPayload
-func NewCatenaAssetFromPayload(payload DataPayload, contentType string) CatenaAsset {
-	return CatenaAsset{
-		ContentType: contentType,
-		Payload:     payload,
-	}
-}
-
-// WithFilename sets the Content-Disposition header for download
-func (ca CatenaAsset) WithFilename(filename string) CatenaAsset {
-	ca.ContentDisposition = fmt.Sprintf("attachment; filename=%q", filename)
-	return ca
-}
-
-// WithInlineFilename sets the Content-Disposition header for inline display
-func (ca CatenaAsset) WithInlineFilename(filename string) CatenaAsset {
-	ca.ContentDisposition = fmt.Sprintf("inline; filename=%q", filename)
-	return ca
-}
-
-// WithCustomHeader adds a custom HTTP header
-func (ca CatenaAsset) WithCustomHeader(key, value string) CatenaAsset {
-	if ca.CustomHeaders == nil {
-		ca.CustomHeaders = make(map[string]string)
-	}
-	ca.CustomHeaders[key] = value
-	return ca
-}
-
-// WithCompression sets the payload encoding (gzip, deflate, or uncompressed)
-func (ca CatenaAsset) WithCompression(encoding string) CatenaAsset {
-	ca.Payload.PayloadEncoding = encoding
-	return ca
-}
-
-// WithDigest sets the digest/checksum for the payload
-func (ca CatenaAsset) WithDigest(digest []byte) CatenaAsset {
-	ca.Payload.Digest = digest
-	return ca
-}
-
-// WithMetadata adds metadata to the payload
-func (ca CatenaAsset) WithMetadata(key, value string) CatenaAsset {
-	if ca.Payload.Metadata == nil {
-		ca.Payload.Metadata = make(map[string]string)
-	}
-	ca.Payload.Metadata[key] = value
-	return ca
-}
-
-// IsURL returns true if this asset is a URL reference
-func (ca CatenaAsset) IsURL() bool {
-	return ca.Payload.URL != ""
-}
-
-// GetData returns the embedded payload data (nil if URL-based)
-func (ca CatenaAsset) GetData() []byte {
-	return ca.Payload.Payload
-}
-
-// GetURL returns the URL (empty string if embedded data)
-func (ca CatenaAsset) GetURL() string {
-	return ca.Payload.URL
-}
-
-// ContentLength returns the size of the payload (0 for URL-based assets)
-func (ca CatenaAsset) ContentLength() int64 {
-	if ca.Payload.Payload != nil {
-		return int64(len(ca.Payload.Payload))
-	}
-	return 0
-}
-
 // ToProto converts native Go types to protos.Value
 func ToProto(v any) (*protos.Value, error) {
 	switch val := v.(type) {
+	case *protos.DataPayload:
+		// Pass through DataPayload directly
+		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: val}}, nil
 	case UndefinedValue:
 		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, nil
 	case EmptyValue:
@@ -235,34 +127,6 @@ func ToProto(v any) (*protos.Value, error) {
 		return &protos.Value{Kind: &protos.Value_StructVariantArrayValues{StructVariantArrayValues: &protos.StructVariantList{
 			StructVariants: structVariants,
 		}}}, nil
-	case DataPayload:
-		// Convert payload encoding string to enum
-		var encoding protos.DataPayload_PayloadEncoding
-		switch val.PayloadEncoding {
-		case "gzip":
-			encoding = protos.DataPayload_GZIP
-		case "deflate":
-			encoding = protos.DataPayload_DEFLATE
-		default:
-			encoding = protos.DataPayload_UNCOMPRESSED
-		}
-
-		dp := &protos.DataPayload{
-			Metadata:        val.Metadata,
-			Digest:          val.Digest,
-			PayloadEncoding: encoding,
-		}
-
-		// Set either URL or Payload based on which is provided
-		if val.URL != "" && val.Payload == nil {
-			dp.Kind = &protos.DataPayload_Url{Url: val.URL}
-		} else if val.Payload != nil && val.URL == "" {
-			dp.Kind = &protos.DataPayload_Payload{Payload: val.Payload}
-		} else {
-			return nil, fmt.Errorf("DataPayload must have either URL or Payload set, but not both")
-		}
-
-		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: dp}}, nil
 	default:
 		return nil, fmt.Errorf("unsupported type: %T", v)
 	}
@@ -274,6 +138,9 @@ func FromProto(pv *protos.Value) any {
 		return nil
 	}
 	switch pv.GetKind().(type) {
+	case *protos.Value_DataPayload:
+		// Return the raw DataPayload proto
+		return pv.GetDataPayload()
 	case *protos.Value_UndefinedValue:
 		return UndefinedValue(pv.GetUndefinedValue())
 	case *protos.Value_EmptyValue:
@@ -325,35 +192,6 @@ func FromProto(pv *protos.Value) any {
 			})
 		}
 		return arr
-	case *protos.Value_DataPayload:
-		dp := pv.GetDataPayload()
-
-		// Convert encoding enum to string
-		var encoding string
-		switch dp.GetPayloadEncoding() {
-		case protos.DataPayload_GZIP:
-			encoding = "gzip"
-		case protos.DataPayload_DEFLATE:
-			encoding = "deflate"
-		default:
-			encoding = "uncompressed"
-		}
-
-		result := DataPayload{
-			Metadata:        dp.GetMetadata(),
-			Digest:          dp.GetDigest(),
-			PayloadEncoding: encoding,
-		}
-
-		// Get either URL or Payload based on Kind
-		switch kind := dp.GetKind().(type) {
-		case *protos.DataPayload_Url:
-			result.URL = kind.Url
-		case *protos.DataPayload_Payload:
-			result.Payload = kind.Payload
-		}
-
-		return result
 	default:
 		return nil
 	}

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -40,6 +40,14 @@ type CatenaValue struct {
 	Value *protos.Value
 }
 
+// CatenaAsset represents a binary asset with HTTP headers for GetAsset responses
+type CatenaAsset struct {
+	ContentType        string
+	ContentDisposition string
+	Payload            DataPayload       // Use DataPayload instead of raw bytes
+	CustomHeaders      map[string]string // Additional headers if needed
+}
+
 type StructVariantValue struct {
 	StructVariantType string `json:"struct_variant_type"`
 	Value             any    `json:"value"`
@@ -63,6 +71,101 @@ func ToCatenaValue(v any) (CatenaValue, error) {
 		return CatenaValue{}, fmt.Errorf("ToCatenaValue: %w", err)
 	}
 	return CatenaValue{Value: val}, nil
+}
+
+// NewCatenaAsset creates a CatenaAsset from binary data and metadata
+func NewCatenaAsset(data []byte, contentType string) CatenaAsset {
+	return CatenaAsset{
+		ContentType: contentType,
+		Payload: DataPayload{
+			Payload:         data,
+			PayloadEncoding: "uncompressed",
+		},
+	}
+}
+
+// NewCatenaAssetFromURL creates a CatenaAsset that references an external URL
+func NewCatenaAssetFromURL(url string, contentType string) CatenaAsset {
+	return CatenaAsset{
+		ContentType: contentType,
+		Payload: DataPayload{
+			URL:             url,
+			PayloadEncoding: "uncompressed",
+		},
+	}
+}
+
+// NewCatenaAssetFromPayload creates a CatenaAsset from an existing DataPayload
+func NewCatenaAssetFromPayload(payload DataPayload, contentType string) CatenaAsset {
+	return CatenaAsset{
+		ContentType: contentType,
+		Payload:     payload,
+	}
+}
+
+// WithFilename sets the Content-Disposition header for download
+func (ca CatenaAsset) WithFilename(filename string) CatenaAsset {
+	ca.ContentDisposition = fmt.Sprintf("attachment; filename=%q", filename)
+	return ca
+}
+
+// WithInlineFilename sets the Content-Disposition header for inline display
+func (ca CatenaAsset) WithInlineFilename(filename string) CatenaAsset {
+	ca.ContentDisposition = fmt.Sprintf("inline; filename=%q", filename)
+	return ca
+}
+
+// WithCustomHeader adds a custom HTTP header
+func (ca CatenaAsset) WithCustomHeader(key, value string) CatenaAsset {
+	if ca.CustomHeaders == nil {
+		ca.CustomHeaders = make(map[string]string)
+	}
+	ca.CustomHeaders[key] = value
+	return ca
+}
+
+// WithCompression sets the payload encoding (gzip, deflate, or uncompressed)
+func (ca CatenaAsset) WithCompression(encoding string) CatenaAsset {
+	ca.Payload.PayloadEncoding = encoding
+	return ca
+}
+
+// WithDigest sets the digest/checksum for the payload
+func (ca CatenaAsset) WithDigest(digest []byte) CatenaAsset {
+	ca.Payload.Digest = digest
+	return ca
+}
+
+// WithMetadata adds metadata to the payload
+func (ca CatenaAsset) WithMetadata(key, value string) CatenaAsset {
+	if ca.Payload.Metadata == nil {
+		ca.Payload.Metadata = make(map[string]string)
+	}
+	ca.Payload.Metadata[key] = value
+	return ca
+}
+
+// IsURL returns true if this asset is a URL reference
+func (ca CatenaAsset) IsURL() bool {
+	return ca.Payload.URL != ""
+}
+
+// GetData returns the embedded payload data (nil if URL-based)
+func (ca CatenaAsset) GetData() []byte {
+	return ca.Payload.Payload
+}
+
+// GetURL returns the URL (empty string if embedded data)
+func (ca CatenaAsset) GetURL() string {
+	return ca.Payload.URL
+}
+
+// ContentLength returns the size of the payload (0 for URL-based assets)
+func (ca CatenaAsset) ContentLength() int64 {
+	if ca.Payload.Payload != nil {
+		return int64(len(ca.Payload.Payload))
+	}
+	return 0
 }
 
 // ToProto converts native Go types to protos.Value

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -60,9 +60,6 @@ func ToCatenaValue(v any) (CatenaValue, error) {
 // ToProto converts native Go types to protos.Value
 func ToProto(v any) (*protos.Value, error) {
 	switch val := v.(type) {
-	case *protos.DataPayload:
-		// Pass through DataPayload directly
-		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: val}}, nil
 	case UndefinedValue:
 		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, nil
 	case EmptyValue:
@@ -138,9 +135,6 @@ func FromProto(pv *protos.Value) any {
 		return nil
 	}
 	switch pv.GetKind().(type) {
-	case *protos.Value_DataPayload:
-		// Return the raw DataPayload proto
-		return pv.GetDataPayload()
 	case *protos.Value_UndefinedValue:
 		return UndefinedValue(pv.GetUndefinedValue())
 	case *protos.Value_EmptyValue:

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -60,6 +60,9 @@ func ToCatenaValue(v any) (CatenaValue, error) {
 // ToProto converts native Go types to protos.Value
 func ToProto(v any) (*protos.Value, error) {
 	switch val := v.(type) {
+	case *protos.DataPayload:
+		// Pass through DataPayload directly
+		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: val}}, nil
 	case UndefinedValue:
 		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, nil
 	case EmptyValue:
@@ -135,6 +138,9 @@ func FromProto(pv *protos.Value) any {
 		return nil
 	}
 	switch pv.GetKind().(type) {
+	case *protos.Value_DataPayload:
+		// Return the raw DataPayload proto
+		return pv.GetDataPayload()
 	case *protos.Value_UndefinedValue:
 		return UndefinedValue(pv.GetUndefinedValue())
 	case *protos.Value_EmptyValue:

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -31,8 +31,10 @@
 package rest
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"strconv"
@@ -45,10 +47,10 @@ import (
 )
 
 // Handlers now return (CatenaValue, StatusResult) so the server can respond consistently.
-type DeviceHandler func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult)
+type DeviceHandler func() (catena.CatenaValue, catena.StatusResult)
 type GetValueHandler func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
 type SetValueHandler func(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
-type GetAssetHandler func(w http.ResponseWriter, r *http.Request, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
+type GetAssetHandler func(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult)
 type ConnectHandler func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult)
 type ExecuteCommandHandler func(w http.ResponseWriter, r *http.Request, slot int, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult)
 type FallbackHandler func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult)
@@ -95,6 +97,70 @@ func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result cat
 	}
 }
 
+// writeAssetResult writes a CatenaAsset to the HTTP response with appropriate headers
+func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, result catena.StatusResult) {
+	httpStatus := result.Code.ToHTTPStatus()
+
+	// If there's an error, write error response
+	if result.Error != "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(httpStatus)
+		fmt.Fprintf(w, `{"error": "%s"}`, result.Error)
+		return
+	}
+
+	// If URL-based asset, redirect or return URL
+	if asset.IsURL() {
+		// Option 1: Redirect to the URL
+		w.Header().Set("Location", asset.GetURL())
+		w.WriteHeader(http.StatusFound) // 302 redirect
+		return
+
+		// Option 2: Return URL as JSON (uncomment if preferred)
+		// w.Header().Set("Content-Type", "application/json")
+		// w.WriteHeader(httpStatus)
+		// fmt.Fprintf(w, `{"url": "%s"}`, asset.GetURL())
+		// return
+	}
+
+	// Handle embedded data
+	data := asset.GetData()
+	if len(data) == 0 {
+		w.WriteHeader(httpStatus)
+		return
+	}
+
+	// Set asset headers
+	if asset.ContentType != "" {
+		w.Header().Set("Content-Type", asset.ContentType)
+	}
+	if asset.ContentDisposition != "" {
+		w.Header().Set("Content-Disposition", asset.ContentDisposition)
+	}
+
+	contentLength := asset.ContentLength()
+	if contentLength > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
+	}
+
+	// Set compression encoding if specified
+	if asset.Payload.PayloadEncoding != "" && asset.Payload.PayloadEncoding != "uncompressed" {
+		w.Header().Set("Content-Encoding", asset.Payload.PayloadEncoding)
+	}
+
+	// Set custom headers
+	for key, value := range asset.CustomHeaders {
+		w.Header().Set(key, value)
+	}
+
+	// Write status and stream data
+	w.WriteHeader(httpStatus)
+	reader := bytes.NewReader(data)
+	if _, err := io.Copy(w, reader); err != nil {
+		logger.Error("failed to stream asset data", "error", err)
+	}
+}
+
 // NewServer creates a new REST server for the given device slots
 func NewServer(slots []int) *Server {
 	s := &Server{
@@ -133,7 +199,7 @@ func (s *Server) Start(port int) error {
 
 // Default handlers that return "not implemented"
 
-func DefaultDeviceHandler(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
+func DefaultDeviceHandler() (catena.CatenaValue, catena.StatusResult) {
 	return catena.ReplyNotImplemented("GetDevice not implemented")
 }
 
@@ -145,8 +211,8 @@ func DefaultSetValueHandler(value any, slot int, fqoid string) (catena.CatenaVal
 	return catena.ReplyNotImplemented("SetValue not implemented")
 }
 
-func DefaultGetAssetHandler(w http.ResponseWriter, r *http.Request, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyNotImplemented("GetAsset not implemented")
+func DefaultGetAssetHandler(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	return catena.ReplyAssetNotFound("GetAsset not implemented")
 }
 
 func DefaultConnectHandler(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
@@ -266,7 +332,7 @@ func (s *Server) RegisterRoutes() {
 				writeHTTPResult(w, val, res)
 				return
 			}
-			val, res := handler(w, r)
+			val, res := handler()
 			writeHTTPResult(w, val, res)
 			return
 		}
@@ -356,8 +422,8 @@ func (s *Server) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slo
 
 	fqoid := strings.Join(pathParts, "/")
 	handler := s.lookupGetAsset(slot)
-	val, res := handler(w, r, slot, fqoid)
-	writeHTTPResult(w, val, res)
+	val, res := handler(slot, fqoid)
+	writeAssetResult(w, val, res)
 }
 
 func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, slot int, pathParts []string) {

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -31,10 +31,8 @@
 package rest
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"strconv"
@@ -136,78 +134,27 @@ func writeDeviceResult(w http.ResponseWriter, device catena.CatenaDevice, httpSt
 	}
 }
 
-// writeAssetResult writes a CatenaAsset with appropriate headers for binary/redirect responses
+// writeAssetResult writes a CatenaAsset as JSON-encoded ExternalObjectPayload
 func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, httpStatus int) {
 	protoAsset := asset.GetProtoAsset()
 	if protoAsset == nil {
-		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid asset structure"})
 		return
 	}
 
-	// Set cachability headers
-	if !protoAsset.Cachable {
-		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
-	}
-
-	payload := protoAsset.Payload
-	if payload == nil {
+	// Convert asset to JSON
+	jsonData, err := asset.ToJSON()
+	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Asset payload is missing"})
 		return
 	}
 
-	// If URL-based asset, redirect to the URL
-	if payload.GetUrl() != "" {
-		w.Header().Set("Location", payload.GetUrl())
-		w.WriteHeader(http.StatusFound) // 302 redirect
-		return
-	}
-
-	// Handle embedded data
-	data := payload.GetPayload()
-	if len(data) == 0 {
-		w.WriteHeader(httpStatus)
-		return
-	}
-
-	// Set metadata headers
-	if payload.Metadata != nil {
-		if contentType, ok := payload.Metadata["content-type"]; ok {
-			w.Header().Set("Content-Type", contentType)
-		}
-		if contentDisposition, ok := payload.Metadata["content-disposition"]; ok {
-			w.Header().Set("Content-Disposition", contentDisposition)
-		}
-		// Set all custom headers from metadata (skip standard ones we already handled)
-		for key, value := range payload.Metadata {
-			if key != "content-type" && key != "content-disposition" {
-				w.Header().Set(key, value)
-			}
-		}
-	}
-
-	// Set content-length
-	if len(data) > 0 {
-		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
-	}
-
-	// Set compression encoding if specified
-	if payload.PayloadEncoding != 0 { // 0 is UNCOMPRESSED
-		switch payload.PayloadEncoding {
-		case 1: // GZIP
-			w.Header().Set("Content-Encoding", "gzip")
-		case 2: // DEFLATE
-			w.Header().Set("Content-Encoding", "deflate")
-		}
-	}
-
-	// Write status and stream data
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
-	if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
-		logger.Error("failed to stream asset data", "error", err)
+	if _, writeErr := w.Write(jsonData); writeErr != nil {
+		logger.Error("failed to write asset response", "error", writeErr)
 	}
 }
 
@@ -250,27 +197,27 @@ func (s *Server) Start(port int) error {
 // Default handlers that return "not implemented"
 
 func DefaultDeviceHandler() (catena.CatenaDevice, catena.StatusResult) {
-	return catena.ReplyDeviceNotFound("GetDevice not implemented")
+	return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "GetDevice not implemented")
 }
 
 func DefaultGetValueHandler(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyNotImplemented("GetValue not implemented")
+	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "GetValue not implemented")
 }
 
 func DefaultSetValueHandler(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyNotImplemented("SetValue not implemented")
+	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "SetValue not implemented")
 }
 
 func DefaultGetAssetHandler(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
-	return catena.ReplyAssetNotFound("GetAsset not implemented")
+	return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "GetAsset not implemented")
 }
 
 func DefaultConnectHandler(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyNotImplemented("Connect not implemented")
+	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "Connect not implemented")
 }
 
 func DefaultExecuteCommandHandler(w http.ResponseWriter, r *http.Request, slot int, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyNotImplemented("ExecuteCommand not implemented")
+	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "ExecuteCommand not implemented")
 }
 
 // Handler registration methods
@@ -360,7 +307,7 @@ func (s *Server) RegisterRoutes() {
 	s.mux.HandleFunc("/st2138-api/v1/", func(w http.ResponseWriter, r *http.Request) {
 		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 		if len(parts) < 3 {
-			val, res := catena.ReplyBadRequest("invalid path format")
+			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid path format")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -368,7 +315,7 @@ func (s *Server) RegisterRoutes() {
 		slotStr := parts[2]
 		slot, err := strconv.Atoi(slotStr)
 		if err != nil || slot < 0 || slot > math.MaxInt16 {
-			val, res := catena.ReplyBadRequest("invalid slot number")
+			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid slot number")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -378,7 +325,7 @@ func (s *Server) RegisterRoutes() {
 			// GET /st2138-api/v1/{slot} - Get device info
 			handler, ok := s.getDeviceHandlers[slot]
 			if !ok {
-				device, res := catena.ReplyDeviceNotFound("device not found")
+				device, res := catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
 				writeHTTPResult(w, res, device)
 				return
 			}
@@ -397,20 +344,20 @@ func (s *Server) RegisterRoutes() {
 			case "command":
 				s.handleCommandEndpoint(w, r, slot, parts[4:])
 			default:
-				val, res := catena.ReplyNotFound("unknown endpoint")
+				val, res := catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "unknown endpoint")
 				writeHTTPResult(w, res, val)
 			}
 			return
 		}
 
-		val, res := catena.ReplyNotFound("endpoint not found")
+		val, res := catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
 		writeHTTPResult(w, res, val)
 	})
 
 	// Connect endpoint: GET /st2138-api/v1/connect
 	s.mux.HandleFunc("/st2138-api/v1/connect", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			val, res := catena.ReplyMethodNotAllowed("only GET allowed")
+			val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -426,7 +373,7 @@ func (s *Server) RegisterRoutes() {
 			writeHTTPResult(w, res, val)
 			return
 		}
-		val, res := catena.ReplyNotFound("endpoint not found")
+		val, res := catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
 		writeHTTPResult(w, res, val)
 	})
 }
@@ -445,7 +392,7 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		reqValue, err := internal.ReadRequestJSON(r)
 		if err != nil {
 			logger.Error("failed to read request", "error", err)
-			val, res := catena.ReplyBadRequest("invalid request body")
+			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid request body")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -458,14 +405,14 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		writeHTTPResult(w, res, val)
 
 	default:
-		val, res := catena.ReplyMethodNotAllowed("only GET, PUT, PATCH allowed")
+		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET, PUT, PATCH allowed")
 		writeHTTPResult(w, res, val)
 	}
 }
 
 func (s *Server) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slot int, pathParts []string) {
 	if r.Method != http.MethodGet {
-		val, res := catena.ReplyMethodNotAllowed("only GET allowed")
+		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -478,7 +425,7 @@ func (s *Server) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slo
 
 func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, slot int, pathParts []string) {
 	if r.Method != http.MethodPost {
-		val, res := catena.ReplyMethodNotAllowed("only POST allowed")
+		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only POST allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -491,7 +438,7 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 		reqValue, err := internal.ReadRequestJSON(r)
 		if err != nil {
 			logger.Error("failed to read command payload", "error", err)
-			val, res := catena.ReplyBadRequest("invalid command payload")
+			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid command payload")
 			writeHTTPResult(w, res, val)
 			return
 		}

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -398,7 +398,13 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		}
 
 		// Convert proto value to native Go type
-		nativeValue := catena.FromProto(reqValue)
+		nativeValue, err := catena.FromProto(reqValue)
+		if err != nil {
+			logger.Error("failed to convert proto value to native Go type", "error", err)
+			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid request body")
+			writeHTTPResult(w, res, val)
+			return
+		}
 
 		handler := s.lookupSetValue(slot)
 		val, res := handler(nativeValue, slot, fqoid)
@@ -442,7 +448,13 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 			writeHTTPResult(w, res, val)
 			return
 		}
-		payload = catena.FromProto(reqValue)
+		payload, err = catena.FromProto(reqValue)
+		if err != nil {
+			logger.Error("failed to convert proto value to native Go type", "error", err)
+			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid command payload")
+			writeHTTPResult(w, res, val)
+			return
+		}
 	}
 
 	handler := s.lookupExecuteCommand(slot)

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -41,13 +41,15 @@ import (
 	"strings"
 	"sync"
 
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/rossvideo/catena/sdks/go/internal"
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 )
 
 // Handlers now return (CatenaValue, StatusResult) so the server can respond consistently.
-type DeviceHandler func() (catena.CatenaValue, catena.StatusResult)
+type DeviceHandler func() (catena.CatenaDevice, catena.StatusResult)
 type GetValueHandler func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
 type SetValueHandler func(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
 type GetAssetHandler func(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult)
@@ -68,8 +70,8 @@ type Server struct {
 	fallbackHandler        FallbackHandler
 }
 
-// writeHTTPResult writes a CatenaValue and StatusResult to the HTTP response.
-func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result catena.StatusResult) {
+// writeHTTPResult is a unified function that handles writing different response types
+func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value interface{}) {
 	httpStatus := result.Code.ToHTTPStatus()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -84,33 +86,63 @@ func writeHTTPResult(w http.ResponseWriter, value catena.CatenaValue, result cat
 		}
 	}
 
-	// If Value is nil, just write the status code
-	if value.Value == nil {
+	// Handle different value types
+	switch v := value.(type) {
+	case catena.CatenaValue:
+		writeValueResult(w, v, httpStatus)
+	case catena.CatenaDevice:
+		writeDeviceResult(w, v, httpStatus)
+	case catena.CatenaAsset:
+		writeAssetResult(w, v, httpStatus)
+	default:
+		w.WriteHeader(httpStatus)
+	}
+}
+
+// writeValueResult writes a CatenaValue as JSON
+func writeValueResult(w http.ResponseWriter, value catena.CatenaValue, httpStatus int) {
+	protoValue := value.Value
+	if protoValue == nil {
 		w.WriteHeader(httpStatus)
 		return
 	}
 
-	// Write the protobuf value as JSON
-	if err := internal.WriteResponseJSON(w, value.Value, httpStatus); err != nil {
-		logger.Error("failed to write response", "error", err)
+	if err := internal.WriteResponseJSON(w, protoValue, httpStatus); err != nil {
+		logger.Error("failed to write value response", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 
-// writeAssetResult writes a CatenaAsset to the HTTP response with appropriate headers
-func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, result catena.StatusResult) {
-	httpStatus := result.Code.ToHTTPStatus()
-
-	// If there's an error, write error response
-	if result.Error != "" {
-		w.Header().Set("Content-Type", "application/json")
+// writeDeviceResult writes a CatenaDevice as JSON
+func writeDeviceResult(w http.ResponseWriter, device catena.CatenaDevice, httpStatus int) {
+	protoDevice := device.GetProtoDevice()
+	if protoDevice == nil {
 		w.WriteHeader(httpStatus)
-		json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
 		return
 	}
 
-	// Validate asset structure
-	if asset.ExternalObject == nil || asset.ExternalObject.Payload == nil {
+	w.Header().Set("Content-Type", "application/json")
+	b, err := (protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}).Marshal(protoDevice)
+	if err != nil {
+		logger.Error("failed to marshal device response", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to marshal device response"})
+		return
+	}
+
+	w.WriteHeader(httpStatus)
+	if _, writeErr := w.Write(b); writeErr != nil {
+		logger.Error("failed to write device response", "error", writeErr)
+	}
+}
+
+// writeAssetResult writes a CatenaAsset with appropriate headers for binary/redirect responses
+func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, httpStatus int) {
+	protoAsset := asset.GetProtoAsset()
+	if protoAsset == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid asset structure"})
@@ -118,44 +150,56 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, result ca
 	}
 
 	// Set cachability headers
-	if !asset.IsCachable() {
+	if !protoAsset.Cachable {
 		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 	}
 
+	payload := protoAsset.Payload
+	if payload == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Asset payload is missing"})
+		return
+	}
+
 	// If URL-based asset, redirect to the URL
-	if asset.IsURL() {
-		w.Header().Set("Location", asset.GetURL())
+	if payload.GetUrl() != "" {
+		w.Header().Set("Location", payload.GetUrl())
 		w.WriteHeader(http.StatusFound) // 302 redirect
 		return
 	}
 
 	// Handle embedded data
-	data := asset.GetData()
+	data := payload.GetPayload()
 	if len(data) == 0 {
 		w.WriteHeader(httpStatus)
 		return
 	}
 
-	// Set content-type from metadata
-	if contentType := asset.GetContentType(); contentType != "" {
-		w.Header().Set("Content-Type", contentType)
-	}
-
-	// Set content-disposition from metadata
-	if contentDisposition := asset.GetContentDisposition(); contentDisposition != "" {
-		w.Header().Set("Content-Disposition", contentDisposition)
+	// Set metadata headers
+	if payload.Metadata != nil {
+		if contentType, ok := payload.Metadata["content-type"]; ok {
+			w.Header().Set("Content-Type", contentType)
+		}
+		if contentDisposition, ok := payload.Metadata["content-disposition"]; ok {
+			w.Header().Set("Content-Disposition", contentDisposition)
+		}
+		// Set all custom headers from metadata (skip standard ones we already handled)
+		for key, value := range payload.Metadata {
+			if key != "content-type" && key != "content-disposition" {
+				w.Header().Set(key, value)
+			}
+		}
 	}
 
 	// Set content-length
-	contentLength := asset.ContentLength()
-	if contentLength > 0 {
-		w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
+	if len(data) > 0 {
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	}
 
 	// Set compression encoding if specified
-	encoding := asset.ExternalObject.Payload.PayloadEncoding
-	if encoding != 0 { // 0 is UNCOMPRESSED
-		switch encoding {
+	if payload.PayloadEncoding != 0 { // 0 is UNCOMPRESSED
+		switch payload.PayloadEncoding {
 		case 1: // GZIP
 			w.Header().Set("Content-Encoding", "gzip")
 		case 2: // DEFLATE
@@ -163,17 +207,9 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, result ca
 		}
 	}
 
-	// Set all custom headers from metadata (skip standard ones we already handled)
-	for key, value := range asset.GetAllMetadata() {
-		if key != "content-type" && key != "content-disposition" {
-			w.Header().Set(key, value)
-		}
-	}
-
 	// Write status and stream data
 	w.WriteHeader(httpStatus)
-	reader := bytes.NewReader(data)
-	if _, err := io.Copy(w, reader); err != nil {
+	if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
 		logger.Error("failed to stream asset data", "error", err)
 	}
 }
@@ -216,8 +252,8 @@ func (s *Server) Start(port int) error {
 
 // Default handlers that return "not implemented"
 
-func DefaultDeviceHandler() (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyNotImplemented("GetDevice not implemented")
+func DefaultDeviceHandler() (catena.CatenaDevice, catena.StatusResult) {
+	return catena.ReplyDeviceNotFound("GetDevice not implemented")
 }
 
 func DefaultGetValueHandler(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
@@ -328,7 +364,7 @@ func (s *Server) RegisterRoutes() {
 		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 		if len(parts) < 3 {
 			val, res := catena.ReplyBadRequest("invalid path format")
-			writeHTTPResult(w, val, res)
+			writeHTTPResult(w, res, val)
 			return
 		}
 
@@ -336,7 +372,7 @@ func (s *Server) RegisterRoutes() {
 		slot, err := strconv.Atoi(slotStr)
 		if err != nil || slot < 0 || slot > math.MaxInt16 {
 			val, res := catena.ReplyBadRequest("invalid slot number")
-			writeHTTPResult(w, val, res)
+			writeHTTPResult(w, res, val)
 			return
 		}
 
@@ -345,12 +381,12 @@ func (s *Server) RegisterRoutes() {
 			// GET /st2138-api/v1/{slot} - Get device info
 			handler, ok := s.getDeviceHandlers[slot]
 			if !ok {
-				val, res := catena.ReplyNotFound("device not found")
-				writeHTTPResult(w, val, res)
+				device, res := catena.ReplyDeviceNotFound("device not found")
+				writeHTTPResult(w, res, device)
 				return
 			}
-			val, res := handler()
-			writeHTTPResult(w, val, res)
+			device, res := handler()
+			writeHTTPResult(w, res, device)
 			return
 		}
 
@@ -365,36 +401,36 @@ func (s *Server) RegisterRoutes() {
 				s.handleCommandEndpoint(w, r, slot, parts[4:])
 			default:
 				val, res := catena.ReplyNotFound("unknown endpoint")
-				writeHTTPResult(w, val, res)
+				writeHTTPResult(w, res, val)
 			}
 			return
 		}
 
 		val, res := catena.ReplyNotFound("endpoint not found")
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 	})
 
 	// Connect endpoint: GET /st2138-api/v1/connect
 	s.mux.HandleFunc("/st2138-api/v1/connect", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			val, res := catena.ReplyMethodNotAllowed("only GET allowed")
-			writeHTTPResult(w, val, res)
+			writeHTTPResult(w, res, val)
 			return
 		}
 		handler := s.lookupConnect()
 		val, res := handler(w, r)
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 	})
 
 	// Catch-all for 404 - must be registered last
 	s.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if s.fallbackHandler != nil {
 			val, res := s.fallbackHandler(w, r)
-			writeHTTPResult(w, val, res)
+			writeHTTPResult(w, res, val)
 			return
 		}
 		val, res := catena.ReplyNotFound("endpoint not found")
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 	})
 }
 
@@ -405,7 +441,7 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 	case http.MethodGet:
 		handler := s.lookupGetValue(slot)
 		val, res := handler(slot, fqoid)
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 
 	case http.MethodPut:
 		// Read request body
@@ -413,7 +449,7 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		if err != nil {
 			logger.Error("failed to read request", "error", err)
 			val, res := catena.ReplyBadRequest("invalid request body")
-			writeHTTPResult(w, val, res)
+			writeHTTPResult(w, res, val)
 			return
 		}
 
@@ -422,31 +458,31 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 
 		handler := s.lookupSetValue(slot)
 		val, res := handler(nativeValue, slot, fqoid)
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 
 	default:
 		val, res := catena.ReplyMethodNotAllowed("only GET, PUT, PATCH allowed")
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 	}
 }
 
 func (s *Server) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slot int, pathParts []string) {
 	if r.Method != http.MethodGet {
 		val, res := catena.ReplyMethodNotAllowed("only GET allowed")
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 		return
 	}
 
 	fqoid := strings.Join(pathParts, "/")
 	handler := s.lookupGetAsset(slot)
 	val, res := handler(slot, fqoid)
-	writeAssetResult(w, val, res)
+	writeHTTPResult(w, res, val)
 }
 
 func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, slot int, pathParts []string) {
 	if r.Method != http.MethodPost {
 		val, res := catena.ReplyMethodNotAllowed("only POST allowed")
-		writeHTTPResult(w, val, res)
+		writeHTTPResult(w, res, val)
 		return
 	}
 
@@ -459,7 +495,7 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 		if err != nil {
 			logger.Error("failed to read command payload", "error", err)
 			val, res := catena.ReplyBadRequest("invalid command payload")
-			writeHTTPResult(w, val, res)
+			writeHTTPResult(w, res, val)
 			return
 		}
 		payload = catena.FromProto(reqValue)
@@ -467,5 +503,5 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 
 	handler := s.lookupExecuteCommand(slot)
 	val, res := handler(w, r, slot, commandFqoid, payload)
-	writeHTTPResult(w, val, res)
+	writeHTTPResult(w, res, val)
 }

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -105,22 +105,28 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, result ca
 	if result.Error != "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(httpStatus)
-		fmt.Fprintf(w, `{"error": "%s"}`, result.Error)
+		json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
 		return
 	}
 
-	// If URL-based asset, redirect or return URL
+	// Validate asset structure
+	if asset.ExternalObject == nil || asset.ExternalObject.Payload == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid asset structure"})
+		return
+	}
+
+	// Set cachability headers
+	if !asset.IsCachable() {
+		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+	}
+
+	// If URL-based asset, redirect to the URL
 	if asset.IsURL() {
-		// Option 1: Redirect to the URL
 		w.Header().Set("Location", asset.GetURL())
 		w.WriteHeader(http.StatusFound) // 302 redirect
 		return
-
-		// Option 2: Return URL as JSON (uncomment if preferred)
-		// w.Header().Set("Content-Type", "application/json")
-		// w.WriteHeader(httpStatus)
-		// fmt.Fprintf(w, `{"url": "%s"}`, asset.GetURL())
-		// return
 	}
 
 	// Handle embedded data
@@ -130,27 +136,38 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, result ca
 		return
 	}
 
-	// Set asset headers
-	if asset.ContentType != "" {
-		w.Header().Set("Content-Type", asset.ContentType)
-	}
-	if asset.ContentDisposition != "" {
-		w.Header().Set("Content-Disposition", asset.ContentDisposition)
+	// Set content-type from metadata
+	if contentType := asset.GetContentType(); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
 	}
 
+	// Set content-disposition from metadata
+	if contentDisposition := asset.GetContentDisposition(); contentDisposition != "" {
+		w.Header().Set("Content-Disposition", contentDisposition)
+	}
+
+	// Set content-length
 	contentLength := asset.ContentLength()
 	if contentLength > 0 {
 		w.Header().Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	}
 
 	// Set compression encoding if specified
-	if asset.Payload.PayloadEncoding != "" && asset.Payload.PayloadEncoding != "uncompressed" {
-		w.Header().Set("Content-Encoding", asset.Payload.PayloadEncoding)
+	encoding := asset.ExternalObject.Payload.PayloadEncoding
+	if encoding != 0 { // 0 is UNCOMPRESSED
+		switch encoding {
+		case 1: // GZIP
+			w.Header().Set("Content-Encoding", "gzip")
+		case 2: // DEFLATE
+			w.Header().Set("Content-Encoding", "deflate")
+		}
 	}
 
-	// Set custom headers
-	for key, value := range asset.CustomHeaders {
-		w.Header().Set(key, value)
+	// Set all custom headers from metadata (skip standard ones we already handled)
+	for key, value := range asset.GetAllMetadata() {
+		if key != "content-type" && key != "content-disposition" {
+			w.Header().Set(key, value)
+		}
 	}
 
 	// Write status and stream data

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -74,9 +74,6 @@ type Server struct {
 func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value interface{}) {
 	httpStatus := result.Code.ToHTTPStatus()
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(httpStatus)
-
 	if result.Error != "" {
 		// Only return detailed error messages in dev mode
 		if catena.IsDev() {
@@ -144,7 +141,7 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, httpStatu
 	protoAsset := asset.GetProtoAsset()
 	if protoAsset == nil {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(httpStatus)
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid asset structure"})
 		return
 	}

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -144,7 +144,7 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, httpStatu
 	protoAsset := asset.GetProtoAsset()
 	if protoAsset == nil {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(httpStatus)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid asset structure"})
 		return
 	}


### PR DESCRIPTION
## 📖 Description
Closes issue 1151

Adds new type CatenaAsset, which is returned by asset endpoint callbacks.

---

## ✅ Definition of Done (DoD)
- [x] Feature is implemented and works as expected
- [x] Edge cases are handled
- [ ] Tests are added or updated (if applicable)
- [x] Documentation is updated (if needed)
- [ ] Code is reviewed and approved -->

---

## 🛠️ Implementation Notes
Implemented new type CatenaAsset:
Contains ContentType, ContentDisposition, Payload and CustomHeaders Payload is of type DataPayload, and it stores the actual asset data

Added new type CatenaDevice:
CatenaAsset and CatenaDevice now use json marshaling to validate proto
Marshals a value to json, then unmarshals to proto
json value is cached if successful otherwise set to nil
cached json value is used to populate response

Also removed http objects from handlers
Left http handler in fallback
fallback handler is http specific and it would be good to have scope of the objects Shown in ExecuteCommand example, it allows for webpages for example


---

## 🔗 Related Issues / Links
<!-- Links to the relevant issues  -->


---
## 📝 Additional Context
<!-- (Optional) Any extra information, screenshots, or background. -->


---

## 🚧 Risks / Open Questions
<!-- (Optional) Anything unclear or potentially risky. -->

---
## ✨ Updates
<!-- (Optional) List summarizing changes made when editing the pull request>
 
