### PR TITLE
[GO] Refactored functions to return StatusResult

### DIFF
--- a/sdks/go/examples/getAsset_REST/getAsset_REST.go
+++ b/sdks/go/examples/getAsset_REST/getAsset_REST.go
@@ -125,10 +125,10 @@ func main() {
 		payload := val.(catena.DataPayload)
 
 		// Convert DataPayload to CatenaAsset when returning
-		catenaAsset, err := catena.ToCatenaAsset(payload, true)
-		if err != nil {
-			logger.Error("Failed to convert payload to asset", "slot", slot, "fqoid", fqoid, "error", err)
-			return catena.ReplyError[catena.CatenaAsset](catena.INTERNAL, "failed to convert asset: "+err.Error())
+		catenaAsset, res := catena.ToCatenaAsset(payload, true)
+		if res.Code != catena.OK {
+			logger.Error("Failed to convert payload to asset", "slot", slot, "fqoid", fqoid, "error", res.Error)
+			return catena.ReplyError[catena.CatenaAsset](catena.INTERNAL, "failed to convert asset: "+res.Error)
 		}
 
 		logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(payload.Payload))

--- a/sdks/go/examples/getDevice_GRPC/getDevice_GRPC.go
+++ b/sdks/go/examples/getDevice_GRPC/getDevice_GRPC.go
@@ -358,9 +358,9 @@ func main() {
 				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
 			}
 
-			device, err := catena.ToCatenaDevice(devices[slot])
-			if err != nil {
-				logger.Error("failed to convert device", "slot", slot, "error", err)
+			device, res := catena.ToCatenaDevice(devices[slot])
+			if res.Code != catena.OK {
+				logger.Error("failed to convert device", "slot", slot, "error", res.Error)
 				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL, "failed to convert device")
 			}
 

--- a/sdks/go/examples/getDevice_REST/getDevice_REST.go
+++ b/sdks/go/examples/getDevice_REST/getDevice_REST.go
@@ -471,9 +471,9 @@ func main() {
 				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
 			}
 
-			device, err := catena.ToCatenaDevice(devices[slot])
-			if err != nil {
-				logger.Error("failed to convert device", "slot", slot, "error", err)
+			device, res := catena.ToCatenaDevice(devices[slot])
+			if res.Code != catena.OK {
+				logger.Error("failed to convert device", "slot", slot, "error", res.Error)
 				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL, "failed to convert device")
 			}
 

--- a/sdks/go/examples/getSetValue_GRPC/getSetValue_GRPC.go
+++ b/sdks/go/examples/getSetValue_GRPC/getSetValue_GRPC.go
@@ -95,9 +95,9 @@ func main() {
 			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "parameter not found")
 		}
 
-		protoValue, err := catena.ToProto(value)
-		if err != nil {
-			logger.Error("GetParam failed to convert value", "slot", slot, "fqoid", fqoid, "error", err)
+		protoValue, res := catena.ToProto(value)
+		if res.Code != catena.OK {
+			logger.Error("GetParam failed to convert value", "slot", slot, "fqoid", fqoid, "error", res.Error)
 			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert value")
 		}
 

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -201,24 +201,6 @@ func main() {
 	// Device 2: basic param handlers for all params.
 	registerBasicParamHandlers(srv, params2, 2)
 
-	// Register command handlers for each slot
-	for _, slot := range slotList {
-		slot := slot // capture loop variable
-		srv.RegisterExecuteCommandHandler(slot, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
-			logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid, "payload", payload)
-			response := map[string]any{
-				"response": map[string]any{
-					"string_value": "Command " + commandFqoid + " executed successfully",
-				},
-			}
-			catenaVal, res := catena.ToCatenaValue(response)
-			if res.Code != catena.OK {
-				return catena.CommandError(catena.INTERNAL, "failed to create command response")
-			}
-			return catena.CommandReply(catenaVal)
-		})
-	}
-
 	// Define device models for each slot
 	devices := map[uint16]map[string]any{
 		0: {

--- a/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
+++ b/sdks/go/examples/getSetValue_REST/getSetValue_REST.go
@@ -81,9 +81,9 @@ func registerBasicParamHandlers(srv *rest.Server, params *sync.Map, slot uint16)
 			logger.Error("GetParam param not found", "slot", slot, "fqoid", fqoid)
 			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "param not found")
 		}
-		catenaVal, err := catena.ToCatenaValue(v)
-		if err != nil {
-			logger.Error("GetParam failed to convert value", "slot", slot, "fqoid", fqoid, "error", err)
+		catenaVal, res := catena.ToCatenaValue(v)
+		if res.Code != catena.OK {
+			logger.Error("GetParam failed to convert value", "slot", slot, "fqoid", fqoid, "error", res.Error)
 			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert value")
 		}
 		return catena.Reply(catenaVal)
@@ -123,9 +123,9 @@ func registerSpecificParamHandlers(srv *rest.Server, params *sync.Map, fqoid str
 			logger.Error("GetSpecificParam param not found", "slot", slot, "fqoid", fqoid_)
 			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "param not found")
 		}
-		catenaVal, err := catena.ToCatenaValue(v)
-		if err != nil {
-			logger.Error("GetSpecificParam failed to convert value", "slot", slot, "fqoid", fqoid_, "error", err)
+		catenaVal, res := catena.ToCatenaValue(v)
+		if res.Code != catena.OK {
+			logger.Error("GetSpecificParam failed to convert value", "slot", slot, "fqoid", fqoid_, "error", res.Error)
 			return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert value")
 		}
 		return catena.Reply(catenaVal)
@@ -206,8 +206,13 @@ func main() {
 		slot := slot // capture loop variable
 		srv.RegisterExecuteCommandHandler(slot, func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 			logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid, "payload", payload)
-			catenaVal, err := catena.ToCatenaValue("Command " + commandFqoid + " executed successfully")
-			if err != nil {
+			response := map[string]any{
+				"response": map[string]any{
+					"string_value": "Command " + commandFqoid + " executed successfully",
+				},
+			}
+			catenaVal, res := catena.ToCatenaValue(response)
+			if res.Code != catena.OK {
 				return catena.CommandError(catena.INTERNAL, "failed to create command response")
 			}
 			return catena.CommandReply(catenaVal)
@@ -245,8 +250,8 @@ func main() {
 		deviceInfo := deviceInfo // capture loop variable
 		srv.RegisterGetDeviceHandler(uint16(slot), func() (catena.CatenaDevice, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
-			device, err := catena.ToCatenaDevice(deviceInfo)
-			if err != nil {
+			device, res := catena.ToCatenaDevice(deviceInfo)
+			if res.Code != catena.OK {
 				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL, "failed to create device info")
 			}
 			return catena.Reply(device)

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -180,7 +180,7 @@ func ToPayloadFromURL(url string) DataPayload {
 }
 
 // dataPayloadToProto converts a DataPayload to its proto representation.
-func dataPayloadToProto(dp DataPayload) (*protos.DataPayload, error) {
+func dataPayloadToProto(dp DataPayload) (*protos.DataPayload, StatusResult) {
 	pdp := &protos.DataPayload{
 		Metadata:        dp.Metadata,
 		Digest:          dp.Digest,
@@ -192,17 +192,17 @@ func dataPayloadToProto(dp DataPayload) (*protos.DataPayload, error) {
 	} else if len(dp.Payload) > 0 && dp.Url == "" {
 		pdp.Kind = &protos.DataPayload_Payload{Payload: dp.Payload}
 	} else {
-		return nil, fmt.Errorf("either payload or url must be provided in DataPayload, but not both")
+		return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "either payload or url must be provided in DataPayload, but not both"}
 	}
 
-	return pdp, nil
+	return pdp, StatusResult{Code: OK}
 }
 
 // ToCatenaAsset converts DataPayload to CatenaAsset by building the proto directly
-func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, error) {
-	protoPayload, err := dataPayloadToProto(dp)
-	if err != nil {
-		return CatenaAsset{asset: nil}, err
+func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, StatusResult) {
+	protoPayload, res := dataPayloadToProto(dp)
+	if res.Code != OK {
+		return CatenaAsset{asset: nil}, res
 	}
 
 	asset := &protos.ExternalObjectPayload{
@@ -210,7 +210,7 @@ func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, error) {
 		Payload:  protoPayload,
 	}
 
-	return CatenaAsset{asset: asset}, nil
+	return CatenaAsset{asset: asset}, StatusResult{Code: OK}
 }
 
 // GetProtoAsset returns the underlying protos.ExternalObjectPayload
@@ -219,15 +219,19 @@ func (ca CatenaAsset) GetProtoAsset() *protos.ExternalObjectPayload {
 }
 
 // ToJSON converts CatenaAsset to JSON bytes using protojson
-func (ca CatenaAsset) ToJSON() ([]byte, error) {
+func (ca CatenaAsset) ToJSON() ([]byte, StatusResult) {
 	if ca.asset == nil {
-		return nil, nil
+		return nil, StatusResult{Code: OK}
 	}
 
-	return (protojson.MarshalOptions{
+	b, err := (protojson.MarshalOptions{
 		UseProtoNames:   true,
 		EmitUnpopulated: false,
 	}).Marshal(ca.asset)
+	if err != nil {
+		return nil, StatusResult{Code: INTERNAL, Error: fmt.Sprintf("failed to marshal asset to JSON: %v", err)}
+	}
+	return b, StatusResult{Code: OK}
 }
 
 func compressGzipTo(w io.Writer, data []byte) error {
@@ -320,16 +324,16 @@ func EncodePayload(data []byte, encoding Encoding) ([]byte, error) {
 
 // ParsePayloadEncoding converts a string (e.g. "GZIP", "DEFLATE", "UNCOMPRESSED")
 // to the corresponding encoding constant.
-func ParsePayloadEncoding(s string) (Encoding, error) {
+func ParsePayloadEncoding(s string) (Encoding, StatusResult) {
 	switch strings.ToUpper(strings.TrimSpace(s)) {
 	case "UNCOMPRESSED", "":
-		return EncodingUncompressed, nil
+		return EncodingUncompressed, StatusResult{Code: OK}
 	case "GZIP":
-		return EncodingGzip, nil
+		return EncodingGzip, StatusResult{Code: OK}
 	case "DEFLATE":
-		return EncodingDeflate, nil
+		return EncodingDeflate, StatusResult{Code: OK}
 	default:
-		return EncodingUncompressed, fmt.Errorf("invalid payload encoding: %s", s)
+		return EncodingUncompressed, StatusResult{Code: INVALID_ARGUMENT, Error: fmt.Sprintf("invalid payload encoding: %s", s)}
 	}
 }
 
@@ -349,27 +353,27 @@ func PayloadEncodingFromExt(filename string) Encoding {
 // TranscodeAssetPayload decodes the asset's current payload encoding and
 // re-encodes it to targetEncoding, modifying the asset in place.
 // If the asset is already in the target encoding, this is a no-op.
-func TranscodeAssetPayload(asset *CatenaAsset, targetEncoding Encoding) error {
+func TranscodeAssetPayload(asset *CatenaAsset, targetEncoding Encoding) StatusResult {
 	original := asset.GetProtoAsset()
 	if original == nil || original.GetPayload() == nil {
-		return fmt.Errorf("asset has no payload")
+		return StatusResult{Code: INVALID_ARGUMENT, Error: "asset has no payload"}
 	}
 
 	dp := original.GetPayload()
 	currentEncoding := Encoding(dp.GetPayloadEncoding())
 
 	if currentEncoding == targetEncoding {
-		return nil
+		return StatusResult{Code: OK}
 	}
 
 	rawData, err := DecodePayload(dp.GetPayload(), currentEncoding)
 	if err != nil {
-		return fmt.Errorf("decode: %w", err)
+		return StatusResult{Code: INTERNAL, Error: fmt.Sprintf("decode: %v", err)}
 	}
 
 	encodedData, err := EncodePayload(rawData, targetEncoding)
 	if err != nil {
-		return fmt.Errorf("encode: %w", err)
+		return StatusResult{Code: INTERNAL, Error: fmt.Sprintf("encode: %v", err)}
 	}
 
 	cloned := proto.Clone(original).(*protos.ExternalObjectPayload)
@@ -379,5 +383,5 @@ func TranscodeAssetPayload(asset *CatenaAsset, targetEncoding Encoding) error {
 	cloned.Payload.Digest = newDigest[:]
 	asset.asset = cloned
 
-	return nil
+	return StatusResult{Code: OK}
 }

--- a/sdks/go/pkg/catena/asset_test.go
+++ b/sdks/go/pkg/catena/asset_test.go
@@ -68,8 +68,8 @@ func TestToCatenaAsset_WithPayload(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -101,8 +101,8 @@ func TestToCatenaAsset_WithUrl(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, false)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -129,7 +129,7 @@ func TestToCatenaAsset_BothPayloadAndUrl_Error(t *testing.T) {
 	}
 
 	_, err := ToCatenaAsset(dp, true)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected error when both payload and url are provided")
 	}
 }
@@ -142,7 +142,7 @@ func TestToCatenaAsset_NeitherPayloadNorUrl_Error(t *testing.T) {
 	}
 
 	_, err := ToCatenaAsset(dp, true)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected error when neither payload nor url are provided")
 	}
 }
@@ -154,8 +154,8 @@ func TestToCatenaAsset_WithGzipEncoding(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -179,8 +179,8 @@ func TestToCatenaAsset_WithDeflateEncoding(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -199,13 +199,13 @@ func TestCatenaAsset_ToJSON(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	jsonData, err := asset.ToJSON()
-	if err != nil {
-		t.Fatalf("ToJSON error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToJSON error: %v", err.Error)
 	}
 	if jsonData == nil {
 		t.Fatal("expected non-nil JSON data")
@@ -226,8 +226,8 @@ func TestCatenaAsset_ToJSON(t *testing.T) {
 func TestCatenaAsset_ToJSON_Nil(t *testing.T) {
 	asset := CatenaAsset{asset: nil}
 	jsonData, err := asset.ToJSON()
-	if err != nil {
-		t.Fatalf("ToJSON error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToJSON error: %v", err.Error)
 	}
 	if jsonData != nil {
 		t.Error("expected nil JSON data for nil asset")
@@ -249,8 +249,8 @@ func TestToCatenaAsset_WithDigest(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -277,8 +277,8 @@ func TestToCatenaAsset_EmptyPayload_WithUrl(t *testing.T) {
 	}
 
 	asset, err := ToCatenaAsset(dp, false)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -641,8 +641,8 @@ func TestParsePayloadEncoding(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			got, err := ParsePayloadEncoding(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ParsePayloadEncoding(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			if (err.Code != OK) != tt.wantErr {
+				t.Fatalf("ParsePayloadEncoding(%q) error = %v, wantErr %v", tt.input, err.Error, tt.wantErr)
 			}
 			if got != tt.want {
 				t.Errorf("ParsePayloadEncoding(%q) = %d, want %d", tt.input, got, tt.want)
@@ -681,14 +681,14 @@ func TestTranscodeAssetPayload(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  original,
 	}
-	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset: %v", err)
+	asset, res := ToCatenaAsset(dp, true)
+	if res.Code != OK {
+		t.Fatalf("ToCatenaAsset: %v", res.Error)
 	}
 
 	// Transcode to GZIP
-	if err := TranscodeAssetPayload(&asset, EncodingGzip); err != nil {
-		t.Fatalf("TranscodeAssetPayload to GZIP: %v", err)
+	if res := TranscodeAssetPayload(&asset, EncodingGzip); res.Code != OK {
+		t.Fatalf("TranscodeAssetPayload to GZIP: %v", res.Error)
 	}
 	proto := asset.GetProtoAsset().GetPayload()
 	if Encoding(proto.GetPayloadEncoding()) != EncodingGzip {
@@ -705,8 +705,8 @@ func TestTranscodeAssetPayload(t *testing.T) {
 	}
 
 	// Transcode from GZIP to DEFLATE
-	if err := TranscodeAssetPayload(&asset, EncodingDeflate); err != nil {
-		t.Fatalf("TranscodeAssetPayload GZIP→DEFLATE: %v", err)
+	if res := TranscodeAssetPayload(&asset, EncodingDeflate); res.Code != OK {
+		t.Fatalf("TranscodeAssetPayload GZIP→DEFLATE: %v", res.Error)
 	}
 	proto = asset.GetProtoAsset().GetPayload()
 	if Encoding(proto.GetPayloadEncoding()) != EncodingDeflate {
@@ -721,8 +721,8 @@ func TestTranscodeAssetPayload(t *testing.T) {
 	}
 
 	// Transcode from DEFLATE to UNCOMPRESSED
-	if err := TranscodeAssetPayload(&asset, EncodingUncompressed); err != nil {
-		t.Fatalf("TranscodeAssetPayload DEFLATE→UNCOMPRESSED: %v", err)
+	if res := TranscodeAssetPayload(&asset, EncodingUncompressed); res.Code != OK {
+		t.Fatalf("TranscodeAssetPayload DEFLATE→UNCOMPRESSED: %v", res.Error)
 	}
 	proto = asset.GetProtoAsset().GetPayload()
 	if Encoding(proto.GetPayloadEncoding()) != EncodingUncompressed {
@@ -738,8 +738,8 @@ func TestTranscodeAssetPayload_RecomputesDigest(t *testing.T) {
 	dp := ToPayload(original, "text/plain", "test.txt")
 
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset: %v", err.Error)
 	}
 
 	originalDigest := make([]byte, len(asset.GetProtoAsset().GetPayload().GetDigest()))
@@ -754,8 +754,8 @@ func TestTranscodeAssetPayload_RecomputesDigest(t *testing.T) {
 		}
 	}
 
-	if err := TranscodeAssetPayload(&asset, EncodingGzip); err != nil {
-		t.Fatalf("TranscodeAssetPayload to GZIP: %v", err)
+	if res := TranscodeAssetPayload(&asset, EncodingGzip); res.Code != OK {
+		t.Fatalf("TranscodeAssetPayload to GZIP: %v", res.Error)
 	}
 
 	newPayloadBytes := asset.GetProtoAsset().GetPayload().GetPayload()
@@ -786,8 +786,8 @@ func TestTranscodeAssetPayload_SameEncoding_Noop(t *testing.T) {
 	asset, _ := ToCatenaAsset(dp, true)
 	originalBytes := asset.GetProtoAsset().GetPayload().GetPayload()
 
-	if err := TranscodeAssetPayload(&asset, EncodingUncompressed); err != nil {
-		t.Fatalf("TranscodeAssetPayload same encoding: %v", err)
+	if res := TranscodeAssetPayload(&asset, EncodingUncompressed); res.Code != OK {
+		t.Fatalf("TranscodeAssetPayload same encoding: %v", res.Error)
 	}
 	if string(asset.GetProtoAsset().GetPayload().GetPayload()) != string(originalBytes) {
 		t.Error("expected no-op when transcoding to same encoding")
@@ -801,15 +801,15 @@ func TestTranscodeAssetPayload_DoesNotMutateOriginalProto(t *testing.T) {
 		Payload:  original,
 	}
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset: %v", err.Error)
 	}
 
 	originalProto := asset.GetProtoAsset()
 
 	copy := asset // shallow copy — shares the pointer
-	if err := TranscodeAssetPayload(&copy, EncodingGzip); err != nil {
-		t.Fatalf("TranscodeAssetPayload: %v", err)
+	if res := TranscodeAssetPayload(&copy, EncodingGzip); res.Code != OK {
+		t.Fatalf("TranscodeAssetPayload: %v", res.Error)
 	}
 
 	if Encoding(originalProto.GetPayload().GetPayloadEncoding()) != EncodingUncompressed {
@@ -829,7 +829,7 @@ func TestTranscodeAssetPayload_DoesNotMutateOriginalProto(t *testing.T) {
 func TestTranscodeAssetPayload_NilAsset(t *testing.T) {
 	asset := CatenaAsset{}
 	err := TranscodeAssetPayload(&asset, EncodingGzip)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected error for nil asset")
 	}
 }
@@ -837,7 +837,7 @@ func TestTranscodeAssetPayload_NilAsset(t *testing.T) {
 func TestTranscodeAssetPayload_NilPayload(t *testing.T) {
 	asset := CatenaAsset{asset: &protos.ExternalObjectPayload{Payload: nil}}
 	err := TranscodeAssetPayload(&asset, EncodingGzip)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected error for nil payload on non-nil asset")
 	}
 }
@@ -848,12 +848,12 @@ func TestTranscodeAssetPayload_DecodeError(t *testing.T) {
 		PayloadEncoding: EncodingGzip,
 	}
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset: %v", err.Error)
 	}
 
 	err = TranscodeAssetPayload(&asset, EncodingUncompressed)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected decode error for corrupt gzip payload")
 	}
 }
@@ -863,12 +863,12 @@ func TestTranscodeAssetPayload_EncodeError(t *testing.T) {
 		Payload: []byte("valid data"),
 	}
 	asset, err := ToCatenaAsset(dp, true)
-	if err != nil {
-		t.Fatalf("ToCatenaAsset: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaAsset: %v", err.Error)
 	}
 
 	err = TranscodeAssetPayload(&asset, Encoding(99))
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected encode error for unsupported target encoding")
 	}
 }

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -69,31 +69,30 @@ type CatenaDevice struct {
 
 // ToCatenaDevice converts a Go map/struct to CatenaDevice
 // This allows developers to work with native Go types and convert to the protobuf format
-func ToCatenaDevice(m map[string]any) (CatenaDevice, error) {
-	device, jsonData, err := toProtoDevice(m)
-	if err != nil {
-		return CatenaDevice{jsonData: nil}, fmt.Errorf("ToCatenaDevice: %w", err)
+func ToCatenaDevice(m map[string]any) (CatenaDevice, StatusResult) {
+	device, jsonData, res := toProtoDevice(m)
+	if res.Code != OK {
+		return CatenaDevice{jsonData: nil}, StatusResult{Code: res.Code, Error: "ToCatenaDevice: " + res.Error}
 	}
-	return CatenaDevice{device: device, jsonData: jsonData}, nil
+	return CatenaDevice{device: device, jsonData: jsonData}, StatusResult{Code: OK}
 }
 
 // toProtoDevice converts native Go types to protos.Device
 // For complex nested types (params, constraints, etc.), uses JSON marshaling
 // to leverage protojson's automatic conversion and validation
-// Returns the device, cached JSON data, and any error
-func toProtoDevice(m map[string]any) (*protos.Device, []byte, error) {
-	// For complex types, use JSON marshaling to handle nested structures
+// Returns the device, cached JSON data, and a StatusResult
+func toProtoDevice(m map[string]any) (*protos.Device, []byte, StatusResult) {
 	jsonData, err := json.Marshal(m)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to marshal map to JSON: %w", err)
+		return nil, nil, StatusResult{Code: INTERNAL, Error: fmt.Sprintf("failed to marshal map to JSON: %v", err)}
 	}
 
 	device := &protos.Device{}
 	if err := protojson.Unmarshal(jsonData, device); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal JSON to Device proto: %w", err)
+		return nil, nil, StatusResult{Code: INTERNAL, Error: fmt.Sprintf("failed to unmarshal JSON to Device proto: %v", err)}
 	}
 
-	return device, jsonData, nil
+	return device, jsonData, StatusResult{Code: OK}
 }
 
 // GetProtoDevice returns the underlying protos.Device
@@ -103,19 +102,21 @@ func (cd CatenaDevice) GetProtoDevice() *protos.Device {
 
 // ToJSON converts CatenaDevice to JSON bytes using protojson
 // Uses cached JSON if available, otherwise generates new JSON
-func (cd CatenaDevice) ToJSON() ([]byte, error) {
+func (cd CatenaDevice) ToJSON() ([]byte, StatusResult) {
 	if cd.device == nil {
-		return nil, nil
+		return nil, StatusResult{Code: OK}
 	}
 
-	// Return cached JSON if available
 	if cd.jsonData != nil {
-		return cd.jsonData, nil
+		return cd.jsonData, StatusResult{Code: OK}
 	}
 
-	// Generate JSON from protobuf if not cached
-	return (protojson.MarshalOptions{
+	b, err := (protojson.MarshalOptions{
 		UseProtoNames:   true,
 		EmitUnpopulated: false,
 	}).Marshal(cd.device)
+	if err != nil {
+		return nil, StatusResult{Code: INTERNAL, Error: fmt.Sprintf("failed to marshal device to JSON: %v", err)}
+	}
+	return b, StatusResult{Code: OK}
 }

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -50,8 +50,8 @@ func TestToCatenaDevice_Basic(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	if cd.GetProtoDevice() == nil {
 		t.Error("expected non-nil proto device")
@@ -77,8 +77,8 @@ func TestToCatenaDevice_WithParams(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -119,8 +119,8 @@ func TestToCatenaDevice_WithConstraints(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -188,8 +188,8 @@ func TestToCatenaDevice_WithLanguagePacks(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -243,8 +243,8 @@ func TestToCatenaDevice_WithMenuGroups(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -294,8 +294,8 @@ func TestToCatenaDevice_WithCommands(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -333,13 +333,13 @@ func TestCatenaDevice_ToJSON(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 
 	jsonData, err := cd.ToJSON()
-	if err != nil {
-		t.Fatalf("ToJSON error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToJSON error: %v", err.Error)
 	}
 	if jsonData == nil {
 		t.Fatal("expected non-nil JSON data")
@@ -360,8 +360,8 @@ func TestCatenaDevice_ToJSON(t *testing.T) {
 func TestCatenaDevice_ToJSON_Nil(t *testing.T) {
 	cd := CatenaDevice{device: nil}
 	jsonData, err := cd.ToJSON()
-	if err != nil {
-		t.Fatalf("ToJSON error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToJSON error: %v", err.Error)
 	}
 	if jsonData != nil {
 		t.Error("expected nil JSON data for nil device")
@@ -472,8 +472,8 @@ func TestToCatenaDevice_CompleteDevice(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 
 	proto := cd.GetProtoDevice()
@@ -503,8 +503,8 @@ func TestToCatenaDevice_CompleteDevice(t *testing.T) {
 
 	// Verify JSON output works
 	jsonData, err := cd.ToJSON()
-	if err != nil {
-		t.Fatalf("ToJSON error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToJSON error: %v", err.Error)
 	}
 	if len(jsonData) == 0 {
 		t.Error("expected non-empty JSON")
@@ -526,8 +526,8 @@ func TestToCatenaDevice_FloatRangeConstraint(t *testing.T) {
 	}
 
 	cd, err := ToCatenaDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToCatenaDevice error: %v", err.Error)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -80,78 +80,78 @@ const (
 	ParamTypeData               ParamType = protos.ParamType_DATA
 )
 
-func ToCatenaValue(v any) (CatenaValue, error) {
-	val, err := ToProto(v)
-	if err != nil {
-		return CatenaValue{}, fmt.Errorf("ToCatenaValue: %w", err)
+func ToCatenaValue(v any) (CatenaValue, StatusResult) {
+	val, res := ToProto(v)
+	if res.Code != OK {
+		return CatenaValue{}, StatusResult{Code: res.Code, Error: "ToCatenaValue: " + res.Error}
 	}
-	return CatenaValue{Value: val}, nil
+	return CatenaValue{Value: val}, StatusResult{Code: OK}
 }
 
 // ToProto converts native Go types to protos.Value
-func ToProto(v any) (*protos.Value, error) {
+func ToProto(v any) (*protos.Value, StatusResult) {
 	switch val := v.(type) {
 	case DataPayload:
-		pdp, err := dataPayloadToProto(val)
-		if err != nil {
-			return nil, err
+		pdp, res := dataPayloadToProto(val)
+		if res.Code != OK {
+			return nil, res
 		}
-		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}, nil
+		return &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}, StatusResult{Code: OK}
 	case UndefinedValue:
-		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, nil
+		return &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: protos.UndefinedValue(val)}}, StatusResult{Code: OK}
 	case EmptyValue:
-		return &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}}, nil
+		return &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}}, StatusResult{Code: OK}
 	case int32:
-		return &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: val}}, nil
+		return &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: val}}, StatusResult{Code: OK}
 	case float32:
-		return &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: val}}, nil
+		return &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: val}}, StatusResult{Code: OK}
 	case string:
-		return &protos.Value{Kind: &protos.Value_StringValue{StringValue: val}}, nil
+		return &protos.Value{Kind: &protos.Value_StringValue{StringValue: val}}, StatusResult{Code: OK}
 	case []int32:
-		return &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: val}}}, nil
+		return &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: val}}}, StatusResult{Code: OK}
 	case []float32:
-		return &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: val}}}, nil
+		return &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: val}}}, StatusResult{Code: OK}
 	case []string:
-		return &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: val}}}, nil
+		return &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: val}}}, StatusResult{Code: OK}
 	case map[string]any:
 		fields := make(map[string]*protos.Value)
 		for k, v := range val {
-			res, err := ToProto(v)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert map field %s: %w", k, err)
+			res, sr := ToProto(v)
+			if sr.Code != OK {
+				return nil, StatusResult{Code: sr.Code, Error: fmt.Sprintf("failed to convert map field %s: %s", k, sr.Error)}
 			}
 			fields[k] = res
 		}
-		return &protos.Value{Kind: &protos.Value_StructValue{StructValue: &protos.StructValue{Fields: fields}}}, nil
+		return &protos.Value{Kind: &protos.Value_StructValue{StructValue: &protos.StructValue{Fields: fields}}}, StatusResult{Code: OK}
 	case []map[string]any:
 		structArr := make([]*protos.StructValue, len(val))
 		for i, m := range val {
 			fields := make(map[string]*protos.Value)
 			for k, v := range m {
-				res, err := ToProto(v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert map field %s: %w", k, err)
+				res, sr := ToProto(v)
+				if sr.Code != OK {
+					return nil, StatusResult{Code: sr.Code, Error: fmt.Sprintf("failed to convert map field %s: %s", k, sr.Error)}
 				}
 				fields[k] = res
 			}
 			structArr[i] = &protos.StructValue{Fields: fields}
 		}
-		return &protos.Value{Kind: &protos.Value_StructArrayValues{StructArrayValues: &protos.StructList{StructValues: structArr}}}, nil
+		return &protos.Value{Kind: &protos.Value_StructArrayValues{StructArrayValues: &protos.StructList{StructValues: structArr}}}, StatusResult{Code: OK}
 	case StructVariantValue:
-		protoVal, err := ToProto(val.Value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert StructVariantValue.Value: %w", err)
+		protoVal, sr := ToProto(val.Value)
+		if sr.Code != OK {
+			return nil, StatusResult{Code: sr.Code, Error: "failed to convert StructVariantValue.Value: " + sr.Error}
 		}
 		return &protos.Value{Kind: &protos.Value_StructVariantValue{StructVariantValue: &protos.StructVariantValue{
 			StructVariantType: val.StructVariantType,
 			Value:             protoVal,
-		}}}, nil
+		}}}, StatusResult{Code: OK}
 	case []StructVariantValue:
 		var structVariants []*protos.StructVariantValue
 		for _, sv := range val {
-			protoVal, err := ToProto(sv.Value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert StructVariantValue.Value in array: %w", err)
+			protoVal, sr := ToProto(sv.Value)
+			if sr.Code != OK {
+				return nil, StatusResult{Code: sr.Code, Error: "failed to convert StructVariantValue.Value in array: " + sr.Error}
 			}
 			structVariants = append(structVariants, &protos.StructVariantValue{
 				StructVariantType: sv.StructVariantType,
@@ -160,22 +160,22 @@ func ToProto(v any) (*protos.Value, error) {
 		}
 		return &protos.Value{Kind: &protos.Value_StructVariantArrayValues{StructVariantArrayValues: &protos.StructVariantList{
 			StructVariants: structVariants,
-		}}}, nil
+		}}}, StatusResult{Code: OK}
 	default:
-		return nil, fmt.Errorf("unsupported type: %T", v)
+		return nil, StatusResult{Code: INVALID_ARGUMENT, Error: fmt.Sprintf("unsupported type: %T", v)}
 	}
 }
 
 // FromProto converts protos.Value to native Go types
-func FromProto(pv *protos.Value) (any, error) {
+func FromProto(pv *protos.Value) (any, StatusResult) {
 	if pv == nil {
-		return nil, fmt.Errorf("nil Value")
+		return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil Value"}
 	}
 	switch pv.GetKind().(type) {
 	case *protos.Value_DataPayload:
 		pdp := pv.GetDataPayload()
 		if pdp == nil {
-			return nil, fmt.Errorf("nil DataPayload in Value")
+			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil DataPayload in Value"}
 		}
 		dp := DataPayload{
 			Metadata:        pdp.GetMetadata(),
@@ -188,34 +188,34 @@ func FromProto(pv *protos.Value) (any, error) {
 		case *protos.DataPayload_Payload:
 			dp.Payload = k.Payload
 		}
-		return dp, nil
+		return dp, StatusResult{Code: OK}
 	case *protos.Value_UndefinedValue:
-		return UndefinedValue(pv.GetUndefinedValue()), nil
+		return UndefinedValue(pv.GetUndefinedValue()), StatusResult{Code: OK}
 	case *protos.Value_EmptyValue:
-		return EmptyValue{}, nil
+		return EmptyValue{}, StatusResult{Code: OK}
 	case *protos.Value_Int32Value:
-		return pv.GetInt32Value(), nil
+		return pv.GetInt32Value(), StatusResult{Code: OK}
 	case *protos.Value_Float32Value:
-		return pv.GetFloat32Value(), nil
+		return pv.GetFloat32Value(), StatusResult{Code: OK}
 	case *protos.Value_StringValue:
-		return pv.GetStringValue(), nil
+		return pv.GetStringValue(), StatusResult{Code: OK}
 	case *protos.Value_Int32ArrayValues:
-		return pv.GetInt32ArrayValues().GetInts(), nil
+		return pv.GetInt32ArrayValues().GetInts(), StatusResult{Code: OK}
 	case *protos.Value_Float32ArrayValues:
-		return pv.GetFloat32ArrayValues().GetFloats(), nil
+		return pv.GetFloat32ArrayValues().GetFloats(), StatusResult{Code: OK}
 	case *protos.Value_StringArrayValues:
-		return pv.GetStringArrayValues().GetStrings(), nil
+		return pv.GetStringArrayValues().GetStrings(), StatusResult{Code: OK}
 	case *protos.Value_StructValue:
 		fields := pv.GetStructValue().GetFields()
 		m := make(map[string]any, len(fields))
 		for k, v := range fields {
-			val, err := FromProto(v)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert struct field %s: %w", k, err)
+			val, sr := FromProto(v)
+			if sr.Code != OK {
+				return nil, StatusResult{Code: sr.Code, Error: fmt.Sprintf("failed to convert struct field %s: %s", k, sr.Error)}
 			}
 			m[k] = val
 		}
-		return m, nil
+		return m, StatusResult{Code: OK}
 	case *protos.Value_StructArrayValues:
 		list := pv.GetStructArrayValues().GetStructValues()
 		arr := make([]map[string]any, len(list))
@@ -223,40 +223,40 @@ func FromProto(pv *protos.Value) (any, error) {
 			fields := sv.GetFields()
 			m := make(map[string]any, len(fields))
 			for k, v := range fields {
-				val, err := FromProto(v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to convert struct field %s: %w", k, err)
+				val, sr := FromProto(v)
+				if sr.Code != OK {
+					return nil, StatusResult{Code: sr.Code, Error: fmt.Sprintf("failed to convert struct field %s: %s", k, sr.Error)}
 				}
 				m[k] = val
 			}
 			arr[i] = m
 		}
-		return arr, nil
+		return arr, StatusResult{Code: OK}
 	case *protos.Value_StructVariantValue:
 		sv := pv.GetStructVariantValue()
-		val, err := FromProto(sv.GetValue())
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert struct variant value: %w", err)
+		val, sr := FromProto(sv.GetValue())
+		if sr.Code != OK {
+			return nil, StatusResult{Code: sr.Code, Error: "failed to convert struct variant value: " + sr.Error}
 		}
 		return StructVariantValue{
 			StructVariantType: sv.GetStructVariantType(),
 			Value:             val,
-		}, nil
+		}, StatusResult{Code: OK}
 	case *protos.Value_StructVariantArrayValues:
 		list := pv.GetStructVariantArrayValues().GetStructVariants()
 		arr := make([]StructVariantValue, 0, len(list))
 		for _, sv := range list {
-			val, err := FromProto(sv.GetValue())
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert struct variant value: %w", err)
+			val, sr := FromProto(sv.GetValue())
+			if sr.Code != OK {
+				return nil, StatusResult{Code: sr.Code, Error: "failed to convert struct variant value: " + sr.Error}
 			}
 			arr = append(arr, StructVariantValue{
 				StructVariantType: sv.GetStructVariantType(),
 				Value:             val,
 			})
 		}
-		return arr, nil
+		return arr, StatusResult{Code: OK}
 	default:
-		return nil, fmt.Errorf("unsupported Value type: %T", pv.GetKind())
+		return nil, StatusResult{Code: INVALID_ARGUMENT, Error: fmt.Sprintf("unsupported Value type: %T", pv.GetKind())}
 	}
 }

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -70,13 +70,13 @@ func TestToCatenaValue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cv, err := ToCatenaValue(tt.input)
 			if tt.wantErr {
-				if err == nil {
+				if err.Code == OK {
 					t.Errorf("ToCatenaValue(%v) expected error, got nil", tt.input)
 				}
 				return
 			}
-			if err != nil {
-				t.Errorf("ToCatenaValue(%v) unexpected error: %v", tt.input, err)
+			if err.Code != OK {
+				t.Errorf("ToCatenaValue(%v) unexpected error: %v", tt.input, err.Error)
 				return
 			}
 			if cv.Value == nil {
@@ -89,8 +89,8 @@ func TestToCatenaValue(t *testing.T) {
 func TestToProto_Int32(t *testing.T) {
 	input := int32(42)
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	if pv.GetInt32Value() != 42 {
 		t.Errorf("ToProto(%v) = %v, want 42", input, pv.GetInt32Value())
@@ -100,8 +100,8 @@ func TestToProto_Int32(t *testing.T) {
 func TestToProto_Float32(t *testing.T) {
 	input := float32(3.14)
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	if pv.GetFloat32Value() != input {
 		t.Errorf("ToProto(%v) = %v, want %v", input, pv.GetFloat32Value(), input)
@@ -111,8 +111,8 @@ func TestToProto_Float32(t *testing.T) {
 func TestToProto_String(t *testing.T) {
 	input := "hello world"
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	if pv.GetStringValue() != input {
 		t.Errorf("ToProto(%v) = %v, want %v", input, pv.GetStringValue(), input)
@@ -122,8 +122,8 @@ func TestToProto_String(t *testing.T) {
 func TestToProto_Int32Array(t *testing.T) {
 	input := []int32{1, 2, 3, 4, 5}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	result := pv.GetInt32ArrayValues().GetInts()
 	if !reflect.DeepEqual(result, input) {
@@ -134,8 +134,8 @@ func TestToProto_Int32Array(t *testing.T) {
 func TestToProto_Float32Array(t *testing.T) {
 	input := []float32{1.1, 2.2, 3.3}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	result := pv.GetFloat32ArrayValues().GetFloats()
 	if !reflect.DeepEqual(result, input) {
@@ -146,8 +146,8 @@ func TestToProto_Float32Array(t *testing.T) {
 func TestToProto_StringArray(t *testing.T) {
 	input := []string{"one", "two", "three"}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	result := pv.GetStringArrayValues().GetStrings()
 	if !reflect.DeepEqual(result, input) {
@@ -158,8 +158,8 @@ func TestToProto_StringArray(t *testing.T) {
 func TestToProto_EmptyValue(t *testing.T) {
 	input := EmptyValue{}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(EmptyValue{}) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(EmptyValue{}) error: %v", err.Error)
 	}
 	if pv.GetEmptyValue() == nil {
 		t.Error("ToProto(EmptyValue{}) expected EmptyValue kind")
@@ -169,8 +169,8 @@ func TestToProto_EmptyValue(t *testing.T) {
 func TestToProto_UndefinedValue(t *testing.T) {
 	input := UndefinedValue(0)
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(UndefinedValue) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(UndefinedValue) error: %v", err.Error)
 	}
 	// Check that it has the UndefinedValue kind
 	if pv.GetUndefinedValue() == 0 {
@@ -184,8 +184,8 @@ func TestToProto_StructValue(t *testing.T) {
 		"count": int32(42),
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	sv := pv.GetStructValue()
 	if sv == nil {
@@ -206,8 +206,8 @@ func TestToProto_StructArray(t *testing.T) {
 		{"id": int32(2), "label": "second"},
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(%v) error: %v", input, err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(%v) error: %v", input, err.Error)
 	}
 	sa := pv.GetStructArrayValues()
 	if sa == nil {
@@ -233,8 +233,8 @@ func TestToProto_StructVariantValue(t *testing.T) {
 		},
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(StructVariantValue) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(StructVariantValue) error: %v", err.Error)
 	}
 	sv := pv.GetStructVariantValue()
 	if sv == nil {
@@ -251,8 +251,8 @@ func TestToProto_StructVariantArray(t *testing.T) {
 		{StructVariantType: "TypeB", Value: "hello"},
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto([]StructVariantValue) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto([]StructVariantValue) error: %v", err.Error)
 	}
 	sva := pv.GetStructVariantArrayValues()
 	if sva == nil {
@@ -275,8 +275,8 @@ func TestToProto_DataPayload_WithPayload(t *testing.T) {
 		Payload:         []byte("binary data"),
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(DataPayload) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(DataPayload) error: %v", err.Error)
 	}
 	dp := pv.GetDataPayload()
 	if dp == nil {
@@ -299,8 +299,8 @@ func TestToProto_DataPayload_WithUrl(t *testing.T) {
 		Url:      "https://example.com/data.json",
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto(DataPayload) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(DataPayload) error: %v", err.Error)
 	}
 	dp := pv.GetDataPayload()
 	if dp == nil {
@@ -317,7 +317,7 @@ func TestToProto_DataPayload_BothPayloadAndUrl_Error(t *testing.T) {
 		Url:     "https://example.com",
 	}
 	_, err := ToProto(input)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected error when both payload and url are provided")
 	}
 }
@@ -327,7 +327,7 @@ func TestToProto_DataPayload_NeitherPayloadNorUrl_Error(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 	}
 	_, err := ToProto(input)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("expected error when neither payload nor url are provided")
 	}
 }
@@ -340,12 +340,12 @@ func TestFromProto_DataPayload_WithPayload(t *testing.T) {
 		Payload:         []byte("binary data"),
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto error: %v", err.Error)
 	}
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	dp, ok := result.(DataPayload)
 	if !ok {
@@ -370,12 +370,12 @@ func TestFromProto_DataPayload_WithUrl(t *testing.T) {
 		Url: "https://example.com/resource",
 	}
 	pv, err := ToProto(input)
-	if err != nil {
-		t.Fatalf("ToProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto error: %v", err.Error)
 	}
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	dp, ok := result.(DataPayload)
 	if !ok {
@@ -419,12 +419,12 @@ func TestRoundTrip_DataPayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pv, err := ToProto(tt.input)
-			if err != nil {
-				t.Fatalf("ToProto error: %v", err)
+			if err.Code != OK {
+				t.Fatalf("ToProto error: %v", err.Error)
 			}
 			result, err := FromProto(pv)
-			if err != nil {
-				t.Fatalf("FromProto error: %v", err)
+			if err.Code != OK {
+				t.Fatalf("FromProto error: %v", err.Error)
 			}
 			dp, ok := result.(DataPayload)
 			if !ok {
@@ -463,7 +463,7 @@ func TestToProto_UnsupportedType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ToProto(tt.input)
-			if err == nil {
+			if err.Code == OK {
 				t.Errorf("ToProto(%T) expected error for unsupported type", tt.input)
 			}
 		})
@@ -472,7 +472,7 @@ func TestToProto_UnsupportedType(t *testing.T) {
 
 func TestFromProto_Nil(t *testing.T) {
 	_, err := FromProto(nil)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto(nil) expected error")
 	}
 }
@@ -480,8 +480,8 @@ func TestFromProto_Nil(t *testing.T) {
 func TestFromProto_Int32(t *testing.T) {
 	pv, _ := ToProto(int32(42))
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if v, ok := result.(int32); !ok || v != 42 {
 		t.Errorf("FromProto expected int32(42), got %T(%v)", result, result)
@@ -491,8 +491,8 @@ func TestFromProto_Int32(t *testing.T) {
 func TestFromProto_Float32(t *testing.T) {
 	pv, _ := ToProto(float32(3.14))
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if v, ok := result.(float32); !ok || v != 3.14 {
 		t.Errorf("FromProto expected float32(3.14), got %T(%v)", result, result)
@@ -502,8 +502,8 @@ func TestFromProto_Float32(t *testing.T) {
 func TestFromProto_String(t *testing.T) {
 	pv, _ := ToProto("hello")
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if v, ok := result.(string); !ok || v != "hello" {
 		t.Errorf("FromProto expected string(hello), got %T(%v)", result, result)
@@ -514,8 +514,8 @@ func TestFromProto_Int32Array(t *testing.T) {
 	input := []int32{1, 2, 3}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if !reflect.DeepEqual(result, input) {
 		t.Errorf("FromProto expected %v, got %v", input, result)
@@ -526,8 +526,8 @@ func TestFromProto_Float32Array(t *testing.T) {
 	input := []float32{1.1, 2.2}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if !reflect.DeepEqual(result, input) {
 		t.Errorf("FromProto expected %v, got %v", input, result)
@@ -538,8 +538,8 @@ func TestFromProto_StringArray(t *testing.T) {
 	input := []string{"a", "b", "c"}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if !reflect.DeepEqual(result, input) {
 		t.Errorf("FromProto expected %v, got %v", input, result)
@@ -549,8 +549,8 @@ func TestFromProto_StringArray(t *testing.T) {
 func TestFromProto_EmptyValue(t *testing.T) {
 	pv, _ := ToProto(EmptyValue{})
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	if _, ok := result.(EmptyValue); !ok {
 		t.Errorf("FromProto expected EmptyValue, got %T", result)
@@ -564,8 +564,8 @@ func TestFromProto_StructValue(t *testing.T) {
 	}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	m, ok := result.(map[string]any)
 	if !ok {
@@ -586,8 +586,8 @@ func TestFromProto_StructArray(t *testing.T) {
 	}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	arr, ok := result.([]map[string]any)
 	if !ok {
@@ -605,8 +605,8 @@ func TestFromProto_StructVariantValue(t *testing.T) {
 	}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	sv, ok := result.(StructVariantValue)
 	if !ok {
@@ -624,8 +624,8 @@ func TestFromProto_StructVariantArray(t *testing.T) {
 	}
 	pv, _ := ToProto(input)
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	arr, ok := result.([]StructVariantValue)
 	if !ok {
@@ -659,12 +659,12 @@ func TestRoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pv, err := ToProto(tt.input)
-			if err != nil {
-				t.Fatalf("ToProto error: %v", err)
+			if err.Code != OK {
+				t.Fatalf("ToProto error: %v", err.Error)
 			}
 			result, err := FromProto(pv)
-			if err != nil {
-				t.Fatalf("FromProto error: %v", err)
+			if err.Code != OK {
+				t.Fatalf("FromProto error: %v", err.Error)
 			}
 			if !reflect.DeepEqual(result, tt.input) {
 				t.Errorf("round trip failed: input=%v, result=%v", tt.input, result)
@@ -675,12 +675,12 @@ func TestRoundTrip(t *testing.T) {
 
 func TestFromProto_UndefinedValue(t *testing.T) {
 	pv, err := ToProto(UndefinedValue(42))
-	if err != nil {
-		t.Fatalf("ToProto(UndefinedValue) error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("ToProto(UndefinedValue) error: %v", err.Error)
 	}
 	result, err := FromProto(pv)
-	if err != nil {
-		t.Fatalf("FromProto error: %v", err)
+	if err.Code != OK {
+		t.Fatalf("FromProto error: %v", err.Error)
 	}
 	uv, ok := result.(UndefinedValue)
 	if !ok {
@@ -694,7 +694,7 @@ func TestFromProto_UndefinedValue(t *testing.T) {
 func TestFromProto_NilDataPayload(t *testing.T) {
 	pv := &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: nil}}
 	_, err := FromProto(pv)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto with nil DataPayload expected error")
 	}
 }
@@ -702,7 +702,7 @@ func TestFromProto_NilDataPayload(t *testing.T) {
 func TestFromProto_UnsupportedKind(t *testing.T) {
 	pv := &protos.Value{}
 	_, err := FromProto(pv)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto with nil Kind expected error")
 	}
 }
@@ -714,7 +714,7 @@ func TestFromProto_StructFieldError(t *testing.T) {
 		},
 	}}}
 	_, err := FromProto(pv)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto with nil struct field value expected error")
 	}
 }
@@ -726,7 +726,7 @@ func TestFromProto_StructArrayFieldError(t *testing.T) {
 		},
 	}}}
 	_, err := FromProto(pv)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto with nil struct array field value expected error")
 	}
 }
@@ -737,7 +737,7 @@ func TestFromProto_StructVariantValueError(t *testing.T) {
 		Value:             nil,
 	}}}
 	_, err := FromProto(pv)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto with nil struct variant value expected error")
 	}
 }
@@ -749,7 +749,7 @@ func TestFromProto_StructVariantArrayError(t *testing.T) {
 		},
 	}}}
 	_, err := FromProto(pv)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("FromProto with nil struct variant array value expected error")
 	}
 }
@@ -759,7 +759,7 @@ func TestToProto_StructFieldError(t *testing.T) {
 		"bad": int64(1),
 	}
 	_, err := ToProto(input)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("ToProto with unsupported struct field type expected error")
 	}
 }
@@ -769,7 +769,7 @@ func TestToProto_StructArrayFieldError(t *testing.T) {
 		{"bad": int64(1)},
 	}
 	_, err := ToProto(input)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("ToProto with unsupported struct array field type expected error")
 	}
 }
@@ -780,7 +780,7 @@ func TestToProto_StructVariantValueError(t *testing.T) {
 		Value:             int64(1),
 	}
 	_, err := ToProto(input)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("ToProto with unsupported struct variant value type expected error")
 	}
 }
@@ -790,7 +790,7 @@ func TestToProto_StructVariantArrayError(t *testing.T) {
 		{StructVariantType: "bad", Value: int64(1)},
 	}
 	_, err := ToProto(input)
-	if err == nil {
+	if err.Code == OK {
 		t.Error("ToProto with unsupported struct variant array value type expected error")
 	}
 }

--- a/sdks/go/pkg/grpc/server.go
+++ b/sdks/go/pkg/grpc/server.go
@@ -208,9 +208,9 @@ func (s *Server) SetValue(ctx context.Context, req *protos.SingleSetValuePayload
 
 	// Convert proto value to native Go type
 	nativeValue, errProto := catena.FromProto(req.Value.Value)
-	if errProto != nil {
-		logger.Error("SetValue failed to convert proto value", "slot", slot, "fqoid", fqoid, "error", err.Error)
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid value: %v", err.Error))
+	if errProto.Code != catena.OK {
+		logger.Error("SetValue failed to convert proto value", "slot", slot, "fqoid", fqoid, "error", errProto.Error)
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid value: %v", errProto.Error))
 	}
 
 	handler := s.baseServer.LookupSetValueHandler(slot)
@@ -237,9 +237,9 @@ func (s *Server) MultiSetValue(ctx context.Context, req *protos.MultiSetValuePay
 		fqoid := setValue.Oid
 
 		nativeValue, errProto := catena.FromProto(setValue.Value)
-		if errProto != nil {
-			logger.Error("MultiSetValue failed to convert proto value", "slot", slot, "fqoid", fqoid, "error", err.Error)
-			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid value for %s: %v", fqoid, err.Error))
+		if errProto.Code != catena.OK {
+			logger.Error("MultiSetValue failed to convert proto value", "slot", slot, "fqoid", fqoid, "error", errProto.Error)
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid value for %s: %v", fqoid, errProto.Error))
 		}
 
 		result := handler(nativeValue, slot, fqoid)
@@ -290,11 +290,11 @@ func (s *Server) ExecuteCommand(req *protos.ExecuteCommandPayload, stream grpc.S
 
 	var payload any
 	if req.Value != nil {
-		var errProto error
+		var errProto catena.StatusResult
 		payload, errProto = catena.FromProto(req.Value)
-		if errProto != nil {
-			logger.Error("ExecuteCommand failed to convert payload", "slot", slot, "command", commandFqoid, "error", err.Error)
-			return status.Error(codes.InvalidArgument, fmt.Sprintf("invalid command payload: %v", err.Error))
+		if errProto.Code != catena.OK {
+			logger.Error("ExecuteCommand failed to convert payload", "slot", slot, "command", commandFqoid, "error", errProto.Error)
+			return status.Error(codes.InvalidArgument, fmt.Sprintf("invalid command payload: %v", errProto.Error))
 		}
 	}
 

--- a/sdks/go/pkg/grpc/server_test.go
+++ b/sdks/go/pkg/grpc/server_test.go
@@ -199,8 +199,8 @@ func TestServer_DeviceRequest_Success(t *testing.T) {
 			"detail_level": catena.DetailLevelFull,
 		}
 		device, err := catena.ToCatenaDevice(deviceMap)
-		if err != nil {
-			t.Fatalf("ToCatenaDevice failed: %v", err)
+		if err.Code != catena.OK {
+			t.Fatalf("ToCatenaDevice failed: %v", err.Error)
 		}
 		return catena.Reply(device)
 	})

--- a/sdks/go/pkg/grpc/test_helpers_test.go
+++ b/sdks/go/pkg/grpc/test_helpers_test.go
@@ -95,8 +95,8 @@ func makeSetValueRequest(t *testing.T, client protos.CatenaServiceClient, ctx co
 	t.Helper()
 
 	protoValue, err := catena.ToProto(value)
-	if err != nil {
-		t.Fatalf("failed to convert value to proto: %v", err)
+	if err.Code != catena.OK {
+		t.Fatalf("failed to convert value to proto: %v", err.Error)
 	}
 
 	return client.SetValue(ctx, &protos.SingleSetValuePayload{
@@ -115,8 +115,8 @@ func makeMultiSetValueRequest(t *testing.T, client protos.CatenaServiceClient, c
 	setValues := make([]*protos.SetValuePayload, 0, len(values))
 	for oid, value := range values {
 		protoValue, err := catena.ToProto(value)
-		if err != nil {
-			t.Fatalf("failed to convert value for %s to proto: %v", oid, err)
+		if err.Code != catena.OK {
+			t.Fatalf("failed to convert value for %s to proto: %v", oid, err.Error)
 		}
 		setValues = append(setValues, &protos.SetValuePayload{
 			Oid:   oid,
@@ -158,8 +158,8 @@ func makeExecuteCommandRequest(t *testing.T, client protos.CatenaServiceClient, 
 
 	if payload != nil {
 		protoValue, err := catena.ToProto(payload)
-		if err != nil {
-			t.Fatalf("failed to convert command payload to proto: %v", err)
+		if err.Code != catena.OK {
+			t.Fatalf("failed to convert command payload to proto: %v", err.Error)
 		}
 		req.Value = protoValue
 	}

--- a/sdks/go/pkg/internal/base_server.go
+++ b/sdks/go/pkg/internal/base_server.go
@@ -193,9 +193,9 @@ func (bs *BaseServer) ConnectionCount() int {
 // and sends it to all connected streaming clients. Business logic calls this with
 // plain Go types; the proto serialization is handled internally.
 func (bs *BaseServer) BroadcastUpdate(slot uint16, oid string, value any) {
-	protoValue, err := catena.ToProto(value)
-	if err != nil {
-		logger.Error("BroadcastUpdate: failed to convert value to proto", "error", err)
+	protoValue, res := catena.ToProto(value)
+	if res.Code != catena.OK {
+		logger.Error("BroadcastUpdate: failed to convert value to proto", "error", res.Error)
 		return
 	}
 	update := &protos.PushUpdates{

--- a/sdks/go/pkg/rest/server.go
+++ b/sdks/go/pkg/rest/server.go
@@ -159,8 +159,8 @@ func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, httpStatu
 	}
 
 	// Convert asset to JSON
-	jsonData, err := asset.ToJSON()
-	if err != nil {
+	jsonData, res := asset.ToJSON()
+	if res.Code != catena.OK {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Asset payload is missing"})
@@ -395,8 +395,8 @@ func (s *Server) handleValueEndpoint(w http.ResponseWriter, r *http.Request, slo
 
 		// Convert proto value to native Go type
 		nativeValue, errProto := catena.FromProto(reqValue)
-		if errProto != nil {
-			logger.Error("failed to convert proto value to native Go type", "error", err.Error)
+		if errProto.Code != catena.OK {
+			logger.Error("failed to convert proto value to native Go type", "error", errProto.Error)
 			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid request body")
 			writeHTTPResult(w, res, val)
 			return
@@ -425,15 +425,15 @@ func (s *Server) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slo
 
 	if res.Error == "" {
 		if compressionStr := r.URL.Query().Get("compression"); compressionStr != "" {
-			targetEncoding, err := catena.ParsePayloadEncoding(compressionStr)
-			if err != nil {
-				_, errRes := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, err.Error())
+			targetEncoding, encRes := catena.ParsePayloadEncoding(compressionStr)
+			if encRes.Code != catena.OK {
+				_, errRes := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, encRes.Error)
 				writeHTTPResult(w, errRes, catena.CatenaValue{})
 				return
 			}
-			if err := catena.TranscodeAssetPayload(&asset, targetEncoding); err != nil {
-				logger.Error("failed to transcode asset payload", "error", err)
-				_, errRes := catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to transcode payload: "+err.Error())
+			if tcRes := catena.TranscodeAssetPayload(&asset, targetEncoding); tcRes.Code != catena.OK {
+				logger.Error("failed to transcode asset payload", "error", tcRes.Error)
+				_, errRes := catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to transcode payload: "+tcRes.Error)
 				writeHTTPResult(w, errRes, catena.CatenaValue{})
 				return
 			}
@@ -467,10 +467,10 @@ func (s *Server) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, s
 			writeHTTPResult(w, res, val)
 			return
 		}
-		var errProto error
+		var errProto catena.StatusResult
 		payload, errProto = catena.FromProto(reqValue)
-		if errProto != nil {
-			logger.Error("failed to convert proto value to native Go type", "error", err.Error)
+		if errProto.Code != catena.OK {
+			logger.Error("failed to convert proto value to native Go type", "error", errProto.Error)
 			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid command payload")
 			writeHTTPResult(w, res, val)
 			return


### PR DESCRIPTION
## 📖 Description

Refactored the Go `FromProto`, `ToProto`, and other conversion/utility methods across the SDK to return `StatusResult` instead of Go `error`. This makes the codebase more cohesive and gives errors passed up through the chain richer info (status code + message) for handling.

---

## ✅ Definition of Done (DoD)
- [x] Feature is implemented and works as expected
- [x] Edge cases are handled
- [x] Tests are added or updated (if applicable)

---

## 🛠️ Implementation Notes

### Core `catena` package (`sdks/go/pkg/catena/`)
- **`value.go`** — Changed `ToProto`, `FromProto`, and `ToCatenaValue` to return `StatusResult` instead of `error`. All internal `fmt.Errorf` calls replaced with `StatusResult{Code: ..., Error: "..."}`.
- **`device.go`** — Changed `ToCatenaDevice`, `toProtoDevice` (unexported), and `CatenaDevice.ToJSON` to return `StatusResult`.
- **`asset.go`** — Changed `ToCatenaAsset`, `dataPayloadToProto` (unexported), `CatenaAsset.ToJSON`, `ParsePayloadEncoding`, and `TranscodeAssetPayload` to return `StatusResult`.

### Error-to-StatusCode mapping convention
- Type mismatches, unsupported types, nil values → `INVALID_ARGUMENT`
- Serialization/marshaling failures → `INTERNAL`
- Invalid payload configurations (both/neither payload+URL) → `INVALID_ARGUMENT`
- Compression decode/encode failures → `INTERNAL`

### Server call sites
- **`sdks/go/pkg/rest/server.go`** — Updated `handleValueEndpoint`, `handleAssetEndpoint`, `handleCommandEndpoint`, and `writeAssetResult` to check `StatusResult.Code` instead of `err != nil`.
- **`sdks/go/pkg/grpc/server.go`** — Updated `SetValue`, `MultiSetValue`, and `ExecuteCommand` to check `StatusResult.Code`.
- **`sdks/go/pkg/internal/base_server.go`** — Updated `BroadcastUpdate` to check `StatusResult.Code`.

### Bug fixes
- Fixed 5 pre-existing logging bugs where `err.Error` (from a `StatusResult` returned by `ReadRequestJSON`) was incorrectly logged instead of `errProto` (the actual conversion error) in:
  - REST `handleValueEndpoint`
  - REST `handleCommandEndpoint`
  - gRPC `SetValue`
  - gRPC `MultiSetValue`
  - gRPC `ExecuteCommand`

### Tests
- **`value_test.go`** — Updated ~50+ assertions from `err != nil` / `err == nil` to `err.Code != OK` / `err.Code == OK`, and format strings from `err` to `err.Error`.
- **`device_test.go`** — Updated ~10 assertions.
- **`asset_test.go`** — Updated ~25 assertions (only for `ToCatenaAsset`, `TranscodeAssetPayload`, `ParsePayloadEncoding`, `ToJSON`; compress/decompress helpers left unchanged).
- **`grpc/server_test.go`** and **`grpc/test_helpers_test.go`** — Updated call sites.
- **`rest/server_test.go`** — No changes needed (all relevant calls already discard the second return value).

### Examples (6 files in `sdks/go/examples/`)
- `getSetValue_REST.go` — Updated `ToCatenaValue`, `ToCatenaDevice` calls.
- `getSetValue_GRPC.go` — Updated `ToProto` call.
- `getDevice_REST.go` — Updated `ToCatenaDevice` call.
- `getDevice_GRPC.go` — Updated `ToCatenaDevice` call.
- `getAsset_REST.go` — Updated `ToCatenaAsset` call.
- `executeCommand_REST.go` — No changes needed (all calls discard the result).

---

## 🔗 Related Issues / Links

Closes issue #1284