### PR TITLE
gRPC external object request #1225

### DIFF
--- a/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Ross Video Ltd
+ * Copyright 2026 Ross Video Ltd
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
+++ b/sdks/cpp/connections/gRPC/src/controllers/ExternalObjectRequest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Ross Video Ltd
+ * Copyright 2024 Ross Video Ltd
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -143,6 +143,18 @@ void ExternalObjectRequest::proceed(bool ok) {
                 st2138::ExternalObjectPayload obj;
                 obj.mutable_payload()->set_payload(file_data.data(), file_data.size()); 
                 //obj.mutable_payload()->set_meta(file.);
+
+                //Calculate SHA-256 digest
+                unsigned char digest[EVP_MAX_MD_SIZE];
+                unsigned int digest_len;
+                EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+                EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL);
+                EVP_DigestUpdate(mdctx, file_data.data(), file_data.size());
+                EVP_DigestFinal_ex(mdctx, digest, &digest_len);
+                EVP_MD_CTX_free(mdctx);
+
+                // Set the digest using the digest array
+                obj.mutable_payload()->set_digest(digest, digest_len);
 
                 //For now we are sending the whole file in one go
                 VLOG(1) << "ExternalObjectRequest[" << objectId_ << "] sent";

--- a/unittests/cpp/gRPC/tests/ExternalObjectRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/ExternalObjectRequest_test.cpp
@@ -33,7 +33,7 @@
  * @author nelson.daniels@rossvideo.com
  * @author jason.chen@rossvideo.com
  * @author keon.foster@rossvideo.com
- * @date 22/01/26
+ * @date 2026/02/11
  * @copyright Copyright © 2026 Ross Video Ltd
  */
 

--- a/unittests/cpp/gRPC/tests/ExternalObjectRequest_test.cpp
+++ b/unittests/cpp/gRPC/tests/ExternalObjectRequest_test.cpp
@@ -97,9 +97,13 @@ class gRPCExternalObjectRequestTests : public GRPCTest {
     }
 
     // Adds an expected external object payload to the expected values.
-    void expPayload(const std::string& content) {
+    // digest is the SHA-256 digest of content, base64-encoded.
+    void expPayload(const std::string& content, const std::string& digest) {
         expVals_.push_back(st2138::ExternalObjectPayload());
-        expVals_.back().mutable_payload()->set_payload(content.data(), content.size());
+        auto* objPayload = expVals_.back().mutable_payload();
+        objPayload->set_payload(content.data(), content.size());
+        std::string digestBytes = catena::from_base64(digest);
+        objPayload->set_digest(digestBytes.data(), digestBytes.size());
     }
 
     // Makes an async RPC to the MockServer and waits for responses before comparing output.
@@ -148,6 +152,12 @@ class gRPCExternalObjectRequestTests : public GRPCTest {
 
     // Test file path for external objects
     std::string testEOPath_ = "/tmp/catena_test_eo/";
+
+    // Precomputed SHA-256 digests (base64) for test payloads.
+    std::string digestNormal_ = "IA6PlY/NIwnLzNC76J+Bz2z+AdeqCq8AF+xPZYkmy08=";
+    std::string digestSpecialChars_ = "cqGM/92veCrMRfOrvfp6NlpRdGJzHVO4PSL78rE2vTA=";
+    std::string digestEmpty_ = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
+    std::string digestBinary256_ = "QK/y6dLYki5Hr9RkjmlnSXFYeF+9Hahw5xECZr+USIA=";
     
     // Input/output values
     st2138::ExternalObjectRequestPayload inVal_;
@@ -187,7 +197,7 @@ TEST_F(gRPCExternalObjectRequestTests, ExternalObjectRequest_Normal) {
     
     // Initialize request payload
     initPayload("/test_file.txt");
-    expPayload(testContent);
+    expPayload(testContent, digestNormal_);
     
     // Send the RPC
     testRPC();
@@ -204,7 +214,7 @@ TEST_F(gRPCExternalObjectRequestTests, ExternalObjectRequest_SpecialCharacters) 
     
     // Initialize request payload
     initPayload(specialPath);
-    expPayload(testContent);
+    expPayload(testContent, digestSpecialChars_);
     
     // Send the RPC
     testRPC();
@@ -219,7 +229,7 @@ TEST_F(gRPCExternalObjectRequestTests, ExternalObjectRequest_EmptyFile) {
     
     // Initialize request payload
     initPayload("/empty_file.txt");
-    expPayload("");
+    expPayload("", digestEmpty_);
     
     // Send the RPC
     testRPC();
@@ -238,7 +248,7 @@ TEST_F(gRPCExternalObjectRequestTests, ExternalObjectRequest_BinaryFile) {
     
     // Initialize request payload
     initPayload("/binary_file.bin");
-    expPayload(binaryContent);
+    expPayload(binaryContent, digestBinary256_);
     
     // Send the RPC
     testRPC();
@@ -322,7 +332,7 @@ TEST_F(gRPCExternalObjectRequestTests, ExternalObjectRequest_NullSlotCase) {
     // Initialize request payload
     initPayload("/test_file.txt");
     inVal_.clear_slot();
-    expPayload(testContent);
+    expPayload(testContent, digestNormal_);
     
     // Send the RPC
     testRPC();


### PR DESCRIPTION
<!-- please continue to update this as work is being done to add context, links, scope creep, and any other useful info -->

## 📖 Description
<!-- A clear and concise explanation of what this pull request is about and what it accomplishes. -->
gRPC ExternalObjectRequest now calculates and returns the digest as part of the payload.

---

## ✅ Definition of Done (DoD)
- [x] Feature is implemented and works as expected
- [x] Edge cases are handled
- [x] Tests are added or updated (if applicable)
- [ ] Documentation is updated (if needed)
- [x] Code is reviewed and approved

---

## 🛠️ Implementation Notes
<!-- List of changes made:
- Added file.cpp to src
- Added function to file2.cpp
- Deleted file3.cpp-->
- Modified `ExternalObjectRequest.cpp`
    - Added SHA-256 digest calculation and set in payload
- Modified `ExternalObjectReqest_test.cpp`
    - Added expected digests to payloads in `expVals_`

---

## 🔗 Related Issues / Links
<!-- Links to the relevant issues  -->
[Issue #1225](https://github.com/rossvideo/Catena/issues/1225)

---
## 📝 Additional Context
<!-- (Optional) Any extra information, screenshots, or background. -->
Copied the digest calculation logic from the REST `AssetRequest.cpp`
 
