### PR TITLE
[GO] Payload Helpers

### DIFF
--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -39,7 +39,6 @@
 package main
 
 import (
-	"crypto/sha256"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -202,19 +201,8 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map) {
 		// Normalize path separators for URL use
 		assetID := strings.ReplaceAll(relPath, string(filepath.Separator), "/")
 
-		// Build metadata
-		metadata := map[string]string{
-			"content-type": contentType,
-			"file-name":    filepath.Base(path),
-		}
-
-		// Calculate SHA-256 digest
-		hash := sha256.Sum256(data)
-
-		// Store as DataPayload directly
-		payload := catena.FromBytes(data)
-		payload.Metadata = metadata
-		payload.Digest = hash[:]
+		// Create payload with metadata and digest
+		payload := catena.ToPayload(data, contentType, filepath.Base(path))
 
 		assets.Store(assetID, payload)
 		logger.Info("Loaded asset", "id", assetID, "size", len(data), "type", contentType)

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -212,11 +212,9 @@ func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map) {
 		hash := sha256.Sum256(data)
 
 		// Store as DataPayload directly
-		payload := catena.DataPayload{
-			Payload:  data,
-			Metadata: metadata,
-			Digest:   hash[:],
-		}
+		payload := catena.FromBytes(data)
+		payload.Metadata = metadata
+		payload.Digest = hash[:]
 
 		assets.Store(assetID, payload)
 		logger.Info("Loaded asset", "id", assetID, "size", len(data), "type", contentType)

--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -41,13 +41,9 @@ package main
 import (
 	"embed"
 	"fmt"
-	"io/fs"
-	"mime"
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -91,8 +87,15 @@ func main() {
 	// ==========================================================================
 	assets := &sync.Map{}
 
-	// Load assets from embedded static directory
-	loadAssetsFromEmbedded(staticFS, "static", assets)
+	// Load assets from embedded static directory using catena helper
+	payloads, err := catena.LoadPayloadsFromEmbed(staticFS, "static")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load embedded assets: %v\n", err)
+		os.Exit(1)
+	}
+	for id, payload := range payloads {
+		assets.Store(id, payload)
+	}
 
 	// Collect asset names for example curl command
 	var firstAssetName string
@@ -165,52 +168,4 @@ func main() {
 	// Wait for shutdown signal
 	<-shutdownChan
 	logger.Info("Server shutdown complete")
-}
-
-// loadAssetsFromEmbedded loads all files from the embedded filesystem into the asset store
-func loadAssetsFromEmbedded(embedFS embed.FS, root string, assets *sync.Map) {
-	err := fs.WalkDir(embedFS, root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			logger.Warning("Error accessing path", "path", path, "error", err)
-			return nil // Continue walking
-		}
-
-		if d.IsDir() {
-			return nil // Skip directories
-		}
-
-		// Read file contents
-		data, err := embedFS.ReadFile(path)
-		if err != nil {
-			logger.Warning("Failed to read file", "path", path, "error", err)
-			return nil
-		}
-
-		// Determine content type from extension
-		ext := filepath.Ext(path)
-		contentType := mime.TypeByExtension(ext)
-		if contentType == "" {
-			contentType = "application/octet-stream"
-		}
-
-		// Use relative path from root as the asset ID
-		relPath, err := filepath.Rel(root, path)
-		if err != nil {
-			relPath = filepath.Base(path)
-		}
-		// Normalize path separators for URL use
-		assetID := strings.ReplaceAll(relPath, string(filepath.Separator), "/")
-
-		// Create payload with metadata and digest
-		payload := catena.ToPayload(data, contentType, filepath.Base(path))
-
-		assets.Store(assetID, payload)
-		logger.Info("Loaded asset", "id", assetID, "size", len(data), "type", contentType)
-
-		return nil
-	})
-
-	if err != nil {
-		logger.Error("Error walking embedded directory", "root", root, "error", err)
-	}
 }

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -39,7 +39,12 @@
 package catena
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+	"strconv"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -59,6 +64,48 @@ type DataPayload struct {
 	PayloadEncoding int32             // 0=UNCOMPRESSED, 1=GZIP, 2=DEFLATE
 	Payload         []byte            // Embedded binary data (use this OR Url, not both)
 	Url             string            // URL to external resource (use this OR Payload, not both)
+}
+
+// ToPayload creates a DataPayload from raw bytes with metadata and auto-computed SHA-256 digest.
+// This is the primary helper for creating asset payloads from in-memory data.
+func ToPayload(data []byte, contentType string, filename string) DataPayload {
+	hash := sha256.Sum256(data)
+	return DataPayload{
+		Payload:         data,
+		PayloadEncoding: 0, // UNCOMPRESSED
+		Metadata: map[string]string{
+			"content-type": contentType,
+			"file-name":    filename,
+			"size":         strconv.Itoa(len(data)),
+		},
+		Digest: hash[:],
+	}
+}
+
+// ToPayloadFromPath creates a DataPayload by reading a file from disk.
+// Auto-detects content type from file extension and computes SHA-256 digest.
+func ToPayloadFromPath(path string) (DataPayload, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return DataPayload{}, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// Auto-detect content type from extension
+	contentType := mime.TypeByExtension(filepath.Ext(path))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	filename := filepath.Base(path)
+	return ToPayload(data, contentType, filename), nil
+}
+
+// ToPayloadFromURL creates a DataPayload with a URL reference (no embedded data).
+// Use this when the asset is hosted externally and shouldn't be embedded.
+func ToPayloadFromURL(url string) DataPayload {
+	return DataPayload{
+		Url: url,
+	}
 }
 
 // ToCatenaAsset converts DataPayload to CatenaAsset by building the proto directly

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -85,21 +85,11 @@ func ToPayload(data []byte, contentType string, filename string) DataPayload {
 }
 
 // ToPayloadFromPath creates a DataPayload by reading a file from disk.
-// Auto-detects content type from file extension and computes SHA-256 digest.
+// Implemented by treating the file's directory as an fs.FS and delegating to ToPayloadFromFS.
 func ToPayloadFromPath(path string) (DataPayload, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return DataPayload{}, fmt.Errorf("failed to read file: %w", err)
-	}
-
-	// Auto-detect content type from extension
-	contentType := mime.TypeByExtension(filepath.Ext(path))
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	}
-
-	filename := filepath.Base(path)
-	return ToPayload(data, contentType, filename), nil
+	dir := filepath.Dir(path)
+	name := filepath.Base(path)
+	return ToPayloadFromFS(os.DirFS(dir), name)
 }
 
 // ToPayloadFromFS creates a DataPayload by reading a file from an fs.FS (e.g. embed.FS).

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -41,10 +41,12 @@ package catena
 import (
 	"crypto/sha256"
 	"fmt"
+	"io/fs"
 	"mime"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -98,6 +100,54 @@ func ToPayloadFromPath(path string) (DataPayload, error) {
 
 	filename := filepath.Base(path)
 	return ToPayload(data, contentType, filename), nil
+}
+
+// ToPayloadFromFS creates a DataPayload by reading a file from an fs.FS (e.g. embed.FS).
+func ToPayloadFromFS(fsys fs.FS, path string) (DataPayload, error) {
+	data, err := fs.ReadFile(fsys, path)
+	if err != nil {
+		return DataPayload{}, fmt.Errorf("failed to read file from FS: %w", err)
+	}
+
+	// Use forward slashes for base name in case path is from embed (always /)
+	name := path
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	contentType := mime.TypeByExtension(filepath.Ext(name))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	return ToPayload(data, contentType, name), nil
+}
+
+// LoadPayloadsFromEmbed walks an embedded filesystem from root and returns a map of
+func LoadPayloadsFromEmbed(embedFS fs.FS, root string) (map[string]DataPayload, error) {
+	out := make(map[string]DataPayload)
+	err := fs.WalkDir(embedFS, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		payload, err := ToPayloadFromFS(embedFS, path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			relPath = filepath.Base(path)
+		}
+		assetID := strings.ReplaceAll(relPath, string(filepath.Separator), "/")
+		out[assetID] = payload
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ToPayloadFromURL creates a DataPayload with a URL reference (no embedded data).

--- a/sdks/go/pkg/catena/asset_test.go
+++ b/sdks/go/pkg/catena/asset_test.go
@@ -41,8 +41,11 @@ package catena
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -439,6 +442,46 @@ func TestLoadPayloadsFromEmbed_EmptyRoot(t *testing.T) {
 	}
 	if len(out) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(out))
+	}
+}
+
+// openFailFS wraps an fs.FS and returns an error from Open for a specific path.
+type openFailFS struct {
+	fs.FS
+	failPath string
+}
+
+func (f openFailFS) Open(name string) (fs.File, error) {
+	if name == f.failPath {
+		return nil, errors.New("read forbidden")
+	}
+	return f.FS.Open(name)
+}
+
+func TestLoadPayloadsFromEmbed_WalkDirError(t *testing.T) {
+	// Non-existent root: WalkDir calls the callback with err != nil (covers lines 120 and 138).
+	fsys := fstest.MapFS{"root/a.txt": {Data: []byte("a")}}
+	_, err := LoadPayloadsFromEmbed(fsys, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error when root does not exist")
+	}
+}
+
+func TestLoadPayloadsFromEmbed_ToPayloadFromFSError(t *testing.T) {
+	// FS that lists a file but Open fails for it, so ToPayloadFromFS fails (covers line 127).
+	fsys := openFailFS{
+		FS: fstest.MapFS{
+			"root/ok.txt":  {Data: []byte("ok")},
+			"root/bad.txt": {Data: []byte("bad")},
+		},
+		failPath: "root/bad.txt",
+	}
+	_, err := LoadPayloadsFromEmbed(fsys, "root")
+	if err == nil {
+		t.Fatal("expected error when ToPayloadFromFS fails for a file")
+	}
+	if err.Error() == "" || !strings.Contains(err.Error(), "root/bad.txt") {
+		t.Errorf("expected error to mention path root/bad.txt: %v", err)
 	}
 }
 

--- a/sdks/go/pkg/catena/asset_test.go
+++ b/sdks/go/pkg/catena/asset_test.go
@@ -39,8 +39,12 @@
 package catena
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"testing/fstest"
 )
 
 func TestToCatenaAsset_WithPayload(t *testing.T) {
@@ -299,5 +303,152 @@ func TestDataPayload_Fields(t *testing.T) {
 	}
 	if string(dp.Payload) != "test" {
 		t.Errorf("expected Payload 'test', got %s", dp.Payload)
+	}
+}
+
+func TestToPayload(t *testing.T) {
+	data := []byte("hello world")
+	contentType := "text/plain"
+	filename := "hello.txt"
+
+	dp := ToPayload(data, contentType, filename)
+
+	if dp.PayloadEncoding != 0 {
+		t.Errorf("expected PayloadEncoding 0 (UNCOMPRESSED), got %d", dp.PayloadEncoding)
+	}
+	if string(dp.Payload) != string(data) {
+		t.Errorf("expected Payload %q, got %q", data, dp.Payload)
+	}
+	if dp.Metadata["content-type"] != contentType {
+		t.Errorf("expected content-type %q, got %q", contentType, dp.Metadata["content-type"])
+	}
+	if dp.Metadata["file-name"] != filename {
+		t.Errorf("expected file-name %q, got %q", filename, dp.Metadata["file-name"])
+	}
+	if dp.Metadata["size"] != "11" {
+		t.Errorf("expected size \"11\", got %q", dp.Metadata["size"])
+	}
+	expectedHash := sha256.Sum256(data)
+	if len(dp.Digest) != len(expectedHash) {
+		t.Fatalf("expected digest length %d, got %d", len(expectedHash), len(dp.Digest))
+	}
+	for i := range expectedHash {
+		if dp.Digest[i] != expectedHash[i] {
+			t.Errorf("digest byte %d: expected %x, got %x", i, expectedHash[i], dp.Digest[i])
+		}
+	}
+}
+
+func TestToPayloadFromPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "asset.bin")
+	data := []byte("file contents")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	dp, err := ToPayloadFromPath(path)
+	if err != nil {
+		t.Fatalf("ToPayloadFromPath: %v", err)
+	}
+	if string(dp.Payload) != string(data) {
+		t.Errorf("expected Payload %q, got %q", data, dp.Payload)
+	}
+	if dp.Metadata["file-name"] != "asset.bin" {
+		t.Errorf("expected file-name asset.bin, got %q", dp.Metadata["file-name"])
+	}
+}
+
+func TestToPayloadFromPath_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.txt")
+
+	_, err := ToPayloadFromPath(path)
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestToPayloadFromFS_Success(t *testing.T) {
+	fsys := fstest.MapFS{
+		"dir/file.txt": {Data: []byte("hello")},
+	}
+	dp, err := ToPayloadFromFS(fsys, "dir/file.txt")
+	if err != nil {
+		t.Fatalf("ToPayloadFromFS: %v", err)
+	}
+	if string(dp.Payload) != "hello" {
+		t.Errorf("expected Payload \"hello\", got %q", dp.Payload)
+	}
+	if dp.Metadata["content-type"] != "text/plain; charset=utf-8" {
+		t.Errorf("expected content-type for .txt, got %q", dp.Metadata["content-type"])
+	}
+	if dp.Metadata["file-name"] != "file.txt" {
+		t.Errorf("expected file-name file.txt, got %q", dp.Metadata["file-name"])
+	}
+}
+
+func TestToPayloadFromFS_UnknownExtension(t *testing.T) {
+	fsys := fstest.MapFS{
+		"data.unknown": {Data: []byte("x")},
+	}
+	dp, err := ToPayloadFromFS(fsys, "data.unknown")
+	if err != nil {
+		t.Fatalf("ToPayloadFromFS: %v", err)
+	}
+	if dp.Metadata["content-type"] != "application/octet-stream" {
+		t.Errorf("expected application/octet-stream for unknown ext, got %q", dp.Metadata["content-type"])
+	}
+}
+
+func TestToPayloadFromFS_ReadError(t *testing.T) {
+	fsys := fstest.MapFS{}
+	_, err := ToPayloadFromFS(fsys, "missing.txt")
+	if err == nil {
+		t.Error("expected error when file does not exist")
+	}
+}
+
+func TestLoadPayloadsFromEmbed(t *testing.T) {
+	fsys := fstest.MapFS{
+		"root/a.txt":   {Data: []byte("a")},
+		"root/b/c.txt": {Data: []byte("c")},
+	}
+	out, err := LoadPayloadsFromEmbed(fsys, "root")
+	if err != nil {
+		t.Fatalf("LoadPayloadsFromEmbed: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(out))
+	}
+	if p, ok := out["a.txt"]; !ok || string(p.Payload) != "a" {
+		t.Errorf("expected out[\"a.txt\"] with payload \"a\", got ok=%v payload=%q", ok, out["a.txt"].Payload)
+	}
+	if p, ok := out["b/c.txt"]; !ok || string(p.Payload) != "c" {
+		t.Errorf("expected out[\"b/c.txt\"] with payload \"c\", got ok=%v payload=%q", ok, out["b/c.txt"].Payload)
+	}
+}
+
+func TestLoadPayloadsFromEmbed_EmptyRoot(t *testing.T) {
+	fsys := fstest.MapFS{
+		"f1.txt": {Data: []byte("1")},
+	}
+	out, err := LoadPayloadsFromEmbed(fsys, ".")
+	if err != nil {
+		t.Fatalf("LoadPayloadsFromEmbed: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(out))
+	}
+}
+
+func TestToPayloadFromURL(t *testing.T) {
+	url := "https://example.com/asset.json"
+	dp := ToPayloadFromURL(url)
+	if dp.Url != url {
+		t.Errorf("expected Url %q, got %q", url, dp.Url)
+	}
+	if len(dp.Payload) != 0 {
+		t.Errorf("expected empty Payload, got %d bytes", len(dp.Payload))
 	}
 }


### PR DESCRIPTION
## 📖 Description

Added helper functions to simplify `DataPayload` creation in business logic.

- **`ToPayload(data, contentType, filename)`** — Create from in-memory bytes (SHA-256 digest computed).
- **`ToPayloadFromPath(path)`** — Create from a file path on disk (content type from extension).
- **`ToPayloadFromFS(fsys, path)`** — Create from any `fs.FS` (e.g. `embed.FS`); shared implementation for FS and disk.
- **`ToPayloadFromURL(url)`** — Create from an external URL reference (no embedded data).

`ToPayloadFromPath` is implemented by treating the file’s directory as an `fs.FS` via `os.DirFS(dir)` and delegating to `ToPayloadFromFS`, so disk and embedded assets share one code path.

**`LoadPayloadsFromEmbed(embedFS, root)`** — Walks an embedded FS from `root` and returns a `map[string]DataPayload` keyed by relative path, using `ToPayloadFromFS` for each file.

---

## ✅ Definition of Done (DoD)

- [x] Helper functions for all input types: bytes, path, URL, and `fs.FS`
- [x] `ToPayload` and file-based helpers compute SHA-256 digest
- [x] `ToPayloadFromPath` and `ToPayloadFromFS` auto-detect content type from file extension
- [x] `ToPayloadFromPath` implemented via `os.DirFS` + `ToPayloadFromFS` (no duplicated logic)
- [x] Example (`getAsset_REST.go`) uses `LoadPayloadsFromEmbed` for embedded static assets

---

## 🛠️ Implementation Notes

- **`asset.go`**: Added `ToPayload`, `ToPayloadFromPath`, `ToPayloadFromFS`, `ToPayloadFromURL`, and `LoadPayloadsFromEmbed`. `ToPayloadFromPath` delegates to `ToPayloadFromFS(os.DirFS(filepath.Dir(path)), filepath.Base(path))`.
- **`getAsset_REST.go`**: Loads assets with `catena.LoadPayloadsFromEmbed(staticFS, "static")` and serves them via the GetAsset handler.
- **`asset_test.go`**: Added unit tests for new functions. Coverage is at 97%

---

## 🔗 Related Issues / Links

Closes issue #1213