### PR TITLE
enable subscriptions for OOE

### DIFF
--- a/sdks/cpp/connections/REST/examples/one_of_everything_REST/device.one_of_everything.yaml
+++ b/sdks/cpp/connections/REST/examples/one_of_everything_REST/device.one_of_everything.yaml
@@ -4,6 +4,7 @@ multi_set_enabled: true
 detail_level: FULL
 access_scopes: ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"]
 default_scope: st2138:mon
+subscriptions: true
 language_packs:
   packs:
     es:

--- a/sdks/cpp/connections/gRPC/examples/one_of_everything/device.one_of_everything.yaml
+++ b/sdks/cpp/connections/gRPC/examples/one_of_everything/device.one_of_everything.yaml
@@ -3,6 +3,7 @@ multi_set_enabled: true
 detail_level: FULL
 access_scopes: ["st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"]
 default_scope: st2138:mon
+subscriptions: true
 language_packs:
   packs:
     es:


### PR DESCRIPTION
Enabling subscriptions on the one-of-everythings for Troy (and cause they are one of EVERYTHING)