### PR TITLE
[GO] SetValue Return Type

### DIFF
--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -55,6 +55,10 @@ var (
 func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid string) catena.StatusResult {
 		logger.Info("SetParam", "slot", slot, "fqoid", fqoid)
+		if value == nil {
+			logger.Error("SetParam nil value received", "slot", slot, "fqoid", fqoid)
+			return catena.StatusInternalError("nil value received")
+		}
 		val, ok := params.Load(fqoid)
 		if !ok {
 			logger.Error("SetParam param not found", "slot", slot, "fqoid", fqoid)
@@ -73,12 +77,12 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 		v, ok := params.Load(fqoid)
 		if !ok {
 			logger.Error("GetParam param not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
+			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "param not found")
 		}
 		catenaVal, err := catena.ToCatenaValue(v)
 		if err != nil {
 			logger.Error("GetParam failed to convert value", "slot", slot, "fqoid", fqoid, "error", err)
-			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to convert value")
+			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert value")
 		}
 		return catena.Reply(catenaVal)
 	})
@@ -88,7 +92,7 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid string, slot int) {
 	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid_ string) catena.StatusResult {
 		if fqoid_ != fqoid {
-			return catena.StatusNotImplemented("no handler for fqoid " + fqoid_)
+			return catena.StatusWithCode(catena.UNIMPLEMENTED, "no handler for fqoid "+fqoid_)
 		}
 		logger.Info("SetSpecificParam", "slot", slot, "fqoid", fqoid_)
 		val, ok := params.Load(fqoid_)
@@ -101,23 +105,23 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 			return catena.StatusBadRequest("type mismatch")
 		}
 		params.Store(fqoid_, value)
-		return catena.StatusNoContent()
+		return catena.StatusOK()
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid_ string) (catena.CatenaValue, catena.StatusResult) {
 		if fqoid_ != fqoid {
-			return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED,"no handler for fqoid " + fqoid_)
+			return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "no handler for fqoid "+fqoid_)
 		}
 		logger.Info("GetSpecificParam", "slot", slot, "fqoid", fqoid_)
 		v, ok := params.Load(fqoid_)
 		if !ok {
 			logger.Error("GetSpecificParam param not found", "slot", slot, "fqoid", fqoid_)
-			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
+			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "param not found")
 		}
 		catenaVal, err := catena.ToCatenaValue(v)
 		if err != nil {
 			logger.Error("GetSpecificParam failed to convert value", "slot", slot, "fqoid", fqoid_, "error", err)
-			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to convert value")
+			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert value")
 		}
 		return catena.Reply(catenaVal)
 	})
@@ -203,7 +207,7 @@ func main() {
 		// A real implementation would keep the connection open and push updates
 		catenaVal, err := catena.ToCatenaValue("connected")
 		if err != nil {
-			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to create response")
+			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to create response")
 		}
 		return catena.Reply(catenaVal)
 	})
@@ -222,7 +226,7 @@ func main() {
 			}
 			catenaVal, err := catena.ToCatenaValue(response)
 			if err != nil {
-				return catena.ReplyError[catena.CatenaValue](catena.INTERNAL,"failed to create command response")
+				return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to create command response")
 			}
 			return catena.Reply(catenaVal)
 		})
@@ -261,7 +265,7 @@ func main() {
 			logger.Info("GetDevice", "slot", slot)
 			device, err := catena.ToCatenaDevice(deviceInfo)
 			if err != nil {
-				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL,"failed to create device info")
+				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL, "failed to create device info")
 			}
 			return catena.Reply(device)
 		})
@@ -270,7 +274,7 @@ func main() {
 	// Register handler for non-existent endpoints
 	srv.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
 		logger.Error("Endpoint not found")
-		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"endpoint not found")
+		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
 	})
 
 	addr := ":" + strconv.Itoa(port)

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -53,19 +53,19 @@ var (
 
 // Implementation for registering parameter handlers for every fqoid on a given slot
 func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
-	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid string) catena.StatusResult {
 		logger.Info("SetParam", "slot", slot, "fqoid", fqoid)
 		val, ok := params.Load(fqoid)
 		if !ok {
 			logger.Error("SetParam param not found", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
+			return catena.StatusNotFound("param not found")
 		}
 		if reflect.TypeOf(val) != reflect.TypeOf(value) {
 			logger.Error("SetParam type mismatch", "slot", slot, "fqoid", fqoid)
-			return catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT,"type mismatch")
+			return catena.StatusBadRequest("type mismatch")
 		}
 		params.Store(fqoid, value)
-		return catena.ReplyError[catena.CatenaValue](catena.NO_CONTENT, "")
+		return catena.StatusNoContent()
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
@@ -86,22 +86,22 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 
 // For a given slot implement param handlers for a specific param oid only
 func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid string, slot int) {
-	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid_ string) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterSetValueHandler(slot, func(value any, slot int, fqoid_ string) catena.StatusResult {
 		if fqoid_ != fqoid {
-			return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED,"no handler for fqoid " + fqoid_)
+			return catena.StatusNotImplemented("no handler for fqoid " + fqoid_)
 		}
 		logger.Info("SetSpecificParam", "slot", slot, "fqoid", fqoid_)
 		val, ok := params.Load(fqoid_)
 		if !ok {
 			logger.Error("SetSpecificParam param not found", "slot", slot, "fqoid", fqoid_)
-			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND,"param not found")
+			return catena.StatusNotFound("param not found")
 		}
 		if reflect.TypeOf(val) != reflect.TypeOf(value) {
 			logger.Error("SetSpecificParam type mismatch", "slot", slot, "fqoid", fqoid_)
-			return catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT,"type mismatch")
+			return catena.StatusBadRequest("type mismatch")
 		}
 		params.Store(fqoid_, value)
-		return catena.ReplyError[catena.CatenaValue](catena.NO_CONTENT, "")
+		return catena.StatusNoContent()
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid_ string) (catena.CatenaValue, catena.StatusResult) {

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -57,19 +57,19 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot int) {
 		logger.Info("SetParam", "slot", slot, "fqoid", fqoid)
 		if value == nil {
 			logger.Error("SetParam nil value received", "slot", slot, "fqoid", fqoid)
-			return catena.StatusInternalError("nil value received")
+			return catena.StatusWithCode(catena.INTERNAL, "nil value received")
 		}
 		val, ok := params.Load(fqoid)
 		if !ok {
 			logger.Error("SetParam param not found", "slot", slot, "fqoid", fqoid)
-			return catena.StatusNotFound("param not found")
+			return catena.StatusWithCode(catena.NOT_FOUND, "param not found")
 		}
 		if reflect.TypeOf(val) != reflect.TypeOf(value) {
 			logger.Error("SetParam type mismatch", "slot", slot, "fqoid", fqoid)
-			return catena.StatusBadRequest("type mismatch")
+			return catena.StatusWithCode(catena.INVALID_ARGUMENT, "type mismatch")
 		}
 		params.Store(fqoid, value)
-		return catena.StatusNoContent()
+		return catena.StatusWithCode(catena.NO_CONTENT, "")
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
@@ -98,14 +98,14 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 		val, ok := params.Load(fqoid_)
 		if !ok {
 			logger.Error("SetSpecificParam param not found", "slot", slot, "fqoid", fqoid_)
-			return catena.StatusNotFound("param not found")
+			return catena.StatusWithCode(catena.NOT_FOUND, "param not found")
 		}
 		if reflect.TypeOf(val) != reflect.TypeOf(value) {
 			logger.Error("SetSpecificParam type mismatch", "slot", slot, "fqoid", fqoid_)
-			return catena.StatusBadRequest("type mismatch")
+			return catena.StatusWithCode(catena.INVALID_ARGUMENT, "type mismatch")
 		}
 		params.Store(fqoid_, value)
-		return catena.StatusOK()
+		return catena.StatusWithCode(catena.OK, "")
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot int, fqoid_ string) (catena.CatenaValue, catena.StatusResult) {

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -209,39 +209,8 @@ func ReplyError[T ResponseType](code StatusCode, msg string) (T, StatusResult) {
 	return zero, StatusResult{Code: code, Error: msg}
 }
 
-// StatusResult-only reply helpers for handlers that don't return values (e.g., SetValue).
-
-// StatusOK returns a successful StatusResult (200 OK).
-func StatusOK() StatusResult {
-	return StatusResult{Code: OK}
-}
-
-// StatusNoContent returns a 204 No Content StatusResult.
-func StatusNoContent() StatusResult {
-	return StatusResult{Code: NO_CONTENT}
-}
-
-// StatusBadRequest returns a 400 Bad Request StatusResult with an optional message.
-func StatusBadRequest(msg string) StatusResult {
-	return StatusResult{Code: INVALID_ARGUMENT, Error: msg}
-}
-
-// StatusNotFound returns a 404 Not Found StatusResult with an optional message.
-func StatusNotFound(msg string) StatusResult {
-	return StatusResult{Code: NOT_FOUND, Error: msg}
-}
-
-// StatusNotImplemented returns a 501 Not Implemented StatusResult with an optional message.
-func StatusNotImplemented(msg string) StatusResult {
-	return StatusResult{Code: UNIMPLEMENTED, Error: msg}
-}
-
-// StatusInternalError returns a 500 Internal Server Error StatusResult with an optional message.
-func StatusInternalError(msg string) StatusResult {
-	return StatusResult{Code: INTERNAL, Error: msg}
-}
-
 // StatusWithCode returns a StatusResult with the given StatusCode and optional message.
+
 func StatusWithCode(code StatusCode, msg string) StatusResult {
 	return StatusResult{Code: code, Error: msg}
 }

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -208,3 +208,40 @@ func ReplyError[T ResponseType](code StatusCode, msg string) (T, StatusResult) {
 	var zero T
 	return zero, StatusResult{Code: code, Error: msg}
 }
+
+// StatusResult-only reply helpers for handlers that don't return values (e.g., SetValue).
+
+// StatusOK returns a successful StatusResult (200 OK).
+func StatusOK() StatusResult {
+	return StatusResult{Code: OK}
+}
+
+// StatusNoContent returns a 204 No Content StatusResult.
+func StatusNoContent() StatusResult {
+	return StatusResult{Code: NO_CONTENT}
+}
+
+// StatusBadRequest returns a 400 Bad Request StatusResult with an optional message.
+func StatusBadRequest(msg string) StatusResult {
+	return StatusResult{Code: INVALID_ARGUMENT, Error: msg}
+}
+
+// StatusNotFound returns a 404 Not Found StatusResult with an optional message.
+func StatusNotFound(msg string) StatusResult {
+	return StatusResult{Code: NOT_FOUND, Error: msg}
+}
+
+// StatusNotImplemented returns a 501 Not Implemented StatusResult with an optional message.
+func StatusNotImplemented(msg string) StatusResult {
+	return StatusResult{Code: UNIMPLEMENTED, Error: msg}
+}
+
+// StatusInternalError returns a 500 Internal Server Error StatusResult with an optional message.
+func StatusInternalError(msg string) StatusResult {
+	return StatusResult{Code: INTERNAL, Error: msg}
+}
+
+// StatusWithCode returns a StatusResult with the given StatusCode and optional message.
+func StatusWithCode(code StatusCode, msg string) StatusResult {
+	return StatusResult{Code: code, Error: msg}
+}

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -74,11 +74,15 @@ func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value in
 
 	if result.Error != "" {
 		// Only return detailed error messages in dev mode
+		// Must set header and status before writing body to avoid implicit 200 OK
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(httpStatus)
 		if catena.IsDev() {
 			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
 		} else {
 			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
 		}
+		return
 	}
 
 	// Handle different value types
@@ -99,11 +103,15 @@ func writeHTTPStatusResult(w http.ResponseWriter, result catena.StatusResult) {
 	httpStatus := result.Code.ToHTTPStatus()
 
 	if result.Error != "" {
+		// Must set header and status before writing body to avoid implicit 200 OK
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(httpStatus)
 		if catena.IsDev() {
 			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
 		} else {
 			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
 		}
+		return
 	}
 
 	w.WriteHeader(httpStatus)

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -68,20 +68,26 @@ type Server struct {
 	fallbackHandler        FallbackHandler
 }
 
+// writeErrorResponse writes an error JSON response if errorMsg is non-empty.
+func writeErrorResponse(w http.ResponseWriter, errorMsg string, httpStatus int) bool {
+	if errorMsg == "" {
+		return false
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(httpStatus)
+	if catena.IsDev() { // Only return detailed error messages in dev mode
+		json.NewEncoder(w).Encode(map[string]string{"error": errorMsg})
+	} else {
+		json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
+	}
+	return true
+}
+
 // writeHTTPResult is a unified function that handles writing different response types
 func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value interface{}) {
 	httpStatus := result.Code.ToHTTPStatus()
 
-	if result.Error != "" {
-		// Only return detailed error messages in dev mode
-		// Must set header and status before writing body to avoid implicit 200 OK
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(httpStatus)
-		if catena.IsDev() {
-			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
-		} else {
-			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
-		}
+	if writeErrorResponse(w, result.Error, httpStatus) {
 		return
 	}
 
@@ -102,15 +108,7 @@ func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value in
 func writeHTTPStatusResult(w http.ResponseWriter, result catena.StatusResult) {
 	httpStatus := result.Code.ToHTTPStatus()
 
-	if result.Error != "" {
-		// Must set header and status before writing body to avoid implicit 200 OK
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(httpStatus)
-		if catena.IsDev() {
-			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
-		} else {
-			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
-		}
+	if writeErrorResponse(w, result.Error, httpStatus) {
 		return
 	}
 

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -49,7 +49,7 @@ import (
 // Handlers now return (CatenaValue, StatusResult) so the server can respond consistently.
 type DeviceHandler func() (catena.CatenaDevice, catena.StatusResult)
 type GetValueHandler func(slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
-type SetValueHandler func(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)
+type SetValueHandler func(value any, slot int, fqoid string) catena.StatusResult
 type GetAssetHandler func(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult)
 type ConnectHandler func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult)
 type ExecuteCommandHandler func(w http.ResponseWriter, r *http.Request, slot int, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult)
@@ -92,6 +92,21 @@ func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value in
 	default:
 		w.WriteHeader(httpStatus)
 	}
+}
+
+// writeHTTPStatusResult writes a StatusResult to the HTTP response (no value).
+func writeHTTPStatusResult(w http.ResponseWriter, result catena.StatusResult) {
+	httpStatus := result.Code.ToHTTPStatus()
+
+	if result.Error != "" {
+		if catena.IsDev() {
+			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
+		}
+	}
+
+	w.WriteHeader(httpStatus)
 }
 
 // writeValueResult writes a CatenaValue as JSON
@@ -204,8 +219,8 @@ func DefaultGetValueHandler(slot int, fqoid string) (catena.CatenaValue, catena.
 	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "GetValue not implemented")
 }
 
-func DefaultSetValueHandler(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "SetValue not implemented")
+func DefaultSetValueHandler(value any, slot int, fqoid string) catena.StatusResult {
+	return catena.StatusNotImplemented("SetValue not implemented")
 }
 
 func DefaultGetAssetHandler(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
@@ -392,8 +407,7 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		reqValue, err := internal.ReadRequestJSON(r)
 		if err != nil {
 			logger.Error("failed to read request", "error", err)
-			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid request body")
-			writeHTTPResult(w, res, val)
+			writeHTTPStatusResult(w, catena.StatusBadRequest("invalid request body"))
 			return
 		}
 
@@ -407,8 +421,8 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		}
 
 		handler := s.lookupSetValue(slot)
-		val, res := handler(nativeValue, slot, fqoid)
-		writeHTTPResult(w, res, val)
+		res := handler(nativeValue, slot, fqoid)
+		writeHTTPStatusResult(w, res)
 
 	default:
 		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET, PUT, PATCH allowed")

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -68,28 +68,9 @@ type Server struct {
 	fallbackHandler        FallbackHandler
 }
 
-// writeErrorResponse writes an error JSON response if errorMsg is non-empty.
-func writeErrorResponse(w http.ResponseWriter, errorMsg string, httpStatus int) bool {
-	if errorMsg == "" {
-		return false
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(httpStatus)
-	if catena.IsDev() { // Only return detailed error messages in dev mode
-		json.NewEncoder(w).Encode(map[string]string{"error": errorMsg})
-	} else {
-		json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
-	}
-	return true
-}
-
 // writeHTTPResult is a unified function that handles writing different response types
 func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value interface{}) {
 	httpStatus := result.Code.ToHTTPStatus()
-
-	if writeErrorResponse(w, result.Error, httpStatus) {
-		return
-	}
 
 	// Handle different value types
 	switch v := value.(type) {
@@ -107,11 +88,6 @@ func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value in
 // writeHTTPStatusResult writes a StatusResult to the HTTP response (no value).
 func writeHTTPStatusResult(w http.ResponseWriter, result catena.StatusResult) {
 	httpStatus := result.Code.ToHTTPStatus()
-
-	if writeErrorResponse(w, result.Error, httpStatus) {
-		return
-	}
-
 	w.WriteHeader(httpStatus)
 }
 
@@ -226,7 +202,7 @@ func DefaultGetValueHandler(slot int, fqoid string) (catena.CatenaValue, catena.
 }
 
 func DefaultSetValueHandler(value any, slot int, fqoid string) catena.StatusResult {
-	return catena.StatusNotImplemented("SetValue not implemented")
+	return catena.StatusWithCode(catena.UNIMPLEMENTED, "SetValue not implemented")
 }
 
 func DefaultGetAssetHandler(slot int, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
@@ -413,7 +389,7 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 		reqValue, err := internal.ReadRequestJSON(r)
 		if err != nil {
 			logger.Error("failed to read request", "error", err)
-			writeHTTPStatusResult(w, catena.StatusBadRequest("invalid request body"))
+			writeHTTPStatusResult(w, catena.StatusWithCode(catena.INVALID_ARGUMENT, "invalid request body"))
 			return
 		}
 

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -72,6 +72,15 @@ type Server struct {
 func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value interface{}) {
 	httpStatus := result.Code.ToHTTPStatus()
 
+	if result.Error != "" {
+		// Only return detailed error messages in dev mode
+		if catena.IsDev() {
+			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
+		}
+	}
+
 	// Handle different value types
 	switch v := value.(type) {
 	case catena.CatenaValue:
@@ -88,6 +97,16 @@ func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value in
 // writeHTTPStatusResult writes a StatusResult to the HTTP response (no value).
 func writeHTTPStatusResult(w http.ResponseWriter, result catena.StatusResult) {
 	httpStatus := result.Code.ToHTTPStatus()
+
+	if result.Error != "" {
+		// Only return detailed error messages in dev mode
+		if catena.IsDev() {
+			json.NewEncoder(w).Encode(map[string]string{"error": result.Error})
+		} else {
+			json.NewEncoder(w).Encode(map[string]string{"error": http.StatusText(httpStatus)})
+		}
+	}
+
 	w.WriteHeader(httpStatus)
 }
 


### PR DESCRIPTION
## 📖 Description

Updated the GO SDK's SetValue endpoint no longer requires CatenaValue return

---

## ✅ Definition of Done (DoD)

- [x] Update SetValue method signature
- [x] Update examples
- [x] Test code

---

## 🛠️ Implementation Notes

- Added `StatusResult` only helper functions for SetValue handlers:
- Changed `SetValueHandler` type signature from `func(value any, slot int, fqoid string) (catena.CatenaValue, catena.StatusResult)` to `func(value any, slot int, fqoid string) catena.StatusResult`
- Added `writeStatusHeaders()` helper to reduce code duplication between `writeHTTPResult` and `writeHTTPStatusResult`
- Added `writeHTTPStatusResult()` for status-only responses
- Updated getSetValue example

---

## 🔗 Related Issues / Links

Closes issue #1215 