### PR TITLE
[GO] GRPC getAsset Example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -231,6 +231,7 @@
         "getSetValue/grpc",
         "executeCommand/rest",
         "getAsset/rest",
+        "getAsset/grpc",
         "oneOfEverything/rest",
         "oneOfEverything/grpc"
       ],

--- a/sdks/go/Makefile
+++ b/sdks/go/Makefile
@@ -1,5 +1,5 @@
-CMDS_PAIRED := getDevice getSetValue oneOfEverything
-CMDS_REST_ONLY := executeCommand getAsset
+CMDS_PAIRED := getAsset getDevice getSetValue oneOfEverything
+CMDS_REST_ONLY := executeCommand
 BIN_DIR := $(HOME)/Catena/$(BUILD_TARGET)
 LOG_DIR := ./logs
 

--- a/sdks/go/examples/getAsset/getasset.go
+++ b/sdks/go/examples/getAsset/getasset.go
@@ -41,6 +41,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/rossvideo/catena/sdks/go/examples/exampleutil"
@@ -117,11 +118,6 @@ func RunExample(appName string, makeServer func(slots []uint16, cfg catena.Confi
 			logger.Info("=======================================================")
 			logger.Info("Listening", "port", port)
 			logger.Info("")
-			logger.Info("Available endpoint:")
-			logger.Info("  GET  /st2138-api/v1/0/asset/{oid}")
-			logger.Info("  GET  /st2138-api/v1/0/asset/{oid}?compression=GZIP")
-			logger.Info("  GET  /st2138-api/v1/0/asset/{oid}?compression=DEFLATE")
-			logger.Info("")
 			logger.Info("Available assets:")
 			assets.Range(func(key, _ any) bool {
 				logger.Info(fmt.Sprintf("  %s", key.(string)))
@@ -129,9 +125,21 @@ func RunExample(appName string, makeServer func(slots []uint16, cfg catena.Confi
 			})
 			logger.Info("")
 			if firstAssetName != "" {
-				logger.Info("Example curl:")
-				logger.Info(fmt.Sprintf("  curl http://localhost:%d/st2138-api/v1/0/asset/%s", port, firstAssetName))
-				logger.Info(fmt.Sprintf("  curl http://localhost:%d/st2138-api/v1/0/asset/%s?compression=GZIP", port, firstAssetName))
+				if strings.Contains(appName, "GRPC") {
+					logger.Info("Test with grpcurl:")
+					logger.Info(fmt.Sprintf("  grpcurl -plaintext -d '{\"slot\": 0, \"oid\": \"%s\"}' localhost:%d st2138.CatenaService/ExternalObjectRequest", firstAssetName, port))
+					logger.Info(fmt.Sprintf("  grpcurl -plaintext localhost:%d list", port))
+					logger.Info(fmt.Sprintf("  grpcurl -plaintext localhost:%d st2138.CatenaService/GetPopulatedSlots", port))
+				} else {
+					logger.Info("Available endpoint:")
+					logger.Info("  GET  /st2138-api/v1/0/asset/{oid}")
+					logger.Info("  GET  /st2138-api/v1/0/asset/{oid}?compression=GZIP")
+					logger.Info("  GET  /st2138-api/v1/0/asset/{oid}?compression=DEFLATE")
+					logger.Info("")
+					logger.Info("Example curl:")
+					logger.Info(fmt.Sprintf("  curl http://localhost:%d/st2138-api/v1/0/asset/%s", port, firstAssetName))
+					logger.Info(fmt.Sprintf("  curl http://localhost:%d/st2138-api/v1/0/asset/%s?compression=GZIP", port, firstAssetName))
+				}
 			}
 			logger.Info("=======================================================")
 		},

--- a/sdks/go/examples/getAsset/grpc/main.go
+++ b/sdks/go/examples/getAsset/grpc/main.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package main
+
+import (
+	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	grpcServer "github.com/rossvideo/catena/sdks/go/pkg/grpc"
+
+	getasset "github.com/rossvideo/catena/sdks/go/examples/getAsset"
+)
+
+func main() {
+	getasset.RunExample("getAsset_GRPC", func(slots []uint16, cfg catena.Config) catena.CatenaServer {
+		return grpcServer.NewServer(slots, 100, cfg)
+	})
+}


### PR DESCRIPTION
## 📖 Description
Adds a gRPC transport for the `getAsset` example, following the merged REST/gRPC example structure introduced in #1289. The `getAsset` example is promoted from REST-only to a paired (REST + gRPC) example with a thin `grpc/main.go` wrapper that reuses the shared logic in `getasset.go`.

---

## 🎯 Goal / Outcome
After merging, the `getAsset` example supports both REST and gRPC transports using the same shared handler code, consistent with how `getDevice` and `getSetValue` examples are structured.

---

## ✅ Definition of Done (DoD)
- [x] `getAsset/grpc/main.go` created as a thin wrapper matching the paired example pattern (`getDevice/grpc/main.go`)
- [x] `getAsset` moved from `CMDS_REST_ONLY` to `CMDS_PAIRED` in the Makefile
- [x] Shared `RunExample` in `getasset.go` updated to display transport-appropriate startup messages (grpcurl commands for gRPC, curl/REST endpoints for REST)

---

## 🛠️ Implementation Notes (Optional)
- The gRPC `main.go` follows the exact same pattern as `getDevice/grpc/main.go`: imports the shared package and calls `RunExample` with a gRPC server factory.
- The `RunExample` `OnReady` callback now branches on `strings.Contains(appName, "GRPC")` to show `grpcurl` test commands for gRPC vs REST endpoint/curl examples for REST.
- No duplicate static asset files — the gRPC wrapper reuses the embedded assets already in `getAsset/static/` via the shared `RegisterHandlers`.

---

## 🔗 Related Issues / Links
Closes issue #1296 


