### PR TITLE
Updated Trivy to 0.35.0

### DIFF
--- a/.github/workflows/cpp-pull-request.yml
+++ b/.github/workflows/cpp-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/go-pull-request.yml
+++ b/.github/workflows/go-pull-request.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
## 📖 Description
Updates the Trivy vulnerability scanner GitHub Action from version 0.28.0 to 0.35.0 in both the C++ and Go pull request workflows.

---

## 🎯 Goal / Outcome

---

## ✅ Definition of Done (DoD)
- [x] `aquasecurity/trivy-action` version bumped to `0.35.0` in `cpp-pull-request.yml`
- [x] `aquasecurity/trivy-action` version bumped to `0.35.0` in `go-pull-request.yml`


**Files changed:**

| File | Change |
|------|--------|
| `.github/workflows/cpp-pull-request.yml` | `trivy-action@0.28.0` → `trivy-action@0.35.0` |
| `.github/workflows/go-pull-request.yml`  | `trivy-action@0.28.0` → `trivy-action@0.35.0` |
