### PR TITLE
[GO] Fixed Race Conditions

### DIFF
--- a/sdks/go/Makefile
+++ b/sdks/go/Makefile
@@ -53,8 +53,8 @@ protos-grpc: proto-tools
 clean-protos:
 	rm -rf "$(GENERATED_DIR)"
 
-# Test coverage targets
-.PHONY: test coverage coverage-html coverage-lcov clean-coverage
+# Test targets
+.PHONY: test race coverage coverage-html coverage-lcov clean-coverage
 
 # Exclude generated protos from tests + coverage accounting
 PROTO_PKG := github.com/rossvideo/catena/sdks/go/pkg/protos
@@ -69,6 +69,16 @@ VERBOSE ?= 0
 
 test:
 	go test -v ./...
+
+RACE_PACKAGES ?= $(TEST_PACKAGES)
+RACE_COUNT ?= 10
+
+race: protos-all
+	go test \
+		-race \
+		-count=$(RACE_COUNT) \
+		$(if $(filter 1,$(VERBOSE)),-v) \
+		$(RACE_PACKAGES)
 
 coverage: | $(COVERAGE_DIR) protos-all
 	go test \

--- a/sdks/go/Makefile
+++ b/sdks/go/Makefile
@@ -1,14 +1,6 @@
+CMDS := oneOfEverything
 BIN_DIR := $(HOME)/Catena/$(BUILD_TARGET)
 LOG_DIR := ./logs
-
-# Examples with a single main.go at top level
-SINGLE_CMDS := oneOfEverything
-# Examples with grpc/ and rest/ sub-mains
-MULTI_CMDS := getAsset getDevice getSetValue paramInfo
-# Examples with only a rest/ sub-main
-REST_CMDS := executeCommand
-
-ALL_CMDS := $(SINGLE_CMDS) $(MULTI_CMDS) $(REST_CMDS)
 
 # Proto config
 GOBIN         := $(shell go env GOPATH)/bin
@@ -19,24 +11,15 @@ PROTO_FILES   := $(wildcard $(PROTO_DIR)/*.proto)
 GO_M_OPTS     := $(patsubst %,--go_opt=M%=$(IMPORT_PATH),$(notdir $(PROTO_FILES)))
 GO_GRPC_M_OPTS:= $(patsubst %,--go-grpc_opt=M%=$(IMPORT_PATH),$(notdir $(PROTO_FILES)))
 
-.PHONY: proto-tools protos protos-grpc protos-all clean-protos examples $(ALL_CMDS)
+.PHONY: proto-tools protos protos-grpc protos-all clean-protos
 
 all: protos-all examples
 
-examples: $(ALL_CMDS)
+examples: $(CMDS)
 
-$(SINGLE_CMDS):
+$(CMDS):
 	mkdir -p $(BIN_DIR)/$@
 	go build -o $(BIN_DIR)/$@/$@ ./examples/$@
-
-$(MULTI_CMDS):
-	mkdir -p $(BIN_DIR)/$@
-	go build -o $(BIN_DIR)/$@/$@-grpc ./examples/$@/grpc
-	go build -o $(BIN_DIR)/$@/$@-rest ./examples/$@/rest
-
-$(REST_CMDS):
-	mkdir -p $(BIN_DIR)/$@
-	go build -o $(BIN_DIR)/$@/$@-rest ./examples/$@/rest
 
 # Clean build artifacts and logs
 clean:

--- a/sdks/go/Makefile
+++ b/sdks/go/Makefile
@@ -1,6 +1,14 @@
-CMDS := oneOfEverything
 BIN_DIR := $(HOME)/Catena/$(BUILD_TARGET)
 LOG_DIR := ./logs
+
+# Examples with a single main.go at top level
+SINGLE_CMDS := oneOfEverything
+# Examples with grpc/ and rest/ sub-mains
+MULTI_CMDS := getAsset getDevice getSetValue paramInfo
+# Examples with only a rest/ sub-main
+REST_CMDS := executeCommand
+
+ALL_CMDS := $(SINGLE_CMDS) $(MULTI_CMDS) $(REST_CMDS)
 
 # Proto config
 GOBIN         := $(shell go env GOPATH)/bin
@@ -11,15 +19,24 @@ PROTO_FILES   := $(wildcard $(PROTO_DIR)/*.proto)
 GO_M_OPTS     := $(patsubst %,--go_opt=M%=$(IMPORT_PATH),$(notdir $(PROTO_FILES)))
 GO_GRPC_M_OPTS:= $(patsubst %,--go-grpc_opt=M%=$(IMPORT_PATH),$(notdir $(PROTO_FILES)))
 
-.PHONY: proto-tools protos protos-grpc protos-all clean-protos
+.PHONY: proto-tools protos protos-grpc protos-all clean-protos examples $(ALL_CMDS)
 
 all: protos-all examples
 
-examples: $(CMDS)
+examples: $(ALL_CMDS)
 
-$(CMDS):
+$(SINGLE_CMDS):
 	mkdir -p $(BIN_DIR)/$@
 	go build -o $(BIN_DIR)/$@/$@ ./examples/$@
+
+$(MULTI_CMDS):
+	mkdir -p $(BIN_DIR)/$@
+	go build -o $(BIN_DIR)/$@/$@-grpc ./examples/$@/grpc
+	go build -o $(BIN_DIR)/$@/$@-rest ./examples/$@/rest
+
+$(REST_CMDS):
+	mkdir -p $(BIN_DIR)/$@
+	go build -o $(BIN_DIR)/$@/$@-rest ./examples/$@/rest
 
 # Clean build artifacts and logs
 clean:

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -57,9 +57,7 @@ const (
 	EnvProd Environment = "prod" // production mode
 )
 
-// currentEnv holds the active SDK environment (dev/prod). Stored atomically so
-// concurrent readers (e.g. gRPC interceptors) and writers (e.g. tests calling
-// SetEnv across subtests) do not race.
+// currentEnv holds the active SDK environment (dev/prod). Stored atomically so concurrent readers and writers do not race.
 var currentEnv atomic.Pointer[Environment]
 
 func init() {

--- a/sdks/go/pkg/catena/config.go
+++ b/sdks/go/pkg/catena/config.go
@@ -44,6 +44,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 )
@@ -56,7 +57,15 @@ const (
 	EnvProd Environment = "prod" // production mode
 )
 
-var currentEnv Environment = EnvProd // default to prod
+// currentEnv holds the active SDK environment (dev/prod). Stored atomically so
+// concurrent readers (e.g. gRPC interceptors) and writers (e.g. tests calling
+// SetEnv across subtests) do not race.
+var currentEnv atomic.Pointer[Environment]
+
+func init() {
+	defaultEnv := EnvProd
+	currentEnv.Store(&defaultEnv)
+}
 
 // parseEnvString parses an environment string to Environment type.
 func parseEnvString(s string) Environment {
@@ -72,22 +81,22 @@ func parseEnvString(s string) Environment {
 
 // IsDev returns true if the SDK is running in development mode.
 func IsDev() bool {
-	return currentEnv == EnvDev
+	return *currentEnv.Load() == EnvDev
 }
 
 // IsProd returns true if the SDK is running in production mode.
 func IsProd() bool {
-	return currentEnv == EnvProd
+	return *currentEnv.Load() == EnvProd
 }
 
 // GetEnv returns the current environment (dev or prod).
 func GetEnv() Environment {
-	return currentEnv
+	return *currentEnv.Load()
 }
 
 // SetEnv allows programmatic override of the environment.
 func SetEnv(env Environment) {
-	currentEnv = env
+	currentEnv.Store(&env)
 }
 
 // Config holds all Catena SDK configuration.
@@ -195,7 +204,7 @@ func InitOptions(opts ...Options) (Config, error) {
 	if opt.AppName != "" {
 		cfg.Logger.AppName = opt.AppName
 	}
-	currentEnv = cfg.Env
+	SetEnv(cfg.Env)
 	if err := logger.Init(cfg.Logger); err != nil {
 		return Config{}, err
 	}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -204,6 +204,10 @@ type ServerRuntime interface {
 	DeregisterConnection(connID int)
 }
 
+// CatenaServer is an alias for Server, following the CatenaValue/CatenaDevice
+// naming convention used by the rest of the public API.
+type CatenaServer = Server
+
 var _ Server = (*server)(nil)
 var _ ServerRuntime = (*server)(nil)
 

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -204,10 +204,6 @@ type ServerRuntime interface {
 	DeregisterConnection(connID int)
 }
 
-// CatenaServer is an alias for Server, following the CatenaValue/CatenaDevice
-// naming convention used by the rest of the public API.
-type CatenaServer = Server
-
 var _ Server = (*server)(nil)
 var _ ServerRuntime = (*server)(nil)
 

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -71,28 +71,7 @@ type GrpcTransport struct {
 var _ catena.Transport = (*GrpcTransport)(nil)
 
 func NewGrpcTransport(port uint16, reflectionEnabled bool) *GrpcTransport {
-	transport := &GrpcTransport{
-		catenaService: &catenaService{},
-		grpcServer: grpc.NewServer(
-			grpc.UnaryInterceptor(unaryInterceptor),
-			grpc.StreamInterceptor(streamInterceptor),
-		),
-		port:       port,
-		reflection: reflectionEnabled,
-	}
-	transport.catenaService.transport = transport
-
-	// Register the CatenaService with the gRPC server
-	protos.RegisterCatenaServiceServer(transport.grpcServer, transport.catenaService)
-
-	// Register reflection service on gRPC server if enabled
-	if reflectionEnabled {
-		reflection.Register(transport.grpcServer)
-		logger.Info("gRPC server created with reflection enabled")
-	} else {
-		logger.Info("gRPC server created")
-	}
-	return transport
+	return newGrpcTransport(port, nil, reflectionEnabled)
 }
 
 // NewGrpcTransportWithListener creates a GrpcTransport that will use the
@@ -100,6 +79,10 @@ func NewGrpcTransport(port uint16, reflectionEnabled bool) *GrpcTransport {
 // a TOCTOU race in tests where the port could be claimed between Close()
 // and rebind.
 func NewGrpcTransportWithListener(lis net.Listener, reflectionEnabled bool) *GrpcTransport {
+	return newGrpcTransport(uint16(lis.Addr().(*net.TCPAddr).Port), lis, reflectionEnabled)
+}
+
+func newGrpcTransport(port uint16, lis net.Listener, reflectionEnabled bool) *GrpcTransport {
 	transport := &GrpcTransport{
 		catenaService: &catenaService{},
 		grpcServer: grpc.NewServer(
@@ -107,7 +90,7 @@ func NewGrpcTransportWithListener(lis net.Listener, reflectionEnabled bool) *Grp
 			grpc.StreamInterceptor(streamInterceptor),
 		),
 		listener:   lis,
-		port:       uint16(lis.Addr().(*net.TCPAddr).Port),
+		port:       port,
 		reflection: reflectionEnabled,
 	}
 	transport.catenaService.transport = transport

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -95,6 +95,34 @@ func NewGrpcTransport(port uint16, reflectionEnabled bool) *GrpcTransport {
 	return transport
 }
 
+// NewGrpcTransportWithListener creates a GrpcTransport that will use the
+// provided listener instead of binding a new one in Start(). This avoids
+// a TOCTOU race in tests where the port could be claimed between Close()
+// and rebind.
+func NewGrpcTransportWithListener(lis net.Listener, reflectionEnabled bool) *GrpcTransport {
+	transport := &GrpcTransport{
+		catenaService: &catenaService{},
+		grpcServer: grpc.NewServer(
+			grpc.UnaryInterceptor(unaryInterceptor),
+			grpc.StreamInterceptor(streamInterceptor),
+		),
+		listener:   lis,
+		port:       uint16(lis.Addr().(*net.TCPAddr).Port),
+		reflection: reflectionEnabled,
+	}
+	transport.catenaService.transport = transport
+
+	protos.RegisterCatenaServiceServer(transport.grpcServer, transport.catenaService)
+
+	if reflectionEnabled {
+		reflection.Register(transport.grpcServer)
+		logger.Info("gRPC server created with reflection enabled")
+	} else {
+		logger.Info("gRPC server created")
+	}
+	return transport
+}
+
 func NewDefaultGrpcTransport() *GrpcTransport {
 	return NewGrpcTransport(
 		6254,  // default port
@@ -105,15 +133,17 @@ func NewDefaultGrpcTransport() *GrpcTransport {
 func (t *GrpcTransport) Start(context context.Context, runtime catena.ServerRuntime) error {
 	t.runtime = runtime
 
-	addr := fmt.Sprintf(":%d", t.port)
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		logger.Error("Failed to create listener", "address", addr, "error", err)
-		return fmt.Errorf("failed to listen on %s: %w", addr, err)
+	if t.listener == nil {
+		addr := fmt.Sprintf(":%d", t.port)
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			logger.Error("Failed to create listener", "address", addr, "error", err)
+			return fmt.Errorf("failed to listen on %s: %w", addr, err)
+		}
+		t.listener = listener
 	}
-	t.listener = listener
 
-	logger.Info("Starting gRPC transport", "address", addr)
+	logger.Info("Starting gRPC transport", "address", t.listener.Addr().String())
 	logger.Info("grpc listening and ready to accept connections")
 
 	go func() {

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -71,25 +71,12 @@ type GrpcTransport struct {
 var _ catena.Transport = (*GrpcTransport)(nil)
 
 func NewGrpcTransport(port uint16, reflectionEnabled bool) *GrpcTransport {
-	return newGrpcTransport(port, nil, reflectionEnabled)
-}
-
-// NewGrpcTransportWithListener creates a GrpcTransport that will use the
-// provided listener instead of binding a new one in Start(). This avoids
-// a TOCTOU race in tests where the port could be claimed between Close()
-// and rebind.
-func NewGrpcTransportWithListener(lis net.Listener, reflectionEnabled bool) *GrpcTransport {
-	return newGrpcTransport(uint16(lis.Addr().(*net.TCPAddr).Port), lis, reflectionEnabled)
-}
-
-func newGrpcTransport(port uint16, lis net.Listener, reflectionEnabled bool) *GrpcTransport {
 	transport := &GrpcTransport{
 		catenaService: &catenaService{},
 		grpcServer: grpc.NewServer(
 			grpc.UnaryInterceptor(unaryInterceptor),
 			grpc.StreamInterceptor(streamInterceptor),
 		),
-		listener:   lis,
 		port:       port,
 		reflection: reflectionEnabled,
 	}

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -2015,6 +2015,7 @@ func TestGrpcTransport_Shutdown_GracefulConnectionClose(t *testing.T) {
 		port = portListener.Addr().(*net.TCPAddr).Port
 		portListener.Close()
 	}
+	addr := fmt.Sprintf("localhost:%d", port)
 
 	transport := NewGrpcTransport(uint16(port), false)
 	runtime := makeStubServerRuntime(t)
@@ -2030,12 +2031,10 @@ func TestGrpcTransport_Shutdown_GracefulConnectionClose(t *testing.T) {
 		t.Fatalf("failed to start server: %v", err)
 	}
 
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
-
-	// Create client and establish streaming connection
+	// Create client and establish streaming connection.
+	// grpc.WithBlock() blocks until the listener accepts, so no startup sleep
+	// is required.
 	ctx := context.Background()
-	addr := fmt.Sprintf("localhost:%d", port)
 	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		transport.Shutdown(context.Background())
@@ -2202,12 +2201,17 @@ func TestGrpcTransport_MultipleClients_RealNetwork(t *testing.T) {
 		return catena.Reply(value)
 	}
 
-	// Use port 0 to let OS assign available port
-	port := 0
-	if portListener, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
-		port = portListener.Addr().(*net.TCPAddr).Port
-		portListener.Close()
+	// Bind to an OS-assigned port and hand the listener directly to the server,
+	// avoiding a TOCTOU race where another process could grab the port between
+	// Close() and rebind.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
 	}
+	addr := lis.Addr().String()
+
+	port := lis.Addr().(*net.TCPAddr).Port
+	lis.Close()
 
 	transport := NewGrpcTransport(uint16(port), false)
 
@@ -2223,14 +2227,10 @@ func TestGrpcTransport_MultipleClients_RealNetwork(t *testing.T) {
 	}()
 	defer transport.Shutdown(context.Background())
 
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
-
-	// Launch multiple concurrent clients
+	// Launch multiple concurrent clients. grpc.WithBlock() in each dial below
+	// waits for the listener to be ready, so no startup sleep is required.
 	numClients := 5
 	results := make(chan error, numClients)
-
-	addr := fmt.Sprintf("localhost:%d", port)
 	for i := 0; i < numClients; i++ {
 		go func(clientID int) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -1907,15 +1907,8 @@ func TestGrpcTransport_Start_EndpointsReachable(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	// Use port 0 to let OS assign available port
-	port := 0
-	if portListener, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
-		port = portListener.Addr().(*net.TCPAddr).Port
-		portListener.Close()
-	}
-
 	shutdownCalled := false
-	transport := NewGrpcTransport(uint16(port), false)
+	transport := NewGrpcTransport(0, false)
 	runtime := makeStubServerRuntime(t)
 	runtime.slots = []uint16{0, 1}
 	runtime.shutdownTransportConnsFn = func(gotCtx context.Context, gotTransport catena.Transport) {
@@ -1940,19 +1933,17 @@ func TestGrpcTransport_Start_EndpointsReachable(t *testing.T) {
 		return catena.Reply(device)
 	}
 
-	// Start server in background
+	// Start server in background. Port 0 makes net.Listen pick an available
+	// port; read the bound address back from the listener after Start.
 	if err := transport.Start(context.Background(), runtime); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
-
-	// Give server time to start
-	time.Sleep(100 * time.Millisecond)
 
 	// Create real gRPC client connection
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	addr := fmt.Sprintf("localhost:%d", port)
+	addr := transport.listener.Addr().String()
 	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		transport.Shutdown(context.Background())
@@ -2009,15 +2000,7 @@ func TestGrpcTransport_Shutdown_GracefulConnectionClose(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	// Use port 0 to let OS assign available port
-	port := 0
-	if portListener, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
-		port = portListener.Addr().(*net.TCPAddr).Port
-		portListener.Close()
-	}
-	addr := fmt.Sprintf("localhost:%d", port)
-
-	transport := NewGrpcTransport(uint16(port), false)
+	transport := NewGrpcTransport(0, false)
 	runtime := makeStubServerRuntime(t)
 	runtime.WithConnection(makeTestConnection(1))
 	runtime.shutdownTransportConnsFn = func(gotCtx context.Context, gotTransport catena.Transport) {
@@ -2026,7 +2009,8 @@ func TestGrpcTransport_Shutdown_GracefulConnectionClose(t *testing.T) {
 		}
 	}
 
-	// Start server in background
+	// Start server in background. Port 0 lets net.Listen pick an available
+	// port; read the bound address back from the listener after Start.
 	if err := transport.Start(context.Background(), runtime); err != nil {
 		t.Fatalf("failed to start server: %v", err)
 	}
@@ -2035,6 +2019,7 @@ func TestGrpcTransport_Shutdown_GracefulConnectionClose(t *testing.T) {
 	// grpc.WithBlock() blocks until the listener accepts, so no startup sleep
 	// is required.
 	ctx := context.Background()
+	addr := transport.listener.Addr().String()
 	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		transport.Shutdown(context.Background())
@@ -2080,13 +2065,7 @@ func TestGrpcTransport_Shutdown_ReturnsContextErrorWhenForced(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	port := 0
-	if portListener, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
-		port = portListener.Addr().(*net.TCPAddr).Port
-		portListener.Close()
-	}
-
-	transport := NewGrpcTransport(uint16(port), false)
+	transport := NewGrpcTransport(0, false)
 	runtime := makeStubServerRuntime(t)
 	runtime.WithConnection(makeTestConnection(1))
 	runtime.shutdownTransportConnsFn = func(gotCtx context.Context, gotTransport catena.Transport) {
@@ -2099,9 +2078,7 @@ func TestGrpcTransport_Shutdown_ReturnsContextErrorWhenForced(t *testing.T) {
 		t.Fatalf("failed to start server: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
-	addr := fmt.Sprintf("localhost:%d", port)
+	addr := transport.listener.Addr().String()
 	conn, err := grpc.DialContext(context.Background(), addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		transport.Shutdown(context.Background())
@@ -2201,16 +2178,10 @@ func TestGrpcTransport_MultipleClients_RealNetwork(t *testing.T) {
 		return catena.Reply(value)
 	}
 
-	// Bind to an OS-assigned port and hand the listener directly to the server,
-	// avoiding a TOCTOU race where another process could grab the port between
-	// Close() and rebind.
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("net.Listen: %v", err)
-	}
-	addr := lis.Addr().String()
-
-	transport := NewGrpcTransportWithListener(lis, false)
+	// Use port 0 so net.Listen picks an available port; read the bound
+	// address back from the listener after Start to avoid a TOCTOU race
+	// between Close() and rebind.
+	transport := NewGrpcTransport(0, false)
 
 	runtime.shutdownTransportConnsFn = func(gotCtx context.Context, gotTransport catena.Transport) {
 		if gotTransport != transport {
@@ -2218,11 +2189,13 @@ func TestGrpcTransport_MultipleClients_RealNetwork(t *testing.T) {
 		}
 	}
 
-	// Start server
-	go func() {
-		transport.Start(context.Background(), runtime)
-	}()
+	// Start server synchronously so the listener is ready before we dial.
+	if err := transport.Start(context.Background(), runtime); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
 	defer transport.Shutdown(context.Background())
+
+	addr := transport.listener.Addr().String()
 
 	// Launch multiple concurrent clients. grpc.WithBlock() in each dial below
 	// waits for the listener to be ready, so no startup sleep is required.

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -2210,10 +2210,7 @@ func TestGrpcTransport_MultipleClients_RealNetwork(t *testing.T) {
 	}
 	addr := lis.Addr().String()
 
-	port := lis.Addr().(*net.TCPAddr).Port
-	lis.Close()
-
-	transport := NewGrpcTransport(uint16(port), false)
+	transport := NewGrpcTransportWithListener(lis, false)
 
 	runtime.shutdownTransportConnsFn = func(gotCtx context.Context, gotTransport catena.Transport) {
 		if gotTransport != transport {

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -1448,10 +1448,9 @@ func TestRestTransport_Connect_ServerShutdown(t *testing.T) {
 	runtime.WithConnection(connection)
 
 	_, cancel := setupSSEConnection(t, transport)
-	defer cancel()
 
 	connection.Done <- struct{}{}
-	time.Sleep(100 * time.Millisecond)
+	cancel()
 
 	if runtime.registerCalls != runtime.deregisterCalls {
 		t.Errorf("expected deregister calls to match register calls after server shutdown, got %d deregister calls and %d register calls", runtime.deregisterCalls, runtime.registerCalls)

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -836,7 +836,7 @@ func TestRestTransport_Connect_TooManyConnections(t *testing.T) {
 		return nil, catena.StatusResult{Code: catena.RESOURCE_EXHAUSTED, Error: "connection rejected"}
 	}
 
-	_, cancel1 := setupSSEConnection(t, transport)
+	_, cleanup1 := setupSSEConnection(t, transport)
 
 	rec2 := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/connect", "")
 	assertStatus(t, rec2, http.StatusTooManyRequests)
@@ -845,7 +845,7 @@ func TestRestTransport_Connect_TooManyConnections(t *testing.T) {
 		t.Errorf("expected error \"connection rejected\" (dev) or \"Too Many Requests\" (prod), got %q", errMsg)
 	}
 
-	cleanupSSE(cancel1)
+	cleanup1()
 }
 
 func TestWriteResults_ValidData(t *testing.T) {

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -41,12 +41,14 @@ package transports
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 )
 
 type stubServerRuntime struct {
+	mu                       sync.Mutex
 	tb                       testing.TB
 	slots                    []uint16
 	getSlotsFn               func(ctx catena.TransportContext) ([]uint16, catena.StatusResult)
@@ -136,6 +138,8 @@ func (s *stubServerRuntime) InvokeParamInfoHandler(slot uint16, oidPrefix string
 }
 
 func (s *stubServerRuntime) RegisterTransportConnection(transport catena.Transport, ctx catena.TransportContext) (*catena.Connection, catena.StatusResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.registerTransportConnFn != nil {
 		conn, res := s.registerTransportConnFn(transport, ctx)
 		s.registerCalls++
@@ -150,6 +154,8 @@ func (s *stubServerRuntime) RegisterTransportConnection(transport catena.Transpo
 }
 
 func (s *stubServerRuntime) DeregisterConnection(connID int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.deregisterConnFn != nil {
 		s.deregisterCalls++
 		s.lastDeregisterID = connID
@@ -160,6 +166,8 @@ func (s *stubServerRuntime) DeregisterConnection(connID int) {
 }
 
 func (s *stubServerRuntime) ShutdownTransportConnections(ctx context.Context, transport catena.Transport) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.shutdownTransportConnsFn != nil {
 		s.lastShutdownOwner = transport
 		s.shutdownCalls++

--- a/sdks/go/pkg/transports/test_helpers_test.go
+++ b/sdks/go/pkg/transports/test_helpers_test.go
@@ -200,6 +200,9 @@ func assertBodyNotContains(t *testing.T, rec *httptest.ResponseRecorder, substr 
 // function to tear down the connection.
 func setupSSEConnection(t *testing.T, transport *RestTransport) (*httptest.ResponseRecorder, func()) {
 	t.Helper()
+
+	countBefore := srv.ConnectionCount()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/connect", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()

--- a/sdks/go/pkg/transports/test_helpers_test.go
+++ b/sdks/go/pkg/transports/test_helpers_test.go
@@ -200,9 +200,6 @@ func assertBodyNotContains(t *testing.T, rec *httptest.ResponseRecorder, substr 
 // function to tear down the connection.
 func setupSSEConnection(t *testing.T, transport *RestTransport) (*httptest.ResponseRecorder, func()) {
 	t.Helper()
-
-	countBefore := srv.ConnectionCount()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/connect", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()

--- a/sdks/go/pkg/transports/test_helpers_test.go
+++ b/sdks/go/pkg/transports/test_helpers_test.go
@@ -196,21 +196,32 @@ func assertBodyNotContains(t *testing.T, rec *httptest.ResponseRecorder, substr 
 // --- SSE helpers ---
 
 // setupSSEConnection starts a background SSE connection to /st2138-api/v1/connect
-// and waits for the handler to be established. Returns the recorder and a cancel
+// and waits for the handler to be established. Returns the recorder and a cleanup
 // function to tear down the connection.
-func setupSSEConnection(t *testing.T, transport *RestTransport) (*httptest.ResponseRecorder, context.CancelFunc) {
+func setupSSEConnection(t *testing.T, transport *RestTransport) (*httptest.ResponseRecorder, func()) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/connect", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
-	go transport.mux.ServeHTTP(rec, req)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		transport.mux.ServeHTTP(rec, req)
+	}()
 	time.Sleep(150 * time.Millisecond)
-	return rec, cancel
+	return rec, func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("SSE handler did not exit after context cancel")
+		}
+	}
 }
 
-// cleanupSSE cancels the SSE context and waits for the handler goroutine to exit.
-func cleanupSSE(cancel context.CancelFunc) {
-	cancel()
+// cleanupSSE tears down an SSE connection and waits briefly for cleanup.
+func cleanupSSE(cleanup func()) {
+	cleanup()
 	time.Sleep(50 * time.Millisecond)
 }
 


### PR DESCRIPTION
## 📖 Description
Fixes multiple data races in the Go SDK uncovered by `go test -race`, and adds a Makefile target to run the race detector as part of the development workflow.

---

## 🎯 Goal / Outcome
All Go SDK tests pass cleanly under the race detector (`go test -race`) with no reported data races, and the team has a convenient `make race` target to catch future regressions.

---

## ✅ Definition of Done (DoD)
- [x] `currentEnv` global in `config.go` is converted from a plain variable to `atomic.Pointer[Environment]` so concurrent readers and writers no longer race
- [x] `time.Sleep` startup waits removed from gRPC integration tests; replaced with synchronous `Start` + `grpc.WithBlock()` dial to guarantee the server is ready
- [x] `stubServerRuntime` test double protected with a `sync.Mutex` around `RegisterTransportConnection`, `DeregisterConnection`, and `ShutdownTransportConnections`
- [x] `setupSSEConnection` rewritten to return a cleanup function that cancels the context **and** waits for the SSE handler goroutine to exit, preventing goroutine leaks and races on shared counters
- [x] REST transport tests updated to use the new cleanup function instead of raw `context.CancelFunc`
- [x] `gRPC Start()` now skips listener creation when one is already set (supports test injection)
- [x] `make race` target added with configurable `RACE_PACKAGES` and `RACE_COUNT` variables

---

## 🛠️ Implementation Notes (Optional)
- **`atomic.Pointer[Environment]`** was chosen over a `sync.RWMutex` for `currentEnv` because the access pattern is overwhelmingly reads (gRPC interceptors on every RPC) with rare writes (test setup / `InitOptions`). An atomic pointer is lock-free on the read path and has zero contention.
- **Listener injection in `GrpcTransport.Start`**: the `if t.listener == nil` guard allows tests to pre-set a listener (e.g. `bufconn`) without `Start` clobbering it, while production callers that leave it `nil` still get the normal `net.Listen` path.
- **`setupSSEConnection` cleanup function**: the old pattern returned a bare `context.CancelFunc`, which cancelled the request but never waited for the handler goroutine to finish. This caused races on the shared `stubServerRuntime` counters (`registerCalls`, `deregisterCalls`). The new cleanup function blocks until the handler exits (with a 2-second safety timeout).
- The `make race` target defaults to `RACE_COUNT=10` iterations to surface intermittent races.

---


## 🔗 Related Issues / Links

Closes issue #1320


