### PR TITLE
[GO] Command Fix

### DIFF
--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -56,8 +56,8 @@ import (
 //go:embed static/*
 var staticFS embed.FS
 
-// CommandHandler processes a command and returns a response
-type CommandHandler func(payload any) (catena.CatenaValue, catena.StatusResult)
+// CommandHandler processes a command and returns a CommandResult
+type CommandHandler func(payload any) (catena.CommandResult, catena.StatusResult)
 
 // Global state for graceful shutdown
 var (
@@ -174,45 +174,45 @@ func main() {
 	// ==========================================================================
 	commands := map[string]CommandHandler{
 		// Start command
-		"start": func(payload any) (catena.CatenaValue, catena.StatusResult) {
+		"start": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			if counter.IsRunning() {
 				logger.Info("Start command - already running")
 				val, _ := catena.ToCatenaValue(buildResponse())
-				return catena.Reply(val)
+				return catena.CommandReply(val)
 			}
 			counter.Start()
 			logger.Info("Counter started", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.Reply(val)
+			return catena.CommandReply(val)
 		},
 
 		// Stop command
-		"stop": func(payload any) (catena.CatenaValue, catena.StatusResult) {
+		"stop": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			if !counter.IsRunning() {
 				logger.Info("Stop command - already stopped")
 				val, _ := catena.ToCatenaValue(buildResponse())
-				return catena.Reply(val)
+				return catena.CommandReply(val)
 			}
 			counter.Stop()
 			logger.Info("Counter stopped", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.Reply(val)
+			return catena.CommandReply(val)
 		},
 
 		// Add10 command
-		"add10": func(payload any) (catena.CatenaValue, catena.StatusResult) {
+		"add10": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			counter.Add(10)
 			logger.Info("Added 10 to counter", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.Reply(val)
+			return catena.CommandReply(val)
 		},
 
 		// Reset command
-		"reset": func(payload any) (catena.CatenaValue, catena.StatusResult) {
+		"reset": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			counter.Reset()
 			logger.Info("Counter reset", "value", counter.GetValue())
 			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.Reply(val)
+			return catena.CommandReply(val)
 		},
 	}
 
@@ -232,20 +232,17 @@ func main() {
 	})
 
 	// Register ExecuteCommand handler
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid)
 
 		handler, ok := commands[commandFqoid]
 		if !ok {
 			logger.Warning("Command not found", "slot", slot, "command", commandFqoid)
-			exception := map[string]any{
-				"exception": map[string]any{
-					"type":    "Invalid Command",
-					"details": "Command not found: " + commandFqoid,
-				},
-			}
-			val, _ := catena.ToCatenaValue(exception)
-			return catena.Reply(val)
+			return catena.CommandExceptionResult(
+				"InvalidCommand",
+				"Command not found: "+commandFqoid,
+				map[string]string{"en": "Command not found: " + commandFqoid},
+			)
 		}
 
 		return handler(payload)

--- a/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
+++ b/sdks/go/examples/executeCommand_REST/executeCommand_REST.go
@@ -173,7 +173,7 @@ func main() {
 	// Commands
 	// ==========================================================================
 	commands := map[string]CommandHandler{
-		// Start command
+		// Start command - returns a response with current state
 		"start": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			if counter.IsRunning() {
 				logger.Info("Start command - already running")
@@ -186,7 +186,7 @@ func main() {
 			return catena.CommandReply(val)
 		},
 
-		// Stop command
+		// Stop command - returns a response with current state
 		"stop": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			if !counter.IsRunning() {
 				logger.Info("Stop command - already stopped")
@@ -199,7 +199,7 @@ func main() {
 			return catena.CommandReply(val)
 		},
 
-		// Add10 command
+		// Add10 command - returns a response with current state
 		"add10": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			counter.Add(10)
 			logger.Info("Added 10 to counter", "value", counter.GetValue())
@@ -207,12 +207,21 @@ func main() {
 			return catena.CommandReply(val)
 		},
 
-		// Reset command
+		// Reset command - returns no response
 		"reset": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			counter.Reset()
-			logger.Info("Counter reset", "value", counter.GetValue())
-			val, _ := catena.ToCatenaValue(buildResponse())
-			return catena.CommandReply(val)
+			logger.Info("Counter reset")
+			return catena.CommandNoResponse()
+		},
+
+		// Error command - returns a command exception
+		"error": func(payload any) (catena.CommandResult, catena.StatusResult) {
+			logger.Info("Error command executed")
+			return catena.CommandExceptionResult(
+				"DemoError",
+				"This is a demonstration of a command exception",
+				catena.NewPolyglotText("en", "An example error occurred"),
+			)
 		},
 	}
 
@@ -238,11 +247,7 @@ func main() {
 		handler, ok := commands[commandFqoid]
 		if !ok {
 			logger.Warning("Command not found", "slot", slot, "command", commandFqoid)
-			return catena.CommandExceptionResult(
-				"InvalidCommand",
-				"Command not found: "+commandFqoid,
-				map[string]string{"en": "Command not found: " + commandFqoid},
-			)
+			return catena.CommandError(catena.NOT_FOUND, "Command not found: "+commandFqoid)
 		}
 
 		return handler(payload)

--- a/sdks/go/examples/getSetValue_GRPC/getSetValue_GRPC.go
+++ b/sdks/go/examples/getSetValue_GRPC/getSetValue_GRPC.go
@@ -121,12 +121,10 @@ func main() {
 	})
 
 	// Register ExecuteCommand handler
-	server.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	server.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		logger.Info("Command executed", "command", commandFqoid, "payload", payload)
-
-		// Return a simple response
-		response, _ := catena.ToProto("Command executed successfully")
-		return catena.CatenaValue{Value: response}, catena.StatusWithCode(catena.OK, "")
+		val, _ := catena.ToCatenaValue("Command executed successfully")
+		return catena.CommandReply(val)
 	})
 
 	logger.Info("Starting gRPC server", "port", port)

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -204,20 +204,13 @@ func main() {
 	// Register command handlers for each slot
 	for _, slot := range slotList {
 		slot := slot // capture loop variable
-		srv.RegisterExecuteCommandHandler(slot, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+		srv.RegisterExecuteCommandHandler(slot, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 			logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid, "payload", payload)
-			// Return schema-compliant command_response format
-			// Options: {response: value}, {no_response: {}}, or {exception: {...}}
-			response := map[string]any{
-				"response": map[string]any{
-					"string_value": "Command " + commandFqoid + " executed successfully",
-				},
-			}
-			catenaVal, err := catena.ToCatenaValue(response)
+			catenaVal, err := catena.ToCatenaValue("Command " + commandFqoid + " executed successfully")
 			if err != nil {
-				return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to create command response")
+				return catena.CommandError(catena.INTERNAL, "failed to create command response")
 			}
-			return catena.Reply(catenaVal)
+			return catena.CommandReply(catenaVal)
 		})
 	}
 

--- a/sdks/go/pkg/catena/command.go
+++ b/sdks/go/pkg/catena/command.go
@@ -42,90 +42,90 @@ import (
 	"github.com/rossvideo/catena/build/go/protos"
 )
 
-type commandResultKind int
+// PolyglotText maps BCP-47 language codes to display strings.
+type PolyglotText map[string]string
 
-const (
-	commandResultEmpty commandResultKind = iota
-	commandResultValue
-	commandResultException
-)
-
-// CommandException represents a server/device error executing a command,
-// matching the proto Exception message.
-type CommandException struct {
-	Type         string
-	ErrorMessage map[string]string // language code -> display string
-	Details      string
+// NewPolyglotText creates a PolyglotText with a single language entry.
+func NewPolyglotText(lang, text string) PolyglotText {
+	return PolyglotText{lang: text}
 }
 
-// CommandResult represents the three possible outcomes of ExecuteCommand,
-// matching the proto CommandResponse oneof: no_response, response, or exception.
+// With returns the PolyglotText with an additional language entry added.
+func (p PolyglotText) With(lang, text string) PolyglotText {
+	p[lang] = text
+	return p
+}
+
+// Get returns the display string for lang, falling back to fallback if not present.
+func (p PolyglotText) Get(lang, fallback string) string {
+	if s, ok := p[lang]; ok {
+		return s
+	}
+	return p[fallback]
+}
+
+// CommandResult wraps protos.CommandResponse, representing the three possible
+// outcomes of ExecuteCommand: no_response, response, or exception.
 type CommandResult struct {
-	kind      commandResultKind
-	value     CatenaValue
-	exception CommandException
+	response *protos.CommandResponse
 }
 
 // IsEmpty returns true if this is a no_response result.
 func (r CommandResult) IsEmpty() bool {
-	return r.kind == commandResultEmpty
+	return r.response == nil || r.response.GetNoResponse() != nil
 }
 
 // IsException returns true if this is an exception result.
 func (r CommandResult) IsException() bool {
-	return r.kind == commandResultException
+	return r.response != nil && r.response.GetException() != nil
 }
 
-// GetException returns the exception data. Only valid when IsException() is true.
-func (r CommandResult) GetException() CommandException {
-	return r.exception
-}
-
-// ToProto converts the CommandResult to a proto CommandResponse message.
-func (r CommandResult) ToProto() *protos.CommandResponse {
-	switch r.kind {
-	case commandResultValue:
-		return &protos.CommandResponse{
-			Kind: &protos.CommandResponse_Response{Response: r.value.Value},
-		}
-	case commandResultException:
-		exc := &protos.Exception{
-			Type:    r.exception.Type,
-			Details: r.exception.Details,
-		}
-		if r.exception.ErrorMessage != nil {
-			exc.ErrorMessage = &protos.PolyglotText{DisplayStrings: r.exception.ErrorMessage}
-		}
-		return &protos.CommandResponse{
-			Kind: &protos.CommandResponse_Exception{Exception: exc},
-		}
-	default:
-		return &protos.CommandResponse{
-			Kind: &protos.CommandResponse_NoResponse{NoResponse: &protos.Empty{}},
-		}
+// GetException returns the underlying proto Exception.
+// Only valid when IsException() is true.
+func (r CommandResult) GetException() *protos.Exception {
+	if r.response != nil {
+		return r.response.GetException()
 	}
+	return nil
+}
+
+// GetProtoResponse returns the underlying protos.CommandResponse.
+func (r CommandResult) GetProtoResponse() *protos.CommandResponse {
+	return r.response
 }
 
 // CommandReply returns a successful command response wrapping a value.
 func CommandReply(value CatenaValue) (CommandResult, StatusResult) {
-	return CommandResult{kind: commandResultValue, value: value}, StatusResult{Code: OK}
+	return CommandResult{
+		response: &protos.CommandResponse{
+			Kind: &protos.CommandResponse_Response{Response: value.Value},
+		},
+	}, StatusResult{Code: OK}
 }
 
 // CommandNoResponse returns an empty command response (no_response).
 func CommandNoResponse() (CommandResult, StatusResult) {
-	return CommandResult{kind: commandResultEmpty}, StatusResult{Code: OK}
+	return CommandResult{
+		response: &protos.CommandResponse{
+			Kind: &protos.CommandResponse_NoResponse{NoResponse: &protos.Empty{}},
+		},
+	}, StatusResult{Code: OK}
 }
 
 // CommandExceptionResult returns a command exception response.
 // exType is the exception type, details provides additional context,
-// and errorMessage is a map of language code to display string (may be nil).
-func CommandExceptionResult(exType, details string, errorMessage map[string]string) (CommandResult, StatusResult) {
+// and errorMessage is a PolyglotText map of language code to display string (may be nil).
+func CommandExceptionResult(exType, details string, errorMessage PolyglotText) (CommandResult, StatusResult) {
+	exc := &protos.Exception{
+		Type:    exType,
+		Details: details,
+	}
+	if errorMessage != nil {
+		exc.ErrorMessage = &protos.PolyglotText{DisplayStrings: errorMessage}
+	}
 	return CommandResult{
-		kind: commandResultException,
-		exception: CommandException{
-			Type:         exType,
-			ErrorMessage: errorMessage,
-			Details:      details,
+		response: &protos.CommandResponse{
+			Kind: &protos.CommandResponse_Exception{Exception: exc},
 		},
 	}, StatusResult{Code: OK}
 }

--- a/sdks/go/pkg/catena/command.go
+++ b/sdks/go/pkg/catena/command.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Command response types for the Catena SDK.
+ * @file command.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-10
+ */
+
+package catena
+
+import (
+	"github.com/rossvideo/catena/build/go/protos"
+)
+
+type commandResultKind int
+
+const (
+	commandResultEmpty commandResultKind = iota
+	commandResultValue
+	commandResultException
+)
+
+// CommandException represents a server/device error executing a command,
+// matching the proto Exception message.
+type CommandException struct {
+	Type         string
+	ErrorMessage map[string]string // language code -> display string
+	Details      string
+}
+
+// CommandResult represents the three possible outcomes of ExecuteCommand,
+// matching the proto CommandResponse oneof: no_response, response, or exception.
+type CommandResult struct {
+	kind      commandResultKind
+	value     CatenaValue
+	exception CommandException
+}
+
+// IsEmpty returns true if this is a no_response result.
+func (r CommandResult) IsEmpty() bool {
+	return r.kind == commandResultEmpty
+}
+
+// IsException returns true if this is an exception result.
+func (r CommandResult) IsException() bool {
+	return r.kind == commandResultException
+}
+
+// GetException returns the exception data. Only valid when IsException() is true.
+func (r CommandResult) GetException() CommandException {
+	return r.exception
+}
+
+// ToProto converts the CommandResult to a proto CommandResponse message.
+func (r CommandResult) ToProto() *protos.CommandResponse {
+	switch r.kind {
+	case commandResultValue:
+		return &protos.CommandResponse{
+			Kind: &protos.CommandResponse_Response{Response: r.value.Value},
+		}
+	case commandResultException:
+		exc := &protos.Exception{
+			Type:    r.exception.Type,
+			Details: r.exception.Details,
+		}
+		if r.exception.ErrorMessage != nil {
+			exc.ErrorMessage = &protos.PolyglotText{DisplayStrings: r.exception.ErrorMessage}
+		}
+		return &protos.CommandResponse{
+			Kind: &protos.CommandResponse_Exception{Exception: exc},
+		}
+	default:
+		return &protos.CommandResponse{
+			Kind: &protos.CommandResponse_NoResponse{NoResponse: &protos.Empty{}},
+		}
+	}
+}
+
+// CommandReply returns a successful command response wrapping a value.
+func CommandReply(value CatenaValue) (CommandResult, StatusResult) {
+	return CommandResult{kind: commandResultValue, value: value}, StatusResult{Code: OK}
+}
+
+// CommandNoResponse returns an empty command response (no_response).
+func CommandNoResponse() (CommandResult, StatusResult) {
+	return CommandResult{kind: commandResultEmpty}, StatusResult{Code: OK}
+}
+
+// CommandExceptionResult returns a command exception response.
+// exType is the exception type, details provides additional context,
+// and errorMessage is a map of language code to display string (may be nil).
+func CommandExceptionResult(exType, details string, errorMessage map[string]string) (CommandResult, StatusResult) {
+	return CommandResult{
+		kind: commandResultException,
+		exception: CommandException{
+			Type:         exType,
+			ErrorMessage: errorMessage,
+			Details:      details,
+		},
+	}, StatusResult{Code: OK}
+}
+
+// CommandError returns a transport-level error (not a CommandResponse exception).
+// Use this for infrastructure errors like "handler not found" or "unimplemented".
+func CommandError(code StatusCode, msg string) (CommandResult, StatusResult) {
+	return CommandResult{}, StatusResult{Code: code, Error: msg}
+}

--- a/sdks/go/pkg/catena/command_test.go
+++ b/sdks/go/pkg/catena/command_test.go
@@ -44,6 +44,40 @@ import (
 	"github.com/rossvideo/catena/build/go/protos"
 )
 
+func TestNewPolyglotText(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello")
+	if pt["en"] != "Hello" {
+		t.Errorf("expected 'Hello', got %s", pt["en"])
+	}
+}
+
+func TestPolyglotText_With(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello").With("fr", "Bonjour")
+	if pt["en"] != "Hello" {
+		t.Errorf("expected 'Hello', got %s", pt["en"])
+	}
+	if pt["fr"] != "Bonjour" {
+		t.Errorf("expected 'Bonjour', got %s", pt["fr"])
+	}
+}
+
+func TestPolyglotText_Get(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello").With("fr", "Bonjour")
+	if pt.Get("fr", "en") != "Bonjour" {
+		t.Errorf("expected 'Bonjour', got %s", pt.Get("fr", "en"))
+	}
+	if pt.Get("de", "en") != "Hello" {
+		t.Errorf("expected fallback 'Hello', got %s", pt.Get("de", "en"))
+	}
+}
+
+func TestPolyglotText_Get_MissingFallback(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello")
+	if pt.Get("de", "fr") != "" {
+		t.Errorf("expected empty string for missing fallback, got %s", pt.Get("de", "fr"))
+	}
+}
+
 func TestCommandReply(t *testing.T) {
 	val, _ := ToCatenaValue(int32(42))
 	result, status := CommandReply(val)
@@ -58,7 +92,7 @@ func TestCommandReply(t *testing.T) {
 		t.Error("expected non-exception result")
 	}
 
-	proto := result.ToProto()
+	proto := result.GetProtoResponse()
 	resp := proto.GetResponse()
 	if resp == nil {
 		t.Fatal("expected response in proto")
@@ -81,7 +115,7 @@ func TestCommandNoResponse(t *testing.T) {
 		t.Error("expected non-exception result")
 	}
 
-	proto := result.ToProto()
+	proto := result.GetProtoResponse()
 	if proto.GetNoResponse() == nil {
 		t.Error("expected no_response in proto")
 	}
@@ -94,7 +128,7 @@ func TestCommandNoResponse(t *testing.T) {
 }
 
 func TestCommandExceptionResult(t *testing.T) {
-	errorMsg := map[string]string{"en": "Something failed"}
+	errorMsg := NewPolyglotText("en", "Something failed")
 	result, status := CommandExceptionResult("TestError", "detailed info", errorMsg)
 
 	if status.Code != OK {
@@ -108,17 +142,18 @@ func TestCommandExceptionResult(t *testing.T) {
 	}
 
 	exc := result.GetException()
-	if exc.Type != "TestError" {
-		t.Errorf("expected type 'TestError', got %s", exc.Type)
+	if exc.GetType() != "TestError" {
+		t.Errorf("expected type 'TestError', got %s", exc.GetType())
 	}
-	if exc.Details != "detailed info" {
-		t.Errorf("expected details 'detailed info', got %s", exc.Details)
+	if exc.GetDetails() != "detailed info" {
+		t.Errorf("expected details 'detailed info', got %s", exc.GetDetails())
 	}
-	if exc.ErrorMessage["en"] != "Something failed" {
-		t.Errorf("expected en error message 'Something failed', got %s", exc.ErrorMessage["en"])
+	if exc.GetErrorMessage().GetDisplayStrings()["en"] != "Something failed" {
+		t.Errorf("expected en error message 'Something failed', got %s",
+			exc.GetErrorMessage().GetDisplayStrings()["en"])
 	}
 
-	proto := result.ToProto()
+	proto := result.GetProtoResponse()
 	protoExc := proto.GetException()
 	if protoExc == nil {
 		t.Fatal("expected exception in proto")
@@ -135,10 +170,24 @@ func TestCommandExceptionResult(t *testing.T) {
 	}
 }
 
+func TestCommandExceptionResult_MultipleLanguages(t *testing.T) {
+	errorMsg := NewPolyglotText("en", "Command not found").With("fr", "Commande introuvable")
+	result, _ := CommandExceptionResult("NotFound", "missing", errorMsg)
+
+	exc := result.GetException()
+	ds := exc.GetErrorMessage().GetDisplayStrings()
+	if ds["en"] != "Command not found" {
+		t.Errorf("expected en='Command not found', got %s", ds["en"])
+	}
+	if ds["fr"] != "Commande introuvable" {
+		t.Errorf("expected fr='Commande introuvable', got %s", ds["fr"])
+	}
+}
+
 func TestCommandExceptionResult_NilErrorMessage(t *testing.T) {
 	result, _ := CommandExceptionResult("Error", "details", nil)
 
-	proto := result.ToProto()
+	proto := result.GetProtoResponse()
 	protoExc := proto.GetException()
 	if protoExc == nil {
 		t.Fatal("expected exception in proto")
@@ -162,10 +211,20 @@ func TestCommandError(t *testing.T) {
 	}
 }
 
-func TestCommandResult_ToProto_Response(t *testing.T) {
+func TestCommandError_NilResponse(t *testing.T) {
+	result, _ := CommandError(INTERNAL, "error")
+	if result.GetProtoResponse() != nil {
+		t.Error("expected nil proto response for CommandError")
+	}
+	if result.GetException() != nil {
+		t.Error("expected nil exception for CommandError")
+	}
+}
+
+func TestCommandResult_GetProtoResponse_Response(t *testing.T) {
 	val, _ := ToCatenaValue("hello")
 	result, _ := CommandReply(val)
-	proto := result.ToProto()
+	proto := result.GetProtoResponse()
 
 	if _, ok := proto.Kind.(*protos.CommandResponse_Response); !ok {
 		t.Errorf("expected CommandResponse_Response, got %T", proto.Kind)
@@ -175,18 +234,18 @@ func TestCommandResult_ToProto_Response(t *testing.T) {
 	}
 }
 
-func TestCommandResult_ToProto_NoResponse(t *testing.T) {
+func TestCommandResult_GetProtoResponse_NoResponse(t *testing.T) {
 	result, _ := CommandNoResponse()
-	proto := result.ToProto()
+	proto := result.GetProtoResponse()
 
 	if _, ok := proto.Kind.(*protos.CommandResponse_NoResponse); !ok {
 		t.Errorf("expected CommandResponse_NoResponse, got %T", proto.Kind)
 	}
 }
 
-func TestCommandResult_ToProto_Exception(t *testing.T) {
-	result, _ := CommandExceptionResult("E", "d", map[string]string{"fr": "erreur"})
-	proto := result.ToProto()
+func TestCommandResult_GetProtoResponse_Exception(t *testing.T) {
+	result, _ := CommandExceptionResult("E", "d", NewPolyglotText("fr", "erreur"))
+	proto := result.GetProtoResponse()
 
 	if _, ok := proto.Kind.(*protos.CommandResponse_Exception); !ok {
 		t.Errorf("expected CommandResponse_Exception, got %T", proto.Kind)

--- a/sdks/go/pkg/catena/command_test.go
+++ b/sdks/go/pkg/catena/command_test.go
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for command response types.
+ * @file command_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-10
+ */
+
+package catena
+
+import (
+	"testing"
+
+	"github.com/rossvideo/catena/build/go/protos"
+)
+
+func TestCommandReply(t *testing.T) {
+	val, _ := ToCatenaValue(int32(42))
+	result, status := CommandReply(val)
+
+	if status.Code != OK {
+		t.Errorf("expected OK status, got %v", status.Code)
+	}
+	if result.IsEmpty() {
+		t.Error("expected non-empty result")
+	}
+	if result.IsException() {
+		t.Error("expected non-exception result")
+	}
+
+	proto := result.ToProto()
+	resp := proto.GetResponse()
+	if resp == nil {
+		t.Fatal("expected response in proto")
+	}
+	if resp.GetInt32Value() != 42 {
+		t.Errorf("expected int32_value 42, got %v", resp.GetInt32Value())
+	}
+}
+
+func TestCommandNoResponse(t *testing.T) {
+	result, status := CommandNoResponse()
+
+	if status.Code != OK {
+		t.Errorf("expected OK status, got %v", status.Code)
+	}
+	if !result.IsEmpty() {
+		t.Error("expected empty result")
+	}
+	if result.IsException() {
+		t.Error("expected non-exception result")
+	}
+
+	proto := result.ToProto()
+	if proto.GetNoResponse() == nil {
+		t.Error("expected no_response in proto")
+	}
+	if proto.GetResponse() != nil {
+		t.Error("expected nil response in proto")
+	}
+	if proto.GetException() != nil {
+		t.Error("expected nil exception in proto")
+	}
+}
+
+func TestCommandExceptionResult(t *testing.T) {
+	errorMsg := map[string]string{"en": "Something failed"}
+	result, status := CommandExceptionResult("TestError", "detailed info", errorMsg)
+
+	if status.Code != OK {
+		t.Errorf("expected OK status, got %v", status.Code)
+	}
+	if result.IsEmpty() {
+		t.Error("expected non-empty result")
+	}
+	if !result.IsException() {
+		t.Error("expected exception result")
+	}
+
+	exc := result.GetException()
+	if exc.Type != "TestError" {
+		t.Errorf("expected type 'TestError', got %s", exc.Type)
+	}
+	if exc.Details != "detailed info" {
+		t.Errorf("expected details 'detailed info', got %s", exc.Details)
+	}
+	if exc.ErrorMessage["en"] != "Something failed" {
+		t.Errorf("expected en error message 'Something failed', got %s", exc.ErrorMessage["en"])
+	}
+
+	proto := result.ToProto()
+	protoExc := proto.GetException()
+	if protoExc == nil {
+		t.Fatal("expected exception in proto")
+	}
+	if protoExc.GetType() != "TestError" {
+		t.Errorf("expected proto type 'TestError', got %s", protoExc.GetType())
+	}
+	if protoExc.GetDetails() != "detailed info" {
+		t.Errorf("expected proto details 'detailed info', got %s", protoExc.GetDetails())
+	}
+	if protoExc.GetErrorMessage().GetDisplayStrings()["en"] != "Something failed" {
+		t.Errorf("expected proto en display string 'Something failed', got %s",
+			protoExc.GetErrorMessage().GetDisplayStrings()["en"])
+	}
+}
+
+func TestCommandExceptionResult_NilErrorMessage(t *testing.T) {
+	result, _ := CommandExceptionResult("Error", "details", nil)
+
+	proto := result.ToProto()
+	protoExc := proto.GetException()
+	if protoExc == nil {
+		t.Fatal("expected exception in proto")
+	}
+	if protoExc.GetErrorMessage() != nil {
+		t.Errorf("expected nil error_message when none provided, got %v", protoExc.GetErrorMessage())
+	}
+}
+
+func TestCommandError(t *testing.T) {
+	result, status := CommandError(UNIMPLEMENTED, "not implemented")
+
+	if status.Code != UNIMPLEMENTED {
+		t.Errorf("expected UNIMPLEMENTED status, got %v", status.Code)
+	}
+	if status.Error != "not implemented" {
+		t.Errorf("expected error 'not implemented', got %s", status.Error)
+	}
+	if !result.IsEmpty() {
+		t.Error("expected empty result for CommandError")
+	}
+}
+
+func TestCommandResult_ToProto_Response(t *testing.T) {
+	val, _ := ToCatenaValue("hello")
+	result, _ := CommandReply(val)
+	proto := result.ToProto()
+
+	if _, ok := proto.Kind.(*protos.CommandResponse_Response); !ok {
+		t.Errorf("expected CommandResponse_Response, got %T", proto.Kind)
+	}
+	if proto.GetResponse().GetStringValue() != "hello" {
+		t.Errorf("expected string_value 'hello', got %v", proto.GetResponse().GetStringValue())
+	}
+}
+
+func TestCommandResult_ToProto_NoResponse(t *testing.T) {
+	result, _ := CommandNoResponse()
+	proto := result.ToProto()
+
+	if _, ok := proto.Kind.(*protos.CommandResponse_NoResponse); !ok {
+		t.Errorf("expected CommandResponse_NoResponse, got %T", proto.Kind)
+	}
+}
+
+func TestCommandResult_ToProto_Exception(t *testing.T) {
+	result, _ := CommandExceptionResult("E", "d", map[string]string{"fr": "erreur"})
+	proto := result.ToProto()
+
+	if _, ok := proto.Kind.(*protos.CommandResponse_Exception); !ok {
+		t.Errorf("expected CommandResponse_Exception, got %T", proto.Kind)
+	}
+	exc := proto.GetException()
+	if exc.GetType() != "E" {
+		t.Errorf("expected type 'E', got %s", exc.GetType())
+	}
+	if exc.GetErrorMessage().GetDisplayStrings()["fr"] != "erreur" {
+		t.Errorf("expected fr='erreur', got %s", exc.GetErrorMessage().GetDisplayStrings()["fr"])
+	}
+}

--- a/sdks/go/pkg/grpc/server.go
+++ b/sdks/go/pkg/grpc/server.go
@@ -299,24 +299,13 @@ func (s *Server) ExecuteCommand(req *protos.ExecuteCommandPayload, stream grpc.S
 	}
 
 	handler := s.baseServer.LookupExecuteCommandHandler(slot)
-	value, result := handler(slot, commandFqoid, payload)
+	cmdResult, result := handler(slot, commandFqoid, payload)
 	if result.Error != "" {
 		logger.Error("ExecuteCommand handler error", "slot", slot, "command", commandFqoid, "error", result.Error)
 		return status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
-	response := &protos.CommandResponse{}
-	if value.Value != nil {
-		response.Kind = &protos.CommandResponse_Response{
-			Response: value.Value,
-		}
-	} else {
-		response.Kind = &protos.CommandResponse_NoResponse{
-			NoResponse: &protos.Empty{},
-		}
-	}
-
-	return stream.Send(response)
+	return stream.Send(cmdResult.ToProto())
 }
 
 // GetParam returns a single parameter's metadata

--- a/sdks/go/pkg/grpc/server.go
+++ b/sdks/go/pkg/grpc/server.go
@@ -305,7 +305,7 @@ func (s *Server) ExecuteCommand(req *protos.ExecuteCommandPayload, stream grpc.S
 		return status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
-	return stream.Send(cmdResult.ToProto())
+	return stream.Send(cmdResult.GetProtoResponse())
 }
 
 // GetParam returns a single parameter's metadata

--- a/sdks/go/pkg/grpc/server_test.go
+++ b/sdks/go/pkg/grpc/server_test.go
@@ -662,17 +662,16 @@ func TestServer_ExecuteCommand_WithResponse(t *testing.T) {
 	defer cleanup()
 
 	handlerCalled := false
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		handlerCalled = true
 		if fqoid != "device.reboot" {
 			t.Errorf("expected fqoid 'device.reboot', got %s", fqoid)
 		}
-		// Verify payload was passed
 		if payload == nil {
 			t.Error("expected non-nil payload")
 		}
 		value, _ := catena.ToCatenaValue(string("Command executed"))
-		return catena.Reply(value)
+		return catena.CommandReply(value)
 	})
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -698,9 +697,8 @@ func TestServer_ExecuteCommand_WithoutResponse(t *testing.T) {
 	srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
 	defer cleanup()
 
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
-		// Return empty value (no response)
-		return catena.Reply(catena.CatenaValue{})
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		return catena.CommandNoResponse()
 	})
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -719,14 +717,14 @@ func TestServer_ExecuteCommand_NilPayload(t *testing.T) {
 	defer cleanup()
 
 	receivedPayload := "not nil"
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		if payload != nil {
 			receivedPayload = "not nil"
 		} else {
 			receivedPayload = "nil"
 		}
 		value, _ := catena.ToCatenaValue(string("OK"))
-		return catena.Reply(value)
+		return catena.CommandReply(value)
 	})
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -765,8 +763,8 @@ func TestServer_ExecuteCommand_HandlerError(t *testing.T) {
 	srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
 	defer cleanup()
 
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
-		return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "command not supported")
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		return catena.CommandError(catena.UNIMPLEMENTED, "command not supported")
 	})
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)

--- a/sdks/go/pkg/internal/base_server.go
+++ b/sdks/go/pkg/internal/base_server.go
@@ -16,7 +16,7 @@ type DeviceHandler func() (catena.CatenaDevice, catena.StatusResult)
 type GetValueHandler func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult)
 type SetValueHandler func(value any, slot uint16, fqoid string) catena.StatusResult
 type GetAssetHandler func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult)
-type ExecuteCommandHandler func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult)
+type ExecuteCommandHandler func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult)
 
 type BaseServer struct {
 	Mu                     sync.Mutex
@@ -46,8 +46,8 @@ func DefaultGetAssetHandler(slot uint16, fqoid string) (catena.CatenaAsset, cate
 	return catena.ReplyError[catena.CatenaAsset](catena.UNIMPLEMENTED, "GetAsset not implemented")
 }
 
-func DefaultExecuteCommandHandler(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
-	return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "ExecuteCommand not implemented")
+func DefaultExecuteCommandHandler(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+	return catena.CommandError(catena.UNIMPLEMENTED, "ExecuteCommand not implemented")
 }
 
 // Handler registration methods

--- a/sdks/go/pkg/rest/json_utils.go
+++ b/sdks/go/pkg/rest/json_utils.go
@@ -50,6 +50,33 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+// WriteCommandResponseJSON marshals a protos.CommandResponse to JSON and writes it
+// to the HTTP response with the specified status code.
+func WriteCommandResponseJSON(w http.ResponseWriter, cmdResp *protos.CommandResponse, statusCode int) error {
+	w.Header().Set("Content-Type", "application/json")
+
+	if cmdResp == nil {
+		w.WriteHeader(statusCode)
+		return nil
+	}
+
+	b, err := (protojson.MarshalOptions{
+		UseProtoNames:   true,
+		EmitUnpopulated: false,
+	}).Marshal(cmdResp)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error": "failed to marshal command response",
+		})
+		return fmt.Errorf("failed to marshal command response: %w", err)
+	}
+
+	w.WriteHeader(statusCode)
+	_, writeErr := w.Write(b)
+	return writeErr
+}
+
 // ReadRequestJSON reads and unmarshals a JSON request body into a protos.Value.
 // It validates the Content-Type header and returns an error if it's not application/json.
 func ReadRequestJSON(r *http.Request) (*protos.Value, catena.StatusResult) {

--- a/sdks/go/pkg/rest/json_utils_test.go
+++ b/sdks/go/pkg/rest/json_utils_test.go
@@ -324,3 +324,88 @@ func TestWriteResponseJSON_WriteError(t *testing.T) {
 		t.Fatal("expected error when Write fails")
 	}
 }
+
+func TestWriteCommandResponseJSON_NilResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	err := WriteCommandResponseJSON(w, nil, http.StatusOK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body, got %q", w.Body.String())
+	}
+}
+
+func TestWriteCommandResponseJSON_ValidNoResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+	cmdResp := &protos.CommandResponse{
+		Kind: &protos.CommandResponse_NoResponse{NoResponse: &protos.Empty{}},
+	}
+
+	err := WriteCommandResponseJSON(w, cmdResp, http.StatusOK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "no_response") {
+		t.Errorf("expected body to contain 'no_response', got %q", w.Body.String())
+	}
+}
+
+func TestWriteCommandResponseJSON_ValidResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+	cmdResp := &protos.CommandResponse{
+		Kind: &protos.CommandResponse_Response{
+			Response: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 42}},
+		},
+	}
+
+	err := WriteCommandResponseJSON(w, cmdResp, http.StatusOK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(w.Body.String(), "response") {
+		t.Errorf("expected body to contain 'response', got %q", w.Body.String())
+	}
+}
+
+func TestWriteCommandResponseJSON_MarshalError(t *testing.T) {
+	w := httptest.NewRecorder()
+	cmdResp := &protos.CommandResponse{
+		Kind: &protos.CommandResponse_Response{
+			Response: &protos.Value{Kind: &protos.Value_StringValue{StringValue: "\xff"}},
+		},
+	}
+
+	err := WriteCommandResponseJSON(w, cmdResp, http.StatusOK)
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8 string")
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "failed to marshal command response") {
+		t.Errorf("expected error body, got %q", w.Body.String())
+	}
+}
+
+func TestWriteCommandResponseJSON_WriteError(t *testing.T) {
+	w := &errorWriter{}
+	cmdResp := &protos.CommandResponse{
+		Kind: &protos.CommandResponse_NoResponse{NoResponse: &protos.Empty{}},
+	}
+
+	err := WriteCommandResponseJSON(w, cmdResp, http.StatusOK)
+	if err == nil {
+		t.Fatal("expected error when Write fails")
+	}
+}

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -488,7 +488,7 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 		cmdResult, _ = catena.CommandNoResponse()
 	}
 
-	_ = WriteCommandResponseJSON(w, cmdResult.ToProto(), http.StatusOK)
+	_ = WriteCommandResponseJSON(w, cmdResult.GetProtoResponse(), http.StatusOK)
 }
 
 // ToHTTPStatus converts a StatusCode to an HTTP status code.

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -452,6 +452,11 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 
 	commandFqoid := strings.Join(pathParts, "/")
 
+	respond := true
+	if r.URL.Query().Get("respond") == "false" {
+		respond = false
+	}
+
 	// Read command payload
 	var payload any
 	if r.ContentLength > 0 {
@@ -479,9 +484,8 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 
-	respond := r.URL.Query().Get("respond")
-	if respond == "false" {
-		cmdResult = catena.CommandResult{}
+	if !respond {
+		cmdResult, _ = catena.CommandNoResponse()
 	}
 
 	_ = WriteCommandResponseJSON(w, cmdResult.ToProto(), http.StatusOK)

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -473,8 +473,18 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 	}
 
 	handler := s.baseServer.LookupExecuteCommandHandler(slot)
-	val, res := handler(slot, commandFqoid, payload)
-	writeHTTPResult(w, res, val)
+	cmdResult, res := handler(slot, commandFqoid, payload)
+	if res.Code != catena.OK {
+		writeHTTPResult(w, res, catena.CatenaValue{})
+		return
+	}
+
+	respond := r.URL.Query().Get("respond")
+	if respond == "false" {
+		cmdResult = catena.CommandResult{}
+	}
+
+	_ = WriteCommandResponseJSON(w, cmdResult.ToProto(), http.StatusOK)
 }
 
 // ToHTTPStatus converts a StatusCode to an HTTP status code.

--- a/sdks/go/pkg/rest/server_test.go
+++ b/sdks/go/pkg/rest/server_test.go
@@ -496,7 +496,6 @@ func TestServer_DefaultHandlers(t *testing.T) {
 	}
 }
 
-
 func TestServer_NestedValuePath(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
 
@@ -792,7 +791,7 @@ func TestCommandEndpoint_ExceptionResponse(t *testing.T) {
 		return catena.CommandExceptionResult(
 			"InvalidCommand",
 			"Command not found: "+fqoid,
-			map[string]string{"en": "Command not found"},
+			catena.NewPolyglotText("en", "Command not found"),
 		)
 	})
 

--- a/sdks/go/pkg/rest/server_test.go
+++ b/sdks/go/pkg/rest/server_test.go
@@ -136,12 +136,12 @@ func TestServer_RegisterExecuteCommandHandler(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
 
 	handlerCalled := false
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		handlerCalled = true
 		if commandFqoid != "test/command" {
 			t.Errorf("expected commandFqoid 'test/command', got %s", commandFqoid)
 		}
-		return catena.CatenaValue{}, catena.StatusResult{Code: catena.OK}
+		return catena.CommandNoResponse()
 	})
 
 	handler := srv.LookupExecuteCommandHandler(0)
@@ -324,16 +324,21 @@ func TestServer_ExecuteCommand_Route(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
 
 	handlerCalled := false
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		handlerCalled = true
 		if commandFqoid != "reboot" {
 			t.Errorf("expected commandFqoid 'reboot', got %s", commandFqoid)
 		}
-		return catena.Reply(catena.CatenaValue{})
+		return catena.CommandNoResponse()
 	})
 
 	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/reboot", "")
 	assertStatus(t, rec, http.StatusOK)
+	assertContentType(t, rec, "application/json")
+	response := parseJSONBody(t, rec)
+	if _, ok := response["no_response"]; !ok {
+		t.Errorf("expected no_response in CommandResponse, got %v", response)
+	}
 	if !handlerCalled {
 		t.Error("registered handler was not called")
 	}
@@ -343,16 +348,21 @@ func TestServer_ExecuteCommand_WithPayload(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
 
 	handlerCalled := false
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		handlerCalled = true
 		if payload == nil {
 			t.Error("expected payload to be non-nil")
 		}
-		return catena.Reply(catena.CatenaValue{})
+		val, _ := catena.ToCatenaValue(payload)
+		return catena.CommandReply(val)
 	})
 
 	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/process", `{"string_value": "test"}`)
 	assertStatus(t, rec, http.StatusOK)
+	response := parseJSONBody(t, rec)
+	if _, ok := response["response"]; !ok {
+		t.Errorf("expected response field in CommandResponse, got %v", response)
+	}
 	if !handlerCalled {
 		t.Error("registered handler was not called")
 	}
@@ -362,9 +372,9 @@ func TestServer_ExecuteCommand_MethodNotAllowed(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
 
 	handlerCalled := false
-	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		handlerCalled = true
-		return catena.Reply(catena.CatenaValue{})
+		return catena.CommandNoResponse()
 	})
 
 	rec := makeRequest(t, srv, http.MethodGet, "/st2138-api/v1/0/command/reboot", "")
@@ -480,11 +490,12 @@ func TestServer_DefaultHandlers(t *testing.T) {
 	}
 
 	// Test default execute command handler
-	value, status = srv.LookupExecuteCommandHandler(0)(0, "test", nil)
-	if status.Code != catena.UNIMPLEMENTED {
-		t.Errorf("default execute command handler should return UNIMPLEMENTED, got %v", status.Code)
+	_, cmdStatus := srv.LookupExecuteCommandHandler(0)(0, "test", nil)
+	if cmdStatus.Code != catena.UNIMPLEMENTED {
+		t.Errorf("default execute command handler should return UNIMPLEMENTED, got %v", cmdStatus.Code)
 	}
 }
+
 
 func TestServer_NestedValuePath(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
@@ -630,9 +641,9 @@ func TestCommandEndpoint_PayloadHandling(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := NewServer([]uint16{0}, 100)
 			var receivedPayload any
-			srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CatenaValue, catena.StatusResult) {
+			srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 				receivedPayload = payload
-				return catena.Reply(catena.CatenaValue{})
+				return catena.CommandNoResponse()
 			})
 
 			makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/test", tt.body)
@@ -748,6 +759,147 @@ func TestCommandEndpoint_FromProtoError(t *testing.T) {
 	srv := NewServer([]uint16{0}, 100)
 	makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/exec",
 		`{"struct_variant_value": {"variant_name": "test"}}`)
+}
+
+func TestCommandEndpoint_ResponseValue(t *testing.T) {
+	srv := NewServer([]uint16{0}, 100)
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		val, _ := catena.ToCatenaValue("command executed")
+		return catena.CommandReply(val)
+	})
+
+	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/run", "")
+	assertStatus(t, rec, http.StatusOK)
+	assertContentType(t, rec, "application/json")
+
+	response := parseJSONBody(t, rec)
+	resp, ok := response["response"]
+	if !ok {
+		t.Fatalf("expected 'response' field in CommandResponse, got %v", response)
+	}
+	respMap, ok := resp.(map[string]any)
+	if !ok {
+		t.Fatalf("expected response to be an object, got %T", resp)
+	}
+	if respMap["string_value"] != "command executed" {
+		t.Errorf("expected string_value 'command executed', got %v", respMap["string_value"])
+	}
+}
+
+func TestCommandEndpoint_ExceptionResponse(t *testing.T) {
+	srv := NewServer([]uint16{0}, 100)
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		return catena.CommandExceptionResult(
+			"InvalidCommand",
+			"Command not found: "+fqoid,
+			map[string]string{"en": "Command not found"},
+		)
+	})
+
+	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/bad_cmd", "")
+	assertStatus(t, rec, http.StatusOK)
+	assertContentType(t, rec, "application/json")
+
+	response := parseJSONBody(t, rec)
+	exc, ok := response["exception"]
+	if !ok {
+		t.Fatalf("expected 'exception' field in CommandResponse, got %v", response)
+	}
+	excMap, ok := exc.(map[string]any)
+	if !ok {
+		t.Fatalf("expected exception to be an object, got %T", exc)
+	}
+	if excMap["type"] != "InvalidCommand" {
+		t.Errorf("expected exception type 'InvalidCommand', got %v", excMap["type"])
+	}
+	if excMap["details"] != "Command not found: bad_cmd" {
+		t.Errorf("expected exception details, got %v", excMap["details"])
+	}
+	errMsg, ok := excMap["error_message"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error_message to be an object, got %T", excMap["error_message"])
+	}
+	displayStrings, ok := errMsg["display_strings"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected display_strings in error_message, got %T", errMsg["display_strings"])
+	}
+	if displayStrings["en"] != "Command not found" {
+		t.Errorf("expected en display string 'Command not found', got %v", displayStrings["en"])
+	}
+}
+
+func TestCommandEndpoint_RespondFalse(t *testing.T) {
+	srv := NewServer([]uint16{0}, 100)
+
+	handlerCalled := false
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		handlerCalled = true
+		val, _ := catena.ToCatenaValue("should be thrown away")
+		return catena.CommandReply(val)
+	})
+
+	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/run?respond=false", "")
+	assertStatus(t, rec, http.StatusOK)
+	assertContentType(t, rec, "application/json")
+
+	if !handlerCalled {
+		t.Error("handler should still be called when respond=false")
+	}
+
+	response := parseJSONBody(t, rec)
+	if _, ok := response["no_response"]; !ok {
+		t.Errorf("expected no_response when respond=false, got %v", response)
+	}
+	if _, ok := response["response"]; ok {
+		t.Error("should not have response field when respond=false")
+	}
+}
+
+func TestCommandEndpoint_RespondTrue(t *testing.T) {
+	srv := NewServer([]uint16{0}, 100)
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		val, _ := catena.ToCatenaValue(int32(42))
+		return catena.CommandReply(val)
+	})
+
+	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/run?respond=true", "")
+	assertStatus(t, rec, http.StatusOK)
+
+	response := parseJSONBody(t, rec)
+	if _, ok := response["response"]; !ok {
+		t.Errorf("expected response field when respond=true, got %v", response)
+	}
+}
+
+func TestCommandEndpoint_RespondDefaultIsTrue(t *testing.T) {
+	srv := NewServer([]uint16{0}, 100)
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		val, _ := catena.ToCatenaValue(int32(42))
+		return catena.CommandReply(val)
+	})
+
+	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/run", "")
+	assertStatus(t, rec, http.StatusOK)
+
+	response := parseJSONBody(t, rec)
+	if _, ok := response["response"]; !ok {
+		t.Errorf("expected response field by default (respond not set), got %v", response)
+	}
+}
+
+func TestCommandEndpoint_RespondFalseWithException(t *testing.T) {
+	srv := NewServer([]uint16{0}, 100)
+	srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+		return catena.CommandExceptionResult("Error", "something failed", nil)
+	})
+
+	rec := makeRequest(t, srv, http.MethodPost, "/st2138-api/v1/0/command/run?respond=false", "")
+	assertStatus(t, rec, http.StatusOK)
+
+	response := parseJSONBody(t, rec)
+	if _, ok := response["no_response"]; !ok {
+		t.Errorf("expected no_response even when handler returns exception and respond=false, got %v", response)
+	}
 }
 
 func TestWriteHTTPStatusResult_WithError(t *testing.T) {


### PR DESCRIPTION
## 📖 Description

Added `CommandResult` type that wraps `*protos.CommandResponse`, following the same proto-wrapper pattern used by `CatenaDevice` and other SDK types. 

Added `PolyglotText` type mapping BCP-47 language codes to display strings.

The REST server now also supports the `respond` query parameter, allowing clients to opt out of receiving command responses.

---

## ✅ Definition of Done (DoD)
- [x] `CommandResult` type wraps `*protos.CommandResponse` with `no_response`, `response`, and `exception` variants
- [x] Helper constructors provided (`CommandReply`, `CommandNoResponse`, `CommandExceptionResult`, `CommandError`)
- [x] `GetProtoResponse()` accessor exposes the underlying `*protos.CommandResponse`
- [x] `PolyglotText` type added with `NewPolyglotText`, `With`, and `Get` methods
- [x] `ExecuteCommandHandler` signature updated to return `(CommandResult, StatusResult)` without `http.ResponseWriter`/`*http.Request` params
- [x] `respond` query parameter support added to the REST command endpoint (defaults to `true`)
- [x] `WriteCommandResponseJSON` helper added for serializing `CommandResponse` proto to JSON
- [x] Examples updated with commands demonstrating all three result types (response, no\_response, exception)
- [x] "Command not found" in examples uses transport-level `CommandError` instead of `CommandExceptionResult`
- [x] Tests added for `PolyglotText`, response value, exception response, `respond=false`/`true`, and default behavior

---

## 🛠️ Implementation Notes
<!-- List of changes made: -->
- Added `command.go` — `CommandResult` wrapping `*protos.CommandResponse`, `PolyglotText` type, and helper constructors
- Modified `server.go` — removed `http.ResponseWriter`/`*http.Request` from `ExecuteCommandHandler` signature, replaced `ToProto()` with `GetProtoResponse()`, added `respond` query param logic
- Modified `json_utils.go` — added `WriteCommandResponseJSON` for marshalling `*protos.CommandResponse`
- Modified `executeCommand_REST.go` — migrated to proto-wrapper `CommandResult` API, changed "command not found" to transport-level `CommandError`, added `reset` (no\_response) and `error` (exception) example commands
- Modified `getSetValue_REST.go` — updated `ExecuteCommandHandler` signature
- Modified `server_test.go` — updated handler signatures and added tests for response/exception/respond-param behavior
- Modified `command_test.go` — updated tests for proto-wrapper pattern and added `PolyglotText` tests

---

## 🔗 Related Issues / Links

Closes issue #1270