### PR TITLE
[GO] Datapayload handling for Value

### DIFF
--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -34,7 +34,7 @@
  * @copyright Copyright © 2026 Ross Video Ltd
  * @author Christian Twarog (christian.twarog@rossvideo.com)
  * @author Nelson Daniels (nelson.daniels@rossvideo.com)
- * @date 2026-02-04
+ * @date 2026-03-09
  */
 
 package catena

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -179,25 +179,32 @@ func ToPayloadFromURL(url string) DataPayload {
 	}
 }
 
-// ToCatenaAsset converts DataPayload to CatenaAsset by building the proto directly
-func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, error) {
-	// Build the proto DataPayload directly
-	protoPayload := &protos.DataPayload{
+// dataPayloadToProto converts a DataPayload to its proto representation.
+func dataPayloadToProto(dp DataPayload) (*protos.DataPayload, error) {
+	pdp := &protos.DataPayload{
 		Metadata:        dp.Metadata,
 		Digest:          dp.Digest,
 		PayloadEncoding: protos.DataPayload_PayloadEncoding(dp.PayloadEncoding),
 	}
 
-	// Handle oneof: either url or payload (not both)
 	if dp.Url != "" && len(dp.Payload) == 0 {
-		protoPayload.Kind = &protos.DataPayload_Url{Url: dp.Url}
+		pdp.Kind = &protos.DataPayload_Url{Url: dp.Url}
 	} else if len(dp.Payload) > 0 && dp.Url == "" {
-		protoPayload.Kind = &protos.DataPayload_Payload{Payload: dp.Payload}
+		pdp.Kind = &protos.DataPayload_Payload{Payload: dp.Payload}
 	} else {
-		return CatenaAsset{asset: nil}, fmt.Errorf("either payload or url must be provided in DataPayload, but not both")
+		return nil, fmt.Errorf("either payload or url must be provided in DataPayload, but not both")
 	}
 
-	// Build the ExternalObjectPayload
+	return pdp, nil
+}
+
+// ToCatenaAsset converts DataPayload to CatenaAsset by building the proto directly
+func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, error) {
+	protoPayload, err := dataPayloadToProto(dp)
+	if err != nil {
+		return CatenaAsset{asset: nil}, err
+	}
+
 	asset := &protos.ExternalObjectPayload{
 		Cachable: cachable,
 		Payload:  protoPayload,

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -90,9 +90,20 @@ func ToCatenaValue(v any) (CatenaValue, error) {
 // ToProto converts native Go types to protos.Value
 func ToProto(v any) (*protos.Value, error) {
 	switch val := v.(type) {
-	case *protos.DataPayload:
-		// Pass through DataPayload directly
-		return nil, fmt.Errorf("DataPayload is not supported in ToProto")
+	case DataPayload:
+		pdp := &protos.DataPayload{
+			Metadata:        val.Metadata,
+			Digest:          val.Digest,
+			PayloadEncoding: protos.DataPayload_PayloadEncoding(val.PayloadEncoding),
+		}
+		if val.Url != "" && len(val.Payload) == 0 {
+			pdp.Kind = &protos.DataPayload_Url{Url: val.Url}
+		} else if len(val.Payload) > 0 && val.Url == "" {
+			pdp.Kind = &protos.DataPayload_Payload{Payload: val.Payload}
+		} else {
+			return nil, fmt.Errorf("either payload or url must be provided in DataPayload, but not both")
+		}
+		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}, nil
 	case UndefinedValue:
 		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, nil
 	case EmptyValue:
@@ -169,8 +180,22 @@ func FromProto(pv *protos.Value) (any, error) {
 	}
 	switch pv.GetKind().(type) {
 	case *protos.Value_DataPayload:
-		// Return the raw DataPayload proto
-		return nil, fmt.Errorf("DataPayload is not supported in FromProto")
+		pdp := pv.GetDataPayload()
+		if pdp == nil {
+			return nil, fmt.Errorf("nil DataPayload in Value")
+		}
+		dp := DataPayload{
+			Metadata:        pdp.GetMetadata(),
+			Digest:          pdp.GetDigest(),
+			PayloadEncoding: int32(pdp.GetPayloadEncoding()),
+		}
+		switch k := pdp.GetKind().(type) {
+		case *protos.DataPayload_Url:
+			dp.Url = k.Url
+		case *protos.DataPayload_Payload:
+			dp.Payload = k.Payload
+		}
+		return dp, nil
 	case *protos.Value_UndefinedValue:
 		return UndefinedValue(pv.GetUndefinedValue()), nil
 	case *protos.Value_EmptyValue:

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -187,7 +187,7 @@ func FromProto(pv *protos.Value) (any, error) {
 		dp := DataPayload{
 			Metadata:        pdp.GetMetadata(),
 			Digest:          pdp.GetDigest(),
-			PayloadEncoding: int32(pdp.GetPayloadEncoding()),
+			PayloadEncoding: Encoding(pdp.GetPayloadEncoding()),
 		}
 		switch k := pdp.GetKind().(type) {
 		case *protos.DataPayload_Url:

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -33,7 +33,8 @@
  * @file value.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @author Christian Twarog (christian.twarog@rossvideo.com)
- * @date 2026-02-04
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-09
  */
 
 package catena

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -91,17 +91,9 @@ func ToCatenaValue(v any) (CatenaValue, error) {
 func ToProto(v any) (*protos.Value, error) {
 	switch val := v.(type) {
 	case DataPayload:
-		pdp := &protos.DataPayload{
-			Metadata:        val.Metadata,
-			Digest:          val.Digest,
-			PayloadEncoding: protos.DataPayload_PayloadEncoding(val.PayloadEncoding),
-		}
-		if val.Url != "" && len(val.Payload) == 0 {
-			pdp.Kind = &protos.DataPayload_Url{Url: val.Url}
-		} else if len(val.Payload) > 0 && val.Url == "" {
-			pdp.Kind = &protos.DataPayload_Payload{Payload: val.Payload}
-		} else {
-			return nil, fmt.Errorf("either payload or url must be provided in DataPayload, but not both")
+		pdp, err := dataPayloadToProto(val)
+		if err != nil {
+			return nil, err
 		}
 		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}, nil
 	case UndefinedValue:

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -58,6 +58,8 @@ func TestToCatenaValue(t *testing.T) {
 		{"empty value", EmptyValue{}, false},
 		{"undefined value", UndefinedValue(0), false},
 		{"struct value", map[string]any{"key": int32(1)}, false},
+		{"data payload with payload", DataPayload{Payload: []byte("test")}, false},
+		{"data payload with url", DataPayload{Url: "https://example.com"}, false},
 		{"unsupported type", int64(100), true},
 	}
 
@@ -259,6 +261,188 @@ func TestToProto_StructVariantArray(t *testing.T) {
 	}
 	if list[0].GetStructVariantType() != "TypeA" {
 		t.Errorf("expected first type 'TypeA', got %v", list[0].GetStructVariantType())
+	}
+}
+
+func TestToProto_DataPayload_WithPayload(t *testing.T) {
+	input := DataPayload{
+		Metadata:        map[string]string{"content-type": "image/png"},
+		Digest:          []byte{0xab, 0xcd},
+		PayloadEncoding: 1,
+		Payload:         []byte("binary data"),
+	}
+	pv, err := ToProto(input)
+	if err != nil {
+		t.Fatalf("ToProto(DataPayload) error: %v", err)
+	}
+	dp := pv.GetDataPayload()
+	if dp == nil {
+		t.Fatal("expected DataPayload kind")
+	}
+	if dp.GetMetadata()["content-type"] != "image/png" {
+		t.Errorf("expected content-type 'image/png', got %v", dp.GetMetadata()["content-type"])
+	}
+	if string(dp.GetPayload()) != "binary data" {
+		t.Errorf("expected payload 'binary data', got %v", string(dp.GetPayload()))
+	}
+	if dp.GetPayloadEncoding() != 1 {
+		t.Errorf("expected encoding 1 (GZIP), got %v", dp.GetPayloadEncoding())
+	}
+}
+
+func TestToProto_DataPayload_WithUrl(t *testing.T) {
+	input := DataPayload{
+		Metadata: map[string]string{"content-type": "application/json"},
+		Url:      "https://example.com/data.json",
+	}
+	pv, err := ToProto(input)
+	if err != nil {
+		t.Fatalf("ToProto(DataPayload) error: %v", err)
+	}
+	dp := pv.GetDataPayload()
+	if dp == nil {
+		t.Fatal("expected DataPayload kind")
+	}
+	if dp.GetUrl() != "https://example.com/data.json" {
+		t.Errorf("expected URL, got %v", dp.GetUrl())
+	}
+}
+
+func TestToProto_DataPayload_BothPayloadAndUrl_Error(t *testing.T) {
+	input := DataPayload{
+		Payload: []byte("data"),
+		Url:     "https://example.com",
+	}
+	_, err := ToProto(input)
+	if err == nil {
+		t.Error("expected error when both payload and url are provided")
+	}
+}
+
+func TestToProto_DataPayload_NeitherPayloadNorUrl_Error(t *testing.T) {
+	input := DataPayload{
+		Metadata: map[string]string{"content-type": "text/plain"},
+	}
+	_, err := ToProto(input)
+	if err == nil {
+		t.Error("expected error when neither payload nor url are provided")
+	}
+}
+
+func TestFromProto_DataPayload_WithPayload(t *testing.T) {
+	input := DataPayload{
+		Metadata:        map[string]string{"content-type": "image/png"},
+		Digest:          []byte{0xab, 0xcd},
+		PayloadEncoding: 1,
+		Payload:         []byte("binary data"),
+	}
+	pv, err := ToProto(input)
+	if err != nil {
+		t.Fatalf("ToProto error: %v", err)
+	}
+	result, err := FromProto(pv)
+	if err != nil {
+		t.Fatalf("FromProto error: %v", err)
+	}
+	dp, ok := result.(DataPayload)
+	if !ok {
+		t.Fatalf("expected DataPayload, got %T", result)
+	}
+	if dp.Metadata["content-type"] != "image/png" {
+		t.Errorf("expected content-type 'image/png', got %v", dp.Metadata["content-type"])
+	}
+	if string(dp.Payload) != "binary data" {
+		t.Errorf("expected payload 'binary data', got %q", dp.Payload)
+	}
+	if dp.PayloadEncoding != 1 {
+		t.Errorf("expected encoding 1, got %d", dp.PayloadEncoding)
+	}
+	if !reflect.DeepEqual(dp.Digest, []byte{0xab, 0xcd}) {
+		t.Errorf("expected digest [ab cd], got %v", dp.Digest)
+	}
+}
+
+func TestFromProto_DataPayload_WithUrl(t *testing.T) {
+	input := DataPayload{
+		Url: "https://example.com/resource",
+	}
+	pv, err := ToProto(input)
+	if err != nil {
+		t.Fatalf("ToProto error: %v", err)
+	}
+	result, err := FromProto(pv)
+	if err != nil {
+		t.Fatalf("FromProto error: %v", err)
+	}
+	dp, ok := result.(DataPayload)
+	if !ok {
+		t.Fatalf("expected DataPayload, got %T", result)
+	}
+	if dp.Url != "https://example.com/resource" {
+		t.Errorf("expected URL, got %v", dp.Url)
+	}
+}
+
+func TestRoundTrip_DataPayload(t *testing.T) {
+	tests := []struct {
+		name  string
+		input DataPayload
+	}{
+		{
+			"with payload",
+			DataPayload{
+				Metadata:        map[string]string{"content-type": "application/octet-stream", "file-name": "test.bin"},
+				Digest:          []byte{0x01, 0x02, 0x03},
+				PayloadEncoding: 0,
+				Payload:         []byte("round trip data"),
+			},
+		},
+		{
+			"with url",
+			DataPayload{
+				Metadata: map[string]string{"content-type": "text/html"},
+				Url:      "https://example.com/page.html",
+			},
+		},
+		{
+			"with gzip encoding",
+			DataPayload{
+				PayloadEncoding: 1,
+				Payload:         []byte("compressed"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pv, err := ToProto(tt.input)
+			if err != nil {
+				t.Fatalf("ToProto error: %v", err)
+			}
+			result, err := FromProto(pv)
+			if err != nil {
+				t.Fatalf("FromProto error: %v", err)
+			}
+			dp, ok := result.(DataPayload)
+			if !ok {
+				t.Fatalf("expected DataPayload, got %T", result)
+			}
+			if !reflect.DeepEqual(dp.Metadata, tt.input.Metadata) {
+				t.Errorf("metadata mismatch: got %v, want %v", dp.Metadata, tt.input.Metadata)
+			}
+			if !reflect.DeepEqual(dp.Digest, tt.input.Digest) {
+				t.Errorf("digest mismatch: got %v, want %v", dp.Digest, tt.input.Digest)
+			}
+			if dp.PayloadEncoding != tt.input.PayloadEncoding {
+				t.Errorf("encoding mismatch: got %d, want %d", dp.PayloadEncoding, tt.input.PayloadEncoding)
+			}
+			if !reflect.DeepEqual(dp.Payload, tt.input.Payload) {
+				t.Errorf("payload mismatch: got %v, want %v", dp.Payload, tt.input.Payload)
+			}
+			if dp.Url != tt.input.Url {
+				t.Errorf("url mismatch: got %v, want %v", dp.Url, tt.input.Url)
+			}
+		})
 	}
 }
 

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -33,7 +33,8 @@
  * @file value_test.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @author Christian Twarog (christian.twarog@rossvideo.com)
- * @date 2026-02-04
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-09
  */
 
 package catena

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -41,6 +41,8 @@ package catena
 import (
 	"reflect"
 	"testing"
+
+	"github.com/rossvideo/catena/build/go/protos"
 )
 
 func TestToCatenaValue(t *testing.T) {
@@ -667,6 +669,128 @@ func TestRoundTrip(t *testing.T) {
 				t.Errorf("round trip failed: input=%v, result=%v", tt.input, result)
 			}
 		})
+	}
+}
+
+func TestFromProto_UndefinedValue(t *testing.T) {
+	pv, err := ToProto(UndefinedValue(42))
+	if err != nil {
+		t.Fatalf("ToProto(UndefinedValue) error: %v", err)
+	}
+	result, err := FromProto(pv)
+	if err != nil {
+		t.Fatalf("FromProto error: %v", err)
+	}
+	uv, ok := result.(UndefinedValue)
+	if !ok {
+		t.Fatalf("expected UndefinedValue, got %T", result)
+	}
+	if uv != UndefinedValue(42) {
+		t.Errorf("expected UndefinedValue(42), got %v", uv)
+	}
+}
+
+func TestFromProto_NilDataPayload(t *testing.T) {
+	pv := &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: nil}}
+	_, err := FromProto(pv)
+	if err == nil {
+		t.Error("FromProto with nil DataPayload expected error")
+	}
+}
+
+func TestFromProto_UnsupportedKind(t *testing.T) {
+	pv := &protos.Value{}
+	_, err := FromProto(pv)
+	if err == nil {
+		t.Error("FromProto with nil Kind expected error")
+	}
+}
+
+func TestFromProto_StructFieldError(t *testing.T) {
+	pv := &protos.Value{Kind: &protos.Value_StructValue{StructValue: &protos.StructValue{
+		Fields: map[string]*protos.Value{
+			"bad": nil,
+		},
+	}}}
+	_, err := FromProto(pv)
+	if err == nil {
+		t.Error("FromProto with nil struct field value expected error")
+	}
+}
+
+func TestFromProto_StructArrayFieldError(t *testing.T) {
+	pv := &protos.Value{Kind: &protos.Value_StructArrayValues{StructArrayValues: &protos.StructList{
+		StructValues: []*protos.StructValue{
+			{Fields: map[string]*protos.Value{"bad": nil}},
+		},
+	}}}
+	_, err := FromProto(pv)
+	if err == nil {
+		t.Error("FromProto with nil struct array field value expected error")
+	}
+}
+
+func TestFromProto_StructVariantValueError(t *testing.T) {
+	pv := &protos.Value{Kind: &protos.Value_StructVariantValue{StructVariantValue: &protos.StructVariantValue{
+		StructVariantType: "bad",
+		Value:             nil,
+	}}}
+	_, err := FromProto(pv)
+	if err == nil {
+		t.Error("FromProto with nil struct variant value expected error")
+	}
+}
+
+func TestFromProto_StructVariantArrayError(t *testing.T) {
+	pv := &protos.Value{Kind: &protos.Value_StructVariantArrayValues{StructVariantArrayValues: &protos.StructVariantList{
+		StructVariants: []*protos.StructVariantValue{
+			{StructVariantType: "bad", Value: nil},
+		},
+	}}}
+	_, err := FromProto(pv)
+	if err == nil {
+		t.Error("FromProto with nil struct variant array value expected error")
+	}
+}
+
+func TestToProto_StructFieldError(t *testing.T) {
+	input := map[string]any{
+		"bad": int64(1),
+	}
+	_, err := ToProto(input)
+	if err == nil {
+		t.Error("ToProto with unsupported struct field type expected error")
+	}
+}
+
+func TestToProto_StructArrayFieldError(t *testing.T) {
+	input := []map[string]any{
+		{"bad": int64(1)},
+	}
+	_, err := ToProto(input)
+	if err == nil {
+		t.Error("ToProto with unsupported struct array field type expected error")
+	}
+}
+
+func TestToProto_StructVariantValueError(t *testing.T) {
+	input := StructVariantValue{
+		StructVariantType: "bad",
+		Value:             int64(1),
+	}
+	_, err := ToProto(input)
+	if err == nil {
+		t.Error("ToProto with unsupported struct variant value type expected error")
+	}
+}
+
+func TestToProto_StructVariantArrayError(t *testing.T) {
+	input := []StructVariantValue{
+		{StructVariantType: "bad", Value: int64(1)},
+	}
+	_, err := ToProto(input)
+	if err == nil {
+		t.Error("ToProto with unsupported struct variant array value type expected error")
 	}
 }
 


### PR DESCRIPTION
## 📖 Description
`DataPayload` is a valid value type in the proto `Value` oneof, but `ToProto` and `FromProto` in `value.go` did not handle it — both cases returned hardcoded errors. This PR implements the conversions so that `DataPayload` can be used as a first-class value type through the SDK's value layer.

---

## ✅ Definition of Done (DoD)

- [x] `ToProto` converts `DataPayload` → `protos.Value` with `Value_DataPayload` kind
- [x] `FromProto` converts `Value_DataPayload` → `DataPayload`
- [x] Edge cases are handled (both payload and url set, neither set, nil proto)
- [x] Tests are added for `ToProto`, `FromProto`, and round-trip with `DataPayload`
- [x] `DataPayload` → `protos.DataPayload` conversion logic is shared between `ToProto` and `ToCatenaAsset` via a common helper

---

## 🛠️ Implementation Notes

- Updated `ToProto` in `value.go` to handle the `DataPayload` case by building `protos.DataPayload` and wrapping it in `Value_DataPayload`
- Updated `FromProto` in `value.go` to handle the `Value_DataPayload` case by extracting fields from the proto back into a `DataPayload` struct
- Extracted `dataPayloadToProto` helper in `asset.go` to deduplicate the `DataPayload` → `protos.DataPayload` conversion that was identical in both `ToProto` and `ToCatenaAsset`. Both functions now delegate to this single helper.
- Added tests covering new features to `value_test.go`:
- Added `DataPayload` entries to the existing `TestToCatenaValue` table test

---

## 🔗 Related Issues / Links

Closes issue #1217
