### PR TITLE
[GO] Value return fix

### DIFF
--- a/sdks/go/examples/oneOfEverything/oneofeverything.go
+++ b/sdks/go/examples/oneOfEverything/oneofeverything.go
@@ -401,7 +401,12 @@ func InitSlotParams() map[uint16]*sync.Map {
 	return slotParams
 }
 
-func BuildCounterResponse(counter *CounterState) map[string]any {
+// BuildCounterCommandResponse builds the command-result payload that includes
+// both the current counter value and the running flag. It is used as the
+// response body for start/stop/add10/reset commands so callers can observe
+// the side effects of a command in a single round trip. The "counter" param
+// itself is a plain int32 — see the GetValue handler and the broadcasts below.
+func BuildCounterCommandResponse(counter *CounterState) map[string]any {
 	var runningVal int32 = 0
 	if counter.IsRunning() {
 		runningVal = 1
@@ -439,9 +444,8 @@ func RegisterHandlers(srv catena.CatenaServer) {
 				counter.Start()
 				logger.Info("Counter started", "value", counter.GetValue())
 			}
-			resp := BuildCounterResponse(counter)
-			srv.BroadcastUpdate(0, "counter", resp)
-			val, _ := catena.ToCatenaValue(resp)
+			srv.BroadcastUpdate(0, "counter", counter.GetValue())
+			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
 			return catena.CommandReply(val)
 		},
 
@@ -452,27 +456,24 @@ func RegisterHandlers(srv catena.CatenaServer) {
 				counter.Stop()
 				logger.Info("Counter stopped", "value", counter.GetValue())
 			}
-			resp := BuildCounterResponse(counter)
-			srv.BroadcastUpdate(0, "counter", resp)
-			val, _ := catena.ToCatenaValue(resp)
+			srv.BroadcastUpdate(0, "counter", counter.GetValue())
+			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
 			return catena.CommandReply(val)
 		},
 
 		"add10": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			counter.Add(10)
 			logger.Info("Added 10 to counter", "value", counter.GetValue())
-			resp := BuildCounterResponse(counter)
-			srv.BroadcastUpdate(0, "counter", resp)
-			val, _ := catena.ToCatenaValue(resp)
+			srv.BroadcastUpdate(0, "counter", counter.GetValue())
+			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
 			return catena.CommandReply(val)
 		},
 
 		"reset": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			counter.Reset()
 			logger.Info("Counter reset", "value", counter.GetValue())
-			resp := BuildCounterResponse(counter)
-			srv.BroadcastUpdate(0, "counter", resp)
-			val, _ := catena.ToCatenaValue(resp)
+			srv.BroadcastUpdate(0, "counter", counter.GetValue())
+			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
 			return catena.CommandReply(val)
 		},
 	}
@@ -512,7 +513,10 @@ func RegisterHandlers(srv catena.CatenaServer) {
 			key := normalizeFqoid(fqoid)
 
 			if slot == 0 && key == "counter" {
-				val, _ := catena.ToCatenaValue(BuildCounterResponse(counter))
+				val, res := catena.ToCatenaValue(counter.GetValue())
+				if res.Code != catena.OK {
+					return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert counter value")
+				}
 				return catena.Reply(val)
 			}
 

--- a/sdks/go/examples/oneOfEverything/oneofeverything.go
+++ b/sdks/go/examples/oneOfEverything/oneofeverything.go
@@ -81,6 +81,15 @@ func (c *CounterState) IsRunning() bool {
 	return c.running
 }
 
+// RunningInt32 returns the running state as an int32 (1 = running, 0 = stopped),
+// matching the on-the-wire representation of the "running" param.
+func (c *CounterState) RunningInt32() int32 {
+	if c.IsRunning() {
+		return 1
+	}
+	return 0
+}
+
 func (c *CounterState) Start() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -128,6 +137,17 @@ var Devices = map[uint16]map[string]any{
 				"name": map[string]any{
 					"display_strings": map[string]string{
 						"en": "Counter",
+					},
+				},
+				"type": catena.ParamTypeInt32,
+				"value": map[string]any{
+					"int32_value": 0,
+				},
+			},
+			"running": map[string]any{
+				"name": map[string]any{
+					"display_strings": map[string]string{
+						"en": "Running",
 					},
 				},
 				"type": catena.ParamTypeInt32,
@@ -185,7 +205,7 @@ var Devices = map[uint16]map[string]any{
 								"en": "Status",
 							},
 						},
-						"param_oids": []string{"counter"},
+						"param_oids": []string{"counter", "running"},
 					},
 				},
 			},
@@ -401,22 +421,6 @@ func InitSlotParams() map[uint16]*sync.Map {
 	return slotParams
 }
 
-// BuildCounterCommandResponse builds the command-result payload that includes
-// both the current counter value and the running flag. It is used as the
-// response body for start/stop/add10/reset commands so callers can observe
-// the side effects of a command in a single round trip. The "counter" param
-// itself is a plain int32 — see the GetValue handler and the broadcasts below.
-func BuildCounterCommandResponse(counter *CounterState) map[string]any {
-	var runningVal int32 = 0
-	if counter.IsRunning() {
-		runningVal = 1
-	}
-	return map[string]any{
-		"counter": int32(counter.GetValue()),
-		"running": runningVal,
-	}
-}
-
 // RegisterHandlers registers all GetDevice, GetValue, SetValue, ExecuteCommand,
 // and GetAsset handlers. It also starts a background goroutine that increments
 // the counter every second while running.
@@ -436,6 +440,12 @@ func RegisterHandlers(srv catena.CatenaServer) {
 		}
 	}()
 
+	// broadcastRunning publishes the current running flag on the "running" param
+	// so subscribers (REST SSE / gRPC stream) see the state change live.
+	broadcastRunning := func() {
+		srv.BroadcastUpdate(0, "running", counter.RunningInt32())
+	}
+
 	commands := map[string]CommandHandler{
 		"start": func(payload any) (catena.CommandResult, catena.StatusResult) {
 			if counter.IsRunning() {
@@ -443,9 +453,10 @@ func RegisterHandlers(srv catena.CatenaServer) {
 			} else {
 				counter.Start()
 				logger.Info("Counter started", "value", counter.GetValue())
+				broadcastRunning()
 			}
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
+			val, _ := catena.ToCatenaValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 
@@ -455,9 +466,10 @@ func RegisterHandlers(srv catena.CatenaServer) {
 			} else {
 				counter.Stop()
 				logger.Info("Counter stopped", "value", counter.GetValue())
+				broadcastRunning()
 			}
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
+			val, _ := catena.ToCatenaValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 
@@ -465,7 +477,7 @@ func RegisterHandlers(srv catena.CatenaServer) {
 			counter.Add(10)
 			logger.Info("Added 10 to counter", "value", counter.GetValue())
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
+			val, _ := catena.ToCatenaValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 
@@ -473,7 +485,7 @@ func RegisterHandlers(srv catena.CatenaServer) {
 			counter.Reset()
 			logger.Info("Counter reset", "value", counter.GetValue())
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(BuildCounterCommandResponse(counter))
+			val, _ := catena.ToCatenaValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 	}
@@ -520,6 +532,16 @@ func RegisterHandlers(srv catena.CatenaServer) {
 				return catena.Reply(val)
 			}
 
+			// "running" is a status param backed by CounterState; report the
+			// live state instead of any cached slot-param value.
+			if slot == 0 && key == "running" {
+				val, res := catena.ToCatenaValue(counter.RunningInt32())
+				if res.Code != catena.OK {
+					return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert running value")
+				}
+				return catena.Reply(val)
+			}
+
 			v, ok := p.Load(key)
 			if !ok {
 				return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "parameter not found: "+fqoid)
@@ -543,6 +565,14 @@ func RegisterHandlers(srv catena.CatenaServer) {
 			if value == nil {
 				logger.Error("SetValue nil value received", "slot", slot, "fqoid", fqoid)
 				return catena.StatusWithCode(catena.INVALID_ARGUMENT, "nil value received")
+			}
+
+			// "running" is driven by start/stop commands, not direct writes,
+			// so reject SetValue with a clear hint to avoid silent drift
+			// between CounterState and the slot-param cache.
+			if slot == 0 && key == "running" {
+				logger.Warning("SetValue rejected for running param", "slot", slot, "fqoid", fqoid)
+				return catena.StatusWithCode(catena.INVALID_ARGUMENT, "use start/stop commands to change running state")
 			}
 
 			val, ok := p.Load(key)

--- a/sdks/go/examples/oneOfEverything/oneofeverything.go
+++ b/sdks/go/examples/oneOfEverything/oneofeverything.go
@@ -124,284 +124,325 @@ func (c *CounterState) Increment() {
 
 var SlotList = []uint16{0, 1, 2}
 
-var Devices = map[uint16]map[string]any{
-	0: {
-		"slot":              uint32(0),
-		"detail_level":      catena.DetailLevelFull,
-		"multi_set_enabled": true,
-		"subscriptions":     true,
-		"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-		"default_scope":     "st2138:op",
-		"params": map[string]any{
-			"counter": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Counter",
+// int32ParamValue returns a Catena value{} map containing the int32 currently
+// stored at key in p, or fallback if the key is missing or the wrong type.
+// Used by BuildDevices so slot descriptors serve current values at GetDevice
+// time rather than init-time constants.
+func int32ParamValue(p *sync.Map, key string, fallback int32) map[string]any {
+	v := fallback
+	if raw, ok := p.Load(key); ok {
+		if iv, ok := raw.(int32); ok {
+			v = iv
+		}
+	}
+	return map[string]any{"int32_value": v}
+}
+
+// stringParamValue is the string analogue of int32ParamValue.
+func stringParamValue(p *sync.Map, key string, fallback string) map[string]any {
+	v := fallback
+	if raw, ok := p.Load(key); ok {
+		if sv, ok := raw.(string); ok {
+			v = sv
+		}
+	}
+	return map[string]any{"string_value": v}
+}
+
+// BuildDevices returns the slot -> device-descriptor map. It is a function so
+// every param's "value" can be plugged in live at GetDevice time.
+func BuildDevices(counter *CounterState, slotParams map[uint16]*sync.Map) map[uint16]map[string]any {
+	s1 := slotParams[1]
+	s2 := slotParams[2]
+	return map[uint16]map[string]any{
+		0: {
+			"slot":              uint32(0),
+			"detail_level":      catena.DetailLevelFull,
+			"multi_set_enabled": true,
+			"subscriptions":     true,
+			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
+			"default_scope":     "st2138:op",
+			"params": map[string]any{
+				"counter": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Counter",
+						},
+					},
+					"type": catena.ParamTypeInt32,
+					"value": map[string]any{
+						"int32_value": counter.GetValue(),
 					},
 				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 0,
-				},
-			},
-			"running": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Running",
+				"running": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Counter Running Status",
+						},
 					},
-				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 0,
-				},
-			},
-		},
-		"commands": map[string]any{
-			"start": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Start Counter",
+					"type":      catena.ParamTypeInt32,
+					"read_only": true,
+					"value": map[string]any{
+						"int32_value": counter.RunningInt32(),
 					},
-				},
-				"type": catena.ParamTypeEmpty,
-			},
-			"stop": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Stop Counter",
-					},
-				},
-				"type": catena.ParamTypeEmpty,
-			},
-			"add10": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Add 10 to Counter",
-					},
-				},
-				"type": catena.ParamTypeEmpty,
-			},
-			"reset": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Reset Counter",
-					},
-				},
-				"type": catena.ParamTypeEmpty,
-			},
-		},
-		"menu_groups": map[string]any{
-			"status": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Status",
-					},
-				},
-				"order": 0,
-				"menus": map[string]any{
-					"status": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Status",
+					"constraint": map[string]any{
+						"type": "INT_CHOICE",
+						"int32_choice": map[string]any{
+							"choices": []map[string]any{
+								{
+									"value": int32(0),
+									"name": map[string]any{
+										"display_strings": map[string]string{
+											"en": "Not Counting",
+										},
+									},
+								},
+								{
+									"value": int32(1),
+									"name": map[string]any{
+										"display_strings": map[string]string{
+											"en": "Counting",
+										},
+									},
+								},
 							},
 						},
-						"param_oids": []string{"counter", "running"},
 					},
 				},
 			},
-			"config": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Configuration",
+			"commands": map[string]any{
+				"start": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Start Counter",
+						},
+					},
+					"type": catena.ParamTypeEmpty,
+				},
+				"stop": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Stop Counter",
+						},
+					},
+					"type": catena.ParamTypeEmpty,
+				},
+				"add10": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Add 10 to Counter",
+						},
+					},
+					"type": catena.ParamTypeEmpty,
+				},
+				"reset": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Reset Counter",
+						},
+					},
+					"type": catena.ParamTypeEmpty,
+				},
+			},
+			"menu_groups": map[string]any{
+				"status": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Status",
+						},
+					},
+					"order": 0,
+					"menus": map[string]any{
+						"status": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Status",
+								},
+							},
+							"param_oids": []string{"counter", "running"},
+						},
 					},
 				},
-				"order": 1,
-				"menus": map[string]any{
-					"control": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Control",
-							},
+				"config": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Configuration",
 						},
-						"command_oids": []string{"start", "stop", "add10", "reset"},
+					},
+					"order": 1,
+					"menus": map[string]any{
+						"control": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Control",
+								},
+							},
+							"command_oids": []string{"start", "stop", "add10", "reset"},
+						},
 					},
 				},
 			},
 		},
-	},
-	1: {
-		"slot":              uint32(1),
-		"detail_level":      catena.DetailLevelFull,
-		"multi_set_enabled": false,
-		"subscriptions":     true,
-		"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-		"default_scope":     "st2138:op",
-		"params": map[string]any{
-			"resolution": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Resolution",
-					},
-				},
-				"type": catena.ParamTypeString,
-				"value": map[string]any{
-					"string_value": "1920x1080",
-				},
-			},
-			"brightness": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Brightness",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 50,
-				},
-			},
-			"contrast": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Contrast",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 50,
-				},
-			},
-			"saturation": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Saturation",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 50,
-				},
-			},
-		},
-		"menu_groups": map[string]any{
-			"status": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Status",
-					},
-				},
-				"order": 0,
-				"menus": map[string]any{
-					"status": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Status",
-							},
+		1: {
+			"slot":              uint32(1),
+			"detail_level":      catena.DetailLevelFull,
+			"multi_set_enabled": false,
+			"subscriptions":     true,
+			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
+			"default_scope":     "st2138:op",
+			"params": map[string]any{
+				"resolution": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Resolution",
 						},
-						"param_oids": []string{"resolution"},
 					},
+					"type":  catena.ParamTypeString,
+					"value": stringParamValue(s1, "resolution", "1920x1080"),
+				},
+				"brightness": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Brightness",
+						},
+					},
+					"type":  catena.ParamTypeInt32,
+					"value": int32ParamValue(s1, "brightness", 50),
+				},
+				"contrast": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Contrast",
+						},
+					},
+					"type":  catena.ParamTypeInt32,
+					"value": int32ParamValue(s1, "contrast", 50),
+				},
+				"saturation": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Saturation",
+						},
+					},
+					"type":  catena.ParamTypeInt32,
+					"value": int32ParamValue(s1, "saturation", 50),
 				},
 			},
-			"config": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Configuration",
+			"menu_groups": map[string]any{
+				"status": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Status",
+						},
+					},
+					"order": 0,
+					"menus": map[string]any{
+						"status": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Status",
+								},
+							},
+							"param_oids": []string{"resolution"},
+						},
 					},
 				},
-				"order": 1,
-				"menus": map[string]any{
-					"picture": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Picture",
-							},
+				"config": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Configuration",
 						},
-						"param_oids": []string{"brightness", "contrast", "saturation"},
+					},
+					"order": 1,
+					"menus": map[string]any{
+						"picture": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Picture",
+								},
+							},
+							"param_oids": []string{"brightness", "contrast", "saturation"},
+						},
 					},
 				},
 			},
 		},
-	},
-	2: {
-		"slot":              uint32(2),
-		"detail_level":      catena.DetailLevelFull,
-		"multi_set_enabled": true,
-		"subscriptions":     false,
-		"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-		"default_scope":     "st2138:op",
-		"params": map[string]any{
-			"volume": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Volume",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 75,
-				},
-			},
-			"muted": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Muted",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 0,
-				},
-			},
-			"device_name": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Device Name",
-					},
-				},
-				"type": catena.ParamTypeString,
-				"value": map[string]any{
-					"string_value": "Demo Device",
-				},
-			},
-		},
-		"menu_groups": map[string]any{
-			"status": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Status",
-					},
-				},
-				"order": 0,
-				"menus": map[string]any{
-					"identity": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Identity",
-							},
+		2: {
+			"slot":              uint32(2),
+			"detail_level":      catena.DetailLevelFull,
+			"multi_set_enabled": true,
+			"subscriptions":     false,
+			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
+			"default_scope":     "st2138:op",
+			"params": map[string]any{
+				"volume": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Volume",
 						},
-						"param_oids": []string{"device_name"},
 					},
+					"type":  catena.ParamTypeInt32,
+					"value": int32ParamValue(s2, "volume", 75),
+				},
+				"muted": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Muted",
+						},
+					},
+					"type":  catena.ParamTypeInt32,
+					"value": int32ParamValue(s2, "muted", 0),
+				},
+				"device_name": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Device Name",
+						},
+					},
+					"type":  catena.ParamTypeString,
+					"value": stringParamValue(s2, "device_name", "Demo Device"),
 				},
 			},
-			"config": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Configuration",
+			"menu_groups": map[string]any{
+				"status": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Status",
+						},
+					},
+					"order": 0,
+					"menus": map[string]any{
+						"identity": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Identity",
+								},
+							},
+							"param_oids": []string{"device_name"},
+						},
 					},
 				},
-				"order": 1,
-				"menus": map[string]any{
-					"audio": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Audio",
-							},
+				"config": map[string]any{
+					"name": map[string]any{
+						"display_strings": map[string]string{
+							"en": "Configuration",
 						},
-						"param_oids": []string{"volume", "muted"},
+					},
+					"order": 1,
+					"menus": map[string]any{
+						"audio": map[string]any{
+							"name": map[string]any{
+								"display_strings": map[string]string{
+									"en": "Audio",
+								},
+							},
+							"param_oids": []string{"volume", "muted"},
+						},
 					},
 				},
 			},
 		},
-	},
+	}
 }
 
 func InitSlotParams() map[uint16]*sync.Map {
@@ -504,7 +545,9 @@ func RegisterHandlers(srv catena.CatenaServer) {
 		slot := slot
 		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaDevice, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
-			deviceInfo, ok := Devices[slot]
+
+			// Build per-request so every param's value reflects current state:
+			deviceInfo, ok := BuildDevices(counter, slotParams)[slot]
 			if !ok {
 				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
 			}

--- a/sdks/go/examples/oneOfEverything/rest/webui/index.htm
+++ b/sdks/go/examples/oneOfEverything/rest/webui/index.htm
@@ -52,7 +52,6 @@
                         <div class="card-title">Counter Demo</div>
                         <div class="counter-display">
                             <div class="counter-value" id="counterValue">0</div>
-                            <span class="status-badge stopped" id="statusBadge">Stopped</span>
                         </div>
                         <div class="counter-buttons">
                             <button class="btn start" onclick="cmd('start')">▶ Start</button>

--- a/sdks/go/examples/oneOfEverything/rest/webui/index.htm
+++ b/sdks/go/examples/oneOfEverything/rest/webui/index.htm
@@ -31,6 +31,7 @@
                         <button class="slot-btn active" data-slot="0" onclick="selectSlot(0)">Slot 0</button>
                         <button class="slot-btn" data-slot="1" onclick="selectSlot(1)">Slot 1</button>
                         <button class="slot-btn" data-slot="2" onclick="selectSlot(2)">Slot 2</button>
+                        <button class="expand-btn" onclick="expandDevice()" title="Expand device JSON">⛶ Expand</button>
                     </div>
                     <div class="device-details" id="deviceDetails">
                         <div class="device-loading">Loading...</div>

--- a/sdks/go/examples/oneOfEverything/rest/webui/index.htm
+++ b/sdks/go/examples/oneOfEverything/rest/webui/index.htm
@@ -52,6 +52,7 @@
                         <div class="card-title">Counter Demo</div>
                         <div class="counter-display">
                             <div class="counter-value" id="counterValue">0</div>
+                            <span class="status-badge stopped" id="statusBadge">Stopped</span>
                         </div>
                         <div class="counter-buttons">
                             <button class="btn start" onclick="cmd('start')">▶ Start</button>

--- a/sdks/go/examples/oneOfEverything/rest/webui/script.js
+++ b/sdks/go/examples/oneOfEverything/rest/webui/script.js
@@ -81,7 +81,7 @@ async function cmd(name) {
             headers: { 'Content-Type': 'application/json' }
         });
         const data = await res.json();
-        const counter = extractValue(data.struct_value?.fields?.counter);
+        const counter = extractValue(data);
         if (counter !== null) updateCounter(counter);
     } catch (e) { console.error('cmd error:', e); }
 }
@@ -90,6 +90,20 @@ function updateCounter(value) {
     if (value === undefined || value === null) return;
     const el = document.getElementById('counterValue');
     if (el) el.textContent = value;
+}
+
+// Drives the green "running" highlight on the counter and the status badge.
+// Backed by the standalone "running" int32 param on slot 0.
+function updateRunning(running) {
+    if (running === undefined || running === null) return;
+    const counterEl = document.getElementById('counterValue');
+    const badge = document.getElementById('statusBadge');
+    const isRunning = running === 1;
+    if (counterEl) counterEl.classList.toggle('running', isRunning);
+    if (badge) {
+        badge.className = 'status-badge ' + (isRunning ? 'running' : 'stopped');
+        badge.textContent = isRunning ? 'Running' : 'Stopped';
+    }
 }
 
 // =====================================================================
@@ -197,8 +211,7 @@ async function setParam(name, value, type) {
 async function poll() {
     const fetches = [];
 
-    // Fetch counter from slot 0. The counter param is a plain int32; the
-    // running flag is only conveyed via command responses and SSE updates.
+    // Fetch counter and running flag from slot 0. Both are plain int32 params.
     fetches.push(
         fetch('/st2138-api/v1/0/value/counter')
             .then(r => r.json())
@@ -207,6 +220,15 @@ async function poll() {
                 if (value !== null) updateCounter(value);
             })
             .catch(e => console.error('poll counter error:', e))
+    );
+    fetches.push(
+        fetch('/st2138-api/v1/0/value/running')
+            .then(r => r.json())
+            .then(data => {
+                const value = extractValue(data);
+                if (value !== null) updateRunning(value);
+            })
+            .catch(e => console.error('poll running error:', e))
     );
 
     // Fetch each param from its proper slot
@@ -237,12 +259,14 @@ function connectSSE() {
             if (data.value) {
                 const oid = data.value.oid;
                 const protoVal = data.value.value;
+                const val = extractValue(protoVal);
+                if (val === null) return;
                 if (oid === 'counter') {
-                    const val = extractValue(protoVal);
-                    if (val !== null) updateCounter(val);
+                    updateCounter(val);
+                } else if (oid === 'running') {
+                    updateRunning(val);
                 } else {
-                    const val = extractValue(protoVal);
-                    if (val !== null) updateParamInput(oid, val);
+                    updateParamInput(oid, val);
                 }
             }
         } catch (e) {

--- a/sdks/go/examples/oneOfEverything/rest/webui/script.js
+++ b/sdks/go/examples/oneOfEverything/rest/webui/script.js
@@ -11,6 +11,11 @@ function extractValue(protoVal) {
 // =====================================================================
 // Device Section
 // =====================================================================
+// Cached so the "Expand" button can re-render the most recent fetch in a
+// modal without an extra round-trip.
+let lastDeviceData = null;
+let lastDeviceSlot = null;
+
 async function selectSlot(slot) {
     // Update active button
     document.querySelectorAll('.slot-btn').forEach(btn => {
@@ -34,11 +39,52 @@ async function fetchDevice(slot) {
             return;
         }
         const data = await res.json();
+        lastDeviceData = data;
+        lastDeviceSlot = slot;
         renderDevice(data);
     } catch (e) {
         console.error('fetchDevice error:', e);
         details.innerHTML = `<div class="device-loading">Error loading device</div>`;
     }
+}
+
+// Opens the cached device JSON in the asset-modal popup, re-fetching the
+// active slot first so the modal always reflects the latest server state.
+async function expandDevice() {
+    const slot = lastDeviceSlot ?? 0;
+    await fetchDevice(slot);
+    if (lastDeviceData === null) return;
+    showDeviceModal(lastDeviceData, slot);
+}
+
+// Renders the device JSON inside the same modal scaffold used by viewAsset,
+// just with the .wide content variant and a syntax-highlighted <pre> body.
+function showDeviceModal(deviceData, slot) {
+    const existing = document.getElementById('assetModal');
+    if (existing) existing.remove();
+
+    const highlighted = syntaxHighlight(deviceData);
+
+    const modal = document.createElement('div');
+    modal.id = 'assetModal';
+    modal.className = 'asset-modal';
+    modal.innerHTML = `
+        <div class="asset-modal-content wide">
+            <div class="asset-modal-header">
+                <span class="asset-modal-title">Device · Slot ${escapeHtml(String(slot))}</span>
+                <button class="asset-modal-close" onclick="closeAssetModal()">✕</button>
+            </div>
+            <div class="asset-modal-body">
+                <pre class="json-display">${highlighted}</pre>
+            </div>
+        </div>
+    `;
+
+    modal.addEventListener('click', (e) => {
+        if (e.target === modal) closeAssetModal();
+    });
+
+    document.body.appendChild(modal);
 }
 
 function syntaxHighlight(json) {

--- a/sdks/go/examples/oneOfEverything/rest/webui/script.js
+++ b/sdks/go/examples/oneOfEverything/rest/webui/script.js
@@ -93,16 +93,22 @@ async function cmd(name) {
 function updateCounter(value, running) {
     const el = document.getElementById('counterValue');
     const badge = document.getElementById('statusBadge');
-    el.textContent = value ?? 0;
-    // running is int32: 0 = false, 1 = true
-    if (running === 1) {
-        el.classList.add('running');
-        badge.className = 'status-badge running';
-        badge.textContent = 'Running';
-    } else {
-        el.classList.remove('running');
-        badge.className = 'status-badge stopped';
-        badge.textContent = 'Stopped';
+    if (value !== undefined && value !== null) {
+        el.textContent = value;
+    }
+    // running is int32 (0 = false, 1 = true). Skip if not provided so that
+    // counter-only updates (the "counter" param is a plain int32) leave the
+    // running badge untouched.
+    if (running !== undefined && running !== null) {
+        if (running === 1) {
+            el.classList.add('running');
+            badge.className = 'status-badge running';
+            badge.textContent = 'Running';
+        } else {
+            el.classList.remove('running');
+            badge.className = 'status-badge stopped';
+            badge.textContent = 'Stopped';
+        }
     }
 }
 
@@ -211,15 +217,14 @@ async function setParam(name, value, type) {
 async function poll() {
     const fetches = [];
 
-    // Fetch counter from slot 0
+    // Fetch counter from slot 0. The counter param is a plain int32; the
+    // running flag is only conveyed via command responses and SSE updates.
     fetches.push(
         fetch('/st2138-api/v1/0/value/counter')
             .then(r => r.json())
             .then(data => {
-                const fields = data.struct_value?.fields;
-                if (fields) {
-                    updateCounter(extractValue(fields.counter), extractValue(fields.running));
-                }
+                const value = extractValue(data);
+                if (value !== null) updateCounter(value);
             })
             .catch(e => console.error('poll counter error:', e))
     );
@@ -253,13 +258,8 @@ function connectSSE() {
                 const oid = data.value.oid;
                 const protoVal = data.value.value;
                 if (oid === 'counter') {
-                    if (protoVal.struct_value) {
-                        const fields = protoVal.struct_value.fields;
-                        updateCounter(extractValue(fields.counter), extractValue(fields.running));
-                    } else {
-                        const el = document.getElementById('counterValue');
-                        if (el) el.textContent = extractValue(protoVal) ?? 0;
-                    }
+                    const val = extractValue(protoVal);
+                    if (val !== null) updateCounter(val);
                 } else {
                     const val = extractValue(protoVal);
                     if (val !== null) updateParamInput(oid, val);

--- a/sdks/go/examples/oneOfEverything/rest/webui/script.js
+++ b/sdks/go/examples/oneOfEverything/rest/webui/script.js
@@ -81,35 +81,15 @@ async function cmd(name) {
             headers: { 'Content-Type': 'application/json' }
         });
         const data = await res.json();
-        const fields = data.struct_value?.fields;
-        if (fields) {
-            const counter = extractValue(fields.counter);
-            const running = extractValue(fields.running);
-            updateCounter(counter, running);
-        }
+        const counter = extractValue(data.struct_value?.fields?.counter);
+        if (counter !== null) updateCounter(counter);
     } catch (e) { console.error('cmd error:', e); }
 }
 
-function updateCounter(value, running) {
+function updateCounter(value) {
+    if (value === undefined || value === null) return;
     const el = document.getElementById('counterValue');
-    const badge = document.getElementById('statusBadge');
-    if (value !== undefined && value !== null) {
-        el.textContent = value;
-    }
-    // running is int32 (0 = false, 1 = true). Skip if not provided so that
-    // counter-only updates (the "counter" param is a plain int32) leave the
-    // running badge untouched.
-    if (running !== undefined && running !== null) {
-        if (running === 1) {
-            el.classList.add('running');
-            badge.className = 'status-badge running';
-            badge.textContent = 'Running';
-        } else {
-            el.classList.remove('running');
-            badge.className = 'status-badge stopped';
-            badge.textContent = 'Stopped';
-        }
-    }
+    if (el) el.textContent = value;
 }
 
 // =====================================================================

--- a/sdks/go/examples/oneOfEverything/rest/webui/styles.css
+++ b/sdks/go/examples/oneOfEverything/rest/webui/styles.css
@@ -143,25 +143,6 @@ h1 {
     font-weight: 700;
 }
 
-.counter-value.running { color: var(--success); }
-
-.status-badge {
-    font-size: 0.75rem;
-    padding: 0.25rem 0.75rem;
-    border-radius: 100px;
-    font-weight: 500;
-}
-
-.status-badge.running {
-    background: rgba(34, 197, 94, 0.15);
-    color: var(--success);
-}
-
-.status-badge.stopped {
-    background: var(--border);
-    color: var(--text-muted);
-}
-
 .counter-buttons {
     display: flex;
     gap: 0.5rem;

--- a/sdks/go/examples/oneOfEverything/rest/webui/styles.css
+++ b/sdks/go/examples/oneOfEverything/rest/webui/styles.css
@@ -374,11 +374,36 @@ h1 {
 
 .json-display {
     font-family: 'JetBrains Mono', monospace;
-    font-size: 0.75rem;
-    line-height: 1.5;
+    font-size: 0.85rem;
+    line-height: 1.6;
     white-space: pre-wrap;
     word-break: break-word;
+    text-align: left;
     margin: 0;
+}
+
+/* Expand-to-modal trigger for the device JSON, sits at the right end of the
+   slot-list row (margin-left: auto pushes it past the slot buttons). */
+.expand-btn {
+    margin-left: auto;
+    padding: 0.5rem 0.875rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--section-device);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.expand-btn:hover {
+    background: rgba(139, 92, 246, 0.1);
+    border-color: var(--section-device);
+    color: var(--text);
 }
 
 .json-key { color: var(--section-device); }
@@ -477,6 +502,12 @@ h1 {
     border: 1px solid var(--border);
 }
 
+/* Wider variant used when the modal hosts the device JSON tree, which needs
+   more horizontal room than a typical asset preview. */
+.asset-modal-content.wide {
+    width: min(92vw, 1100px);
+}
+
 .asset-modal-header {
     display: flex;
     justify-content: space-between;
@@ -525,6 +556,20 @@ h1 {
 
 .asset-modal-body img {
     border-radius: 8px;
+}
+
+/* Larger, left-aligned JSON view used inside the device modal. */
+.asset-modal-body .json-display {
+    background: var(--bg);
+    padding: 1.25rem;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    line-height: 1.65;
+    text-align: left;
+    color: var(--text);
+    margin: 0;
+    max-height: calc(90vh - 8rem);
+    overflow: auto;
 }
 
 .asset-loading,

--- a/sdks/go/examples/oneOfEverything/rest/webui/styles.css
+++ b/sdks/go/examples/oneOfEverything/rest/webui/styles.css
@@ -143,6 +143,25 @@ h1 {
     font-weight: 700;
 }
 
+.counter-value.running { color: var(--success); }
+
+.status-badge {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    border-radius: 100px;
+    font-weight: 500;
+}
+
+.status-badge.running {
+    background: rgba(34, 197, 94, 0.15);
+    color: var(--success);
+}
+
+.status-badge.stopped {
+    background: var(--border);
+    color: var(--text-muted);
+}
+
 .counter-buttons {
     display: flex;
     gap: 0.5rem;


### PR DESCRIPTION
## 📖 Description

Refactors the `oneOfEverything` Go example so its on-the-wire model and live updates actually showcase what an adopter would build.

- Slot 0's "counter dashboard" is split from a single struct param into two distinct `int32` params (`counter` and `running`), with `running` made `read_only` and constrained by an `INT_CHOICE` so it serves as a real demo of constraints + read-only.
- `GetDevice` now returns the **current** value of every param across every slot — slot 0 reads from `CounterState`, slots 1 and 2 read from the same `slotParams` store that `SetValue` writes to.
- The bundled REST web UI is updated to consume the new wire shape and gains an `⛶ Expand` button next to the slot picker, opening the device JSON in a wider, syntax-highlighted popup that reuses the asset-modal scaffold.

---

## 🎯 Goal / Outcome

- Address inline review feedback: split the struct-shaped counter, plug live state into the device descriptor, mark `running` as `read_only`, and give it an `INT_CHOICE` constraint so the example demonstrates more of the SDK's surface.
- Keep `CounterState` and the descriptor in sync so a fresh `GetDevice` always reflects the live state, never an init-time zero.
- Make the device JSON in the web UI easy to read without growing the inline section: one click expands it into a roomy modal.

---

## ✅ Definition of Done (DoD)

- [x] `counter` and `running` modelled as two distinct `int32` params on slot 0
- [x] `running` carries `read_only: true` and an `INT_CHOICE` constraint (`0 = Not Counting`, `1 = Counting`), with display name "Counter Running Status"
- [x] `GetDevice` for slot 0 serves live values via `CounterState` (`GetValue()` / `RunningInt32()`)
- [x] `GetDevice` for slots 1 & 2 serves live values via two new helpers (`int32ParamValue`, `stringParamValue`) reading from `slotParams`
- [x] `GetValue` returns the live `CounterState` value for both `counter` and `running`
- [x] `SetValue` on `running` is explicitly rejected with a hint to use `start` / `stop`
- [x] `start` / `stop` broadcast the running flag on the new `running` param
- [x] Web UI polls `counter` and `running` separately, routes SSE updates by oid, and drives the badge + glow from the new flag
- [x] Web UI gains an `⛶ Expand` button that opens the device JSON in a wide, syntax-highlighted modal (reuses `closeAssetModal` and the asset-modal scaffold)

---

## 🛠️ Implementation Notes

- `var Devices = …` was promoted to `func BuildDevices(counter *CounterState, slotParams map[uint16]*sync.Map)`, called once per `GetDevice`. Construction is cheap and the descriptor is small, so per-request rebuild is a non-issue.
- New `CounterState.RunningInt32()` provides the on-the-wire `0` / `1` representation, used consistently by `BuildDevices`, `GetValue`, and the broadcast helper.
- New `int32ParamValue` / `stringParamValue` helpers each return a `value{}` map (`{"int32_value": …}` or `{"string_value": …}`) directly from a `*sync.Map` lookup, with a typed fallback if the key is missing or the wrong type. `sync.Map.Load` is concurrency-safe so this happily races against `SetValue` writes.
- The legacy `BuildCounterResponse(counter)` helper (which produced a `{counter, running}` struct payload) is removed; commands and `GetValue` for slot 0 now return plain `int32`, and a small `broadcastRunning()` closure handles the flag separately.
- `SetValue` on slot 0's `running` is hard-rejected with `INVALID_ARGUMENT` ("use start/stop commands to change running state") to prevent the slot-param cache from drifting away from `CounterState`.

---

## 🔗 Related Issues / Links

---

## 🚧 Risks / Open Questions

- **`BuildDevices` rebuilds the entire slot map per request.** Negligible at three slots with ~10 params; if the example grows substantially we'd want to memoise the static portions and only re-evaluate the live `value` fields.

---

## 📝 Additional Context

Files changed (4 commits, +433 / -260 vs `develop`)