### PR TITLE
[CPP] REST Version of Simple Audiodeck

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -375,7 +375,8 @@
         "use_menus_REST",
         "structs_with_authz_REST",
         "one_of_everything_REST",
-        "structs_with_authz_JSON_REST"
+        "structs_with_authz_JSON_REST",
+        "simple_audiodeck_JSON_REST"
       ],
       "default": "status_update_REST"
     }

--- a/sdks/cpp/connections/REST/examples/CMakeLists.txt
+++ b/sdks/cpp/connections/REST/examples/CMakeLists.txt
@@ -37,6 +37,7 @@ else()
     add_subdirectory("status_update_JSON_REST")
     add_subdirectory("use_commands_REST")
     add_subdirectory("use_menus_REST")
+    add_subdirectory("simple_audiodeck_JSON_REST")
 
 endif()
 

--- a/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/CMakeLists.txt
+++ b/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/CMakeLists.txt
@@ -1,0 +1,64 @@
+#
+# Copyright 2026 Ross Video Ltd
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+cmake_minimum_required(VERSION 3.20)
+
+get_filename_component(TARGET ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+project(${TARGET} C CXX)
+
+add_executable(${TARGET})
+
+include (${CATENA_CPP_ROOT_DIR}/CatenaCodegen.cmake)
+
+generate_catena_device(
+    DEVICE_MODEL_JSON ${CMAKE_CURRENT_SOURCE_DIR}/device.simple_audiodeck.json
+    TARGET ${TARGET}
+)
+
+target_include_directories(${TARGET}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CATENA_CPP_ROOT_DIR}/common/include
+)
+
+target_sources(${TARGET}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${TARGET}.cpp>  
+)
+
+target_link_libraries(${TARGET}
+    catena_connections_REST
+    absl::flags_parse
+)
+
+target_compile_features(${TARGET}
+    PUBLIC
+        cxx_std_20
+)

--- a/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/device.simple_audiodeck.json
+++ b/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/device.simple_audiodeck.json
@@ -1,0 +1,205 @@
+{
+    "slot": 0,
+    "multi_set_enabled": true,
+    "detail_level": "FULL",
+    "access_scopes": ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"],
+    "subscriptions": true,
+    "default_scope": "st2138:mon",
+    "language_packs": {},
+    "params": {
+      "dashboard_UI": {
+        "type": "STRING",
+        "oid_aliases": ["0xFF0E"],
+        "read_only": true,
+        "value": { "string_value": "eo://AudioDeck.grid" }
+      },
+      "dashboard_icon": {
+        "type": "STRING",
+        "oid_aliases": ["0xFF0C"],
+        "read_only": true,
+        "value": { "string_value": "eo://catena_logo.png" }
+      },
+      "audio_deck": {
+        "type": "STRUCT_ARRAY",
+        "name": { "display_strings": { "en": "Audio Deck" } },
+        "params": {
+          "gain": { "name": { "display_strings": { "ai": "Preamp gain in dB (-10.0 to 10.0). Adjust to match source level." } }, "type": "FLOAT32", "precision": 1, "constraint": { "type": "FLOAT_RANGE", "float32_range": { "min_value": -10.0, "max_value": 10.0, "display_min": -10.0, "display_max": 10.0, "step": 0.1 } } },
+          "input": { "name": { "display_strings": { "ai": "Realtime input level meter in dB (stateless). Agents read only." } }, "type": "FLOAT32", "precision": 2, "stateless": true, "constraint": { "type": "FLOAT_RANGE", "float32_range": { "min_value": -10.0, "max_value": 10.0, "display_min": -10.0, "display_max": 10.0, "step": 0.01 } } },
+          "inputLabel": { "name": { "display_strings": { "ai": "Editable input label shown to operators. Provide a human-friendly source name." } }, "type": "STRING" },
+          "invert": { "name": { "display_strings": { "ai": "Polarity toggle. 'Inverted' = flipped polarity; 'Invert' = normal." } }, "type": "STRING", "widget": "toggle", "constraint": { "type": "STRING_CHOICE", "string_choice": { "choices": ["Inverted","Invert"] } } },
+          "roll_off": { "name": { "display_strings": { "ai": "Filter slope in dB/oct. Typical 6-24; higher = steeper." } }, "type": "FLOAT32", "precision": 1, "constraint": { "type": "FLOAT_RANGE", "float32_range": { "min_value": -30.0, "max_value": 30.0, "display_min": -30.0, "display_max": 30.0, "step": 1.0 } } },
+          "frequency": { "name": { "display_strings": { "ai": "Filter cutoff/center frequency in Hz (0-500)." } }, "type": "FLOAT32", "precision": 0, "constraint": { "type": "FLOAT_RANGE", "float32_range": { "min_value": 0.0, "max_value": 500.0, "display_min": 0.0, "display_max": 500.0, "step": 1.0 } } },
+          "ripple": { "name": { "display_strings": { "ai": "Chebyshev ripple in dB. Small positive values (e.g., 0-3 dB) typical." } }, "type": "FLOAT32", "precision": 1, "constraint": { "type": "FLOAT_RANGE", "float32_range": { "min_value": -30.0, "max_value": 30.0, "display_min": -30.0, "display_max": 30.0, "step": 1.0 } } },
+          "resp": { "name": { "display_strings": { "ai": "Filter response type. Choose Butterworth, Cheb II, or Legendre." } }, "type": "STRING", "constraint": { "type": "STRING_CHOICE", "string_choice": { "choices": ["Butterworth", "Cheb II", "Legendre"] } } },
+          "volume": { "name": { "display_strings": { "ai": "Output volume level in percent (0-100%)." } }, "type": "FLOAT32", "constraint": { "type": "FLOAT_RANGE", "float32_range": { "min_value": 0.0, "max_value": 100.0, "display_min": 0.0, "display_max": 100.0, "step": 1.0 } } },
+          "pan": { "name": { "display_strings": { "ai": "Stereo pan position (-100 = left, 0 = center, 100 = right)." } }, "type": "INT32", "constraint": { "type": "INT_RANGE", "int32_range": { "min_value": -100, "max_value": 100, "display_min": -100, "display_max": 100, "step": 1 } } }
+        },
+        "value": {
+          "struct_array_values": {
+            "struct_values": [
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 1" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 2" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 3" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 4" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 5" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 6" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 7" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                    "pan": { "int32_value": 0 }
+                }
+              },
+              {
+                "fields": {
+                  "gain": { "float32_value": 0.0 },
+                  "input": { "float32_value": 0.0 },
+                  "inputLabel": { "string_value": "Channel 8" },
+                  "invert": { "string_value": "Invert" },
+                  "roll_off": { "float32_value": 24.0 },
+                  "frequency": { "float32_value": 85.0 },
+                  "ripple": { "float32_value": 3.0 },
+                  "resp": { "string_value": "Cheb II" },
+                  "volume": { "float32_value": 50.0 },
+                  "pan": { "int32_value": 0 }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "product": {
+        "type": "STRUCT",
+        "read_only": true,
+        "value": {
+          "struct_value": {
+            "fields": {
+              "name": { "string_value": "Audio Deck" },
+              "vendor": { "string_value": "Ross Video" },
+              "version": { "string_value": "1.0.0" },
+              "catena_sdk": { "string_value": "https://github.com/rossvideo/Catena.git" },
+              "serial_number": { "string_value": "SN-7K9M-2024-XR485-BLU" }
+            }
+          }
+        },
+        "params": {
+          "name": {
+            "type": "STRING"
+          },
+          "vendor": {
+            "type": "STRING"
+          },
+          "version": {
+            "type": "STRING"
+          },
+          "catena_sdk": {
+            "type": "STRING"
+          },
+          "catena_sdk_version": {
+            "type": "STRING"
+          },
+          "serial_number": {
+            "type": "STRING"
+          }
+        }
+      }
+    },
+    "commands": {
+      "add_channel": {
+        "name": {"display_strings": {
+          "en": "Add Channel",
+          "fr": "Ajouter un canal",
+          "es": "Agregar canal",
+          "ja": "チャンネルを追加"
+        }},
+        "type": "STRING",
+        "widget": "button",
+        "response": false
+      }
+    }
+  }

--- a/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/simple_audiodeck_JSON_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/simple_audiodeck_JSON_REST.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Example program to demonstrate setting up a full Catena service using REST api.
+ * @file simple_audiodeck_JSON_REST.cpp
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-11
+ */
+
+// device model
+#include "device.simple_audiodeck.json.h" 
+
+//common
+#include <utils.h>
+#include <Device.h>
+#include <ParamWithValue.h>
+#include <ParamDescriptor.h>
+#include <Config.h>
+#include <ConnectionProps.h>
+
+// REST
+#include <ServiceImpl.h>
+
+#include "absl/strings/str_format.h"
+
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <signal.h>
+#include <functional>
+#include <Logger.h>
+
+using namespace catena::common;
+using catena::REST::ServiceConfig;
+using catena::REST::ServiceImpl;
+
+ServiceImpl *globalApi = nullptr;
+std::atomic<bool> globalLoop = true;
+
+// handle SIGINT
+void handle_signal(int sig) {
+    std::thread t([sig]() {
+        LOG(INFO) << "Caught signal " << sig << ", shutting down";
+        globalLoop = false;
+        if (globalApi != nullptr) {
+            globalApi->Shutdown();
+            globalApi = nullptr;
+        }
+    });
+    t.join();
+}
+
+void audioDeckUpdateHandler(const std::string& jptr, const IParam* p) {
+    Path oid(jptr);
+    if (oid.empty()) {
+        LOG(INFO) << "*** Whole struct array was updated";
+    } else {
+        std::size_t index = oid.front_as_index();
+        if (index == Path::kEnd) {
+            LOG(INFO) << "*** Index is \"-\", new element added to struct array";
+        } else {
+            LOG(INFO) << "*** audio_deck[" << index << "] was updated";
+        }
+    }
+}
+
+void inputMeters() {
+    while (globalLoop) {
+        for (size_t ch = 0; ch < 8; ++ch) {
+            try {
+                st2138::Value value;
+                std::string inputOid = absl::StrFormat("/audio_deck/%d/input", ch);
+                std::string gainOid = absl::StrFormat("/audio_deck/%d/gain", ch);
+
+                dm.getValue(gainOid, value);
+                float level = value.float32_value() + (static_cast<float>(rand() % 100) - 50) / 50.0f;
+
+                value.set_float32_value(level);
+                dm.setValue(inputOid, value);
+            } catch (const std::exception& e) {
+                LOG(ERROR) << "Error updating input meter for channel " << ch << ": " << e.what();
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}
+
+void defineCommands() {
+    catena::exception_with_status err{"", catena::StatusCode::OK};
+
+    std::unique_ptr<IParam> addChannel = dm.getCommand("/add_channel", err);
+    assert(addChannel != nullptr);
+
+    addChannel->defineCommand([](const st2138::Value& value, const bool respond) -> std::unique_ptr<IParamDescriptor::ICommandResponder> { 
+        return std::make_unique<ParamDescriptor::CommandResponder>([](const st2138::Value& value, const bool respond) -> ParamDescriptor::CommandResponder {
+            catena::exception_with_status err{"", catena::StatusCode::OK};
+            st2138::CommandResponse response;
+            
+            std::string inputName = value.string_value();
+            
+            if (inputName.empty()) {
+                response.mutable_exception()->set_type("Invalid Command");
+                response.mutable_exception()->set_details("Input name cannot be empty");
+            } else {
+                LOG(INFO) << "Add Channel command called with input name: " << inputName;
+                response.mutable_no_response();
+            }
+            
+            co_return response;
+        }(value, respond));
+    });
+}
+
+void RunRESTServer() {
+    // install signal handlers
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+    signal(SIGKILL, handle_signal);
+
+    try {
+        ServiceConfig config = ServiceConfig().add_dm(&dm);
+        
+        ServiceImpl api(config);
+        globalApi = &api;
+        LOG(INFO) << "API Version: " << api.version();
+        LOG(INFO) << "REST on 0.0.0.0:" << config.port;
+
+        std::map<std::string, std::function<void(const std::string&, const IParam*)>> handlers;
+        handlers["audio_deck"] = audioDeckUpdateHandler;
+
+        dm.getValueSetByClient().connect([&handlers](const std::string& oid, const IParam* p) {
+            if (std::regex_match(oid, std::regex(R"(^/audio_deck/\d+/input$)"))) {
+                return;
+            }
+            LOG(INFO) << "signal received: " << oid << " has been changed by client";
+
+            Path jptr(oid);
+            std::string front = jptr.front_as_string();
+            jptr.pop();
+
+            if (handlers.contains(front)) {
+                handlers[front](jptr.toString(true), p);
+            }
+        });
+
+        std::thread businessLogicThread(inputMeters);
+
+        dm.setHeartbeatParam("/product/version");
+        dm.startHeartbeat();
+        api.run();
+        dm.stopHeartbeat();
+
+        businessLogicThread.join();
+
+    } catch (std::exception &why) {
+        LOG(ERROR) << "Problem: " << why.what();
+    }
+}
+
+int main(int argc, char* argv[]) {
+    const auto [exit, code] = config::initConfigVariables(argc, argv);
+    if (exit) {
+        return code;
+    }
+    Logger::init("simple_audiodeck_JSON_REST");
+
+    defineCommands();
+
+    catena::common::ConnectionProps connectionProps(
+        ConnectionProtocol::ST2138_REST,
+        30000,
+        "simple_audiodeck_JSON_REST",
+        "simple_audiodeck_JSON_REST-a4:bb:6d:6a:6f:a3",
+        "/connect/connection-props.xml"
+    );
+
+    if (!connectionProps.start()) {
+        LOG(WARNING) << "Failed to start connection props server on port " << config::dashboard_port;
+    }
+
+    std::thread catenaRestThread(RunRESTServer);
+    catenaRestThread.join();
+    
+    return 0;
+}

--- a/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/simple_audiodeck_JSON_REST.cpp
+++ b/sdks/cpp/connections/REST/examples/simple_audiodeck_JSON_REST/simple_audiodeck_JSON_REST.cpp
@@ -163,7 +163,8 @@ void RunRESTServer() {
         handlers["audio_deck"] = audioDeckUpdateHandler;
 
         dm.getValueSetByClient().connect([&handlers](const std::string& oid, const IParam* p) {
-            if (std::regex_match(oid, std::regex(R"(^/audio_deck/\d+/input$)"))) {
+            static const std::regex inputMeterPattern(R"(^/audio_deck/\d+/input$)");
+            if (std::regex_match(oid, inputMeterPattern)) {
                 return;
             }
             LOG(INFO) << "signal received: " << oid << " has been changed by client";
@@ -179,10 +180,16 @@ void RunRESTServer() {
 
         std::thread businessLogicThread(inputMeters);
 
-        dm.setHeartbeatParam("/product/version");
-        dm.startHeartbeat();
-        api.run();
-        dm.stopHeartbeat();
+        try {
+            dm.setHeartbeatParam("/product/version");
+            dm.startHeartbeat();
+            api.run();
+            dm.stopHeartbeat();
+        } catch (...) {
+            globalLoop = false;
+            businessLogicThread.join();
+            throw;
+        }
 
         businessLogicThread.join();
 


### PR DESCRIPTION
## 📖 Description

REST version of GRPC Simple Dashboard Audiodeck example

---

## ✅ Definition of Done (DoD)

- [x] Create new example
- [x] Code builds
- [x] Tested with Postman

---

## 🛠️ Implementation Notes

REST service implementation ported from the gRPC `simple_dashboard_audiodeck` example, including input meter simulation, `audio_deck` update handler, and `add_channel` command definition

- Added `simple_audiodeck_JSON_REST.cpp` 
- Added `device.simple_audiodeck.json`
- Added `CMakeLists.txt` 

---

## 🔗 Related Issues / Links
<!-- Links to the relevant issues  -->
