### PR TITLE
[GO] Param Creation Helpers

### DIFF
--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -79,14 +79,14 @@ func NewParamString(value string) *Param {
 	}
 }
 
-func NewParamStruct(value ...map[string]any) *Param {
+func NewParamStruct(value map[string]any) *Param {
 	cp := &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
 	}
-	if len(value) > 0 {
-		pv, res := ToProto(value[0])
+	if value != nil {
+		pv, res := ToProto(value)
 		if res.Code != OK {
 			logger.Warning("NewParamStruct: failed to convert value; value left nil",
 				"error", res.Error)
@@ -97,14 +97,14 @@ func NewParamStruct(value ...map[string]any) *Param {
 	return cp
 }
 
-func NewParamStructVariant(value ...StructVariantValue) *Param {
+func NewParamStructVariant(value *StructVariantValue) *Param {
 	cp := &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT,
 		},
 	}
-	if len(value) > 0 {
-		pv, res := ToProto(value[0])
+	if value != nil {
+		pv, res := ToProto(*value)
 		if res.Code != OK {
 			logger.Warning("NewParamStructVariant: failed to convert value; value left nil",
 				"error", res.Error)
@@ -151,14 +151,14 @@ func NewParamBinary(value []byte) *Param {
 	}
 }
 
-func NewParamStructArray(value ...[]map[string]any) *Param {
+func NewParamStructArray(value []map[string]any) *Param {
 	cp := &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_ARRAY,
 		},
 	}
-	if len(value) > 0 {
-		pv, res := ToProto(value[0])
+	if value != nil {
+		pv, res := ToProto(value)
 		if res.Code != OK {
 			logger.Warning("NewParamStructArray: failed to convert value; value left nil",
 				"error", res.Error)
@@ -169,14 +169,14 @@ func NewParamStructArray(value ...[]map[string]any) *Param {
 	return cp
 }
 
-func NewParamStructVariantArray(value ...[]StructVariantValue) *Param {
+func NewParamStructVariantArray(value []StructVariantValue) *Param {
 	cp := &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
 		},
 	}
-	if len(value) > 0 {
-		pv, res := ToProto(value[0])
+	if value != nil {
+		pv, res := ToProto(value)
 		if res.Code != OK {
 			logger.Warning("NewParamStructVariantArray: failed to convert value; value left nil",
 				"error", res.Error)
@@ -214,7 +214,7 @@ func NewParamData(payload DataPayload) *Param {
 
 // NewParamFromValue creates a Param by inferring the ParamType from the
 // Value's proto kind. This allows dynamic param creation regardless of type.
-// DataPayload values are mapped to ParamType_DATA (not BINARY) since the two
+// DataPayload values are mapped to ParamType_DATA since the two
 // cannot be distinguished from the value alone.
 func NewParamFromValue(v Value) *Param {
 	pt := paramTypeFromValueKind(v.Value)

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -244,6 +244,12 @@ var paramTypesWithSubParams = map[protos.ParamType]bool{
 }
 
 func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
+	if param == nil {
+		logger.Warning("WithParam called with nil sub-param; ignoring",
+			"oid", oid,
+			"param_type", cp.param.Type.String())
+		return cp
+	}
 	if !paramTypesWithSubParams[cp.param.Type] {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
 			"param_type", cp.param.Type.String())

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -39,8 +39,6 @@
 package catena
 
 import (
-	"sync"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
@@ -48,9 +46,7 @@ import (
 )
 
 // CatenaParam wraps a protos.Param and exposes a fluent builder API.
-// All methods are safe for concurrent use.
 type CatenaParam struct {
-	mu    sync.RWMutex
 	proto *protos.Param
 }
 
@@ -236,15 +232,11 @@ func NewParamFromValue(v Value) *CatenaParam {
 // --- Chainable With* methods ---
 
 func (cp *CatenaParam) WithName(name PolyglotText) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.Name = &protos.PolyglotText{DisplayStrings: name}
 	return cp
 }
 
 func (cp *CatenaParam) WithValue(v Value) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if !isValueValidForParamType(v.Value, cp.proto.Type) {
 		logger.Warning("WithValue: value kind incompatible with param type; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -258,8 +250,6 @@ func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
 	if c == nil {
 		return cp
 	}
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if !isConstraintValidForParam(c, cp.proto.Type) {
 		logger.Warning("WithConstraint: constraint type incompatible with param type; ignoring",
 			"constraint_type", c.GetType().String(),
@@ -271,22 +261,16 @@ func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithReadOnly(readOnly bool) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.ReadOnly = readOnly
 	return cp
 }
 
 func (cp *CatenaParam) WithWidget(widget string) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.Widget = widget
 	return cp
 }
 
 func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if cp.proto.Type != protos.ParamType_FLOAT32 && cp.proto.Type != protos.ParamType_FLOAT32_ARRAY {
 		logger.Warning("WithPrecision called on non-float param; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -297,8 +281,6 @@ func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if cp.proto.Type != protos.ParamType_STRING && cp.proto.Type != protos.ParamType_STRING_ARRAY {
 		logger.Warning("WithMaxLength called on param type that does not support max_length; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -309,15 +291,11 @@ func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithAccessScope(scope string) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.AccessScope = scope
 	return cp
 }
 
 func (cp *CatenaParam) WithClientHint(key, value string) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if cp.proto.ClientHints == nil {
 		cp.proto.ClientHints = map[string]string{}
 	}
@@ -339,12 +317,8 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 		return cp
 	}
 
-	param.mu.RLock()
 	cloned := proto.Clone(param.proto).(*protos.Param)
-	param.mu.RUnlock()
 
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if _, ok := paramTypesWithSubParams[cp.proto.Type]; !ok {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -361,36 +335,26 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 // move this there. Consider an unexported baseParam that both CatenaParam and
 // CatenaCommand compose from, since other fields may also be command-specific.
 func (cp *CatenaParam) WithResponse(response bool) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.Response = response
 	return cp
 }
 
 func (cp *CatenaParam) WithHelp(help PolyglotText) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.Help = &protos.PolyglotText{DisplayStrings: help}
 	return cp
 }
 
 func (cp *CatenaParam) WithOidAliases(aliases ...string) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.OidAliases = aliases
 	return cp
 }
 
 func (cp *CatenaParam) WithMinimalSet(minimalSet bool) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.MinimalSet = minimalSet
 	return cp
 }
 
 func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.Stateless = stateless
 	return cp
 }
@@ -401,8 +365,6 @@ func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
 // know their full mounted path, which adds significant complexity. Revisit if
 // we ever add path tracking to the param tree.
 func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	cp.proto.TemplateOid = oid
 	return cp
 }
@@ -416,8 +378,6 @@ func (cp *CatenaParam) SetValue(v any) StatusResult {
 	if res.Code != OK {
 		return res
 	}
-	cp.mu.Lock()
-	defer cp.mu.Unlock()
 	if !isValueValidForParamType(pv, cp.proto.Type) {
 		return StatusResult{Code: INVALID_ARGUMENT, Error: "value kind incompatible with param type " + cp.proto.Type.String()}
 	}
@@ -428,8 +388,6 @@ func (cp *CatenaParam) SetValue(v any) StatusResult {
 // GetValue reads the current value and converts it to a native Go type via
 // FromProto. Returns (nil, OK) if no value is set.
 func (cp *CatenaParam) GetValue() (any, StatusResult) {
-	cp.mu.RLock()
-	defer cp.mu.RUnlock()
 	if cp.proto.Value == nil {
 		return nil, StatusResult{Code: OK}
 	}
@@ -439,8 +397,6 @@ func (cp *CatenaParam) GetValue() (any, StatusResult) {
 // Proto returns the underlying protos.Param. Callers must not mutate the
 // returned proto concurrently with other CatenaParam method calls.
 func (cp *CatenaParam) Proto() *protos.Param {
-	cp.mu.RLock()
-	defer cp.mu.RUnlock()
 	return cp.proto
 }
 

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -363,8 +363,6 @@ func (cp *Param) WithTemplateOid(oid string) *Param {
 	return cp
 }
 
-// --- Thread-safe runtime accessors ---
-
 // SetValue converts v to a proto value via ToProto, validates it against the
 // param type, and sets it.
 func (cp *Param) SetValue(v any) StatusResult {

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -39,6 +39,8 @@
 package catena
 
 import (
+	"sync"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
@@ -46,7 +48,9 @@ import (
 )
 
 // CatenaParam wraps a protos.Param and exposes a fluent builder API.
+// All methods are safe for concurrent use.
 type CatenaParam struct {
+	mu    sync.RWMutex
 	proto *protos.Param
 }
 
@@ -79,20 +83,40 @@ func NewParamString(value string) *CatenaParam {
 	}
 }
 
-func NewParamStruct() *CatenaParam {
-	return &CatenaParam{
+func NewParamStruct(value ...map[string]any) *CatenaParam {
+	cp := &CatenaParam{
 		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
 	}
+	if len(value) > 0 {
+		pv, res := ToProto(value[0])
+		if res.Code != OK {
+			logger.Warning("NewParamStruct: failed to convert value; value left nil",
+				"error", res.Error)
+			return cp
+		}
+		cp.proto.Value = pv
+	}
+	return cp
 }
 
-func NewParamStructVariant() *CatenaParam {
-	return &CatenaParam{
+func NewParamStructVariant(value ...StructVariantValue) *CatenaParam {
+	cp := &CatenaParam{
 		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT,
 		},
 	}
+	if len(value) > 0 {
+		pv, res := ToProto(value[0])
+		if res.Code != OK {
+			logger.Warning("NewParamStructVariant: failed to convert value; value left nil",
+				"error", res.Error)
+			return cp
+		}
+		cp.proto.Value = pv
+	}
+	return cp
 }
 
 func NewParamInt32Array(value []int32) *CatenaParam {
@@ -131,20 +155,40 @@ func NewParamBinary(value []byte) *CatenaParam {
 	}
 }
 
-func NewParamStructArray() *CatenaParam {
-	return &CatenaParam{
+func NewParamStructArray(value ...[]map[string]any) *CatenaParam {
+	cp := &CatenaParam{
 		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_ARRAY,
 		},
 	}
+	if len(value) > 0 {
+		pv, res := ToProto(value[0])
+		if res.Code != OK {
+			logger.Warning("NewParamStructArray: failed to convert value; value left nil",
+				"error", res.Error)
+			return cp
+		}
+		cp.proto.Value = pv
+	}
+	return cp
 }
 
-func NewParamStructVariantArray() *CatenaParam {
-	return &CatenaParam{
+func NewParamStructVariantArray(value ...[]StructVariantValue) *CatenaParam {
+	cp := &CatenaParam{
 		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
 		},
 	}
+	if len(value) > 0 {
+		pv, res := ToProto(value[0])
+		if res.Code != OK {
+			logger.Warning("NewParamStructVariantArray: failed to convert value; value left nil",
+				"error", res.Error)
+			return cp
+		}
+		cp.proto.Value = pv
+	}
+	return cp
 }
 
 func NewParamEmpty() *CatenaParam {
@@ -172,10 +216,41 @@ func NewParamData(payload DataPayload) *CatenaParam {
 	return cp
 }
 
+// NewParamFromValue creates a CatenaParam by inferring the ParamType from the
+// Value's proto kind. This allows dynamic param creation regardless of type.
+// DataPayload values are mapped to ParamType_DATA (not BINARY) since the two
+// cannot be distinguished from the value alone.
+func NewParamFromValue(v Value) *CatenaParam {
+	pt := paramTypeFromValueKind(v.Value)
+	if pt == protos.ParamType_UNDEFINED {
+		logger.Warning("NewParamFromValue: could not infer param type from value; using UNDEFINED")
+	}
+	return &CatenaParam{
+		proto: &protos.Param{
+			Type:  pt,
+			Value: v.Value,
+		},
+	}
+}
+
 // --- Chainable With* methods ---
 
 func (cp *CatenaParam) WithName(name PolyglotText) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.Name = &protos.PolyglotText{DisplayStrings: name}
+	return cp
+}
+
+func (cp *CatenaParam) WithValue(v Value) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	if !isValueValidForParamType(v.Value, cp.proto.Type) {
+		logger.Warning("WithValue: value kind incompatible with param type; ignoring",
+			"param_type", cp.proto.Type.String())
+		return cp
+	}
+	cp.proto.Value = v.Value
 	return cp
 }
 
@@ -183,6 +258,8 @@ func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
 	if c == nil {
 		return cp
 	}
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	if !isConstraintValidForParam(c, cp.proto.Type) {
 		logger.Warning("WithConstraint: constraint type incompatible with param type; ignoring",
 			"constraint_type", c.GetType().String(),
@@ -194,16 +271,22 @@ func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithReadOnly(readOnly bool) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.ReadOnly = readOnly
 	return cp
 }
 
 func (cp *CatenaParam) WithWidget(widget string) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.Widget = widget
 	return cp
 }
 
 func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	if cp.proto.Type != protos.ParamType_FLOAT32 && cp.proto.Type != protos.ParamType_FLOAT32_ARRAY {
 		logger.Warning("WithPrecision called on non-float param; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -214,6 +297,8 @@ func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	if cp.proto.Type != protos.ParamType_STRING && cp.proto.Type != protos.ParamType_STRING_ARRAY {
 		logger.Warning("WithMaxLength called on param type that does not support max_length; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -224,11 +309,15 @@ func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithAccessScope(scope string) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.AccessScope = scope
 	return cp
 }
 
 func (cp *CatenaParam) WithClientHint(key, value string) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	if cp.proto.ClientHints == nil {
 		cp.proto.ClientHints = map[string]string{}
 	}
@@ -246,10 +335,11 @@ var paramTypesWithSubParams = map[protos.ParamType]struct{}{
 func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 	if param == nil {
 		logger.Warning("WithParam called with nil sub-param; ignoring",
-			"oid", oid,
-			"param_type", cp.proto.Type.String())
+			"oid", oid)
 		return cp
 	}
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	if _, ok := paramTypesWithSubParams[cp.proto.Type]; !ok {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
 			"param_type", cp.proto.Type.String())
@@ -258,7 +348,10 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 	if cp.proto.Params == nil {
 		cp.proto.Params = map[string]*protos.Param{}
 	}
-	cp.proto.Params[oid] = proto.Clone(param.proto).(*protos.Param)
+	param.mu.RLock()
+	cloned := proto.Clone(param.proto).(*protos.Param)
+	param.mu.RUnlock()
+	cp.proto.Params[oid] = cloned
 	return cp
 }
 
@@ -266,26 +359,36 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 // move this there. Consider an unexported baseParam that both CatenaParam and
 // CatenaCommand compose from, since other fields may also be command-specific.
 func (cp *CatenaParam) WithResponse(response bool) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.Response = response
 	return cp
 }
 
 func (cp *CatenaParam) WithHelp(help PolyglotText) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.Help = &protos.PolyglotText{DisplayStrings: help}
 	return cp
 }
 
 func (cp *CatenaParam) WithOidAliases(aliases ...string) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.OidAliases = aliases
 	return cp
 }
 
 func (cp *CatenaParam) WithMinimalSet(minimalSet bool) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.MinimalSet = minimalSet
 	return cp
 }
 
 func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.Stateless = stateless
 	return cp
 }
@@ -296,13 +399,126 @@ func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
 // know their full mounted path, which adds significant complexity. Revisit if
 // we ever add path tracking to the param tree.
 func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 	cp.proto.TemplateOid = oid
 	return cp
 }
 
-// Proto returns the underlying protos.Param.
+// --- Thread-safe runtime accessors ---
+
+// SetValue converts v to a proto value via ToProto, validates it against the
+// param type, and sets it.
+func (cp *CatenaParam) SetValue(v any) StatusResult {
+	pv, res := ToProto(v)
+	if res.Code != OK {
+		return res
+	}
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	if !isValueValidForParamType(pv, cp.proto.Type) {
+		return StatusResult{Code: INVALID_ARGUMENT, Error: "value kind incompatible with param type " + cp.proto.Type.String()}
+	}
+	cp.proto.Value = pv
+	return StatusResult{Code: OK}
+}
+
+// GetValue reads the current value and converts it to a native Go type via
+// FromProto. Returns (nil, OK) if no value is set.
+func (cp *CatenaParam) GetValue() (any, StatusResult) {
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
+	if cp.proto.Value == nil {
+		return nil, StatusResult{Code: OK}
+	}
+	return FromProto(cp.proto.Value)
+}
+
+// Proto returns the underlying protos.Param. Callers must not mutate the
+// returned proto concurrently with other CatenaParam method calls.
 func (cp *CatenaParam) Proto() *protos.Param {
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
 	return cp.proto
+}
+
+// --- Validation helpers ---
+
+// isValueValidForParamType checks whether a Value kind is compatible with the
+// given ParamType.
+func isValueValidForParamType(v *protos.Value, pt protos.ParamType) bool {
+	if v == nil {
+		return false
+	}
+	switch v.Kind.(type) {
+	case *protos.Value_Int32Value:
+		return pt == protos.ParamType_INT32
+	case *protos.Value_Float32Value:
+		return pt == protos.ParamType_FLOAT32
+	case *protos.Value_StringValue:
+		return pt == protos.ParamType_STRING
+	case *protos.Value_StructValue:
+		return pt == protos.ParamType_STRUCT
+	case *protos.Value_StructVariantValue:
+		return pt == protos.ParamType_STRUCT_VARIANT
+	case *protos.Value_Int32ArrayValues:
+		return pt == protos.ParamType_INT32_ARRAY
+	case *protos.Value_Float32ArrayValues:
+		return pt == protos.ParamType_FLOAT32_ARRAY
+	case *protos.Value_StringArrayValues:
+		return pt == protos.ParamType_STRING_ARRAY
+	case *protos.Value_DataPayload:
+		return pt == protos.ParamType_BINARY || pt == protos.ParamType_DATA
+	case *protos.Value_StructArrayValues:
+		return pt == protos.ParamType_STRUCT_ARRAY
+	case *protos.Value_StructVariantArrayValues:
+		return pt == protos.ParamType_STRUCT_VARIANT_ARRAY
+	case *protos.Value_EmptyValue:
+		return pt == protos.ParamType_EMPTY
+	case *protos.Value_UndefinedValue:
+		return pt == protos.ParamType_UNDEFINED
+	default:
+		return false
+	}
+}
+
+// paramTypeFromValueKind infers the ParamType from a Value's proto kind.
+// DataPayload maps to DATA (not BINARY) since the two share the same value
+// kind. Returns UNDEFINED for nil or unknown kinds.
+func paramTypeFromValueKind(v *protos.Value) protos.ParamType {
+	if v == nil {
+		return protos.ParamType_UNDEFINED
+	}
+	switch v.Kind.(type) {
+	case *protos.Value_Int32Value:
+		return protos.ParamType_INT32
+	case *protos.Value_Float32Value:
+		return protos.ParamType_FLOAT32
+	case *protos.Value_StringValue:
+		return protos.ParamType_STRING
+	case *protos.Value_StructValue:
+		return protos.ParamType_STRUCT
+	case *protos.Value_StructVariantValue:
+		return protos.ParamType_STRUCT_VARIANT
+	case *protos.Value_Int32ArrayValues:
+		return protos.ParamType_INT32_ARRAY
+	case *protos.Value_Float32ArrayValues:
+		return protos.ParamType_FLOAT32_ARRAY
+	case *protos.Value_StringArrayValues:
+		return protos.ParamType_STRING_ARRAY
+	case *protos.Value_DataPayload:
+		return protos.ParamType_DATA
+	case *protos.Value_StructArrayValues:
+		return protos.ParamType_STRUCT_ARRAY
+	case *protos.Value_StructVariantArrayValues:
+		return protos.ParamType_STRUCT_VARIANT_ARRAY
+	case *protos.Value_EmptyValue:
+		return protos.ParamType_EMPTY
+	case *protos.Value_UndefinedValue:
+		return protos.ParamType_UNDEFINED
+	default:
+		return protos.ParamType_UNDEFINED
+	}
 }
 
 // isConstraintValidForParam checks whether a constraint kind is compatible

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -47,14 +47,14 @@ import (
 
 // CatenaParam wraps a protos.Param and exposes a fluent builder API.
 type CatenaParam struct {
-	param *protos.Param
+	proto *protos.Param
 }
 
 // --- Factory functions (one per ParamType) ---
 
 func NewParamInt32(value int32) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_INT32,
 			Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: value}},
 		},
@@ -63,7 +63,7 @@ func NewParamInt32(value int32) *CatenaParam {
 
 func NewParamFloat32(value float32) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_FLOAT32,
 			Value: &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: value}},
 		},
@@ -72,7 +72,7 @@ func NewParamFloat32(value float32) *CatenaParam {
 
 func NewParamString(value string) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_STRING,
 			Value: &protos.Value{Kind: &protos.Value_StringValue{StringValue: value}},
 		},
@@ -81,7 +81,7 @@ func NewParamString(value string) *CatenaParam {
 
 func NewParamStruct() *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
 	}
@@ -89,7 +89,7 @@ func NewParamStruct() *CatenaParam {
 
 func NewParamStructVariant() *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT,
 		},
 	}
@@ -97,7 +97,7 @@ func NewParamStructVariant() *CatenaParam {
 
 func NewParamInt32Array(value []int32) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_INT32_ARRAY,
 			Value: &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: value}}},
 		},
@@ -106,7 +106,7 @@ func NewParamInt32Array(value []int32) *CatenaParam {
 
 func NewParamFloat32Array(value []float32) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_FLOAT32_ARRAY,
 			Value: &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: value}}},
 		},
@@ -115,7 +115,7 @@ func NewParamFloat32Array(value []float32) *CatenaParam {
 
 func NewParamStringArray(value []string) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_STRING_ARRAY,
 			Value: &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: value}}},
 		},
@@ -124,7 +124,7 @@ func NewParamStringArray(value []string) *CatenaParam {
 
 func NewParamBinary(value []byte) *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_BINARY,
 			Value: &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: value}}}},
 		},
@@ -133,7 +133,7 @@ func NewParamBinary(value []byte) *CatenaParam {
 
 func NewParamStructArray() *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_ARRAY,
 		},
 	}
@@ -141,7 +141,7 @@ func NewParamStructArray() *CatenaParam {
 
 func NewParamStructVariantArray() *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
 		},
 	}
@@ -149,7 +149,7 @@ func NewParamStructVariantArray() *CatenaParam {
 
 func NewParamEmpty() *CatenaParam {
 	return &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type:  protos.ParamType_EMPTY,
 			Value: &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}},
 		},
@@ -158,7 +158,7 @@ func NewParamEmpty() *CatenaParam {
 
 func NewParamData(payload DataPayload) *CatenaParam {
 	cp := &CatenaParam{
-		param: &protos.Param{
+		proto: &protos.Param{
 			Type: protos.ParamType_DATA,
 		},
 	}
@@ -168,14 +168,14 @@ func NewParamData(payload DataPayload) *CatenaParam {
 			"error", res.Error)
 		return cp
 	}
-	cp.param.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
+	cp.proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
 	return cp
 }
 
 // --- Chainable With* methods ---
 
 func (cp *CatenaParam) WithName(name PolyglotText) *CatenaParam {
-	cp.param.Name = &protos.PolyglotText{DisplayStrings: name}
+	cp.proto.Name = &protos.PolyglotText{DisplayStrings: name}
 	return cp
 }
 
@@ -183,56 +183,56 @@ func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
 	if c == nil {
 		return cp
 	}
-	if !isConstraintValidForParam(c, cp.param.Type) {
+	if !isConstraintValidForParam(c, cp.proto.Type) {
 		logger.Warning("WithConstraint: constraint type incompatible with param type; ignoring",
 			"constraint_type", c.GetType().String(),
-			"param_type", cp.param.Type.String())
+			"param_type", cp.proto.Type.String())
 		return cp
 	}
-	cp.param.Constraint = c
+	cp.proto.Constraint = c
 	return cp
 }
 
 func (cp *CatenaParam) WithReadOnly(readOnly bool) *CatenaParam {
-	cp.param.ReadOnly = readOnly
+	cp.proto.ReadOnly = readOnly
 	return cp
 }
 
 func (cp *CatenaParam) WithWidget(widget string) *CatenaParam {
-	cp.param.Widget = widget
+	cp.proto.Widget = widget
 	return cp
 }
 
 func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
-	if cp.param.Type != protos.ParamType_FLOAT32 && cp.param.Type != protos.ParamType_FLOAT32_ARRAY {
+	if cp.proto.Type != protos.ParamType_FLOAT32 && cp.proto.Type != protos.ParamType_FLOAT32_ARRAY {
 		logger.Warning("WithPrecision called on non-float param; ignoring",
-			"param_type", cp.param.Type.String())
+			"param_type", cp.proto.Type.String())
 		return cp
 	}
-	cp.param.Precision = precision
+	cp.proto.Precision = precision
 	return cp
 }
 
 func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
-	if cp.param.Type != protos.ParamType_STRING && cp.param.Type != protos.ParamType_STRING_ARRAY {
+	if cp.proto.Type != protos.ParamType_STRING && cp.proto.Type != protos.ParamType_STRING_ARRAY {
 		logger.Warning("WithMaxLength called on param type that does not support max_length; ignoring",
-			"param_type", cp.param.Type.String())
+			"param_type", cp.proto.Type.String())
 		return cp
 	}
-	cp.param.MaxLength = maxLength
+	cp.proto.MaxLength = maxLength
 	return cp
 }
 
 func (cp *CatenaParam) WithAccessScope(scope string) *CatenaParam {
-	cp.param.AccessScope = scope
+	cp.proto.AccessScope = scope
 	return cp
 }
 
 func (cp *CatenaParam) WithClientHint(key, value string) *CatenaParam {
-	if cp.param.ClientHints == nil {
-		cp.param.ClientHints = map[string]string{}
+	if cp.proto.ClientHints == nil {
+		cp.proto.ClientHints = map[string]string{}
 	}
-	cp.param.ClientHints[key] = value
+	cp.proto.ClientHints[key] = value
 	return cp
 }
 
@@ -247,18 +247,18 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 	if param == nil {
 		logger.Warning("WithParam called with nil sub-param; ignoring",
 			"oid", oid,
-			"param_type", cp.param.Type.String())
+			"param_type", cp.proto.Type.String())
 		return cp
 	}
-	if _, ok := paramTypesWithSubParams[cp.param.Type]; !ok {
+	if _, ok := paramTypesWithSubParams[cp.proto.Type]; !ok {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
-			"param_type", cp.param.Type.String())
+			"param_type", cp.proto.Type.String())
 		return cp
 	}
-	if cp.param.Params == nil {
-		cp.param.Params = map[string]*protos.Param{}
+	if cp.proto.Params == nil {
+		cp.proto.Params = map[string]*protos.Param{}
 	}
-	cp.param.Params[oid] = proto.Clone(param.param).(*protos.Param)
+	cp.proto.Params[oid] = proto.Clone(param.proto).(*protos.Param)
 	return cp
 }
 
@@ -266,27 +266,27 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 // move this there. Consider an unexported baseParam that both CatenaParam and
 // CatenaCommand compose from, since other fields may also be command-specific.
 func (cp *CatenaParam) WithResponse(response bool) *CatenaParam {
-	cp.param.Response = response
+	cp.proto.Response = response
 	return cp
 }
 
 func (cp *CatenaParam) WithHelp(help PolyglotText) *CatenaParam {
-	cp.param.Help = &protos.PolyglotText{DisplayStrings: help}
+	cp.proto.Help = &protos.PolyglotText{DisplayStrings: help}
 	return cp
 }
 
 func (cp *CatenaParam) WithOidAliases(aliases ...string) *CatenaParam {
-	cp.param.OidAliases = aliases
+	cp.proto.OidAliases = aliases
 	return cp
 }
 
 func (cp *CatenaParam) WithMinimalSet(minimalSet bool) *CatenaParam {
-	cp.param.MinimalSet = minimalSet
+	cp.proto.MinimalSet = minimalSet
 	return cp
 }
 
 func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
-	cp.param.Stateless = stateless
+	cp.proto.Stateless = stateless
 	return cp
 }
 
@@ -296,13 +296,13 @@ func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
 // know their full mounted path, which adds significant complexity. Revisit if
 // we ever add path tracking to the param tree.
 func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
-	cp.param.TemplateOid = oid
+	cp.proto.TemplateOid = oid
 	return cp
 }
 
-// Build returns the underlying protos.Param.
-func (cp *CatenaParam) Build() *protos.Param {
-	return cp.param
+// Proto returns the underlying protos.Param.
+func (cp *CatenaParam) Proto() *protos.Param {
+	return cp.proto
 }
 
 // isConstraintValidForParam checks whether a constraint kind is compatible

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -338,6 +338,11 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 			"oid", oid)
 		return cp
 	}
+
+	param.mu.RLock()
+	cloned := proto.Clone(param.proto).(*protos.Param)
+	param.mu.RUnlock()
+
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 	if _, ok := paramTypesWithSubParams[cp.proto.Type]; !ok {
@@ -348,9 +353,6 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 	if cp.proto.Params == nil {
 		cp.proto.Params = map[string]*protos.Param{}
 	}
-	param.mu.RLock()
-	cloned := proto.Clone(param.proto).(*protos.Param)
-	param.mu.RUnlock()
 	cp.proto.Params[oid] = cloned
 	return cp
 }

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -45,43 +45,43 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-// CatenaParam wraps a protos.Param and exposes a fluent builder API.
-type CatenaParam struct {
-	proto *protos.Param
+// Param wraps a protos.Param and exposes a fluent builder API.
+type Param struct {
+	Proto *protos.Param
 }
 
 // --- Factory functions (one per ParamType) ---
 
-func NewParamInt32(value int32) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamInt32(value int32) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_INT32,
 			Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: value}},
 		},
 	}
 }
 
-func NewParamFloat32(value float32) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamFloat32(value float32) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_FLOAT32,
 			Value: &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: value}},
 		},
 	}
 }
 
-func NewParamString(value string) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamString(value string) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_STRING,
 			Value: &protos.Value{Kind: &protos.Value_StringValue{StringValue: value}},
 		},
 	}
 }
 
-func NewParamStruct(value ...map[string]any) *CatenaParam {
-	cp := &CatenaParam{
-		proto: &protos.Param{
+func NewParamStruct(value ...map[string]any) *Param {
+	cp := &Param{
+		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
 	}
@@ -92,14 +92,14 @@ func NewParamStruct(value ...map[string]any) *CatenaParam {
 				"error", res.Error)
 			return cp
 		}
-		cp.proto.Value = pv
+		cp.Proto.Value = pv
 	}
 	return cp
 }
 
-func NewParamStructVariant(value ...StructVariantValue) *CatenaParam {
-	cp := &CatenaParam{
-		proto: &protos.Param{
+func NewParamStructVariant(value ...StructVariantValue) *Param {
+	cp := &Param{
+		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT,
 		},
 	}
@@ -110,50 +110,50 @@ func NewParamStructVariant(value ...StructVariantValue) *CatenaParam {
 				"error", res.Error)
 			return cp
 		}
-		cp.proto.Value = pv
+		cp.Proto.Value = pv
 	}
 	return cp
 }
 
-func NewParamInt32Array(value []int32) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamInt32Array(value []int32) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_INT32_ARRAY,
 			Value: &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: value}}},
 		},
 	}
 }
 
-func NewParamFloat32Array(value []float32) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamFloat32Array(value []float32) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_FLOAT32_ARRAY,
 			Value: &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: value}}},
 		},
 	}
 }
 
-func NewParamStringArray(value []string) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamStringArray(value []string) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_STRING_ARRAY,
 			Value: &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: value}}},
 		},
 	}
 }
 
-func NewParamBinary(value []byte) *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamBinary(value []byte) *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_BINARY,
 			Value: &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: value}}}},
 		},
 	}
 }
 
-func NewParamStructArray(value ...[]map[string]any) *CatenaParam {
-	cp := &CatenaParam{
-		proto: &protos.Param{
+func NewParamStructArray(value ...[]map[string]any) *Param {
+	cp := &Param{
+		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_ARRAY,
 		},
 	}
@@ -164,14 +164,14 @@ func NewParamStructArray(value ...[]map[string]any) *CatenaParam {
 				"error", res.Error)
 			return cp
 		}
-		cp.proto.Value = pv
+		cp.Proto.Value = pv
 	}
 	return cp
 }
 
-func NewParamStructVariantArray(value ...[]StructVariantValue) *CatenaParam {
-	cp := &CatenaParam{
-		proto: &protos.Param{
+func NewParamStructVariantArray(value ...[]StructVariantValue) *Param {
+	cp := &Param{
+		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
 		},
 	}
@@ -182,23 +182,23 @@ func NewParamStructVariantArray(value ...[]StructVariantValue) *CatenaParam {
 				"error", res.Error)
 			return cp
 		}
-		cp.proto.Value = pv
+		cp.Proto.Value = pv
 	}
 	return cp
 }
 
-func NewParamEmpty() *CatenaParam {
-	return &CatenaParam{
-		proto: &protos.Param{
+func NewParamEmpty() *Param {
+	return &Param{
+		Proto: &protos.Param{
 			Type:  protos.ParamType_EMPTY,
 			Value: &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}},
 		},
 	}
 }
 
-func NewParamData(payload DataPayload) *CatenaParam {
-	cp := &CatenaParam{
-		proto: &protos.Param{
+func NewParamData(payload DataPayload) *Param {
+	cp := &Param{
+		Proto: &protos.Param{
 			Type: protos.ParamType_DATA,
 		},
 	}
@@ -208,21 +208,21 @@ func NewParamData(payload DataPayload) *CatenaParam {
 			"error", res.Error)
 		return cp
 	}
-	cp.proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
+	cp.Proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
 	return cp
 }
 
-// NewParamFromValue creates a CatenaParam by inferring the ParamType from the
+// NewParamFromValue creates a Param by inferring the ParamType from the
 // Value's proto kind. This allows dynamic param creation regardless of type.
 // DataPayload values are mapped to ParamType_DATA (not BINARY) since the two
 // cannot be distinguished from the value alone.
-func NewParamFromValue(v Value) *CatenaParam {
+func NewParamFromValue(v Value) *Param {
 	pt := paramTypeFromValueKind(v.Value)
 	if pt == protos.ParamType_UNDEFINED {
 		logger.Warning("NewParamFromValue: could not infer param type from value; using UNDEFINED")
 	}
-	return &CatenaParam{
-		proto: &protos.Param{
+	return &Param{
+		Proto: &protos.Param{
 			Type:  pt,
 			Value: v.Value,
 		},
@@ -231,75 +231,75 @@ func NewParamFromValue(v Value) *CatenaParam {
 
 // --- Chainable With* methods ---
 
-func (cp *CatenaParam) WithName(name PolyglotText) *CatenaParam {
-	cp.proto.Name = &protos.PolyglotText{DisplayStrings: name}
+func (cp *Param) WithName(name PolyglotText) *Param {
+	cp.Proto.Name = &protos.PolyglotText{DisplayStrings: name}
 	return cp
 }
 
-func (cp *CatenaParam) WithValue(v Value) *CatenaParam {
-	if !isValueValidForParamType(v.Value, cp.proto.Type) {
+func (cp *Param) WithValue(v Value) *Param {
+	if !isValueValidForParamType(v.Value, cp.Proto.Type) {
 		logger.Warning("WithValue: value kind incompatible with param type; ignoring",
-			"param_type", cp.proto.Type.String())
+			"param_type", cp.Proto.Type.String())
 		return cp
 	}
-	cp.proto.Value = v.Value
+	cp.Proto.Value = v.Value
 	return cp
 }
 
-func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
+func (cp *Param) WithConstraint(c *protos.Constraint) *Param {
 	if c == nil {
 		return cp
 	}
-	if !isConstraintValidForParam(c, cp.proto.Type) {
+	if !isConstraintValidForParam(c, cp.Proto.Type) {
 		logger.Warning("WithConstraint: constraint type incompatible with param type; ignoring",
 			"constraint_type", c.GetType().String(),
-			"param_type", cp.proto.Type.String())
+			"param_type", cp.Proto.Type.String())
 		return cp
 	}
-	cp.proto.Constraint = c
+	cp.Proto.Constraint = c
 	return cp
 }
 
-func (cp *CatenaParam) WithReadOnly(readOnly bool) *CatenaParam {
-	cp.proto.ReadOnly = readOnly
+func (cp *Param) WithReadOnly(readOnly bool) *Param {
+	cp.Proto.ReadOnly = readOnly
 	return cp
 }
 
-func (cp *CatenaParam) WithWidget(widget string) *CatenaParam {
-	cp.proto.Widget = widget
+func (cp *Param) WithWidget(widget string) *Param {
+	cp.Proto.Widget = widget
 	return cp
 }
 
-func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
-	if cp.proto.Type != protos.ParamType_FLOAT32 && cp.proto.Type != protos.ParamType_FLOAT32_ARRAY {
+func (cp *Param) WithPrecision(precision uint32) *Param {
+	if cp.Proto.Type != protos.ParamType_FLOAT32 && cp.Proto.Type != protos.ParamType_FLOAT32_ARRAY {
 		logger.Warning("WithPrecision called on non-float param; ignoring",
-			"param_type", cp.proto.Type.String())
+			"param_type", cp.Proto.Type.String())
 		return cp
 	}
-	cp.proto.Precision = precision
+	cp.Proto.Precision = precision
 	return cp
 }
 
-func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
-	if cp.proto.Type != protos.ParamType_STRING && cp.proto.Type != protos.ParamType_STRING_ARRAY {
+func (cp *Param) WithMaxLength(maxLength uint32) *Param {
+	if cp.Proto.Type != protos.ParamType_STRING && cp.Proto.Type != protos.ParamType_STRING_ARRAY {
 		logger.Warning("WithMaxLength called on param type that does not support max_length; ignoring",
-			"param_type", cp.proto.Type.String())
+			"param_type", cp.Proto.Type.String())
 		return cp
 	}
-	cp.proto.MaxLength = maxLength
+	cp.Proto.MaxLength = maxLength
 	return cp
 }
 
-func (cp *CatenaParam) WithAccessScope(scope string) *CatenaParam {
-	cp.proto.AccessScope = scope
+func (cp *Param) WithAccessScope(scope string) *Param {
+	cp.Proto.AccessScope = scope
 	return cp
 }
 
-func (cp *CatenaParam) WithClientHint(key, value string) *CatenaParam {
-	if cp.proto.ClientHints == nil {
-		cp.proto.ClientHints = map[string]string{}
+func (cp *Param) WithClientHint(key, value string) *Param {
+	if cp.Proto.ClientHints == nil {
+		cp.Proto.ClientHints = map[string]string{}
 	}
-	cp.proto.ClientHints[key] = value
+	cp.Proto.ClientHints[key] = value
 	return cp
 }
 
@@ -310,62 +310,62 @@ var paramTypesWithSubParams = map[protos.ParamType]struct{}{
 	protos.ParamType_STRUCT_VARIANT_ARRAY: {},
 }
 
-func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
+func (cp *Param) WithParam(oid string, param *Param) *Param {
 	if param == nil {
 		logger.Warning("WithParam called with nil sub-param; ignoring",
 			"oid", oid)
 		return cp
 	}
 
-	cloned := proto.Clone(param.proto).(*protos.Param)
+	cloned := proto.Clone(param.Proto).(*protos.Param)
 
-	if _, ok := paramTypesWithSubParams[cp.proto.Type]; !ok {
+	if _, ok := paramTypesWithSubParams[cp.Proto.Type]; !ok {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
-			"param_type", cp.proto.Type.String())
+			"param_type", cp.Proto.Type.String())
 		return cp
 	}
-	if cp.proto.Params == nil {
-		cp.proto.Params = map[string]*protos.Param{}
+	if cp.Proto.Params == nil {
+		cp.Proto.Params = map[string]*protos.Param{}
 	}
-	cp.proto.Params[oid] = cloned
+	cp.Proto.Params[oid] = cloned
 	return cp
 }
 
 // TODO: WithResponse only applies to commands. When we add a CatenaCommand helper,
-// move this there. Consider an unexported baseParam that both CatenaParam and
+// move this there. Consider an unexported baseParam that both Param and
 // CatenaCommand compose from, since other fields may also be command-specific.
-func (cp *CatenaParam) WithResponse(response bool) *CatenaParam {
-	cp.proto.Response = response
+func (cp *Param) WithResponse(response bool) *Param {
+	cp.Proto.Response = response
 	return cp
 }
 
-func (cp *CatenaParam) WithHelp(help PolyglotText) *CatenaParam {
-	cp.proto.Help = &protos.PolyglotText{DisplayStrings: help}
+func (cp *Param) WithHelp(help PolyglotText) *Param {
+	cp.Proto.Help = &protos.PolyglotText{DisplayStrings: help}
 	return cp
 }
 
-func (cp *CatenaParam) WithOidAliases(aliases ...string) *CatenaParam {
-	cp.proto.OidAliases = aliases
+func (cp *Param) WithOidAliases(aliases ...string) *Param {
+	cp.Proto.OidAliases = aliases
 	return cp
 }
 
-func (cp *CatenaParam) WithMinimalSet(minimalSet bool) *CatenaParam {
-	cp.proto.MinimalSet = minimalSet
+func (cp *Param) WithMinimalSet(minimalSet bool) *Param {
+	cp.Proto.MinimalSet = minimalSet
 	return cp
 }
 
-func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
-	cp.proto.Stateless = stateless
+func (cp *Param) WithStateless(stateless bool) *Param {
+	cp.Proto.Stateless = stateless
 	return cp
 }
 
-// TODO: Ideally this would accept a *CatenaParam reference instead of a raw
-// string, but CatenaParam doesn't track its own OID path (the OID is only
+// TODO: Ideally this would accept a *Param reference instead of a raw
+// string, but Param doesn't track its own OID path (the OID is only
 // assigned externally via WithParam). Auto-linking would require params to
 // know their full mounted path, which adds significant complexity. Revisit if
 // we ever add path tracking to the param tree.
-func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
-	cp.proto.TemplateOid = oid
+func (cp *Param) WithTemplateOid(oid string) *Param {
+	cp.Proto.TemplateOid = oid
 	return cp
 }
 
@@ -373,31 +373,25 @@ func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
 
 // SetValue converts v to a proto value via ToProto, validates it against the
 // param type, and sets it.
-func (cp *CatenaParam) SetValue(v any) StatusResult {
+func (cp *Param) SetValue(v any) StatusResult {
 	pv, res := ToProto(v)
 	if res.Code != OK {
 		return res
 	}
-	if !isValueValidForParamType(pv, cp.proto.Type) {
-		return StatusResult{Code: INVALID_ARGUMENT, Error: "value kind incompatible with param type " + cp.proto.Type.String()}
+	if !isValueValidForParamType(pv, cp.Proto.Type) {
+		return StatusResult{Code: INVALID_ARGUMENT, Error: "value kind incompatible with param type " + cp.Proto.Type.String()}
 	}
-	cp.proto.Value = pv
+	cp.Proto.Value = pv
 	return StatusResult{Code: OK}
 }
 
 // GetValue reads the current value and converts it to a native Go type via
 // FromProto. Returns (nil, OK) if no value is set.
-func (cp *CatenaParam) GetValue() (any, StatusResult) {
-	if cp.proto.Value == nil {
+func (cp *Param) GetValue() (any, StatusResult) {
+	if cp.Proto.Value == nil {
 		return nil, StatusResult{Code: OK}
 	}
-	return FromProto(cp.proto.Value)
-}
-
-// Proto returns the underlying protos.Param. Callers must not mutate the
-// returned proto concurrently with other CatenaParam method calls.
-func (cp *CatenaParam) Proto() *protos.Param {
-	return cp.proto
+	return FromProto(cp.Proto.Value)
 }
 
 // --- Validation helpers ---

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -236,11 +236,11 @@ func (cp *CatenaParam) WithClientHint(key, value string) *CatenaParam {
 	return cp
 }
 
-var paramTypesWithSubParams = map[protos.ParamType]bool{
-	protos.ParamType_STRUCT:               true,
-	protos.ParamType_STRUCT_VARIANT:       true,
-	protos.ParamType_STRUCT_ARRAY:         true,
-	protos.ParamType_STRUCT_VARIANT_ARRAY: true,
+var paramTypesWithSubParams = map[protos.ParamType]struct{}{
+	protos.ParamType_STRUCT:               {},
+	protos.ParamType_STRUCT_VARIANT:       {},
+	protos.ParamType_STRUCT_ARRAY:         {},
+	protos.ParamType_STRUCT_VARIANT_ARRAY: {},
 }
 
 func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
@@ -250,7 +250,7 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 			"param_type", cp.param.Type.String())
 		return cp
 	}
-	if !paramTypesWithSubParams[cp.param.Type] {
+	if _, ok := paramTypesWithSubParams[cp.param.Type]; !ok {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
 			"param_type", cp.param.Type.String())
 		return cp
@@ -262,6 +262,9 @@ func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
 	return cp
 }
 
+// TODO: WithResponse only applies to commands. When we add a CatenaCommand helper,
+// move this there. Consider an unexported baseParam that both CatenaParam and
+// CatenaCommand compose from, since other fields may also be command-specific.
 func (cp *CatenaParam) WithResponse(response bool) *CatenaParam {
 	cp.param.Response = response
 	return cp
@@ -287,6 +290,11 @@ func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
 	return cp
 }
 
+// TODO: Ideally this would accept a *CatenaParam reference instead of a raw
+// string, but CatenaParam doesn't track its own OID path (the OID is only
+// assigned externally via WithParam). Auto-linking would require params to
+// know their full mounted path, which adds significant complexity. Revisit if
+// we ever add path tracking to the param tree.
 func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
 	cp.param.TemplateOid = oid
 	return cp

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -204,8 +204,8 @@ func (cp *CatenaParam) WithWidget(widget string) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
-	if cp.param.Type != protos.ParamType_FLOAT32 {
-		logger.Warning("WithPrecision called on non-FLOAT32 param; ignoring",
+	if cp.param.Type != protos.ParamType_FLOAT32 && cp.param.Type != protos.ParamType_FLOAT32_ARRAY {
+		logger.Warning("WithPrecision called on non-float param; ignoring",
 			"param_type", cp.param.Type.String())
 		return cp
 	}
@@ -214,8 +214,8 @@ func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
 }
 
 func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
-	if cp.param.Type != protos.ParamType_STRING {
-		logger.Warning("WithMaxLength called on non-STRING param; ignoring",
+	if cp.param.Type != protos.ParamType_STRING && cp.param.Type != protos.ParamType_STRING_ARRAY {
+		logger.Warning("WithMaxLength called on param type that does not support max_length; ignoring",
 			"param_type", cp.param.Type.String())
 		return cp
 	}
@@ -298,17 +298,19 @@ func (cp *CatenaParam) Build() *protos.Param {
 }
 
 // isConstraintValidForParam checks whether a constraint kind is compatible
-// with the given ParamType. RefOid constraints are always valid.
+// with the given ParamType. RefOid constraints are always valid. Scalar
+// constraints are also valid on their corresponding array param type
+// (e.g. Int32Range on INT32 or INT32_ARRAY).
 func isConstraintValidForParam(c *protos.Constraint, pt protos.ParamType) bool {
 	switch c.Kind.(type) {
 	case *protos.Constraint_RefOid:
 		return true
 	case *protos.Constraint_Int32Range, *protos.Constraint_Int32Choice, *protos.Constraint_AlarmTable:
-		return pt == protos.ParamType_INT32
+		return pt == protos.ParamType_INT32 || pt == protos.ParamType_INT32_ARRAY
 	case *protos.Constraint_FloatRange:
-		return pt == protos.ParamType_FLOAT32
+		return pt == protos.ParamType_FLOAT32 || pt == protos.ParamType_FLOAT32_ARRAY
 	case *protos.Constraint_StringChoice, *protos.Constraint_StringStringChoice:
-		return pt == protos.ParamType_STRING
+		return pt == protos.ParamType_STRING || pt == protos.ParamType_STRING_ARRAY
 	default:
 		return false
 	}

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -28,6 +28,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * @brief Param handling for the Catena SDK.
+ * @file param.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-05-11
+ */
+
 package catena
 
 import (

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package catena
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// CatenaParam wraps a protos.Param and exposes a fluent builder API.
+type CatenaParam struct {
+	param *protos.Param
+}
+
+// --- Factory functions (one per ParamType) ---
+
+func NewParamInt32(value int32) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_INT32,
+			Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: value}},
+		},
+	}
+}
+
+func NewParamFloat32(value float32) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_FLOAT32,
+			Value: &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: value}},
+		},
+	}
+}
+
+func NewParamString(value string) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_STRING,
+			Value: &protos.Value{Kind: &protos.Value_StringValue{StringValue: value}},
+		},
+	}
+}
+
+func NewParamStruct() *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type: protos.ParamType_STRUCT,
+		},
+	}
+}
+
+func NewParamStructVariant() *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type: protos.ParamType_STRUCT_VARIANT,
+		},
+	}
+}
+
+func NewParamInt32Array(value []int32) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_INT32_ARRAY,
+			Value: &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: value}}},
+		},
+	}
+}
+
+func NewParamFloat32Array(value []float32) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_FLOAT32_ARRAY,
+			Value: &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: value}}},
+		},
+	}
+}
+
+func NewParamStringArray(value []string) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_STRING_ARRAY,
+			Value: &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: value}}},
+		},
+	}
+}
+
+func NewParamBinary(value []byte) *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_BINARY,
+			Value: &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: value}}}},
+		},
+	}
+}
+
+func NewParamStructArray() *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type: protos.ParamType_STRUCT_ARRAY,
+		},
+	}
+}
+
+func NewParamStructVariantArray() *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
+		},
+	}
+}
+
+func NewParamEmpty() *CatenaParam {
+	return &CatenaParam{
+		param: &protos.Param{
+			Type:  protos.ParamType_EMPTY,
+			Value: &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}},
+		},
+	}
+}
+
+func NewParamData(payload DataPayload) *CatenaParam {
+	cp := &CatenaParam{
+		param: &protos.Param{
+			Type: protos.ParamType_DATA,
+		},
+	}
+	pdp, res := dataPayloadToProto(payload)
+	if res.Code != OK {
+		logger.Warning("NewParamData: failed to convert DataPayload; value left nil",
+			"error", res.Error)
+		return cp
+	}
+	cp.param.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
+	return cp
+}
+
+// --- Chainable With* methods ---
+
+func (cp *CatenaParam) WithName(name PolyglotText) *CatenaParam {
+	cp.param.Name = &protos.PolyglotText{DisplayStrings: name}
+	return cp
+}
+
+func (cp *CatenaParam) WithConstraint(c *protos.Constraint) *CatenaParam {
+	if c == nil {
+		return cp
+	}
+	if !isConstraintValidForParam(c, cp.param.Type) {
+		logger.Warning("WithConstraint: constraint type incompatible with param type; ignoring",
+			"constraint_type", c.GetType().String(),
+			"param_type", cp.param.Type.String())
+		return cp
+	}
+	cp.param.Constraint = c
+	return cp
+}
+
+func (cp *CatenaParam) WithReadOnly(readOnly bool) *CatenaParam {
+	cp.param.ReadOnly = readOnly
+	return cp
+}
+
+func (cp *CatenaParam) WithWidget(widget string) *CatenaParam {
+	cp.param.Widget = widget
+	return cp
+}
+
+func (cp *CatenaParam) WithPrecision(precision uint32) *CatenaParam {
+	if cp.param.Type != protos.ParamType_FLOAT32 {
+		logger.Warning("WithPrecision called on non-FLOAT32 param; ignoring",
+			"param_type", cp.param.Type.String())
+		return cp
+	}
+	cp.param.Precision = precision
+	return cp
+}
+
+func (cp *CatenaParam) WithMaxLength(maxLength uint32) *CatenaParam {
+	if cp.param.Type != protos.ParamType_STRING {
+		logger.Warning("WithMaxLength called on non-STRING param; ignoring",
+			"param_type", cp.param.Type.String())
+		return cp
+	}
+	cp.param.MaxLength = maxLength
+	return cp
+}
+
+func (cp *CatenaParam) WithAccessScope(scope string) *CatenaParam {
+	cp.param.AccessScope = scope
+	return cp
+}
+
+func (cp *CatenaParam) WithClientHint(key, value string) *CatenaParam {
+	if cp.param.ClientHints == nil {
+		cp.param.ClientHints = map[string]string{}
+	}
+	cp.param.ClientHints[key] = value
+	return cp
+}
+
+var paramTypesWithSubParams = map[protos.ParamType]bool{
+	protos.ParamType_STRUCT:               true,
+	protos.ParamType_STRUCT_VARIANT:       true,
+	protos.ParamType_STRUCT_ARRAY:         true,
+	protos.ParamType_STRUCT_VARIANT_ARRAY: true,
+}
+
+func (cp *CatenaParam) WithParam(oid string, param *CatenaParam) *CatenaParam {
+	if !paramTypesWithSubParams[cp.param.Type] {
+		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
+			"param_type", cp.param.Type.String())
+		return cp
+	}
+	if cp.param.Params == nil {
+		cp.param.Params = map[string]*protos.Param{}
+	}
+	cp.param.Params[oid] = proto.Clone(param.param).(*protos.Param)
+	return cp
+}
+
+func (cp *CatenaParam) WithResponse(response bool) *CatenaParam {
+	cp.param.Response = response
+	return cp
+}
+
+func (cp *CatenaParam) WithHelp(help PolyglotText) *CatenaParam {
+	cp.param.Help = &protos.PolyglotText{DisplayStrings: help}
+	return cp
+}
+
+func (cp *CatenaParam) WithOidAliases(aliases ...string) *CatenaParam {
+	cp.param.OidAliases = aliases
+	return cp
+}
+
+func (cp *CatenaParam) WithMinimalSet(minimalSet bool) *CatenaParam {
+	cp.param.MinimalSet = minimalSet
+	return cp
+}
+
+func (cp *CatenaParam) WithStateless(stateless bool) *CatenaParam {
+	cp.param.Stateless = stateless
+	return cp
+}
+
+func (cp *CatenaParam) WithTemplateOid(oid string) *CatenaParam {
+	cp.param.TemplateOid = oid
+	return cp
+}
+
+// Build returns the underlying protos.Param.
+func (cp *CatenaParam) Build() *protos.Param {
+	return cp.param
+}
+
+// isConstraintValidForParam checks whether a constraint kind is compatible
+// with the given ParamType. RefOid constraints are always valid.
+func isConstraintValidForParam(c *protos.Constraint, pt protos.ParamType) bool {
+	switch c.Kind.(type) {
+	case *protos.Constraint_RefOid:
+		return true
+	case *protos.Constraint_Int32Range, *protos.Constraint_Int32Choice, *protos.Constraint_AlarmTable:
+		return pt == protos.ParamType_INT32
+	case *protos.Constraint_FloatRange:
+		return pt == protos.ParamType_FLOAT32
+	case *protos.Constraint_StringChoice, *protos.Constraint_StringStringChoice:
+		return pt == protos.ParamType_STRING
+	default:
+		return false
+	}
+}

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -85,15 +85,13 @@ func NewParamStruct(value map[string]any) *Param {
 			Type: protos.ParamType_STRUCT,
 		},
 	}
-	if value != nil {
-		pv, res := ToProto(value)
-		if res.Code != OK {
-			logger.Warning("NewParamStruct: failed to convert value; value left nil",
-				"error", res.Error)
-			return cp
-		}
-		cp.Proto.Value = pv
+	pv, res := ToProto(value)
+	if res.Code != OK {
+		logger.Warning("NewParamStruct: failed to convert value; value left nil",
+			"error", res.Error)
+		return cp
 	}
+	cp.Proto.Value = pv
 	return cp
 }
 
@@ -157,15 +155,13 @@ func NewParamStructArray(value []map[string]any) *Param {
 			Type: protos.ParamType_STRUCT_ARRAY,
 		},
 	}
-	if value != nil {
-		pv, res := ToProto(value)
-		if res.Code != OK {
-			logger.Warning("NewParamStructArray: failed to convert value; value left nil",
-				"error", res.Error)
-			return cp
-		}
-		cp.Proto.Value = pv
+	pv, res := ToProto(value)
+	if res.Code != OK {
+		logger.Warning("NewParamStructArray: failed to convert value; value left nil",
+			"error", res.Error)
+		return cp
 	}
+	cp.Proto.Value = pv
 	return cp
 }
 
@@ -175,15 +171,13 @@ func NewParamStructVariantArray(value []StructVariantValue) *Param {
 			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
 		},
 	}
-	if value != nil {
-		pv, res := ToProto(value)
-		if res.Code != OK {
-			logger.Warning("NewParamStructVariantArray: failed to convert value; value left nil",
-				"error", res.Error)
-			return cp
-		}
-		cp.Proto.Value = pv
+	pv, res := ToProto(value)
+	if res.Code != OK {
+		logger.Warning("NewParamStructVariantArray: failed to convert value; value left nil",
+			"error", res.Error)
+		return cp
 	}
+	cp.Proto.Value = pv
 	return cp
 }
 

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -77,14 +77,14 @@ func TestNewParamString(t *testing.T) {
 }
 
 func TestNewParamStruct(t *testing.T) {
-	p := NewParamStruct().Proto
+	p := NewParamStruct(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariant(t *testing.T) {
-	p := NewParamStructVariant().Proto
+	p := NewParamStructVariant(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
 		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
 	}
@@ -135,14 +135,14 @@ func TestNewParamBinary(t *testing.T) {
 }
 
 func TestNewParamStructArray(t *testing.T) {
-	p := NewParamStructArray().Proto
+	p := NewParamStructArray(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT_ARRAY {
 		t.Errorf("expected STRUCT_ARRAY, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariantArray(t *testing.T) {
-	p := NewParamStructVariantArray().Proto
+	p := NewParamStructVariantArray(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
 		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", p.GetType())
 	}
@@ -262,7 +262,7 @@ func TestWithClientHint(t *testing.T) {
 
 func TestWithParam_Struct(t *testing.T) {
 	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
-	p := NewParamStruct().WithParam("brightness", child).Proto
+	p := NewParamStruct(nil).WithParam("brightness", child).Proto
 
 	sub := p.GetParams()["brightness"]
 	if sub == nil {
@@ -275,7 +275,7 @@ func TestWithParam_Struct(t *testing.T) {
 
 func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
-	parent := NewParamStruct().WithParam("x", child).Proto
+	parent := NewParamStruct(nil).WithParam("x", child).Proto
 
 	child.SetValue(int32(999))
 	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
@@ -295,7 +295,7 @@ func TestWithParam_Nil(t *testing.T) {
 	// Passing a nil sub-param must not panic and must not add an entry,
 	// preserving the contract that method chaining is never interrupted
 	// by error handling.
-	cp := NewParamStruct().WithParam("x", nil)
+	cp := NewParamStruct(nil).WithParam("x", nil)
 	p := cp.Proto
 	if len(p.GetParams()) != 0 {
 		t.Error("expected nil sub-param to be a no-op")
@@ -453,7 +453,7 @@ func TestWithConstraint_RefOid_AnyType(t *testing.T) {
 		func() *Param { return NewParamInt32(0) },
 		func() *Param { return NewParamFloat32(0) },
 		func() *Param { return NewParamString("") },
-		func() *Param { return NewParamStruct() },
+		func() *Param { return NewParamStruct(nil) },
 	} {
 		p := factory().WithConstraint(c).Proto
 		if p.GetConstraint() == nil {
@@ -509,10 +509,7 @@ func TestWithConstraint_Nil(t *testing.T) {
 }
 
 // Scalar constraints must also be accepted on their corresponding array
-// param types, matching the Catena protocol (see param.int_array_range.yaml,
-// param.int_array_choice.yaml, param.int_array_alarm.yaml,
-// param.float_array_range.yaml, param.string_array_choice.yaml,
-// param.string_string_array_choice.yaml).
+// param types, matching the Catena protocol
 
 func TestWithConstraint_ValidIntRangeOnInt32Array(t *testing.T) {
 	c := &protos.Constraint{
@@ -690,7 +687,7 @@ func TestWithValue_Struct(t *testing.T) {
 	if res.Code != OK {
 		t.Fatal(res.Error)
 	}
-	p := NewParamStruct().WithValue(v).Proto
+	p := NewParamStruct(nil).WithValue(v).Proto
 	fields := p.GetValue().GetStructValue().GetFields()
 	if fields["name"].GetStringValue() != "test" {
 		t.Errorf("expected struct field 'name'='test', got %q", fields["name"].GetStringValue())
@@ -703,7 +700,7 @@ func TestWithValue_StructVariant(t *testing.T) {
 	if res.Code != OK {
 		t.Fatal(res.Error)
 	}
-	p := NewParamStructVariant().WithValue(v).Proto
+	p := NewParamStructVariant(nil).WithValue(v).Proto
 	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "type_a" {
 		t.Errorf("expected struct_variant_type 'type_a', got %q",
 			p.GetValue().GetStructVariantValue().GetStructVariantType())
@@ -767,7 +764,7 @@ func TestGetValue_OK(t *testing.T) {
 }
 
 func TestGetValue_Nil(t *testing.T) {
-	cp := NewParamStruct()
+	cp := NewParamStruct(nil)
 	v, res := cp.GetValue()
 	if res.Code != OK {
 		t.Fatalf("expected OK for nil value, got %v: %s", res.Code, res.Error)
@@ -778,7 +775,7 @@ func TestGetValue_Nil(t *testing.T) {
 }
 
 func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
-	cp := NewParamStruct()
+	cp := NewParamStruct(nil)
 	input := map[string]any{"x": int32(1), "y": int32(2)}
 	res := cp.SetValue(input)
 	if res.Code != OK {
@@ -808,7 +805,7 @@ func TestNewParamStruct_WithValue(t *testing.T) {
 }
 
 func TestNewParamStruct_NoValue(t *testing.T) {
-	p := NewParamStruct().Proto
+	p := NewParamStruct(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
@@ -819,7 +816,7 @@ func TestNewParamStruct_NoValue(t *testing.T) {
 
 func TestNewParamStructVariant_WithValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "kind_a", Value: int32(5)}
-	p := NewParamStructVariant(sv).Proto
+	p := NewParamStructVariant(&sv).Proto
 	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "kind_a" {
 		t.Errorf("expected struct_variant_type 'kind_a', got %q",
 			p.GetValue().GetStructVariantValue().GetStructVariantType())
@@ -973,7 +970,7 @@ func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
 }
 
 func TestWithParam_SelfReference(t *testing.T) {
-	cp := NewParamStruct()
+	cp := NewParamStruct(nil)
 	cp.WithParam("self", cp)
 	sub := cp.Proto.GetParams()["self"]
 	if sub == nil {
@@ -995,7 +992,7 @@ func TestNewParamStruct_InvalidValue(t *testing.T) {
 
 func TestNewParamStructVariant_InvalidValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "t", Value: struct{}{}}
-	p := NewParamStructVariant(sv).Proto
+	p := NewParamStructVariant(&sv).Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
 		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
 	}
@@ -1050,7 +1047,7 @@ func TestNewParamData_BothPayloadAndUrl(t *testing.T) {
 
 func TestWithParam_StructVariant(t *testing.T) {
 	child := NewParamInt32(5)
-	p := NewParamStructVariant().WithParam("field", child).Proto
+	p := NewParamStructVariant(nil).WithParam("field", child).Proto
 	sub := p.GetParams()["field"]
 	if sub == nil {
 		t.Fatal("expected sub-param on STRUCT_VARIANT")
@@ -1062,7 +1059,7 @@ func TestWithParam_StructVariant(t *testing.T) {
 
 func TestWithParam_StructArray(t *testing.T) {
 	child := NewParamString("val")
-	p := NewParamStructArray().WithParam("item", child).Proto
+	p := NewParamStructArray(nil).WithParam("item", child).Proto
 	sub := p.GetParams()["item"]
 	if sub == nil {
 		t.Fatal("expected sub-param on STRUCT_ARRAY")
@@ -1074,7 +1071,7 @@ func TestWithParam_StructArray(t *testing.T) {
 
 func TestWithParam_StructVariantArray(t *testing.T) {
 	child := NewParamFloat32(1.5)
-	p := NewParamStructVariantArray().WithParam("entry", child).Proto
+	p := NewParamStructVariantArray(nil).WithParam("entry", child).Proto
 	sub := p.GetParams()["entry"]
 	if sub == nil {
 		t.Fatal("expected sub-param on STRUCT_VARIANT_ARRAY")

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -199,10 +199,20 @@ func TestWithPrecision(t *testing.T) {
 	}
 }
 
+// precision is part of the Catena protocol for both FLOAT32 and FLOAT32_ARRAY
+// params (see device.one_of_everything.yaml, which sets precision: 3 on a
+// FLOAT32_ARRAY).
+func TestWithPrecision_Float32Array(t *testing.T) {
+	p := NewParamFloat32Array([]float32{1.1, 2.2}).WithPrecision(3).Build()
+	if p.GetPrecision() != 3 {
+		t.Errorf("expected precision 3 on FLOAT32_ARRAY, got %d", p.GetPrecision())
+	}
+}
+
 func TestWithPrecision_WrongType(t *testing.T) {
 	p := NewParamInt32(0).WithPrecision(3).Build()
 	if p.GetPrecision() != 0 {
-		t.Error("expected precision to remain 0 for non-FLOAT32 param")
+		t.Error("expected precision to remain 0 for non-float param")
 	}
 }
 
@@ -213,10 +223,20 @@ func TestWithMaxLength(t *testing.T) {
 	}
 }
 
+// max_length is part of the Catena protocol for both STRING and STRING_ARRAY
+// params (see param.string_array_length.yaml, which sets max_length: 10 on a
+// STRING_ARRAY to cap the number of strings in the array).
+func TestWithMaxLength_StringArray(t *testing.T) {
+	p := NewParamStringArray([]string{"a", "b"}).WithMaxLength(10).Build()
+	if p.GetMaxLength() != 10 {
+		t.Errorf("expected max_length 10 on STRING_ARRAY, got %d", p.GetMaxLength())
+	}
+}
+
 func TestWithMaxLength_WrongType(t *testing.T) {
 	p := NewParamInt32(0).WithMaxLength(255).Build()
 	if p.GetMaxLength() != 0 {
-		t.Error("expected max_length to remain 0 for non-STRING param")
+		t.Error("expected max_length to remain 0 for param type that does not support max_length")
 	}
 }
 
@@ -485,6 +505,115 @@ func TestWithConstraint_Nil(t *testing.T) {
 	p := NewParamInt32(0).WithConstraint(nil).Build()
 	if p.GetConstraint() != nil {
 		t.Error("expected nil constraint to be a no-op")
+	}
+}
+
+// Scalar constraints must also be accepted on their corresponding array
+// param types, matching the Catena protocol (see param.int_array_range.yaml,
+// param.int_array_choice.yaml, param.int_array_alarm.yaml,
+// param.float_array_range.yaml, param.string_array_choice.yaml,
+// param.string_string_array_choice.yaml).
+
+func TestWithConstraint_ValidIntRangeOnInt32Array(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_RANGE,
+		Kind: &protos.Constraint_Int32Range{
+			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 10, Step: 2},
+		},
+	}
+	p := NewParamInt32Array([]int32{0, 2, 4}).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected int32 range constraint to be applied to INT32_ARRAY param")
+	}
+}
+
+func TestWithConstraint_ValidInt32ChoiceOnInt32Array(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_CHOICE,
+		Kind: &protos.Constraint_Int32Choice{
+			Int32Choice: &protos.Int32ChoiceConstraint{
+				Choices: []*protos.Int32ChoiceConstraint_IntChoice{
+					{Value: 0, Name: &protos.PolyglotText{DisplayStrings: map[string]string{"en": "Off"}}},
+					{Value: 1, Name: &protos.PolyglotText{DisplayStrings: map[string]string{"en": "On"}}},
+				},
+			},
+		},
+	}
+	p := NewParamInt32Array([]int32{0, 1, 0}).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected int32 choice constraint to be applied to INT32_ARRAY param")
+	}
+}
+
+func TestWithConstraint_ValidAlarmTableOnInt32Array(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_ALARM_TABLE,
+		Kind: &protos.Constraint_AlarmTable{
+			AlarmTable: &protos.AlarmTableConstraint{
+				Alarms: []*protos.Alarm{{BitValue: 0, Severity: protos.Alarm_INFO}},
+			},
+		},
+	}
+	p := NewParamInt32Array([]int32{0, 1, 2}).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected alarm table constraint to be applied to INT32_ARRAY param")
+	}
+}
+
+func TestWithConstraint_ValidFloatRangeOnFloat32Array(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_FLOAT_RANGE,
+		Kind: &protos.Constraint_FloatRange{
+			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 100, Step: 0.5},
+		},
+	}
+	p := NewParamFloat32Array([]float32{1.0, 2.0}).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected float range constraint to be applied to FLOAT32_ARRAY param")
+	}
+}
+
+func TestWithConstraint_ValidStringChoiceOnStringArray(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_STRING_CHOICE,
+		Kind: &protos.Constraint_StringChoice{
+			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
+		},
+	}
+	p := NewParamStringArray([]string{"a", "b"}).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected string choice constraint to be applied to STRING_ARRAY param")
+	}
+}
+
+func TestWithConstraint_ValidStringStringChoiceOnStringArray(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_STRING_STRING_CHOICE,
+		Kind: &protos.Constraint_StringStringChoice{
+			StringStringChoice: &protos.StringStringChoiceConstraint{
+				Choices: []*protos.StringStringChoiceConstraint_StringStringChoice{
+					{Value: "<#FF0000>", Name: &protos.PolyglotText{DisplayStrings: map[string]string{"en": "Red"}}},
+				},
+				Strict: true,
+			},
+		},
+	}
+	p := NewParamStringArray([]string{"<#FF0000>"}).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected string-string choice constraint to be applied to STRING_ARRAY param")
+	}
+}
+
+func TestWithConstraint_InvalidIntOnStringArray(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_RANGE,
+		Kind: &protos.Constraint_Int32Range{
+			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 10, Step: 1},
+		},
+	}
+	p := NewParamStringArray([]string{"a"}).WithConstraint(c).Build()
+	if p.GetConstraint() != nil {
+		t.Error("expected int32 range constraint to be rejected on STRING_ARRAY param")
 	}
 }
 

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package catena
+
+import (
+	"testing"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// --- Factory tests ---
+
+func TestNewParamInt32(t *testing.T) {
+	p := NewParamInt32(42).Build()
+	if p.GetType() != protos.ParamType_INT32 {
+		t.Errorf("expected INT32, got %v", p.GetType())
+	}
+	if p.GetValue().GetInt32Value() != 42 {
+		t.Errorf("expected 42, got %d", p.GetValue().GetInt32Value())
+	}
+}
+
+func TestNewParamFloat32(t *testing.T) {
+	p := NewParamFloat32(3.14).Build()
+	if p.GetType() != protos.ParamType_FLOAT32 {
+		t.Errorf("expected FLOAT32, got %v", p.GetType())
+	}
+	if p.GetValue().GetFloat32Value() != 3.14 {
+		t.Errorf("expected 3.14, got %f", p.GetValue().GetFloat32Value())
+	}
+}
+
+func TestNewParamString(t *testing.T) {
+	p := NewParamString("hello").Build()
+	if p.GetType() != protos.ParamType_STRING {
+		t.Errorf("expected STRING, got %v", p.GetType())
+	}
+	if p.GetValue().GetStringValue() != "hello" {
+		t.Errorf("expected 'hello', got %q", p.GetValue().GetStringValue())
+	}
+}
+
+func TestNewParamStruct(t *testing.T) {
+	p := NewParamStruct().Build()
+	if p.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected STRUCT, got %v", p.GetType())
+	}
+}
+
+func TestNewParamStructVariant(t *testing.T) {
+	p := NewParamStructVariant().Build()
+	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
+		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
+	}
+}
+
+func TestNewParamInt32Array(t *testing.T) {
+	p := NewParamInt32Array([]int32{1, 2, 3}).Build()
+	if p.GetType() != protos.ParamType_INT32_ARRAY {
+		t.Errorf("expected INT32_ARRAY, got %v", p.GetType())
+	}
+	vals := p.GetValue().GetInt32ArrayValues().GetInts()
+	if len(vals) != 3 || vals[0] != 1 {
+		t.Errorf("unexpected int32 array: %v", vals)
+	}
+}
+
+func TestNewParamFloat32Array(t *testing.T) {
+	p := NewParamFloat32Array([]float32{1.1, 2.2}).Build()
+	if p.GetType() != protos.ParamType_FLOAT32_ARRAY {
+		t.Errorf("expected FLOAT32_ARRAY, got %v", p.GetType())
+	}
+	vals := p.GetValue().GetFloat32ArrayValues().GetFloats()
+	if len(vals) != 2 {
+		t.Errorf("expected 2 floats, got %d", len(vals))
+	}
+}
+
+func TestNewParamStringArray(t *testing.T) {
+	p := NewParamStringArray([]string{"a", "b"}).Build()
+	if p.GetType() != protos.ParamType_STRING_ARRAY {
+		t.Errorf("expected STRING_ARRAY, got %v", p.GetType())
+	}
+	vals := p.GetValue().GetStringArrayValues().GetStrings()
+	if len(vals) != 2 || vals[0] != "a" {
+		t.Errorf("unexpected string array: %v", vals)
+	}
+}
+
+func TestNewParamBinary(t *testing.T) {
+	p := NewParamBinary([]byte{0xDE, 0xAD}).Build()
+	if p.GetType() != protos.ParamType_BINARY {
+		t.Errorf("expected BINARY, got %v", p.GetType())
+	}
+	payload := p.GetValue().GetDataPayload().GetPayload()
+	if len(payload) != 2 || payload[0] != 0xDE {
+		t.Errorf("unexpected binary payload: %v", payload)
+	}
+}
+
+func TestNewParamStructArray(t *testing.T) {
+	p := NewParamStructArray().Build()
+	if p.GetType() != protos.ParamType_STRUCT_ARRAY {
+		t.Errorf("expected STRUCT_ARRAY, got %v", p.GetType())
+	}
+}
+
+func TestNewParamStructVariantArray(t *testing.T) {
+	p := NewParamStructVariantArray().Build()
+	if p.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
+		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", p.GetType())
+	}
+}
+
+func TestNewParamEmpty(t *testing.T) {
+	p := NewParamEmpty().Build()
+	if p.GetType() != protos.ParamType_EMPTY {
+		t.Errorf("expected EMPTY, got %v", p.GetType())
+	}
+	if p.GetValue().GetEmptyValue() == nil {
+		t.Error("expected EmptyValue to be set")
+	}
+}
+
+func TestNewParamData(t *testing.T) {
+	dp := ToPayload([]byte("content"), "text/plain", "test.txt")
+	p := NewParamData(dp).Build()
+	if p.GetType() != protos.ParamType_DATA {
+		t.Errorf("expected DATA, got %v", p.GetType())
+	}
+	if p.GetValue().GetDataPayload() == nil {
+		t.Error("expected DataPayload to be set")
+	}
+}
+
+// --- With* method tests ---
+
+func TestWithName(t *testing.T) {
+	p := NewParamInt32(0).WithName(NewPolyglotText("en", "Temperature")).Build()
+	if p.GetName().GetDisplayStrings()["en"] != "Temperature" {
+		t.Errorf("expected 'Temperature', got %q", p.GetName().GetDisplayStrings()["en"])
+	}
+}
+
+func TestWithReadOnly(t *testing.T) {
+	p := NewParamInt32(0).WithReadOnly(true).Build()
+	if !p.GetReadOnly() {
+		t.Error("expected read_only=true")
+	}
+}
+
+func TestWithWidget(t *testing.T) {
+	p := NewParamInt32(0).WithWidget("slider").Build()
+	if p.GetWidget() != "slider" {
+		t.Errorf("expected 'slider', got %q", p.GetWidget())
+	}
+}
+
+func TestWithPrecision(t *testing.T) {
+	p := NewParamFloat32(0).WithPrecision(3).Build()
+	if p.GetPrecision() != 3 {
+		t.Errorf("expected precision 3, got %d", p.GetPrecision())
+	}
+}
+
+func TestWithPrecision_WrongType(t *testing.T) {
+	p := NewParamInt32(0).WithPrecision(3).Build()
+	if p.GetPrecision() != 0 {
+		t.Error("expected precision to remain 0 for non-FLOAT32 param")
+	}
+}
+
+func TestWithMaxLength(t *testing.T) {
+	p := NewParamString("").WithMaxLength(255).Build()
+	if p.GetMaxLength() != 255 {
+		t.Errorf("expected max_length 255, got %d", p.GetMaxLength())
+	}
+}
+
+func TestWithMaxLength_WrongType(t *testing.T) {
+	p := NewParamInt32(0).WithMaxLength(255).Build()
+	if p.GetMaxLength() != 0 {
+		t.Error("expected max_length to remain 0 for non-STRING param")
+	}
+}
+
+func TestWithAccessScope(t *testing.T) {
+	p := NewParamInt32(0).WithAccessScope("admin").Build()
+	if p.GetAccessScope() != "admin" {
+		t.Errorf("expected 'admin', got %q", p.GetAccessScope())
+	}
+}
+
+func TestWithClientHint(t *testing.T) {
+	p := NewParamInt32(0).
+		WithClientHint("display", "compact").
+		WithClientHint("color", "red").
+		Build()
+	if p.GetClientHints()["display"] != "compact" {
+		t.Errorf("expected client_hint 'display'='compact', got %q", p.GetClientHints()["display"])
+	}
+	if p.GetClientHints()["color"] != "red" {
+		t.Errorf("expected client_hint 'color'='red', got %q", p.GetClientHints()["color"])
+	}
+}
+
+func TestWithParam_Struct(t *testing.T) {
+	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
+	p := NewParamStruct().WithParam("brightness", child).Build()
+
+	sub := p.GetParams()["brightness"]
+	if sub == nil {
+		t.Fatal("expected sub-param 'brightness'")
+	}
+	if sub.GetValue().GetInt32Value() != 10 {
+		t.Errorf("expected sub-param value 10, got %d", sub.GetValue().GetInt32Value())
+	}
+}
+
+func TestWithParam_DeepClone(t *testing.T) {
+	child := NewParamInt32(1)
+	parent := NewParamStruct().WithParam("x", child).Build()
+
+	child.param.Value = &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}
+	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
+		t.Error("expected sub-param to be a deep clone, not affected by later mutation")
+	}
+}
+
+func TestWithParam_WrongType(t *testing.T) {
+	child := NewParamInt32(0)
+	p := NewParamInt32(0).WithParam("x", child).Build()
+	if len(p.GetParams()) != 0 {
+		t.Error("expected no sub-params on INT32 param")
+	}
+}
+
+func TestWithResponse(t *testing.T) {
+	p := NewParamEmpty().WithResponse(true).Build()
+	if !p.GetResponse() {
+		t.Error("expected response=true")
+	}
+}
+
+func TestWithHelp(t *testing.T) {
+	p := NewParamInt32(0).WithHelp(NewPolyglotText("en", "Adjusts volume")).Build()
+	if p.GetHelp().GetDisplayStrings()["en"] != "Adjusts volume" {
+		t.Errorf("unexpected help text: %q", p.GetHelp().GetDisplayStrings()["en"])
+	}
+}
+
+func TestWithOidAliases(t *testing.T) {
+	p := NewParamInt32(0).WithOidAliases("/old/path", "/legacy/path").Build()
+	aliases := p.GetOidAliases()
+	if len(aliases) != 2 || aliases[0] != "/old/path" {
+		t.Errorf("unexpected aliases: %v", aliases)
+	}
+}
+
+func TestWithMinimalSet(t *testing.T) {
+	p := NewParamInt32(0).WithMinimalSet(true).Build()
+	if !p.GetMinimalSet() {
+		t.Error("expected minimal_set=true")
+	}
+}
+
+func TestWithStateless(t *testing.T) {
+	p := NewParamInt32(0).WithStateless(true).Build()
+	if !p.GetStateless() {
+		t.Error("expected stateless=true")
+	}
+}
+
+func TestWithTemplateOid(t *testing.T) {
+	p := NewParamInt32(0).WithTemplateOid("templates.volume").Build()
+	if p.GetTemplateOid() != "templates.volume" {
+		t.Errorf("expected 'templates.volume', got %q", p.GetTemplateOid())
+	}
+}
+
+// --- Constraint validation tests ---
+
+func TestWithConstraint_ValidInt32Choice(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_CHOICE,
+		Kind: &protos.Constraint_Int32Choice{
+			Int32Choice: &protos.Int32ChoiceConstraint{
+				Choices: []*protos.Int32ChoiceConstraint_IntChoice{
+					{Value: 1, Name: &protos.PolyglotText{DisplayStrings: map[string]string{"en": "one"}}},
+				},
+			},
+		},
+	}
+	p := NewParamInt32(0).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected constraint to be applied")
+	}
+	if p.GetConstraint().GetType() != protos.Constraint_INT_CHOICE {
+		t.Errorf("expected INT_CHOICE, got %v", p.GetConstraint().GetType())
+	}
+}
+
+func TestWithConstraint_ValidIntRange(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_RANGE,
+		Kind: &protos.Constraint_Int32Range{
+			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1},
+		},
+	}
+	p := NewParamInt32(50).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected constraint to be applied")
+	}
+}
+
+func TestWithConstraint_ValidFloatRange(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_FLOAT_RANGE,
+		Kind: &protos.Constraint_FloatRange{
+			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 1, Step: 0.01},
+		},
+	}
+	p := NewParamFloat32(0.5).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected constraint to be applied")
+	}
+}
+
+func TestWithConstraint_ValidStringChoice(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_STRING_CHOICE,
+		Kind: &protos.Constraint_StringChoice{
+			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
+		},
+	}
+	p := NewParamString("a").WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected constraint to be applied")
+	}
+}
+
+func TestWithConstraint_ValidStringStringChoice(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_STRING_STRING_CHOICE,
+		Kind: &protos.Constraint_StringStringChoice{
+			StringStringChoice: &protos.StringStringChoiceConstraint{
+				Choices: []*protos.StringStringChoiceConstraint_StringStringChoice{
+					{Value: "v", Name: &protos.PolyglotText{DisplayStrings: map[string]string{"en": "V"}}},
+				},
+			},
+		},
+	}
+	p := NewParamString("v").WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected constraint to be applied")
+	}
+}
+
+func TestWithConstraint_ValidAlarmTable(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_ALARM_TABLE,
+		Kind: &protos.Constraint_AlarmTable{
+			AlarmTable: &protos.AlarmTableConstraint{
+				Alarms: []*protos.Alarm{{BitValue: 0, Severity: protos.Alarm_INFO}},
+			},
+		},
+	}
+	p := NewParamInt32(0).WithConstraint(c).Build()
+	if p.GetConstraint() == nil {
+		t.Fatal("expected alarm table constraint to be applied to INT32 param")
+	}
+}
+
+func TestWithConstraint_RefOid_AnyType(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_UNDEFINED,
+		Kind: &protos.Constraint_RefOid{RefOid: "shared.my_constraint"},
+	}
+	for _, factory := range []func() *CatenaParam{
+		func() *CatenaParam { return NewParamInt32(0) },
+		func() *CatenaParam { return NewParamFloat32(0) },
+		func() *CatenaParam { return NewParamString("") },
+		func() *CatenaParam { return NewParamStruct() },
+	} {
+		p := factory().WithConstraint(c).Build()
+		if p.GetConstraint() == nil {
+			t.Errorf("expected RefOid constraint to be valid for param type %v", p.GetType())
+		}
+	}
+}
+
+func TestWithConstraint_InvalidStringOnInt(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_STRING_CHOICE,
+		Kind: &protos.Constraint_StringChoice{
+			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
+		},
+	}
+	p := NewParamInt32(0).WithConstraint(c).Build()
+	if p.GetConstraint() != nil {
+		t.Error("expected string constraint to be rejected on INT32 param")
+	}
+}
+
+func TestWithConstraint_InvalidIntOnFloat(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_RANGE,
+		Kind: &protos.Constraint_Int32Range{
+			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1},
+		},
+	}
+	p := NewParamFloat32(0).WithConstraint(c).Build()
+	if p.GetConstraint() != nil {
+		t.Error("expected int32 range constraint to be rejected on FLOAT32 param")
+	}
+}
+
+func TestWithConstraint_InvalidFloatOnString(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_FLOAT_RANGE,
+		Kind: &protos.Constraint_FloatRange{
+			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 1, Step: 0.1},
+		},
+	}
+	p := NewParamString("x").WithConstraint(c).Build()
+	if p.GetConstraint() != nil {
+		t.Error("expected float range constraint to be rejected on STRING param")
+	}
+}
+
+func TestWithConstraint_Nil(t *testing.T) {
+	p := NewParamInt32(0).WithConstraint(nil).Build()
+	if p.GetConstraint() != nil {
+		t.Error("expected nil constraint to be a no-op")
+	}
+}
+
+// --- Full chaining test ---
+
+func TestFullChaining(t *testing.T) {
+	c := &protos.Constraint{
+		Type: protos.Constraint_INT_RANGE,
+		Kind: &protos.Constraint_Int32Range{
+			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1, DisplayMin: 0, DisplayMax: 100},
+		},
+	}
+	p := NewParamInt32(0).
+		WithName(NewPolyglotText("en", "Volume")).
+		WithConstraint(c).
+		WithReadOnly(false).
+		WithWidget("slider").
+		WithAccessScope("operator").
+		WithClientHint("unit", "dB").
+		WithHelp(NewPolyglotText("en", "Audio volume")).
+		WithOidAliases("/old/volume").
+		WithMinimalSet(true).
+		WithStateless(false).
+		WithTemplateOid("templates.volume").
+		Build()
+
+	if p.GetType() != protos.ParamType_INT32 {
+		t.Errorf("expected INT32, got %v", p.GetType())
+	}
+	if p.GetName().GetDisplayStrings()["en"] != "Volume" {
+		t.Error("name mismatch")
+	}
+	if p.GetConstraint().GetInt32Range().GetMaxValue() != 100 {
+		t.Error("constraint mismatch")
+	}
+	if p.GetWidget() != "slider" {
+		t.Error("widget mismatch")
+	}
+	if p.GetAccessScope() != "operator" {
+		t.Error("access_scope mismatch")
+	}
+	if p.GetClientHints()["unit"] != "dB" {
+		t.Error("client_hint mismatch")
+	}
+	if p.GetHelp().GetDisplayStrings()["en"] != "Audio volume" {
+		t.Error("help mismatch")
+	}
+	if len(p.GetOidAliases()) != 1 {
+		t.Error("oid_aliases mismatch")
+	}
+	if !p.GetMinimalSet() {
+		t.Error("minimal_set mismatch")
+	}
+	if p.GetTemplateOid() != "templates.volume" {
+		t.Error("template_oid mismatch")
+	}
+}

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -980,3 +980,162 @@ func TestWithParam_SelfReference(t *testing.T) {
 		t.Fatal("expected self-referencing sub-param to be set")
 	}
 }
+
+// --- Error path tests ---
+
+func TestNewParamStruct_InvalidValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"bad": struct{}{}}).Proto
+	if p.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected STRUCT, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when conversion fails")
+	}
+}
+
+func TestNewParamStructVariant_InvalidValue(t *testing.T) {
+	sv := StructVariantValue{StructVariantType: "t", Value: struct{}{}}
+	p := NewParamStructVariant(sv).Proto
+	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
+		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when conversion fails")
+	}
+}
+
+func TestNewParamStructArray_InvalidValue(t *testing.T) {
+	arr := []map[string]any{{"bad": struct{}{}}}
+	p := NewParamStructArray(arr).Proto
+	if p.GetType() != protos.ParamType_STRUCT_ARRAY {
+		t.Errorf("expected STRUCT_ARRAY, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when conversion fails")
+	}
+}
+
+func TestNewParamStructVariantArray_InvalidValue(t *testing.T) {
+	arr := []StructVariantValue{{StructVariantType: "t", Value: struct{}{}}}
+	p := NewParamStructVariantArray(arr).Proto
+	if p.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
+		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when conversion fails")
+	}
+}
+
+func TestNewParamData_InvalidPayload(t *testing.T) {
+	dp := DataPayload{}
+	p := NewParamData(dp).Proto
+	if p.GetType() != protos.ParamType_DATA {
+		t.Errorf("expected DATA, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when DataPayload conversion fails")
+	}
+}
+
+func TestNewParamData_BothPayloadAndUrl(t *testing.T) {
+	dp := DataPayload{Payload: []byte("data"), Url: "http://example.com"}
+	p := NewParamData(dp).Proto
+	if p.GetType() != protos.ParamType_DATA {
+		t.Errorf("expected DATA, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when both payload and url are set")
+	}
+}
+
+func TestWithParam_StructVariant(t *testing.T) {
+	child := NewParamInt32(5)
+	p := NewParamStructVariant().WithParam("field", child).Proto
+	sub := p.GetParams()["field"]
+	if sub == nil {
+		t.Fatal("expected sub-param on STRUCT_VARIANT")
+	}
+	if sub.GetValue().GetInt32Value() != 5 {
+		t.Errorf("expected 5, got %d", sub.GetValue().GetInt32Value())
+	}
+}
+
+func TestWithParam_StructArray(t *testing.T) {
+	child := NewParamString("val")
+	p := NewParamStructArray().WithParam("item", child).Proto
+	sub := p.GetParams()["item"]
+	if sub == nil {
+		t.Fatal("expected sub-param on STRUCT_ARRAY")
+	}
+	if sub.GetValue().GetStringValue() != "val" {
+		t.Errorf("expected 'val', got %q", sub.GetValue().GetStringValue())
+	}
+}
+
+func TestWithParam_StructVariantArray(t *testing.T) {
+	child := NewParamFloat32(1.5)
+	p := NewParamStructVariantArray().WithParam("entry", child).Proto
+	sub := p.GetParams()["entry"]
+	if sub == nil {
+		t.Fatal("expected sub-param on STRUCT_VARIANT_ARRAY")
+	}
+	if sub.GetValue().GetFloat32Value() != 1.5 {
+		t.Errorf("expected 1.5, got %f", sub.GetValue().GetFloat32Value())
+	}
+}
+
+func TestIsValueValidForParamType_NilKind(t *testing.T) {
+	v := &protos.Value{}
+	if isValueValidForParamType(v, protos.ParamType_INT32) {
+		t.Error("expected Value with nil Kind to be invalid")
+	}
+}
+
+func TestIsValueValidForParamType_UndefinedValue(t *testing.T) {
+	v := &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: 0}}
+	if !isValueValidForParamType(v, protos.ParamType_UNDEFINED) {
+		t.Error("expected UndefinedValue to be valid for UNDEFINED")
+	}
+	if isValueValidForParamType(v, protos.ParamType_INT32) {
+		t.Error("expected UndefinedValue to be invalid for INT32")
+	}
+}
+
+func TestParamTypeFromValueKind_NilKind(t *testing.T) {
+	v := &protos.Value{}
+	if paramTypeFromValueKind(v) != protos.ParamType_UNDEFINED {
+		t.Error("expected UNDEFINED for Value with nil Kind")
+	}
+}
+
+func TestParamTypeFromValueKind_UndefinedValue(t *testing.T) {
+	v := &protos.Value{Kind: &protos.Value_UndefinedValue{UndefinedValue: 0}}
+	if paramTypeFromValueKind(v) != protos.ParamType_UNDEFINED {
+		t.Error("expected UNDEFINED for UndefinedValue kind")
+	}
+}
+
+func TestIsConstraintValidForParam_NilKind(t *testing.T) {
+	c := &protos.Constraint{}
+	if isConstraintValidForParam(c, protos.ParamType_INT32) {
+		t.Error("expected constraint with nil Kind to be invalid")
+	}
+}
+
+func TestSetValue_InvalidThenValid(t *testing.T) {
+	cp := NewParamInt32(10)
+	res := cp.SetValue("wrong type")
+	if res.Code != INVALID_ARGUMENT {
+		t.Errorf("expected INVALID_ARGUMENT, got %v", res.Code)
+	}
+	if cp.Proto.GetValue().GetInt32Value() != 10 {
+		t.Error("expected original value to be preserved after failed SetValue")
+	}
+	res = cp.SetValue(int32(20))
+	if res.Code != OK {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if cp.Proto.GetValue().GetInt32Value() != 20 {
+		t.Errorf("expected 20, got %d", cp.Proto.GetValue().GetInt32Value())
+	}
+}

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -39,6 +39,7 @@
 package catena
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
@@ -277,7 +278,7 @@ func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
 	parent := NewParamStruct().WithParam("x", child).Proto()
 
-	child.proto.Value = &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}
+	child.SetValue(int32(999))
 	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
 		t.Error("expected sub-param to be a deep clone, not affected by later mutation")
 	}
@@ -670,4 +671,359 @@ func TestFullChaining(t *testing.T) {
 	if p.GetTemplateOid() != "templates.volume" {
 		t.Error("template_oid mismatch")
 	}
+}
+
+// --- WithValue tests ---
+
+func TestWithValue_MatchingType(t *testing.T) {
+	v, res := ToValue(int32(42))
+	if res.Code != OK {
+		t.Fatal(res.Error)
+	}
+	p := NewParamInt32(0).WithValue(v).Proto()
+	if p.GetValue().GetInt32Value() != 42 {
+		t.Errorf("expected 42, got %d", p.GetValue().GetInt32Value())
+	}
+}
+
+func TestWithValue_Struct(t *testing.T) {
+	v, res := ToValue(map[string]any{"name": "test"})
+	if res.Code != OK {
+		t.Fatal(res.Error)
+	}
+	p := NewParamStruct().WithValue(v).Proto()
+	fields := p.GetValue().GetStructValue().GetFields()
+	if fields["name"].GetStringValue() != "test" {
+		t.Errorf("expected struct field 'name'='test', got %q", fields["name"].GetStringValue())
+	}
+}
+
+func TestWithValue_StructVariant(t *testing.T) {
+	sv := StructVariantValue{StructVariantType: "type_a", Value: int32(10)}
+	v, res := ToValue(sv)
+	if res.Code != OK {
+		t.Fatal(res.Error)
+	}
+	p := NewParamStructVariant().WithValue(v).Proto()
+	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "type_a" {
+		t.Errorf("expected struct_variant_type 'type_a', got %q",
+			p.GetValue().GetStructVariantValue().GetStructVariantType())
+	}
+}
+
+func TestWithValue_MismatchedType(t *testing.T) {
+	v, res := ToValue("hello")
+	if res.Code != OK {
+		t.Fatal(res.Error)
+	}
+	p := NewParamInt32(0).WithValue(v).Proto()
+	if p.GetValue().GetInt32Value() != 0 {
+		t.Error("expected mismatched WithValue to be a no-op")
+	}
+}
+
+// --- SetValue / GetValue tests ---
+
+func TestSetValue_OK(t *testing.T) {
+	cp := NewParamInt32(0)
+	res := cp.SetValue(int32(99))
+	if res.Code != OK {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	p := cp.Proto()
+	if p.GetValue().GetInt32Value() != 99 {
+		t.Errorf("expected 99, got %d", p.GetValue().GetInt32Value())
+	}
+}
+
+func TestSetValue_TypeMismatch(t *testing.T) {
+	cp := NewParamInt32(0)
+	res := cp.SetValue("not an int")
+	if res.Code != INVALID_ARGUMENT {
+		t.Errorf("expected INVALID_ARGUMENT, got %v", res.Code)
+	}
+	if cp.Proto().GetValue().GetInt32Value() != 0 {
+		t.Error("expected value to remain unchanged after type mismatch")
+	}
+}
+
+func TestSetValue_ConversionError(t *testing.T) {
+	cp := NewParamInt32(0)
+	res := cp.SetValue(struct{}{})
+	if res.Code == OK {
+		t.Error("expected conversion error for unsupported type")
+	}
+}
+
+func TestGetValue_OK(t *testing.T) {
+	cp := NewParamString("hello")
+	v, res := cp.GetValue()
+	if res.Code != OK {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	s, ok := v.(string)
+	if !ok || s != "hello" {
+		t.Errorf("expected 'hello', got %v", v)
+	}
+}
+
+func TestGetValue_Nil(t *testing.T) {
+	cp := NewParamStruct()
+	v, res := cp.GetValue()
+	if res.Code != OK {
+		t.Fatalf("expected OK for nil value, got %v: %s", res.Code, res.Error)
+	}
+	if v != nil {
+		t.Errorf("expected nil value, got %v", v)
+	}
+}
+
+func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
+	cp := NewParamStruct()
+	input := map[string]any{"x": int32(1), "y": int32(2)}
+	res := cp.SetValue(input)
+	if res.Code != OK {
+		t.Fatalf("SetValue failed: %s", res.Error)
+	}
+	out, res := cp.GetValue()
+	if res.Code != OK {
+		t.Fatalf("GetValue failed: %s", res.Error)
+	}
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", out)
+	}
+	if m["x"] != int32(1) || m["y"] != int32(2) {
+		t.Errorf("round-trip mismatch: got %v", m)
+	}
+}
+
+// --- Typed factory value tests ---
+
+func TestNewParamStruct_WithValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"a": int32(1)}).Proto()
+	fields := p.GetValue().GetStructValue().GetFields()
+	if fields["a"].GetInt32Value() != 1 {
+		t.Errorf("expected struct field 'a'=1, got %d", fields["a"].GetInt32Value())
+	}
+}
+
+func TestNewParamStruct_NoValue(t *testing.T) {
+	p := NewParamStruct().Proto()
+	if p.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected STRUCT, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when no arg provided")
+	}
+}
+
+func TestNewParamStructVariant_WithValue(t *testing.T) {
+	sv := StructVariantValue{StructVariantType: "kind_a", Value: int32(5)}
+	p := NewParamStructVariant(sv).Proto()
+	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "kind_a" {
+		t.Errorf("expected struct_variant_type 'kind_a', got %q",
+			p.GetValue().GetStructVariantValue().GetStructVariantType())
+	}
+}
+
+func TestNewParamStructArray_WithValue(t *testing.T) {
+	arr := []map[string]any{
+		{"x": int32(1)},
+		{"x": int32(2)},
+	}
+	p := NewParamStructArray(arr).Proto()
+	list := p.GetValue().GetStructArrayValues().GetStructValues()
+	if len(list) != 2 {
+		t.Fatalf("expected 2 structs, got %d", len(list))
+	}
+	if list[0].GetFields()["x"].GetInt32Value() != 1 {
+		t.Error("expected first struct field x=1")
+	}
+}
+
+func TestNewParamStructVariantArray_WithValue(t *testing.T) {
+	arr := []StructVariantValue{
+		{StructVariantType: "a", Value: int32(1)},
+		{StructVariantType: "b", Value: int32(2)},
+	}
+	p := NewParamStructVariantArray(arr).Proto()
+	list := p.GetValue().GetStructVariantArrayValues().GetStructVariants()
+	if len(list) != 2 {
+		t.Fatalf("expected 2 variants, got %d", len(list))
+	}
+	if list[0].GetStructVariantType() != "a" {
+		t.Error("expected first variant type 'a'")
+	}
+}
+
+// --- NewParamFromValue tests ---
+
+func TestNewParamFromValue_Int32(t *testing.T) {
+	v, _ := ToValue(int32(42))
+	cp := NewParamFromValue(v)
+	p := cp.Proto()
+	if p.GetType() != protos.ParamType_INT32 {
+		t.Errorf("expected INT32, got %v", p.GetType())
+	}
+	if p.GetValue().GetInt32Value() != 42 {
+		t.Errorf("expected 42, got %d", p.GetValue().GetInt32Value())
+	}
+}
+
+func TestNewParamFromValue_Struct(t *testing.T) {
+	v, _ := ToValue(map[string]any{"k": "v"})
+	cp := NewParamFromValue(v)
+	if cp.Proto().GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected STRUCT, got %v", cp.Proto().GetType())
+	}
+}
+
+func TestNewParamFromValue_StructVariant(t *testing.T) {
+	v, _ := ToValue(StructVariantValue{StructVariantType: "t", Value: int32(0)})
+	cp := NewParamFromValue(v)
+	if cp.Proto().GetType() != protos.ParamType_STRUCT_VARIANT {
+		t.Errorf("expected STRUCT_VARIANT, got %v", cp.Proto().GetType())
+	}
+}
+
+func TestNewParamFromValue_StructArray(t *testing.T) {
+	v, _ := ToValue([]map[string]any{{"a": int32(1)}})
+	cp := NewParamFromValue(v)
+	if cp.Proto().GetType() != protos.ParamType_STRUCT_ARRAY {
+		t.Errorf("expected STRUCT_ARRAY, got %v", cp.Proto().GetType())
+	}
+}
+
+func TestNewParamFromValue_StructVariantArray(t *testing.T) {
+	v, _ := ToValue([]StructVariantValue{{StructVariantType: "t", Value: int32(0)}})
+	cp := NewParamFromValue(v)
+	if cp.Proto().GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
+		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", cp.Proto().GetType())
+	}
+}
+
+func TestNewParamFromValue_Nil(t *testing.T) {
+	cp := NewParamFromValue(Value{})
+	if cp.Proto().GetType() != protos.ParamType_UNDEFINED {
+		t.Errorf("expected UNDEFINED for nil value, got %v", cp.Proto().GetType())
+	}
+}
+
+func TestNewParamFromValue_AllScalarTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		wantType protos.ParamType
+	}{
+		{"float32", float32(1.5), protos.ParamType_FLOAT32},
+		{"string", "hello", protos.ParamType_STRING},
+		{"int32_array", []int32{1, 2}, protos.ParamType_INT32_ARRAY},
+		{"float32_array", []float32{1.0}, protos.ParamType_FLOAT32_ARRAY},
+		{"string_array", []string{"a"}, protos.ParamType_STRING_ARRAY},
+		{"empty", EmptyValue{}, protos.ParamType_EMPTY},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, res := ToValue(tt.input)
+			if res.Code != OK {
+				t.Fatalf("ToValue failed: %s", res.Error)
+			}
+			cp := NewParamFromValue(v)
+			if cp.Proto().GetType() != tt.wantType {
+				t.Errorf("expected %v, got %v", tt.wantType, cp.Proto().GetType())
+			}
+		})
+	}
+}
+
+// --- Validation helper tests ---
+
+func TestIsValueValidForParamType_NilValue(t *testing.T) {
+	if isValueValidForParamType(nil, protos.ParamType_INT32) {
+		t.Error("expected nil value to be invalid")
+	}
+}
+
+func TestIsValueValidForParamType_DataPayload_Binary(t *testing.T) {
+	v := &protos.Value{Kind: &protos.Value_DataPayload{
+		DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: []byte{1}}},
+	}}
+	if !isValueValidForParamType(v, protos.ParamType_BINARY) {
+		t.Error("expected DataPayload to be valid for BINARY")
+	}
+	if !isValueValidForParamType(v, protos.ParamType_DATA) {
+		t.Error("expected DataPayload to be valid for DATA")
+	}
+	if isValueValidForParamType(v, protos.ParamType_INT32) {
+		t.Error("expected DataPayload to be invalid for INT32")
+	}
+}
+
+func TestParamTypeFromValueKind_Nil(t *testing.T) {
+	if paramTypeFromValueKind(nil) != protos.ParamType_UNDEFINED {
+		t.Error("expected UNDEFINED for nil value")
+	}
+}
+
+func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
+	v := &protos.Value{Kind: &protos.Value_DataPayload{}}
+	if paramTypeFromValueKind(v) != protos.ParamType_DATA {
+		t.Error("expected DATA for DataPayload value kind")
+	}
+}
+
+// --- Concurrency tests ---
+
+func TestConcurrentSetGetValue(t *testing.T) {
+	cp := NewParamInt32(0)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		val := int32(i)
+		go func() {
+			defer wg.Done()
+			cp.SetValue(val)
+		}()
+		go func() {
+			defer wg.Done()
+			cp.GetValue()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentWithMethods(t *testing.T) {
+	cp := NewParamStruct()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			cp.WithWidget("w")
+		}()
+		go func() {
+			defer wg.Done()
+			cp.WithAccessScope("admin")
+		}()
+		go func() {
+			defer wg.Done()
+			cp.Proto()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentWithParam(t *testing.T) {
+	parent := NewParamStruct()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		child := NewParamInt32(int32(i))
+		go func(oid string) {
+			defer wg.Done()
+			parent.WithParam(oid, child)
+		}("p" + string(rune('a'+i%26)))
+	}
+	wg.Wait()
 }

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -28,6 +28,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/**
+ * @brief Param test for the Catena SDK.
+ * @file param_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-05-11
+ */
+
 package catena
 
 import (

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -271,6 +271,23 @@ func TestWithParam_WrongType(t *testing.T) {
 	}
 }
 
+func TestWithParam_Nil(t *testing.T) {
+	// Passing a nil sub-param must not panic and must not add an entry,
+	// preserving the contract that method chaining is never interrupted
+	// by error handling.
+	cp := NewParamStruct().WithParam("x", nil)
+	p := cp.Build()
+	if len(p.GetParams()) != 0 {
+		t.Error("expected nil sub-param to be a no-op")
+	}
+	// Chaining must continue to work after the no-op.
+	child := NewParamInt32(7)
+	p = cp.WithParam("y", child).Build()
+	if p.GetParams()["y"].GetValue().GetInt32Value() != 7 {
+		t.Error("expected chaining to continue working after nil sub-param")
+	}
+}
+
 func TestWithResponse(t *testing.T) {
 	p := NewParamEmpty().WithResponse(true).Build()
 	if !p.GetResponse() {

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -39,7 +39,6 @@
 package catena
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
@@ -973,88 +972,11 @@ func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
 	}
 }
 
-// --- Concurrency tests ---
-
-func TestConcurrentSetGetValue(t *testing.T) {
-	cp := NewParamInt32(0)
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(2)
-		val := int32(i)
-		go func() {
-			defer wg.Done()
-			cp.SetValue(val)
-		}()
-		go func() {
-			defer wg.Done()
-			cp.GetValue()
-		}()
-	}
-	wg.Wait()
-}
-
-func TestConcurrentWithMethods(t *testing.T) {
-	cp := NewParamStruct()
-	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(3)
-		go func() {
-			defer wg.Done()
-			cp.WithWidget("w")
-		}()
-		go func() {
-			defer wg.Done()
-			cp.WithAccessScope("admin")
-		}()
-		go func() {
-			defer wg.Done()
-			cp.Proto()
-		}()
-	}
-	wg.Wait()
-}
-
-func TestConcurrentWithParam(t *testing.T) {
-	parent := NewParamStruct()
-	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		child := NewParamInt32(int32(i))
-		go func(oid string) {
-			defer wg.Done()
-			parent.WithParam(oid, child)
-		}("p" + string(rune('a'+i%26)))
-	}
-	wg.Wait()
-}
-
 func TestWithParam_SelfReference(t *testing.T) {
 	cp := NewParamStruct()
 	cp.WithParam("self", cp)
 	sub := cp.Proto().GetParams()["self"]
 	if sub == nil {
 		t.Fatal("expected self-referencing sub-param to be set")
-	}
-}
-
-func TestWithParam_CrossReference(t *testing.T) {
-	a := NewParamStruct()
-	b := NewParamStruct()
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		a.WithParam("b", b)
-	}()
-	go func() {
-		defer wg.Done()
-		b.WithParam("a", a)
-	}()
-	wg.Wait()
-	if a.Proto().GetParams()["b"] == nil {
-		t.Error("expected a to contain sub-param 'b'")
-	}
-	if b.Proto().GetParams()["a"] == nil {
-		t.Error("expected b to contain sub-param 'a'")
 	}
 }

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -47,7 +47,7 @@ import (
 // --- Factory tests ---
 
 func TestNewParamInt32(t *testing.T) {
-	p := NewParamInt32(42).Build()
+	p := NewParamInt32(42).Proto()
 	if p.GetType() != protos.ParamType_INT32 {
 		t.Errorf("expected INT32, got %v", p.GetType())
 	}
@@ -57,7 +57,7 @@ func TestNewParamInt32(t *testing.T) {
 }
 
 func TestNewParamFloat32(t *testing.T) {
-	p := NewParamFloat32(3.14).Build()
+	p := NewParamFloat32(3.14).Proto()
 	if p.GetType() != protos.ParamType_FLOAT32 {
 		t.Errorf("expected FLOAT32, got %v", p.GetType())
 	}
@@ -67,7 +67,7 @@ func TestNewParamFloat32(t *testing.T) {
 }
 
 func TestNewParamString(t *testing.T) {
-	p := NewParamString("hello").Build()
+	p := NewParamString("hello").Proto()
 	if p.GetType() != protos.ParamType_STRING {
 		t.Errorf("expected STRING, got %v", p.GetType())
 	}
@@ -77,21 +77,21 @@ func TestNewParamString(t *testing.T) {
 }
 
 func TestNewParamStruct(t *testing.T) {
-	p := NewParamStruct().Build()
+	p := NewParamStruct().Proto()
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariant(t *testing.T) {
-	p := NewParamStructVariant().Build()
+	p := NewParamStructVariant().Proto()
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
 		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
 	}
 }
 
 func TestNewParamInt32Array(t *testing.T) {
-	p := NewParamInt32Array([]int32{1, 2, 3}).Build()
+	p := NewParamInt32Array([]int32{1, 2, 3}).Proto()
 	if p.GetType() != protos.ParamType_INT32_ARRAY {
 		t.Errorf("expected INT32_ARRAY, got %v", p.GetType())
 	}
@@ -102,7 +102,7 @@ func TestNewParamInt32Array(t *testing.T) {
 }
 
 func TestNewParamFloat32Array(t *testing.T) {
-	p := NewParamFloat32Array([]float32{1.1, 2.2}).Build()
+	p := NewParamFloat32Array([]float32{1.1, 2.2}).Proto()
 	if p.GetType() != protos.ParamType_FLOAT32_ARRAY {
 		t.Errorf("expected FLOAT32_ARRAY, got %v", p.GetType())
 	}
@@ -113,7 +113,7 @@ func TestNewParamFloat32Array(t *testing.T) {
 }
 
 func TestNewParamStringArray(t *testing.T) {
-	p := NewParamStringArray([]string{"a", "b"}).Build()
+	p := NewParamStringArray([]string{"a", "b"}).Proto()
 	if p.GetType() != protos.ParamType_STRING_ARRAY {
 		t.Errorf("expected STRING_ARRAY, got %v", p.GetType())
 	}
@@ -124,7 +124,7 @@ func TestNewParamStringArray(t *testing.T) {
 }
 
 func TestNewParamBinary(t *testing.T) {
-	p := NewParamBinary([]byte{0xDE, 0xAD}).Build()
+	p := NewParamBinary([]byte{0xDE, 0xAD}).Proto()
 	if p.GetType() != protos.ParamType_BINARY {
 		t.Errorf("expected BINARY, got %v", p.GetType())
 	}
@@ -135,21 +135,21 @@ func TestNewParamBinary(t *testing.T) {
 }
 
 func TestNewParamStructArray(t *testing.T) {
-	p := NewParamStructArray().Build()
+	p := NewParamStructArray().Proto()
 	if p.GetType() != protos.ParamType_STRUCT_ARRAY {
 		t.Errorf("expected STRUCT_ARRAY, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariantArray(t *testing.T) {
-	p := NewParamStructVariantArray().Build()
+	p := NewParamStructVariantArray().Proto()
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
 		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", p.GetType())
 	}
 }
 
 func TestNewParamEmpty(t *testing.T) {
-	p := NewParamEmpty().Build()
+	p := NewParamEmpty().Proto()
 	if p.GetType() != protos.ParamType_EMPTY {
 		t.Errorf("expected EMPTY, got %v", p.GetType())
 	}
@@ -160,7 +160,7 @@ func TestNewParamEmpty(t *testing.T) {
 
 func TestNewParamData(t *testing.T) {
 	dp := ToPayload([]byte("content"), "text/plain", "test.txt")
-	p := NewParamData(dp).Build()
+	p := NewParamData(dp).Proto()
 	if p.GetType() != protos.ParamType_DATA {
 		t.Errorf("expected DATA, got %v", p.GetType())
 	}
@@ -172,28 +172,28 @@ func TestNewParamData(t *testing.T) {
 // --- With* method tests ---
 
 func TestWithName(t *testing.T) {
-	p := NewParamInt32(0).WithName(NewPolyglotText("en", "Temperature")).Build()
+	p := NewParamInt32(0).WithName(NewPolyglotText("en", "Temperature")).Proto()
 	if p.GetName().GetDisplayStrings()["en"] != "Temperature" {
 		t.Errorf("expected 'Temperature', got %q", p.GetName().GetDisplayStrings()["en"])
 	}
 }
 
 func TestWithReadOnly(t *testing.T) {
-	p := NewParamInt32(0).WithReadOnly(true).Build()
+	p := NewParamInt32(0).WithReadOnly(true).Proto()
 	if !p.GetReadOnly() {
 		t.Error("expected read_only=true")
 	}
 }
 
 func TestWithWidget(t *testing.T) {
-	p := NewParamInt32(0).WithWidget("slider").Build()
+	p := NewParamInt32(0).WithWidget("slider").Proto()
 	if p.GetWidget() != "slider" {
 		t.Errorf("expected 'slider', got %q", p.GetWidget())
 	}
 }
 
 func TestWithPrecision(t *testing.T) {
-	p := NewParamFloat32(0).WithPrecision(3).Build()
+	p := NewParamFloat32(0).WithPrecision(3).Proto()
 	if p.GetPrecision() != 3 {
 		t.Errorf("expected precision 3, got %d", p.GetPrecision())
 	}
@@ -203,21 +203,21 @@ func TestWithPrecision(t *testing.T) {
 // params (see device.one_of_everything.yaml, which sets precision: 3 on a
 // FLOAT32_ARRAY).
 func TestWithPrecision_Float32Array(t *testing.T) {
-	p := NewParamFloat32Array([]float32{1.1, 2.2}).WithPrecision(3).Build()
+	p := NewParamFloat32Array([]float32{1.1, 2.2}).WithPrecision(3).Proto()
 	if p.GetPrecision() != 3 {
 		t.Errorf("expected precision 3 on FLOAT32_ARRAY, got %d", p.GetPrecision())
 	}
 }
 
 func TestWithPrecision_WrongType(t *testing.T) {
-	p := NewParamInt32(0).WithPrecision(3).Build()
+	p := NewParamInt32(0).WithPrecision(3).Proto()
 	if p.GetPrecision() != 0 {
 		t.Error("expected precision to remain 0 for non-float param")
 	}
 }
 
 func TestWithMaxLength(t *testing.T) {
-	p := NewParamString("").WithMaxLength(255).Build()
+	p := NewParamString("").WithMaxLength(255).Proto()
 	if p.GetMaxLength() != 255 {
 		t.Errorf("expected max_length 255, got %d", p.GetMaxLength())
 	}
@@ -227,21 +227,21 @@ func TestWithMaxLength(t *testing.T) {
 // params (see param.string_array_length.yaml, which sets max_length: 10 on a
 // STRING_ARRAY to cap the number of strings in the array).
 func TestWithMaxLength_StringArray(t *testing.T) {
-	p := NewParamStringArray([]string{"a", "b"}).WithMaxLength(10).Build()
+	p := NewParamStringArray([]string{"a", "b"}).WithMaxLength(10).Proto()
 	if p.GetMaxLength() != 10 {
 		t.Errorf("expected max_length 10 on STRING_ARRAY, got %d", p.GetMaxLength())
 	}
 }
 
 func TestWithMaxLength_WrongType(t *testing.T) {
-	p := NewParamInt32(0).WithMaxLength(255).Build()
+	p := NewParamInt32(0).WithMaxLength(255).Proto()
 	if p.GetMaxLength() != 0 {
 		t.Error("expected max_length to remain 0 for param type that does not support max_length")
 	}
 }
 
 func TestWithAccessScope(t *testing.T) {
-	p := NewParamInt32(0).WithAccessScope("admin").Build()
+	p := NewParamInt32(0).WithAccessScope("admin").Proto()
 	if p.GetAccessScope() != "admin" {
 		t.Errorf("expected 'admin', got %q", p.GetAccessScope())
 	}
@@ -251,7 +251,7 @@ func TestWithClientHint(t *testing.T) {
 	p := NewParamInt32(0).
 		WithClientHint("display", "compact").
 		WithClientHint("color", "red").
-		Build()
+		Proto()
 	if p.GetClientHints()["display"] != "compact" {
 		t.Errorf("expected client_hint 'display'='compact', got %q", p.GetClientHints()["display"])
 	}
@@ -262,7 +262,7 @@ func TestWithClientHint(t *testing.T) {
 
 func TestWithParam_Struct(t *testing.T) {
 	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
-	p := NewParamStruct().WithParam("brightness", child).Build()
+	p := NewParamStruct().WithParam("brightness", child).Proto()
 
 	sub := p.GetParams()["brightness"]
 	if sub == nil {
@@ -275,9 +275,9 @@ func TestWithParam_Struct(t *testing.T) {
 
 func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
-	parent := NewParamStruct().WithParam("x", child).Build()
+	parent := NewParamStruct().WithParam("x", child).Proto()
 
-	child.param.Value = &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}
+	child.proto.Value = &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}
 	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
 		t.Error("expected sub-param to be a deep clone, not affected by later mutation")
 	}
@@ -285,7 +285,7 @@ func TestWithParam_DeepClone(t *testing.T) {
 
 func TestWithParam_WrongType(t *testing.T) {
 	child := NewParamInt32(0)
-	p := NewParamInt32(0).WithParam("x", child).Build()
+	p := NewParamInt32(0).WithParam("x", child).Proto()
 	if len(p.GetParams()) != 0 {
 		t.Error("expected no sub-params on INT32 param")
 	}
@@ -296,34 +296,34 @@ func TestWithParam_Nil(t *testing.T) {
 	// preserving the contract that method chaining is never interrupted
 	// by error handling.
 	cp := NewParamStruct().WithParam("x", nil)
-	p := cp.Build()
+	p := cp.Proto()
 	if len(p.GetParams()) != 0 {
 		t.Error("expected nil sub-param to be a no-op")
 	}
 	// Chaining must continue to work after the no-op.
 	child := NewParamInt32(7)
-	p = cp.WithParam("y", child).Build()
+	p = cp.WithParam("y", child).Proto()
 	if p.GetParams()["y"].GetValue().GetInt32Value() != 7 {
 		t.Error("expected chaining to continue working after nil sub-param")
 	}
 }
 
 func TestWithResponse(t *testing.T) {
-	p := NewParamEmpty().WithResponse(true).Build()
+	p := NewParamEmpty().WithResponse(true).Proto()
 	if !p.GetResponse() {
 		t.Error("expected response=true")
 	}
 }
 
 func TestWithHelp(t *testing.T) {
-	p := NewParamInt32(0).WithHelp(NewPolyglotText("en", "Adjusts volume")).Build()
+	p := NewParamInt32(0).WithHelp(NewPolyglotText("en", "Adjusts volume")).Proto()
 	if p.GetHelp().GetDisplayStrings()["en"] != "Adjusts volume" {
 		t.Errorf("unexpected help text: %q", p.GetHelp().GetDisplayStrings()["en"])
 	}
 }
 
 func TestWithOidAliases(t *testing.T) {
-	p := NewParamInt32(0).WithOidAliases("/old/path", "/legacy/path").Build()
+	p := NewParamInt32(0).WithOidAliases("/old/path", "/legacy/path").Proto()
 	aliases := p.GetOidAliases()
 	if len(aliases) != 2 || aliases[0] != "/old/path" {
 		t.Errorf("unexpected aliases: %v", aliases)
@@ -331,21 +331,21 @@ func TestWithOidAliases(t *testing.T) {
 }
 
 func TestWithMinimalSet(t *testing.T) {
-	p := NewParamInt32(0).WithMinimalSet(true).Build()
+	p := NewParamInt32(0).WithMinimalSet(true).Proto()
 	if !p.GetMinimalSet() {
 		t.Error("expected minimal_set=true")
 	}
 }
 
 func TestWithStateless(t *testing.T) {
-	p := NewParamInt32(0).WithStateless(true).Build()
+	p := NewParamInt32(0).WithStateless(true).Proto()
 	if !p.GetStateless() {
 		t.Error("expected stateless=true")
 	}
 }
 
 func TestWithTemplateOid(t *testing.T) {
-	p := NewParamInt32(0).WithTemplateOid("templates.volume").Build()
+	p := NewParamInt32(0).WithTemplateOid("templates.volume").Proto()
 	if p.GetTemplateOid() != "templates.volume" {
 		t.Errorf("expected 'templates.volume', got %q", p.GetTemplateOid())
 	}
@@ -364,7 +364,7 @@ func TestWithConstraint_ValidInt32Choice(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32(0).WithConstraint(c).Build()
+	p := NewParamInt32(0).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -380,7 +380,7 @@ func TestWithConstraint_ValidIntRange(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1},
 		},
 	}
-	p := NewParamInt32(50).WithConstraint(c).Build()
+	p := NewParamInt32(50).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -393,7 +393,7 @@ func TestWithConstraint_ValidFloatRange(t *testing.T) {
 			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 1, Step: 0.01},
 		},
 	}
-	p := NewParamFloat32(0.5).WithConstraint(c).Build()
+	p := NewParamFloat32(0.5).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -406,7 +406,7 @@ func TestWithConstraint_ValidStringChoice(t *testing.T) {
 			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
 		},
 	}
-	p := NewParamString("a").WithConstraint(c).Build()
+	p := NewParamString("a").WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -423,7 +423,7 @@ func TestWithConstraint_ValidStringStringChoice(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamString("v").WithConstraint(c).Build()
+	p := NewParamString("v").WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -438,7 +438,7 @@ func TestWithConstraint_ValidAlarmTable(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32(0).WithConstraint(c).Build()
+	p := NewParamInt32(0).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected alarm table constraint to be applied to INT32 param")
 	}
@@ -455,7 +455,7 @@ func TestWithConstraint_RefOid_AnyType(t *testing.T) {
 		func() *CatenaParam { return NewParamString("") },
 		func() *CatenaParam { return NewParamStruct() },
 	} {
-		p := factory().WithConstraint(c).Build()
+		p := factory().WithConstraint(c).Proto()
 		if p.GetConstraint() == nil {
 			t.Errorf("expected RefOid constraint to be valid for param type %v", p.GetType())
 		}
@@ -469,7 +469,7 @@ func TestWithConstraint_InvalidStringOnInt(t *testing.T) {
 			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
 		},
 	}
-	p := NewParamInt32(0).WithConstraint(c).Build()
+	p := NewParamInt32(0).WithConstraint(c).Proto()
 	if p.GetConstraint() != nil {
 		t.Error("expected string constraint to be rejected on INT32 param")
 	}
@@ -482,7 +482,7 @@ func TestWithConstraint_InvalidIntOnFloat(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1},
 		},
 	}
-	p := NewParamFloat32(0).WithConstraint(c).Build()
+	p := NewParamFloat32(0).WithConstraint(c).Proto()
 	if p.GetConstraint() != nil {
 		t.Error("expected int32 range constraint to be rejected on FLOAT32 param")
 	}
@@ -495,14 +495,14 @@ func TestWithConstraint_InvalidFloatOnString(t *testing.T) {
 			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 1, Step: 0.1},
 		},
 	}
-	p := NewParamString("x").WithConstraint(c).Build()
+	p := NewParamString("x").WithConstraint(c).Proto()
 	if p.GetConstraint() != nil {
 		t.Error("expected float range constraint to be rejected on STRING param")
 	}
 }
 
 func TestWithConstraint_Nil(t *testing.T) {
-	p := NewParamInt32(0).WithConstraint(nil).Build()
+	p := NewParamInt32(0).WithConstraint(nil).Proto()
 	if p.GetConstraint() != nil {
 		t.Error("expected nil constraint to be a no-op")
 	}
@@ -521,7 +521,7 @@ func TestWithConstraint_ValidIntRangeOnInt32Array(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 10, Step: 2},
 		},
 	}
-	p := NewParamInt32Array([]int32{0, 2, 4}).WithConstraint(c).Build()
+	p := NewParamInt32Array([]int32{0, 2, 4}).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected int32 range constraint to be applied to INT32_ARRAY param")
 	}
@@ -539,7 +539,7 @@ func TestWithConstraint_ValidInt32ChoiceOnInt32Array(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32Array([]int32{0, 1, 0}).WithConstraint(c).Build()
+	p := NewParamInt32Array([]int32{0, 1, 0}).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected int32 choice constraint to be applied to INT32_ARRAY param")
 	}
@@ -554,7 +554,7 @@ func TestWithConstraint_ValidAlarmTableOnInt32Array(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32Array([]int32{0, 1, 2}).WithConstraint(c).Build()
+	p := NewParamInt32Array([]int32{0, 1, 2}).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected alarm table constraint to be applied to INT32_ARRAY param")
 	}
@@ -567,7 +567,7 @@ func TestWithConstraint_ValidFloatRangeOnFloat32Array(t *testing.T) {
 			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 100, Step: 0.5},
 		},
 	}
-	p := NewParamFloat32Array([]float32{1.0, 2.0}).WithConstraint(c).Build()
+	p := NewParamFloat32Array([]float32{1.0, 2.0}).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected float range constraint to be applied to FLOAT32_ARRAY param")
 	}
@@ -580,7 +580,7 @@ func TestWithConstraint_ValidStringChoiceOnStringArray(t *testing.T) {
 			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
 		},
 	}
-	p := NewParamStringArray([]string{"a", "b"}).WithConstraint(c).Build()
+	p := NewParamStringArray([]string{"a", "b"}).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected string choice constraint to be applied to STRING_ARRAY param")
 	}
@@ -598,7 +598,7 @@ func TestWithConstraint_ValidStringStringChoiceOnStringArray(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamStringArray([]string{"<#FF0000>"}).WithConstraint(c).Build()
+	p := NewParamStringArray([]string{"<#FF0000>"}).WithConstraint(c).Proto()
 	if p.GetConstraint() == nil {
 		t.Fatal("expected string-string choice constraint to be applied to STRING_ARRAY param")
 	}
@@ -611,7 +611,7 @@ func TestWithConstraint_InvalidIntOnStringArray(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 10, Step: 1},
 		},
 	}
-	p := NewParamStringArray([]string{"a"}).WithConstraint(c).Build()
+	p := NewParamStringArray([]string{"a"}).WithConstraint(c).Proto()
 	if p.GetConstraint() != nil {
 		t.Error("expected int32 range constraint to be rejected on STRING_ARRAY param")
 	}
@@ -638,7 +638,7 @@ func TestFullChaining(t *testing.T) {
 		WithMinimalSet(true).
 		WithStateless(false).
 		WithTemplateOid("templates.volume").
-		Build()
+		Proto()
 
 	if p.GetType() != protos.ParamType_INT32 {
 		t.Errorf("expected INT32, got %v", p.GetType())

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -47,7 +47,7 @@ import (
 // --- Factory tests ---
 
 func TestNewParamInt32(t *testing.T) {
-	p := NewParamInt32(42).Proto()
+	p := NewParamInt32(42).Proto
 	if p.GetType() != protos.ParamType_INT32 {
 		t.Errorf("expected INT32, got %v", p.GetType())
 	}
@@ -57,7 +57,7 @@ func TestNewParamInt32(t *testing.T) {
 }
 
 func TestNewParamFloat32(t *testing.T) {
-	p := NewParamFloat32(3.14).Proto()
+	p := NewParamFloat32(3.14).Proto
 	if p.GetType() != protos.ParamType_FLOAT32 {
 		t.Errorf("expected FLOAT32, got %v", p.GetType())
 	}
@@ -67,7 +67,7 @@ func TestNewParamFloat32(t *testing.T) {
 }
 
 func TestNewParamString(t *testing.T) {
-	p := NewParamString("hello").Proto()
+	p := NewParamString("hello").Proto
 	if p.GetType() != protos.ParamType_STRING {
 		t.Errorf("expected STRING, got %v", p.GetType())
 	}
@@ -77,21 +77,21 @@ func TestNewParamString(t *testing.T) {
 }
 
 func TestNewParamStruct(t *testing.T) {
-	p := NewParamStruct().Proto()
+	p := NewParamStruct().Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariant(t *testing.T) {
-	p := NewParamStructVariant().Proto()
+	p := NewParamStructVariant().Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
 		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
 	}
 }
 
 func TestNewParamInt32Array(t *testing.T) {
-	p := NewParamInt32Array([]int32{1, 2, 3}).Proto()
+	p := NewParamInt32Array([]int32{1, 2, 3}).Proto
 	if p.GetType() != protos.ParamType_INT32_ARRAY {
 		t.Errorf("expected INT32_ARRAY, got %v", p.GetType())
 	}
@@ -102,7 +102,7 @@ func TestNewParamInt32Array(t *testing.T) {
 }
 
 func TestNewParamFloat32Array(t *testing.T) {
-	p := NewParamFloat32Array([]float32{1.1, 2.2}).Proto()
+	p := NewParamFloat32Array([]float32{1.1, 2.2}).Proto
 	if p.GetType() != protos.ParamType_FLOAT32_ARRAY {
 		t.Errorf("expected FLOAT32_ARRAY, got %v", p.GetType())
 	}
@@ -113,7 +113,7 @@ func TestNewParamFloat32Array(t *testing.T) {
 }
 
 func TestNewParamStringArray(t *testing.T) {
-	p := NewParamStringArray([]string{"a", "b"}).Proto()
+	p := NewParamStringArray([]string{"a", "b"}).Proto
 	if p.GetType() != protos.ParamType_STRING_ARRAY {
 		t.Errorf("expected STRING_ARRAY, got %v", p.GetType())
 	}
@@ -124,7 +124,7 @@ func TestNewParamStringArray(t *testing.T) {
 }
 
 func TestNewParamBinary(t *testing.T) {
-	p := NewParamBinary([]byte{0xDE, 0xAD}).Proto()
+	p := NewParamBinary([]byte{0xDE, 0xAD}).Proto
 	if p.GetType() != protos.ParamType_BINARY {
 		t.Errorf("expected BINARY, got %v", p.GetType())
 	}
@@ -135,21 +135,21 @@ func TestNewParamBinary(t *testing.T) {
 }
 
 func TestNewParamStructArray(t *testing.T) {
-	p := NewParamStructArray().Proto()
+	p := NewParamStructArray().Proto
 	if p.GetType() != protos.ParamType_STRUCT_ARRAY {
 		t.Errorf("expected STRUCT_ARRAY, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariantArray(t *testing.T) {
-	p := NewParamStructVariantArray().Proto()
+	p := NewParamStructVariantArray().Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
 		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", p.GetType())
 	}
 }
 
 func TestNewParamEmpty(t *testing.T) {
-	p := NewParamEmpty().Proto()
+	p := NewParamEmpty().Proto
 	if p.GetType() != protos.ParamType_EMPTY {
 		t.Errorf("expected EMPTY, got %v", p.GetType())
 	}
@@ -160,7 +160,7 @@ func TestNewParamEmpty(t *testing.T) {
 
 func TestNewParamData(t *testing.T) {
 	dp := ToPayload([]byte("content"), "text/plain", "test.txt")
-	p := NewParamData(dp).Proto()
+	p := NewParamData(dp).Proto
 	if p.GetType() != protos.ParamType_DATA {
 		t.Errorf("expected DATA, got %v", p.GetType())
 	}
@@ -172,28 +172,28 @@ func TestNewParamData(t *testing.T) {
 // --- With* method tests ---
 
 func TestWithName(t *testing.T) {
-	p := NewParamInt32(0).WithName(NewPolyglotText("en", "Temperature")).Proto()
+	p := NewParamInt32(0).WithName(NewPolyglotText("en", "Temperature")).Proto
 	if p.GetName().GetDisplayStrings()["en"] != "Temperature" {
 		t.Errorf("expected 'Temperature', got %q", p.GetName().GetDisplayStrings()["en"])
 	}
 }
 
 func TestWithReadOnly(t *testing.T) {
-	p := NewParamInt32(0).WithReadOnly(true).Proto()
+	p := NewParamInt32(0).WithReadOnly(true).Proto
 	if !p.GetReadOnly() {
 		t.Error("expected read_only=true")
 	}
 }
 
 func TestWithWidget(t *testing.T) {
-	p := NewParamInt32(0).WithWidget("slider").Proto()
+	p := NewParamInt32(0).WithWidget("slider").Proto
 	if p.GetWidget() != "slider" {
 		t.Errorf("expected 'slider', got %q", p.GetWidget())
 	}
 }
 
 func TestWithPrecision(t *testing.T) {
-	p := NewParamFloat32(0).WithPrecision(3).Proto()
+	p := NewParamFloat32(0).WithPrecision(3).Proto
 	if p.GetPrecision() != 3 {
 		t.Errorf("expected precision 3, got %d", p.GetPrecision())
 	}
@@ -203,21 +203,21 @@ func TestWithPrecision(t *testing.T) {
 // params (see device.one_of_everything.yaml, which sets precision: 3 on a
 // FLOAT32_ARRAY).
 func TestWithPrecision_Float32Array(t *testing.T) {
-	p := NewParamFloat32Array([]float32{1.1, 2.2}).WithPrecision(3).Proto()
+	p := NewParamFloat32Array([]float32{1.1, 2.2}).WithPrecision(3).Proto
 	if p.GetPrecision() != 3 {
 		t.Errorf("expected precision 3 on FLOAT32_ARRAY, got %d", p.GetPrecision())
 	}
 }
 
 func TestWithPrecision_WrongType(t *testing.T) {
-	p := NewParamInt32(0).WithPrecision(3).Proto()
+	p := NewParamInt32(0).WithPrecision(3).Proto
 	if p.GetPrecision() != 0 {
 		t.Error("expected precision to remain 0 for non-float param")
 	}
 }
 
 func TestWithMaxLength(t *testing.T) {
-	p := NewParamString("").WithMaxLength(255).Proto()
+	p := NewParamString("").WithMaxLength(255).Proto
 	if p.GetMaxLength() != 255 {
 		t.Errorf("expected max_length 255, got %d", p.GetMaxLength())
 	}
@@ -227,21 +227,21 @@ func TestWithMaxLength(t *testing.T) {
 // params (see param.string_array_length.yaml, which sets max_length: 10 on a
 // STRING_ARRAY to cap the number of strings in the array).
 func TestWithMaxLength_StringArray(t *testing.T) {
-	p := NewParamStringArray([]string{"a", "b"}).WithMaxLength(10).Proto()
+	p := NewParamStringArray([]string{"a", "b"}).WithMaxLength(10).Proto
 	if p.GetMaxLength() != 10 {
 		t.Errorf("expected max_length 10 on STRING_ARRAY, got %d", p.GetMaxLength())
 	}
 }
 
 func TestWithMaxLength_WrongType(t *testing.T) {
-	p := NewParamInt32(0).WithMaxLength(255).Proto()
+	p := NewParamInt32(0).WithMaxLength(255).Proto
 	if p.GetMaxLength() != 0 {
 		t.Error("expected max_length to remain 0 for param type that does not support max_length")
 	}
 }
 
 func TestWithAccessScope(t *testing.T) {
-	p := NewParamInt32(0).WithAccessScope("admin").Proto()
+	p := NewParamInt32(0).WithAccessScope("admin").Proto
 	if p.GetAccessScope() != "admin" {
 		t.Errorf("expected 'admin', got %q", p.GetAccessScope())
 	}
@@ -251,7 +251,7 @@ func TestWithClientHint(t *testing.T) {
 	p := NewParamInt32(0).
 		WithClientHint("display", "compact").
 		WithClientHint("color", "red").
-		Proto()
+		Proto
 	if p.GetClientHints()["display"] != "compact" {
 		t.Errorf("expected client_hint 'display'='compact', got %q", p.GetClientHints()["display"])
 	}
@@ -262,7 +262,7 @@ func TestWithClientHint(t *testing.T) {
 
 func TestWithParam_Struct(t *testing.T) {
 	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
-	p := NewParamStruct().WithParam("brightness", child).Proto()
+	p := NewParamStruct().WithParam("brightness", child).Proto
 
 	sub := p.GetParams()["brightness"]
 	if sub == nil {
@@ -275,7 +275,7 @@ func TestWithParam_Struct(t *testing.T) {
 
 func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
-	parent := NewParamStruct().WithParam("x", child).Proto()
+	parent := NewParamStruct().WithParam("x", child).Proto
 
 	child.SetValue(int32(999))
 	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
@@ -285,7 +285,7 @@ func TestWithParam_DeepClone(t *testing.T) {
 
 func TestWithParam_WrongType(t *testing.T) {
 	child := NewParamInt32(0)
-	p := NewParamInt32(0).WithParam("x", child).Proto()
+	p := NewParamInt32(0).WithParam("x", child).Proto
 	if len(p.GetParams()) != 0 {
 		t.Error("expected no sub-params on INT32 param")
 	}
@@ -296,34 +296,34 @@ func TestWithParam_Nil(t *testing.T) {
 	// preserving the contract that method chaining is never interrupted
 	// by error handling.
 	cp := NewParamStruct().WithParam("x", nil)
-	p := cp.Proto()
+	p := cp.Proto
 	if len(p.GetParams()) != 0 {
 		t.Error("expected nil sub-param to be a no-op")
 	}
 	// Chaining must continue to work after the no-op.
 	child := NewParamInt32(7)
-	p = cp.WithParam("y", child).Proto()
+	p = cp.WithParam("y", child).Proto
 	if p.GetParams()["y"].GetValue().GetInt32Value() != 7 {
 		t.Error("expected chaining to continue working after nil sub-param")
 	}
 }
 
 func TestWithResponse(t *testing.T) {
-	p := NewParamEmpty().WithResponse(true).Proto()
+	p := NewParamEmpty().WithResponse(true).Proto
 	if !p.GetResponse() {
 		t.Error("expected response=true")
 	}
 }
 
 func TestWithHelp(t *testing.T) {
-	p := NewParamInt32(0).WithHelp(NewPolyglotText("en", "Adjusts volume")).Proto()
+	p := NewParamInt32(0).WithHelp(NewPolyglotText("en", "Adjusts volume")).Proto
 	if p.GetHelp().GetDisplayStrings()["en"] != "Adjusts volume" {
 		t.Errorf("unexpected help text: %q", p.GetHelp().GetDisplayStrings()["en"])
 	}
 }
 
 func TestWithOidAliases(t *testing.T) {
-	p := NewParamInt32(0).WithOidAliases("/old/path", "/legacy/path").Proto()
+	p := NewParamInt32(0).WithOidAliases("/old/path", "/legacy/path").Proto
 	aliases := p.GetOidAliases()
 	if len(aliases) != 2 || aliases[0] != "/old/path" {
 		t.Errorf("unexpected aliases: %v", aliases)
@@ -331,21 +331,21 @@ func TestWithOidAliases(t *testing.T) {
 }
 
 func TestWithMinimalSet(t *testing.T) {
-	p := NewParamInt32(0).WithMinimalSet(true).Proto()
+	p := NewParamInt32(0).WithMinimalSet(true).Proto
 	if !p.GetMinimalSet() {
 		t.Error("expected minimal_set=true")
 	}
 }
 
 func TestWithStateless(t *testing.T) {
-	p := NewParamInt32(0).WithStateless(true).Proto()
+	p := NewParamInt32(0).WithStateless(true).Proto
 	if !p.GetStateless() {
 		t.Error("expected stateless=true")
 	}
 }
 
 func TestWithTemplateOid(t *testing.T) {
-	p := NewParamInt32(0).WithTemplateOid("templates.volume").Proto()
+	p := NewParamInt32(0).WithTemplateOid("templates.volume").Proto
 	if p.GetTemplateOid() != "templates.volume" {
 		t.Errorf("expected 'templates.volume', got %q", p.GetTemplateOid())
 	}
@@ -364,7 +364,7 @@ func TestWithConstraint_ValidInt32Choice(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32(0).WithConstraint(c).Proto()
+	p := NewParamInt32(0).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -380,7 +380,7 @@ func TestWithConstraint_ValidIntRange(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1},
 		},
 	}
-	p := NewParamInt32(50).WithConstraint(c).Proto()
+	p := NewParamInt32(50).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -393,7 +393,7 @@ func TestWithConstraint_ValidFloatRange(t *testing.T) {
 			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 1, Step: 0.01},
 		},
 	}
-	p := NewParamFloat32(0.5).WithConstraint(c).Proto()
+	p := NewParamFloat32(0.5).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -406,7 +406,7 @@ func TestWithConstraint_ValidStringChoice(t *testing.T) {
 			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
 		},
 	}
-	p := NewParamString("a").WithConstraint(c).Proto()
+	p := NewParamString("a").WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -423,7 +423,7 @@ func TestWithConstraint_ValidStringStringChoice(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamString("v").WithConstraint(c).Proto()
+	p := NewParamString("v").WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected constraint to be applied")
 	}
@@ -438,7 +438,7 @@ func TestWithConstraint_ValidAlarmTable(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32(0).WithConstraint(c).Proto()
+	p := NewParamInt32(0).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected alarm table constraint to be applied to INT32 param")
 	}
@@ -449,13 +449,13 @@ func TestWithConstraint_RefOid_AnyType(t *testing.T) {
 		Type: protos.Constraint_UNDEFINED,
 		Kind: &protos.Constraint_RefOid{RefOid: "shared.my_constraint"},
 	}
-	for _, factory := range []func() *CatenaParam{
-		func() *CatenaParam { return NewParamInt32(0) },
-		func() *CatenaParam { return NewParamFloat32(0) },
-		func() *CatenaParam { return NewParamString("") },
-		func() *CatenaParam { return NewParamStruct() },
+	for _, factory := range []func() *Param{
+		func() *Param { return NewParamInt32(0) },
+		func() *Param { return NewParamFloat32(0) },
+		func() *Param { return NewParamString("") },
+		func() *Param { return NewParamStruct() },
 	} {
-		p := factory().WithConstraint(c).Proto()
+		p := factory().WithConstraint(c).Proto
 		if p.GetConstraint() == nil {
 			t.Errorf("expected RefOid constraint to be valid for param type %v", p.GetType())
 		}
@@ -469,7 +469,7 @@ func TestWithConstraint_InvalidStringOnInt(t *testing.T) {
 			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
 		},
 	}
-	p := NewParamInt32(0).WithConstraint(c).Proto()
+	p := NewParamInt32(0).WithConstraint(c).Proto
 	if p.GetConstraint() != nil {
 		t.Error("expected string constraint to be rejected on INT32 param")
 	}
@@ -482,7 +482,7 @@ func TestWithConstraint_InvalidIntOnFloat(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 100, Step: 1},
 		},
 	}
-	p := NewParamFloat32(0).WithConstraint(c).Proto()
+	p := NewParamFloat32(0).WithConstraint(c).Proto
 	if p.GetConstraint() != nil {
 		t.Error("expected int32 range constraint to be rejected on FLOAT32 param")
 	}
@@ -495,14 +495,14 @@ func TestWithConstraint_InvalidFloatOnString(t *testing.T) {
 			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 1, Step: 0.1},
 		},
 	}
-	p := NewParamString("x").WithConstraint(c).Proto()
+	p := NewParamString("x").WithConstraint(c).Proto
 	if p.GetConstraint() != nil {
 		t.Error("expected float range constraint to be rejected on STRING param")
 	}
 }
 
 func TestWithConstraint_Nil(t *testing.T) {
-	p := NewParamInt32(0).WithConstraint(nil).Proto()
+	p := NewParamInt32(0).WithConstraint(nil).Proto
 	if p.GetConstraint() != nil {
 		t.Error("expected nil constraint to be a no-op")
 	}
@@ -521,7 +521,7 @@ func TestWithConstraint_ValidIntRangeOnInt32Array(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 10, Step: 2},
 		},
 	}
-	p := NewParamInt32Array([]int32{0, 2, 4}).WithConstraint(c).Proto()
+	p := NewParamInt32Array([]int32{0, 2, 4}).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected int32 range constraint to be applied to INT32_ARRAY param")
 	}
@@ -539,7 +539,7 @@ func TestWithConstraint_ValidInt32ChoiceOnInt32Array(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32Array([]int32{0, 1, 0}).WithConstraint(c).Proto()
+	p := NewParamInt32Array([]int32{0, 1, 0}).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected int32 choice constraint to be applied to INT32_ARRAY param")
 	}
@@ -554,7 +554,7 @@ func TestWithConstraint_ValidAlarmTableOnInt32Array(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamInt32Array([]int32{0, 1, 2}).WithConstraint(c).Proto()
+	p := NewParamInt32Array([]int32{0, 1, 2}).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected alarm table constraint to be applied to INT32_ARRAY param")
 	}
@@ -567,7 +567,7 @@ func TestWithConstraint_ValidFloatRangeOnFloat32Array(t *testing.T) {
 			FloatRange: &protos.FloatRangeConstraint{MinValue: 0, MaxValue: 100, Step: 0.5},
 		},
 	}
-	p := NewParamFloat32Array([]float32{1.0, 2.0}).WithConstraint(c).Proto()
+	p := NewParamFloat32Array([]float32{1.0, 2.0}).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected float range constraint to be applied to FLOAT32_ARRAY param")
 	}
@@ -580,7 +580,7 @@ func TestWithConstraint_ValidStringChoiceOnStringArray(t *testing.T) {
 			StringChoice: &protos.StringChoiceConstraint{Choices: []string{"a", "b"}, Strict: true},
 		},
 	}
-	p := NewParamStringArray([]string{"a", "b"}).WithConstraint(c).Proto()
+	p := NewParamStringArray([]string{"a", "b"}).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected string choice constraint to be applied to STRING_ARRAY param")
 	}
@@ -598,7 +598,7 @@ func TestWithConstraint_ValidStringStringChoiceOnStringArray(t *testing.T) {
 			},
 		},
 	}
-	p := NewParamStringArray([]string{"<#FF0000>"}).WithConstraint(c).Proto()
+	p := NewParamStringArray([]string{"<#FF0000>"}).WithConstraint(c).Proto
 	if p.GetConstraint() == nil {
 		t.Fatal("expected string-string choice constraint to be applied to STRING_ARRAY param")
 	}
@@ -611,7 +611,7 @@ func TestWithConstraint_InvalidIntOnStringArray(t *testing.T) {
 			Int32Range: &protos.Int32RangeConstraint{MinValue: 0, MaxValue: 10, Step: 1},
 		},
 	}
-	p := NewParamStringArray([]string{"a"}).WithConstraint(c).Proto()
+	p := NewParamStringArray([]string{"a"}).WithConstraint(c).Proto
 	if p.GetConstraint() != nil {
 		t.Error("expected int32 range constraint to be rejected on STRING_ARRAY param")
 	}
@@ -638,7 +638,7 @@ func TestFullChaining(t *testing.T) {
 		WithMinimalSet(true).
 		WithStateless(false).
 		WithTemplateOid("templates.volume").
-		Proto()
+		Proto
 
 	if p.GetType() != protos.ParamType_INT32 {
 		t.Errorf("expected INT32, got %v", p.GetType())
@@ -679,7 +679,7 @@ func TestWithValue_MatchingType(t *testing.T) {
 	if res.Code != OK {
 		t.Fatal(res.Error)
 	}
-	p := NewParamInt32(0).WithValue(v).Proto()
+	p := NewParamInt32(0).WithValue(v).Proto
 	if p.GetValue().GetInt32Value() != 42 {
 		t.Errorf("expected 42, got %d", p.GetValue().GetInt32Value())
 	}
@@ -690,7 +690,7 @@ func TestWithValue_Struct(t *testing.T) {
 	if res.Code != OK {
 		t.Fatal(res.Error)
 	}
-	p := NewParamStruct().WithValue(v).Proto()
+	p := NewParamStruct().WithValue(v).Proto
 	fields := p.GetValue().GetStructValue().GetFields()
 	if fields["name"].GetStringValue() != "test" {
 		t.Errorf("expected struct field 'name'='test', got %q", fields["name"].GetStringValue())
@@ -703,7 +703,7 @@ func TestWithValue_StructVariant(t *testing.T) {
 	if res.Code != OK {
 		t.Fatal(res.Error)
 	}
-	p := NewParamStructVariant().WithValue(v).Proto()
+	p := NewParamStructVariant().WithValue(v).Proto
 	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "type_a" {
 		t.Errorf("expected struct_variant_type 'type_a', got %q",
 			p.GetValue().GetStructVariantValue().GetStructVariantType())
@@ -715,7 +715,7 @@ func TestWithValue_MismatchedType(t *testing.T) {
 	if res.Code != OK {
 		t.Fatal(res.Error)
 	}
-	p := NewParamInt32(0).WithValue(v).Proto()
+	p := NewParamInt32(0).WithValue(v).Proto
 	if p.GetValue().GetInt32Value() != 0 {
 		t.Error("expected mismatched WithValue to be a no-op")
 	}
@@ -729,7 +729,7 @@ func TestSetValue_OK(t *testing.T) {
 	if res.Code != OK {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
-	p := cp.Proto()
+	p := cp.Proto
 	if p.GetValue().GetInt32Value() != 99 {
 		t.Errorf("expected 99, got %d", p.GetValue().GetInt32Value())
 	}
@@ -741,7 +741,7 @@ func TestSetValue_TypeMismatch(t *testing.T) {
 	if res.Code != INVALID_ARGUMENT {
 		t.Errorf("expected INVALID_ARGUMENT, got %v", res.Code)
 	}
-	if cp.Proto().GetValue().GetInt32Value() != 0 {
+	if cp.Proto.GetValue().GetInt32Value() != 0 {
 		t.Error("expected value to remain unchanged after type mismatch")
 	}
 }
@@ -800,7 +800,7 @@ func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
 // --- Typed factory value tests ---
 
 func TestNewParamStruct_WithValue(t *testing.T) {
-	p := NewParamStruct(map[string]any{"a": int32(1)}).Proto()
+	p := NewParamStruct(map[string]any{"a": int32(1)}).Proto
 	fields := p.GetValue().GetStructValue().GetFields()
 	if fields["a"].GetInt32Value() != 1 {
 		t.Errorf("expected struct field 'a'=1, got %d", fields["a"].GetInt32Value())
@@ -808,7 +808,7 @@ func TestNewParamStruct_WithValue(t *testing.T) {
 }
 
 func TestNewParamStruct_NoValue(t *testing.T) {
-	p := NewParamStruct().Proto()
+	p := NewParamStruct().Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
@@ -819,7 +819,7 @@ func TestNewParamStruct_NoValue(t *testing.T) {
 
 func TestNewParamStructVariant_WithValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "kind_a", Value: int32(5)}
-	p := NewParamStructVariant(sv).Proto()
+	p := NewParamStructVariant(sv).Proto
 	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "kind_a" {
 		t.Errorf("expected struct_variant_type 'kind_a', got %q",
 			p.GetValue().GetStructVariantValue().GetStructVariantType())
@@ -831,7 +831,7 @@ func TestNewParamStructArray_WithValue(t *testing.T) {
 		{"x": int32(1)},
 		{"x": int32(2)},
 	}
-	p := NewParamStructArray(arr).Proto()
+	p := NewParamStructArray(arr).Proto
 	list := p.GetValue().GetStructArrayValues().GetStructValues()
 	if len(list) != 2 {
 		t.Fatalf("expected 2 structs, got %d", len(list))
@@ -846,7 +846,7 @@ func TestNewParamStructVariantArray_WithValue(t *testing.T) {
 		{StructVariantType: "a", Value: int32(1)},
 		{StructVariantType: "b", Value: int32(2)},
 	}
-	p := NewParamStructVariantArray(arr).Proto()
+	p := NewParamStructVariantArray(arr).Proto
 	list := p.GetValue().GetStructVariantArrayValues().GetStructVariants()
 	if len(list) != 2 {
 		t.Fatalf("expected 2 variants, got %d", len(list))
@@ -861,7 +861,7 @@ func TestNewParamStructVariantArray_WithValue(t *testing.T) {
 func TestNewParamFromValue_Int32(t *testing.T) {
 	v, _ := ToValue(int32(42))
 	cp := NewParamFromValue(v)
-	p := cp.Proto()
+	p := cp.Proto
 	if p.GetType() != protos.ParamType_INT32 {
 		t.Errorf("expected INT32, got %v", p.GetType())
 	}
@@ -873,39 +873,39 @@ func TestNewParamFromValue_Int32(t *testing.T) {
 func TestNewParamFromValue_Struct(t *testing.T) {
 	v, _ := ToValue(map[string]any{"k": "v"})
 	cp := NewParamFromValue(v)
-	if cp.Proto().GetType() != protos.ParamType_STRUCT {
-		t.Errorf("expected STRUCT, got %v", cp.Proto().GetType())
+	if cp.Proto.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected STRUCT, got %v", cp.Proto.GetType())
 	}
 }
 
 func TestNewParamFromValue_StructVariant(t *testing.T) {
 	v, _ := ToValue(StructVariantValue{StructVariantType: "t", Value: int32(0)})
 	cp := NewParamFromValue(v)
-	if cp.Proto().GetType() != protos.ParamType_STRUCT_VARIANT {
-		t.Errorf("expected STRUCT_VARIANT, got %v", cp.Proto().GetType())
+	if cp.Proto.GetType() != protos.ParamType_STRUCT_VARIANT {
+		t.Errorf("expected STRUCT_VARIANT, got %v", cp.Proto.GetType())
 	}
 }
 
 func TestNewParamFromValue_StructArray(t *testing.T) {
 	v, _ := ToValue([]map[string]any{{"a": int32(1)}})
 	cp := NewParamFromValue(v)
-	if cp.Proto().GetType() != protos.ParamType_STRUCT_ARRAY {
-		t.Errorf("expected STRUCT_ARRAY, got %v", cp.Proto().GetType())
+	if cp.Proto.GetType() != protos.ParamType_STRUCT_ARRAY {
+		t.Errorf("expected STRUCT_ARRAY, got %v", cp.Proto.GetType())
 	}
 }
 
 func TestNewParamFromValue_StructVariantArray(t *testing.T) {
 	v, _ := ToValue([]StructVariantValue{{StructVariantType: "t", Value: int32(0)}})
 	cp := NewParamFromValue(v)
-	if cp.Proto().GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
-		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", cp.Proto().GetType())
+	if cp.Proto.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
+		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", cp.Proto.GetType())
 	}
 }
 
 func TestNewParamFromValue_Nil(t *testing.T) {
 	cp := NewParamFromValue(Value{})
-	if cp.Proto().GetType() != protos.ParamType_UNDEFINED {
-		t.Errorf("expected UNDEFINED for nil value, got %v", cp.Proto().GetType())
+	if cp.Proto.GetType() != protos.ParamType_UNDEFINED {
+		t.Errorf("expected UNDEFINED for nil value, got %v", cp.Proto.GetType())
 	}
 }
 
@@ -929,8 +929,8 @@ func TestNewParamFromValue_AllScalarTypes(t *testing.T) {
 				t.Fatalf("ToValue failed: %s", res.Error)
 			}
 			cp := NewParamFromValue(v)
-			if cp.Proto().GetType() != tt.wantType {
-				t.Errorf("expected %v, got %v", tt.wantType, cp.Proto().GetType())
+			if cp.Proto.GetType() != tt.wantType {
+				t.Errorf("expected %v, got %v", tt.wantType, cp.Proto.GetType())
 			}
 		})
 	}
@@ -975,7 +975,7 @@ func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
 func TestWithParam_SelfReference(t *testing.T) {
 	cp := NewParamStruct()
 	cp.WithParam("self", cp)
-	sub := cp.Proto().GetParams()["self"]
+	sub := cp.Proto.GetParams()["self"]
 	if sub == nil {
 		t.Fatal("expected self-referencing sub-param to be set")
 	}

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -1027,3 +1027,34 @@ func TestConcurrentWithParam(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestWithParam_SelfReference(t *testing.T) {
+	cp := NewParamStruct()
+	cp.WithParam("self", cp)
+	sub := cp.Proto().GetParams()["self"]
+	if sub == nil {
+		t.Fatal("expected self-referencing sub-param to be set")
+	}
+}
+
+func TestWithParam_CrossReference(t *testing.T) {
+	a := NewParamStruct()
+	b := NewParamStruct()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		a.WithParam("b", b)
+	}()
+	go func() {
+		defer wg.Done()
+		b.WithParam("a", a)
+	}()
+	wg.Wait()
+	if a.Proto().GetParams()["b"] == nil {
+		t.Error("expected a to contain sub-param 'b'")
+	}
+	if b.Proto().GetParams()["a"] == nil {
+		t.Error("expected b to contain sub-param 'a'")
+	}
+}

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -105,6 +105,9 @@ func ToValue(v any) (Value, StatusResult) {
 
 // ToProto converts native Go types to protos.Value
 func ToProto(v any) (*protos.Value, StatusResult) {
+	if v == nil {
+		return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil value"}
+	}
 	switch val := v.(type) {
 	case DataPayload:
 		pdp, res := dataPayloadToProto(val)
@@ -129,6 +132,9 @@ func ToProto(v any) (*protos.Value, StatusResult) {
 	case []string:
 		return &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: val}}}, StatusResult{Code: OK}
 	case map[string]any:
+		if val == nil {
+			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil map[string]any"}
+		}
 		fields := make(map[string]*protos.Value)
 		for k, v := range val {
 			res, sr := ToProto(v)
@@ -139,6 +145,9 @@ func ToProto(v any) (*protos.Value, StatusResult) {
 		}
 		return &protos.Value{Kind: &protos.Value_StructValue{StructValue: &protos.StructValue{Fields: fields}}}, StatusResult{Code: OK}
 	case []map[string]any:
+		if val == nil {
+			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil []map[string]any"}
+		}
 		structArr := make([]*protos.StructValue, len(val))
 		for i, m := range val {
 			fields := make(map[string]*protos.Value)
@@ -162,6 +171,9 @@ func ToProto(v any) (*protos.Value, StatusResult) {
 			Value:             protoVal,
 		}}}, StatusResult{Code: OK}
 	case []StructVariantValue:
+		if val == nil {
+			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil []StructVariantValue"}
+		}
 		var structVariants []*protos.StructVariantValue
 		for _, sv := range val {
 			protoVal, sr := ToProto(sv.Value)

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -132,8 +132,8 @@ func ToProto(v any) (*protos.Value, StatusResult) {
 	case []string:
 		return &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: val}}}, StatusResult{Code: OK}
 	case map[string]any:
-		if val == nil {
-			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil map[string]any"}
+		if len(val) == 0 {
+			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil or empty map[string]any"}
 		}
 		fields := make(map[string]*protos.Value)
 		for k, v := range val {
@@ -162,6 +162,9 @@ func ToProto(v any) (*protos.Value, StatusResult) {
 		}
 		return &protos.Value{Kind: &protos.Value_StructArrayValues{StructArrayValues: &protos.StructList{StructValues: structArr}}}, StatusResult{Code: OK}
 	case StructVariantValue:
+		if val.Value == nil {
+			return nil, StatusResult{Code: INVALID_ARGUMENT, Error: "nil StructVariantValue.Value"}
+		}
 		protoVal, sr := ToProto(val.Value)
 		if sr.Code != OK {
 			return nil, StatusResult{Code: sr.Code, Error: "failed to convert StructVariantValue.Value: " + sr.Error}

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -477,6 +477,42 @@ func TestToProto_TypedNil_StructVariantArray(t *testing.T) {
 	}
 }
 
+func TestToProto_TypedNil_StructVariant(t *testing.T) {
+	sv := StructVariantValue{StructVariantType: "t", Value: nil}
+	_, res := ToProto(sv)
+	if res.Code == OK {
+		t.Error("ToProto(StructVariantValue with nil Value) expected error")
+	}
+}
+
+func TestToProto_EmptyStructArray(t *testing.T) {
+	pv, res := ToProto([]map[string]any{})
+	if res.Code != OK {
+		t.Fatalf("ToProto(empty []map[string]any) expected OK, got %v: %s", res.Code, res.Error)
+	}
+	sa := pv.GetStructArrayValues()
+	if sa == nil {
+		t.Fatal("expected StructArrayValues kind, got nil")
+	}
+	if len(sa.GetStructValues()) != 0 {
+		t.Errorf("expected 0 struct values, got %d", len(sa.GetStructValues()))
+	}
+}
+
+func TestToProto_EmptyStructVariantArray(t *testing.T) {
+	pv, res := ToProto([]StructVariantValue{})
+	if res.Code != OK {
+		t.Fatalf("ToProto(empty []StructVariantValue) expected OK, got %v: %s", res.Code, res.Error)
+	}
+	sva := pv.GetStructVariantArrayValues()
+	if sva == nil {
+		t.Fatal("expected StructVariantArrayValues kind, got nil")
+	}
+	if len(sva.GetStructVariants()) != 0 {
+		t.Errorf("expected 0 struct variants, got %d", len(sva.GetStructVariants()))
+	}
+}
+
 func TestToProto_EmptyMap(t *testing.T) {
 	_, res := ToProto(map[string]any{})
 	if res.Code == OK {

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -477,6 +477,20 @@ func TestToProto_TypedNil_StructVariantArray(t *testing.T) {
 	}
 }
 
+func TestToProto_EmptyMap(t *testing.T) {
+	_, res := ToProto(map[string]any{})
+	if res.Code == OK {
+		t.Error("ToProto(empty map[string]any) expected error")
+	}
+}
+
+func TestToProto_EmptyStructVariant(t *testing.T) {
+	_, res := ToProto(StructVariantValue{})
+	if res.Code == OK {
+		t.Error("ToProto(empty StructVariantValue) expected error")
+	}
+}
+
 func TestToProto_UnsupportedType(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -449,6 +449,34 @@ func TestRoundTrip_DataPayload(t *testing.T) {
 	}
 }
 
+func TestToProto_Nil(t *testing.T) {
+	_, res := ToProto(nil)
+	if res.Code == OK {
+		t.Error("ToProto(nil) expected error")
+	}
+}
+
+func TestToProto_TypedNil_Map(t *testing.T) {
+	_, res := ToProto((map[string]any)(nil))
+	if res.Code == OK {
+		t.Error("ToProto(nil map[string]any) expected error")
+	}
+}
+
+func TestToProto_TypedNil_StructArray(t *testing.T) {
+	_, res := ToProto(([]map[string]any)(nil))
+	if res.Code == OK {
+		t.Error("ToProto(nil []map[string]any) expected error")
+	}
+}
+
+func TestToProto_TypedNil_StructVariantArray(t *testing.T) {
+	_, res := ToProto(([]StructVariantValue)(nil))
+	if res.Code == OK {
+		t.Error("ToProto(nil []StructVariantValue) expected error")
+	}
+}
+
 func TestToProto_UnsupportedType(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION

## 📖 Description
Adds the `Param` builder for the Go Catena SDK for constructing `protos.Param` instances. Provides factory functions for every `ParamType`, chainable `With*` methods for metadata, and runtime `SetValue`/`GetValue` accessors with type validation.

---

## 🎯 Goal / Outcome
Build params using a builder pattern instead of manually constructing proto structs. Type mismatches, invalid constraints, and incompatible values are caught and logged at build time rather than silently producing broken protos.

---

## ✅ Definition of Done (DoD)
- [x] Factory function for every `ParamType` (INT32, FLOAT32, STRING, STRUCT, STRUCT_VARIANT, arrays, BINARY, DATA, EMPTY)
- [x] `NewParamFromValue` for dynamic/type-inferred param creation
- [x] Chainable `With*` methods: Name, Value, Constraint, ReadOnly, Widget, Precision, MaxLength, AccessScope, ClientHint, Param (sub-params), Response, Help, OidAliases, MinimalSet, Stateless, TemplateOid
- [x] `SetValue` / `GetValue` runtime accessors with type validation
- [x] Validation helpers: `isValueValidForParamType`, `isConstraintValidForParam`, `paramTypeFromValueKind`
- [x] Comprehensive test coverage

---

## 🛠️ Implementation Notes (Optional)
- Struct-type factories (`NewParamStruct`, `NewParamStructVariant`, `NewParamStructArray`, `NewParamStructVariantArray`) accept nil-able types rather than variadic args. This avoids the misleading `...` syntax that silently ignores extra arguments.
- `NewParamStructVariant` takes `*StructVariantValue` (pointer) since `StructVariantValue` is a value type — a pointer makes nil-ability idiomatic in Go.
- `WithParam` deep-clones sub-params via `proto.Clone` to prevent mutation of the original after attachment.
- `WithResponse` is noted with a TODO to migrate to a future `CatenaCommand` helper, since it only applies to command params.

---

## 🔗 Related Issues / Links

Closes issue #1306 

