### PR TITLE
Fixed ParamInfo Unary response behaviour

### DIFF
--- a/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
+++ b/sdks/cpp/connections/REST/src/controllers/ParamInfoRequest.cpp
@@ -43,7 +43,7 @@ ParamInfoRequest::ParamInfoRequest(tcp::socket& socket, ISocketReader& context, 
         writer_ = std::make_unique<SSEWriter>(socket_, context_.origin());
     // Unary response
     } else {
-        writer_ = std::make_unique<SocketWriter>(socket_, context_.origin(), true);
+        writer_ = std::make_unique<SocketWriter>(socket_, context_.origin());
     }
 
     
@@ -76,6 +76,11 @@ void ParamInfoRequest::proceed() {
         } else if (!context_.stream() && recursive_) {
             rc_ = catena::exception_with_status("Recursive parameter info request is not supported with unary response", catena::StatusCode::INVALID_ARGUMENT);
         } else {
+            // Check if valid Unary, Unary only supports Mode 3
+            if (!context_.stream() && context_.fqoid().empty()) {
+                throw catena::exception_with_status("Unary request must include fqoid", catena::StatusCode::INVALID_ARGUMENT);
+            }
+
             // Handle authorization setup
             if (context_.authorizationEnabled()) {
                 sharedAuthz = std::make_shared<Authorizer>(context_.jwsToken());
@@ -183,14 +188,20 @@ void ParamInfoRequest::proceed() {
         rc_ = catena::exception_with_status("Unknown error in ParamInfoRequest", catena::StatusCode::UNKNOWN);
     }
 
-    // Writing responses to the client.
-    if (rc_.status == catena::StatusCode::OK && !responses_.empty()) {
-        for (auto& response : responses_) {
-            writer_->sendResponse(rc_, response);
+    if (context_.stream()) {
+        // Writing responses to the client.
+        if (rc_.status == catena::StatusCode::OK && !responses_.empty()) {
+            for (auto& response : responses_) {
+                writer_->sendResponse(rc_, response);
+            }
         }
+        // Required to send errors.
+        writer_->sendResponse(rc_);
+    } else if (responses_.size() == 1) {
+        writer_->sendResponse(rc_, responses_[0]);
+    } else {
+        writer_->sendResponse(rc_);
     }
-    // Required to send errors or flush unary response.
-    writer_->sendResponse(rc_);
     
     // Writing the final status to the console.
     writeConsole_(CallStatus::kFinish, socket_.is_open());

--- a/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
@@ -278,48 +278,6 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsStream) {
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
 }
 
-// Test 1.2: Get all top-level parameters without recursion as a unary response.
-TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsUnary) {
-    // Remake the endpoint with stream set to false
-    stream_ = false;
-    endpoint_.reset(makeOne());
-    
-    // Setup mock parameters
-    catena::REST::test::ParamInfo param1_info{ .oid = "param1", .type = st2138::ParamType::STRING };
-    catena::REST::test::ParamInfo param2_info{ .oid = "param2", .type = st2138::ParamType::STRING };
-    auto desc1 = ParamHierarchyBuilder::createDescriptor("/" + param1_info.oid);
-    auto desc2 = ParamHierarchyBuilder::createDescriptor("/" + param2_info.oid);
-    
-    // Create ParamInfo structs
-    catena::REST::test::ParamInfo param1_info_struct{param1_info.oid, param1_info.type};
-    catena::REST::test::ParamInfo param2_info_struct{param2_info.oid, param2_info.type};
-
-    auto param1 = std::make_unique<MockParam>();
-    catena::REST::test::setupMockParam(*param1, param1_info_struct, *desc1.descriptor);
-
-    auto param2 = std::make_unique<MockParam>();
-    catena::REST::test::setupMockParam(*param2, param2_info_struct, *desc2.descriptor);
-
-    std::vector<std::unique_ptr<IParam>> top_level_params;
-    top_level_params.push_back(std::move(param1));
-    top_level_params.push_back(std::move(param2));
-
-    // Setup mock expectations
-    EXPECT_CALL(dm0_, getTopLevelParams(testing::_, testing::_))
-        .WillOnce(testing::Invoke([&top_level_params](catena::exception_with_status& status, const IAuthorizer&) -> std::vector<std::unique_ptr<IParam>> {
-            status = catena::exception_with_status("", catena::StatusCode::OK);
-            return std::move(top_level_params);
-        }));
-
-    endpoint_->proceed();
-
-    // Match expected and actual responses
-    std::vector<std::string> jsonBodies;
-    jsonBodies.push_back(catena::REST::test::createParamInfoJson(param1_info));
-    jsonBodies.push_back(catena::REST::test::createParamInfoJson(param2_info));
-    EXPECT_EQ(readResponse(), expectedResponse(expRc_, jsonBodies));
-}
-
 // Test 1.3: Get top-level parameters with error returned from getTopLevelParams
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsError) {
     expRc_ = catena::exception_with_status("Error getting top-level parameters", catena::StatusCode::INTERNAL);

--- a/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
+++ b/unittests/cpp/REST/tests/ParamInfoRequest_test.cpp
@@ -278,6 +278,20 @@ TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsStream) {
     EXPECT_EQ(readResponse(), expectedSSEResponse(expRc_, jsonBodies));
 }
 
+// Test 1.2: Unary response without fqoid is rejected.
+TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsUnary) {
+    stream_ = false;
+    fqoid_ = "";
+    expRc_ = catena::exception_with_status("Unary request must include fqoid", catena::StatusCode::INVALID_ARGUMENT);
+    endpoint_.reset(makeOne());
+
+    EXPECT_CALL(dm0_, getTopLevelParams(testing::_, testing::_)).Times(0);
+
+    endpoint_->proceed();
+
+    EXPECT_EQ(readResponse(), expectedResponse(expRc_));
+}
+
 // Test 1.3: Get top-level parameters with error returned from getTopLevelParams
 TEST_F(RESTParamInfoRequestTests, ParamInfoRequest_getTopLevelParamsError) {
     expRc_ = catena::exception_with_status("Error getting top-level parameters", catena::StatusCode::INTERNAL);


### PR DESCRIPTION
<!-- please continue to update this as work is being done to add context, links, scope creep, and any other useful info -->

## 📖 Description
<!-- A clear and concise explanation of what this pull request is about and what it accomplishes. -->
Fixed bug and unintended behavior of ParamInfoRequest with a Unary response. The code would allow for a Mode 1 (no fqoid/GetAllTopLevelParams) Unary response although the `openapi.yaml` doesn't specify it as a supported endpoint. There was also a bug that caused the correctly supported Mode 3 (specified fqoid) to have a `data` wrapper when that is not specified by the `openapi.yaml`.

---

## ✅ Definition of Done (DoD)
<!-- TODO list of the issue that was addressed:
- [ ] Feature is implemented and works as expected
- [ ] Edge cases are handled
- [ ] Tests are added or updated (if applicable)
- [ ] Documentation is updated (if needed)
- [ ] Code is reviewed and approved -->
- [x] Unary response only support mode 3
- [x] Unary response no longer has data wrapper

---

## 🛠️ Implementation Notes
<!-- List of changes made:
- Added file.cpp to src
- Added function to file2.cpp
- Deleted file3.cpp-->
- Modified `ParamInfoRequest.cpp`
    - `SocketWriter` no longer set up to use buffering
    - Now throws error if  Unary and no fqoid
    - Only calls `sendResponse()` once if Unary
- Modified `ParamInfoRequestTest.cpp`
    - Removed test for Mode 1 with Unary response

---

## 🔗 Related Issues / Links
<!-- Links to the relevant issues  -->
[Issue #1288](https://github.com/rossvideo/Catena/issues/1288?reload=1?reload=1)

---
## 📝 Additional Context
<!-- (Optional) Any extra information, screenshots, or background. -->
Could discuss as a team if we want to go through with these changes of enforcing Unary to be only Mode 3, or if we instead want to update the `openapi.yaml` with support for Unary on Mode 1.

---

## 🚧 Risks / Open Questions
<!-- (Optional) Anything unclear or potentially risky. -->

---
## ✨ Updates
<!-- (Optional) List summarizing changes made when editing the pull request>
 
