### PR TITLE
Fix run coverage js

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -34,6 +34,7 @@ javascript () {
   if [ "$clean" = true ]; then
     npm run clean
   fi
+  npm install
   npm test
 }
 


### PR DESCRIPTION
<!-- please continue to update this as work is being done to add context, links, scope creep, and any other useful info -->

## 📖 Description
<!-- A clear and concise explanation of what this pull request is about and what it accomplishes. -->
I messed up the run_coverage by forgetting that cmake runs npm install for us. But then calling npm test before cmake.

---

## ✅ Definition of Done (DoD)
- [x] add `npm install` to `javascript` function

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 2 potential issues for commit <u>96862c8</u></sup><!-- /BUGBOT_STATUS -->