### PR TITLE
[Go] [Env] Fix creating build/go in the wrong place

### DIFF
--- a/.devcontainer/go/postCreateCommand.sh
+++ b/.devcontainer/go/postCreateCommand.sh
@@ -7,8 +7,12 @@ ROOT_DIR=$3
 cd ${ROOT_DIR}/sdks/go
 make protos-all
 
+cd ${ROOT_DIR}
+# should exist cause of volume mount, but just in case
 mkdir -p ${BUILD_TARGET}
+# volume mount might belong to root
 sudo chown -R ${USER_NAME}:${USER_NAME} ${BUILD_TARGET}
+
 cd ${ROOT_DIR}/sdks/go
 go mod tidy
 go mod download


### PR DESCRIPTION
`postCreateCommand.sh` messed up a little in #1302 . Fix creating the dir in the wrong spot.