### PR TITLE
[GO] isDev check for GRPC

### DIFF
--- a/sdks/go/pkg/grpc/server.go
+++ b/sdks/go/pkg/grpc/server.go
@@ -61,6 +61,19 @@ type Server struct {
 	grpcServer *grpc.Server
 }
 
+// sanitizeGRPCError replaces detailed error messages with generic status code
+// descriptions in production mode, matching the REST server's IsDev behavior.
+func sanitizeGRPCError(err error) error {
+	if err == nil || catena.IsDev() {
+		return err
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return err
+	}
+	return status.Error(st.Code(), st.Code().String())
+}
+
 // unaryInterceptor logs all incoming unary RPC calls
 func unaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	logger.Debug("gRPC unary call received", "method", info.FullMethod)
@@ -68,7 +81,7 @@ func unaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServ
 	if err != nil {
 		logger.Error("gRPC unary call error", "method", info.FullMethod, "error", err)
 	}
-	return resp, err
+	return resp, sanitizeGRPCError(err)
 }
 
 // streamInterceptor logs all incoming streaming RPC calls
@@ -83,7 +96,7 @@ func streamInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamS
 			logger.Error("gRPC stream call error", "method", info.FullMethod, "error", err)
 		}
 	}
-	return err
+	return sanitizeGRPCError(err)
 }
 
 // NewServer creates a new gRPC server for the given device slots

--- a/sdks/go/pkg/grpc/server_test.go
+++ b/sdks/go/pkg/grpc/server_test.go
@@ -871,6 +871,106 @@ func TestServer_Connect_ClientDisconnect(t *testing.T) {
 }
 
 // =============================================================================
+// Test: Error Messages Dev vs Prod
+// =============================================================================
+
+func TestErrorMessages_DevVsProd(t *testing.T) {
+	tests := []struct {
+		name            string
+		env             catena.Environment
+		expectedMessage string
+	}{
+		{"dev mode shows details (unary)", catena.EnvDev, "param not supported"},
+		{"prod mode hides details (unary)", catena.EnvProd, "Unimplemented"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := catena.GetEnv()
+			defer catena.SetEnv(original)
+			catena.SetEnv(tt.env)
+
+			ctx := context.Background()
+			srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
+			defer cleanup()
+
+			srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+				return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "param not supported")
+			})
+
+			client, clientCleanup := setupGRPCClient(t, ctx, lis)
+			defer clientCleanup()
+
+			_, err := makeGetValueRequest(t, client, ctx, 0, "device.param1")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected gRPC status error, got %v", err)
+			}
+			if st.Message() != tt.expectedMessage {
+				t.Errorf("expected message %q, got %q", tt.expectedMessage, st.Message())
+			}
+		})
+	}
+}
+
+func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
+	tests := []struct {
+		name            string
+		env             catena.Environment
+		expectedMessage string
+	}{
+		{"dev mode shows details (streaming)", catena.EnvDev, "device not found"},
+		{"prod mode hides details (streaming)", catena.EnvProd, "NotFound"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := catena.GetEnv()
+			defer catena.SetEnv(original)
+			catena.SetEnv(tt.env)
+
+			ctx := context.Background()
+			srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
+			defer cleanup()
+
+			srv.RegisterGetDeviceHandler(0, func() (catena.CatenaDevice, catena.StatusResult) {
+				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
+			})
+
+			client, clientCleanup := setupGRPCClient(t, ctx, lis)
+			defer clientCleanup()
+
+			stream, err := makeDeviceRequest(t, client, ctx, 0)
+			if err != nil {
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("expected gRPC status error, got %v", err)
+				}
+				if st.Message() != tt.expectedMessage {
+					t.Errorf("expected message %q, got %q", tt.expectedMessage, st.Message())
+				}
+				return
+			}
+
+			_, err = stream.Recv()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected gRPC status error, got %v", err)
+			}
+			if st.Message() != tt.expectedMessage {
+				t.Errorf("expected message %q, got %q", tt.expectedMessage, st.Message())
+			}
+		})
+	}
+}
+
+// =============================================================================
 // Test: Unimplemented Endpoints
 // =============================================================================
 

--- a/sdks/go/pkg/grpc/server_test.go
+++ b/sdks/go/pkg/grpc/server_test.go
@@ -875,33 +875,145 @@ func TestServer_Connect_ClientDisconnect(t *testing.T) {
 // =============================================================================
 
 func TestErrorMessages_DevVsProd(t *testing.T) {
-	tests := []struct {
-		name            string
-		env             catena.Environment
-		expectedMessage string
-	}{
-		{"dev mode shows details (unary)", catena.EnvDev, "param not supported"},
-		{"prod mode hides details (unary)", catena.EnvProd, "Unimplemented"},
+	type endpoint struct {
+		name          string
+		devMessage    string
+		grpcCode      codes.Code
+		setupHandlers func(*Server)
+		callEndpoint  func(protos.CatenaServiceClient, context.Context) error
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	endpoints := []endpoint{
+		{
+			name:       "GetValue",
+			devMessage: "param not supported",
+			grpcCode:   codes.Unimplemented,
+			setupHandlers: func(srv *Server) {
+				srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+					return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "param not supported")
+				})
+			},
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.GetValue(ctx, &protos.GetValuePayload{Slot: 0, Oid: "device.param1"})
+				return err
+			},
+		},
+		{
+			name:       "SetValue",
+			devMessage: "value out of range",
+			grpcCode:   codes.InvalidArgument,
+			setupHandlers: func(srv *Server) {
+				srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string) catena.StatusResult {
+					return catena.StatusWithCode(catena.INVALID_ARGUMENT, "value out of range")
+				})
+			},
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				protoValue, _ := catena.ToProto(int32(100))
+				_, err := client.SetValue(ctx, &protos.SingleSetValuePayload{
+					Slot: 0,
+					Value: &protos.SetValuePayload{
+						Oid:   "device.param1",
+						Value: protoValue,
+					},
+				})
+				return err
+			},
+		},
+		{
+			name:       "MultiSetValue",
+			devMessage: "multi set failed",
+			grpcCode:   codes.FailedPrecondition,
+			setupHandlers: func(srv *Server) {
+				srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string) catena.StatusResult {
+					return catena.StatusWithCode(catena.FAILED_PRECONDITION, "multi set failed")
+				})
+			},
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				protoValue, _ := catena.ToProto(int32(1))
+				_, err := client.MultiSetValue(ctx, &protos.MultiSetValuePayload{
+					Slot: 0,
+					Values: []*protos.SetValuePayload{
+						{Oid: "device.param1", Value: protoValue},
+					},
+				})
+				return err
+			},
+		},
+		{
+			name:       "GetParam",
+			devMessage: "GetParam not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.GetParam(ctx, &protos.GetParamPayload{Slot: 0, Oid: "device.param1"})
+				return err
+			},
+		},
+		{
+			name:       "AddLanguage",
+			devMessage: "AddLanguage not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.AddLanguage(ctx, &protos.AddLanguagePayload{Slot: 0})
+				return err
+			},
+		},
+		{
+			name:       "LanguagePackRequest",
+			devMessage: "LanguagePackRequest not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.LanguagePackRequest(ctx, &protos.LanguagePackRequestPayload{Slot: 0})
+				return err
+			},
+		},
+		{
+			name:       "ListLanguages",
+			devMessage: "ListLanguages not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.ListLanguages(ctx, &protos.Slot{Slot: 0})
+				return err
+			},
+		},
+		{
+			name:       "RefreshToken",
+			devMessage: "RefreshToken not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.RefreshToken(ctx, &protos.RefreshTokenPayload{Reason: "test"})
+				return err
+			},
+		},
+		{
+			name:       "RevokeAccess",
+			devMessage: "RevokeAccess not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				_, err := client.RevokeAccess(ctx, &protos.RevokeAccessPayload{Subject: "test-subject"})
+				return err
+			},
+		},
+	}
+
+	for _, ep := range endpoints {
+		ep := ep
+		t.Run(ep.name+"/dev_shows_details", func(t *testing.T) {
 			original := catena.GetEnv()
 			defer catena.SetEnv(original)
-			catena.SetEnv(tt.env)
+			catena.SetEnv(catena.EnvDev)
 
 			ctx := context.Background()
 			srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
 			defer cleanup()
 
-			srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-				return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "param not supported")
-			})
+			if ep.setupHandlers != nil {
+				ep.setupHandlers(srv)
+			}
 
 			client, clientCleanup := setupGRPCClient(t, ctx, lis)
 			defer clientCleanup()
 
-			_, err := makeGetValueRequest(t, client, ctx, 0, "device.param1")
+			err := ep.callEndpoint(client, ctx)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -909,53 +1021,154 @@ func TestErrorMessages_DevVsProd(t *testing.T) {
 			if !ok {
 				t.Fatalf("expected gRPC status error, got %v", err)
 			}
-			if st.Message() != tt.expectedMessage {
-				t.Errorf("expected message %q, got %q", tt.expectedMessage, st.Message())
+			if st.Message() != ep.devMessage {
+				t.Errorf("expected message %q, got %q", ep.devMessage, st.Message())
+			}
+		})
+
+		t.Run(ep.name+"/prod_hides_details", func(t *testing.T) {
+			original := catena.GetEnv()
+			defer catena.SetEnv(original)
+			catena.SetEnv(catena.EnvProd)
+
+			ctx := context.Background()
+			srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
+			defer cleanup()
+
+			if ep.setupHandlers != nil {
+				ep.setupHandlers(srv)
+			}
+
+			client, clientCleanup := setupGRPCClient(t, ctx, lis)
+			defer clientCleanup()
+
+			err := ep.callEndpoint(client, ctx)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected gRPC status error, got %v", err)
+			}
+			expectedMessage := ep.grpcCode.String()
+			if st.Message() != expectedMessage {
+				t.Errorf("expected message %q, got %q", expectedMessage, st.Message())
 			}
 		})
 	}
 }
 
 func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
-	tests := []struct {
-		name            string
-		env             catena.Environment
-		expectedMessage string
-	}{
-		{"dev mode shows details (streaming)", catena.EnvDev, "device not found"},
-		{"prod mode hides details (streaming)", catena.EnvProd, "NotFound"},
+	type endpoint struct {
+		name          string
+		devMessage    string
+		grpcCode      codes.Code
+		setupHandlers func(*Server)
+		callEndpoint  func(protos.CatenaServiceClient, context.Context) error
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	endpoints := []endpoint{
+		{
+			name:       "DeviceRequest",
+			devMessage: "device not found",
+			grpcCode:   codes.NotFound,
+			setupHandlers: func(srv *Server) {
+				srv.RegisterGetDeviceHandler(0, func() (catena.CatenaDevice, catena.StatusResult) {
+					return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
+				})
+			},
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				stream, err := client.DeviceRequest(ctx, &protos.DeviceRequestPayload{Slot: 0})
+				if err != nil {
+					return err
+				}
+				_, err = stream.Recv()
+				return err
+			},
+		},
+		{
+			name:       "ExternalObjectRequest",
+			devMessage: "asset not found",
+			grpcCode:   codes.NotFound,
+			setupHandlers: func(srv *Server) {
+				srv.RegisterGetAssetHandler(0, func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+					return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "asset not found")
+				})
+			},
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				stream, err := client.ExternalObjectRequest(ctx, &protos.ExternalObjectRequestPayload{Slot: 0, Oid: "device.image1"})
+				if err != nil {
+					return err
+				}
+				_, err = stream.Recv()
+				return err
+			},
+		},
+		{
+			name:       "ExecuteCommand",
+			devMessage: "command not supported",
+			grpcCode:   codes.Unimplemented,
+			setupHandlers: func(srv *Server) {
+				srv.RegisterExecuteCommandHandler(0, func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
+					return catena.CommandError(catena.UNIMPLEMENTED, "command not supported")
+				})
+			},
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				stream, err := client.ExecuteCommand(ctx, &protos.ExecuteCommandPayload{Slot: 0, Oid: "device.command"})
+				if err != nil {
+					return err
+				}
+				_, err = stream.Recv()
+				return err
+			},
+		},
+		{
+			name:       "ParamInfoRequest",
+			devMessage: "ParamInfoRequest not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				stream, err := client.ParamInfoRequest(ctx, &protos.ParamInfoRequestPayload{Slot: 0, OidPrefix: "device"})
+				if err != nil {
+					return err
+				}
+				_, err = stream.Recv()
+				return err
+			},
+		},
+		{
+			name:       "UpdateSubscriptions",
+			devMessage: "UpdateSubscriptions not implemented",
+			grpcCode:   codes.Unimplemented,
+			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
+				stream, err := client.UpdateSubscriptions(ctx, &protos.UpdateSubscriptionsPayload{Slot: 0})
+				if err != nil {
+					return err
+				}
+				_, err = stream.Recv()
+				return err
+			},
+		},
+	}
+
+	for _, ep := range endpoints {
+		ep := ep
+		t.Run(ep.name+"/dev_shows_details", func(t *testing.T) {
 			original := catena.GetEnv()
 			defer catena.SetEnv(original)
-			catena.SetEnv(tt.env)
+			catena.SetEnv(catena.EnvDev)
 
 			ctx := context.Background()
 			srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
 			defer cleanup()
 
-			srv.RegisterGetDeviceHandler(0, func() (catena.CatenaDevice, catena.StatusResult) {
-				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
-			})
+			if ep.setupHandlers != nil {
+				ep.setupHandlers(srv)
+			}
 
 			client, clientCleanup := setupGRPCClient(t, ctx, lis)
 			defer clientCleanup()
 
-			stream, err := makeDeviceRequest(t, client, ctx, 0)
-			if err != nil {
-				st, ok := status.FromError(err)
-				if !ok {
-					t.Fatalf("expected gRPC status error, got %v", err)
-				}
-				if st.Message() != tt.expectedMessage {
-					t.Errorf("expected message %q, got %q", tt.expectedMessage, st.Message())
-				}
-				return
-			}
-
-			_, err = stream.Recv()
+			err := ep.callEndpoint(client, ctx)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -963,8 +1176,38 @@ func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
 			if !ok {
 				t.Fatalf("expected gRPC status error, got %v", err)
 			}
-			if st.Message() != tt.expectedMessage {
-				t.Errorf("expected message %q, got %q", tt.expectedMessage, st.Message())
+			if st.Message() != ep.devMessage {
+				t.Errorf("expected message %q, got %q", ep.devMessage, st.Message())
+			}
+		})
+
+		t.Run(ep.name+"/prod_hides_details", func(t *testing.T) {
+			original := catena.GetEnv()
+			defer catena.SetEnv(original)
+			catena.SetEnv(catena.EnvProd)
+
+			ctx := context.Background()
+			srv, lis, cleanup := setupTestServer(t, []uint16{0}, false)
+			defer cleanup()
+
+			if ep.setupHandlers != nil {
+				ep.setupHandlers(srv)
+			}
+
+			client, clientCleanup := setupGRPCClient(t, ctx, lis)
+			defer clientCleanup()
+
+			err := ep.callEndpoint(client, ctx)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected gRPC status error, got %v", err)
+			}
+			expectedMessage := ep.grpcCode.String()
+			if st.Message() != expectedMessage {
+				t.Errorf("expected message %q, got %q", expectedMessage, st.Message())
 			}
 		})
 	}


### PR DESCRIPTION
## 📖 Description
Add `catena.IsDev()` checking to all gRPC server error responses, matching the existing REST server behavior. In production mode, detailed error messages are replaced with generic gRPC status code descriptions (e.g., `"NotFound"`, `"InvalidArgument"`). In development mode, detailed messages pass through unchanged.

---

## 🎯 Goal / Outcome
gRPC error responses should not leak internal error details to clients in production, consistent with how the REST server already handles this via `catena.IsDev()`. Once merged, all gRPC RPCs (unary and streaming) will return sanitized error messages in prod mode.

---

## ✅ Definition of Done (DoD)
- [x] `sanitizeGRPCError` helper added to centrally strip detailed messages in prod mode
- [x] `unaryInterceptor` and `streamInterceptor` wired to use `sanitizeGRPCError`
- [x] Dev mode continues to return full error details (no behavior change)
- [x] Tests added for dev vs prod error messages on unary RPCs (`TestErrorMessages_DevVsProd`)
- [x] Tests added for dev vs prod error messages on streaming RPCs (`TestErrorMessages_DevVsProd_Streaming`)
- [x] All existing gRPC tests pass without modification

---

## 🛠️ Implementation Notes
- **Interceptor-based approach**: Rather than modifying ~28 individual `status.Error(...)` call sites across all RPC handlers, the sanitization is applied centrally in the existing `unaryInterceptor` and `streamInterceptor`. This ensures all current and future RPCs are covered automatically.
- **Non-status errors pass through**: Errors that are not gRPC status errors (e.g., `context.Canceled` from client disconnects) are returned unchanged, preserving correct transport-level behavior.
- **Generic message format**: Prod mode uses `codes.Code.String()` (e.g., `"NotFound"`, `"Internal"`) as the replacement message, which is the gRPC equivalent of the REST server's `http.StatusText(httpStatus)`.
- **Logging unaffected**: The interceptors log the *original* detailed error before sanitization, so server-side logs retain full diagnostic information.

---

## 🔗 Related Issues / Links

Closes issue #1285 