### PR TITLE
[GO] Catena Component Naming Fix

### DIFF
--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -554,7 +554,7 @@ func main() {
 				broadcastRunning()
 			}
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(counter.GetValue())
+			val, _ := catena.ToValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 
@@ -567,7 +567,7 @@ func main() {
 				broadcastRunning()
 			}
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(counter.GetValue())
+			val, _ := catena.ToValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 
@@ -575,7 +575,7 @@ func main() {
 			counter.Add(10)
 			logger.Info("Added 10 to counter", "value", counter.GetValue())
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(counter.GetValue())
+			val, _ := catena.ToValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 
@@ -583,7 +583,7 @@ func main() {
 			counter.Reset()
 			logger.Info("Counter reset", "value", counter.GetValue())
 			srv.BroadcastUpdate(0, "counter", counter.GetValue())
-			val, _ := catena.ToCatenaValue(counter.GetValue())
+			val, _ := catena.ToValue(counter.GetValue())
 			return catena.CommandReply(val)
 		},
 	}
@@ -599,17 +599,17 @@ func main() {
 	}
 
 	for _, slot := range slotList {
-		srv.RegisterGetDeviceHandler(slot, func() (catena.CatenaDevice, catena.StatusResult) {
+		srv.RegisterGetDeviceHandler(slot, func() (catena.Device, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
 
 			// Build per-request so every param's value reflects current state:
 			deviceInfo, ok := BuildDevices(counter, slotParams)[slot]
 			if !ok {
-				return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
+				return catena.ReplyError[catena.Device](catena.NOT_FOUND, "device not found")
 			}
-			device, err := catena.ToCatenaDevice(deviceInfo)
+			device, err := catena.ToDevice(deviceInfo)
 			if err != nil {
-				return catena.ReplyError[catena.CatenaDevice](catena.INTERNAL, err.Error())
+				return catena.ReplyError[catena.Device](catena.INTERNAL, err.Error())
 			}
 			return catena.Reply(device)
 		})
@@ -618,14 +618,14 @@ func main() {
 	for _, slot := range slotList {
 		p := slotParams[slot]
 
-		srv.RegisterGetValueHandler(slot, func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+		srv.RegisterGetValueHandler(slot, func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
 			logger.Info("GetValue", "slot", slot, "fqoid", fqoid)
 			key := normalizeFqoid(fqoid)
 
 			if slot == 0 && key == "counter" {
-				val, res := catena.ToCatenaValue(counter.GetValue())
+				val, res := catena.ToValue(counter.GetValue())
 				if res.Code != catena.OK {
-					return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert counter value")
+					return catena.ReplyError[catena.Value](catena.INTERNAL, "failed to convert counter value")
 				}
 				return catena.Reply(val)
 			}
@@ -633,20 +633,20 @@ func main() {
 			// "running" is a status param backed by CounterState; report the
 			// live state instead of any cached slot-param value.
 			if slot == 0 && key == "running" {
-				val, res := catena.ToCatenaValue(counter.RunningInt32())
+				val, res := catena.ToValue(counter.RunningInt32())
 				if res.Code != catena.OK {
-					return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert running value")
+					return catena.ReplyError[catena.Value](catena.INTERNAL, "failed to convert running value")
 				}
 				return catena.Reply(val)
 			}
 
 			v, ok := p.Load(key)
 			if !ok {
-				return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "parameter not found: "+fqoid)
+				return catena.ReplyError[catena.Value](catena.NOT_FOUND, "parameter not found: "+fqoid)
 			}
-			catenaVal, res := catena.ToCatenaValue(v)
+			catenaVal, res := catena.ToValue(v)
 			if res.Code != catena.OK {
-				return catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to convert value")
+				return catena.ReplyError[catena.Value](catena.INTERNAL, "failed to convert value")
 			}
 			return catena.Reply(catenaVal)
 		})
@@ -705,22 +705,22 @@ func main() {
 	})
 
 	for _, slot := range slotList {
-		srv.RegisterGetAssetHandler(slot, func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+		srv.RegisterGetAssetHandler(slot, func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 			logger.Info("Asset download request", "slot", slot, "fqoid", fqoid)
 			key := normalizeFqoid(fqoid)
 
 			val, ok := assets.Load(key)
 			if !ok {
 				logger.Warning("Asset not found", "slot", slot, "fqoid", fqoid)
-				return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "asset not found: "+fqoid)
+				return catena.ReplyError[catena.Asset](catena.NOT_FOUND, "asset not found: "+fqoid)
 			}
 
 			payload := val.(catena.DataPayload)
 
-			catenaAsset, res := catena.ToCatenaAsset(payload, true)
+			catenaAsset, res := catena.ToAsset(payload, true)
 			if res.Code != catena.OK {
 				logger.Error("Failed to convert payload to asset", "slot", slot, "fqoid", fqoid, "error", res.Error)
-				return catena.ReplyError[catena.CatenaAsset](catena.INTERNAL, "failed to convert asset: "+res.Error)
+				return catena.ReplyError[catena.Asset](catena.INTERNAL, "failed to convert asset: "+res.Error)
 			}
 
 			logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(payload.Payload))
@@ -729,10 +729,10 @@ func main() {
 	}
 
 	for _, slot := range slotList {
-		srv.RegisterParamInfoHandler(slot, func(slot uint16, fqoid string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+		srv.RegisterParamInfoHandler(slot, func(slot uint16, fqoid string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 			if recursive {
 				// TODO: implement recursive param info retrieval in example
-				return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.UNIMPLEMENTED, "recursive param info not implemented in example")
+				return []catena.ParamInfo{}, catena.StatusWithCode(catena.UNIMPLEMENTED, "recursive param info not implemented in example")
 			}
 			logger.Info("GetParamInfo", "slot", slot, "fqoid", fqoid)
 			key := normalizeFqoid(fqoid)
@@ -740,28 +740,28 @@ func main() {
 
 			deviceInfo, ok := BuildDevices(counter, slotParams)[slot]
 			if !ok {
-				return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "device not found")
+				return []catena.ParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "device not found")
 			}
 
 			params, ok := deviceInfo["params"].(map[string]any)
 			if !ok {
-				return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.INTERNAL, "invalid device params structure")
+				return []catena.ParamInfo{}, catena.StatusWithCode(catena.INTERNAL, "invalid device params structure")
 			}
 
 			var paramInfo map[string]any
 			found := false
 			for _, part := range pathParts {
 				if params == nil {
-					return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
+					return []catena.ParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
 				}
 				nextParam, exists := params[part]
 				if !exists {
-					return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
+					return []catena.ParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
 				}
 
 				paramInfo, ok = nextParam.(map[string]any)
 				if !ok {
-					return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
+					return []catena.ParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
 				}
 				found = true
 
@@ -773,7 +773,7 @@ func main() {
 			}
 
 			if !found {
-				return []catena.CatenaParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
+				return []catena.ParamInfo{}, catena.StatusWithCode(catena.NOT_FOUND, "param not found: "+fqoid)
 			}
 
 			oid := pathParts[len(pathParts)-1]
@@ -784,7 +784,7 @@ func main() {
 				}
 			}
 			catenaParamInfo := catena.NewParamInfo(oid, name, paramInfo["type"].(catena.ParamType), "", 0)
-			return []catena.CatenaParamInfo{catenaParamInfo}, catena.StatusWithCode(catena.OK, "")
+			return []catena.ParamInfo{catenaParamInfo}, catena.StatusWithCode(catena.OK, "")
 		})
 	}
 
@@ -836,7 +836,7 @@ func main() {
 		logger.Info("")
 		restTransport := transports.NewDefaultRestTransport()
 
-		restTransport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
+		restTransport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult) {
 			if r.URL.Path == "/assets-list" {
 				var assetList []map[string]any
 				assets.Range(func(key, value any) bool {
@@ -851,7 +851,7 @@ func main() {
 				})
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(assetList)
-				return catena.Reply(catena.CatenaValue{})
+				return catena.Reply(catena.Value{})
 			}
 
 			fileMap := map[string]struct {
@@ -866,13 +866,13 @@ func main() {
 			if file, ok := fileMap[r.URL.Path]; ok {
 				data, err := webFS.ReadFile(file.path)
 				if err != nil {
-					return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "file not found: "+r.URL.Path)
+					return catena.ReplyError[catena.Value](catena.NOT_FOUND, "file not found: "+r.URL.Path)
 				}
 				w.Header().Set("Content-Type", file.contentType)
 				w.Write(data)
-				return catena.Reply(catena.CatenaValue{})
+				return catena.Reply(catena.Value{})
 			}
-			return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found: "+r.URL.Path)
+			return catena.ReplyError[catena.Value](catena.NOT_FOUND, "endpoint not found: "+r.URL.Path)
 		})
 
 		if err := srv.RegisterTransport(restTransport); err != nil {

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -80,8 +80,8 @@ func (e Encoding) String() string {
 	}
 }
 
-// CatenaAsset wraps protos.ExternalObjectPayload for asset handling
-type CatenaAsset struct {
+// Asset wraps protos.ExternalObjectPayload for asset handling
+type Asset struct {
 	asset *protos.ExternalObjectPayload
 }
 
@@ -197,11 +197,11 @@ func dataPayloadToProto(dp DataPayload) (*protos.DataPayload, StatusResult) {
 	return pdp, StatusResult{Code: OK}
 }
 
-// ToCatenaAsset converts DataPayload to CatenaAsset by building the proto directly
-func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, StatusResult) {
+// ToAsset converts DataPayload to Asset by building the proto directly
+func ToAsset(dp DataPayload, cachable bool) (Asset, StatusResult) {
 	protoPayload, res := dataPayloadToProto(dp)
 	if res.Code != OK {
-		return CatenaAsset{asset: nil}, res
+		return Asset{asset: nil}, res
 	}
 
 	asset := &protos.ExternalObjectPayload{
@@ -209,11 +209,11 @@ func ToCatenaAsset(dp DataPayload, cachable bool) (CatenaAsset, StatusResult) {
 		Payload:  protoPayload,
 	}
 
-	return CatenaAsset{asset: asset}, StatusResult{Code: OK}
+	return Asset{asset: asset}, StatusResult{Code: OK}
 }
 
 // GetProtoAsset returns the underlying protos.ExternalObjectPayload
-func (ca CatenaAsset) GetProtoAsset() *protos.ExternalObjectPayload {
+func (ca Asset) GetProtoAsset() *protos.ExternalObjectPayload {
 	return ca.asset
 }
 
@@ -336,7 +336,7 @@ func PayloadEncodingFromExt(filename string) Encoding {
 // TranscodeAssetPayload decodes the asset's current payload encoding and
 // re-encodes it to targetEncoding, modifying the asset in place.
 // If the asset is already in the target encoding, this is a no-op.
-func TranscodeAssetPayload(asset *CatenaAsset, targetEncoding Encoding) StatusResult {
+func TranscodeAssetPayload(asset *Asset, targetEncoding Encoding) StatusResult {
 	original := asset.GetProtoAsset()
 	if original == nil || original.GetPayload() == nil {
 		return StatusResult{Code: INVALID_ARGUMENT, Error: "asset has no payload"}

--- a/sdks/go/pkg/catena/asset_test.go
+++ b/sdks/go/pkg/catena/asset_test.go
@@ -55,7 +55,7 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-func TestToCatenaAsset_WithPayload(t *testing.T) {
+func TestToAsset_WithPayload(t *testing.T) {
 	dp := DataPayload{
 		Metadata: map[string]string{
 			"content-type": "image/png",
@@ -66,9 +66,9 @@ func TestToCatenaAsset_WithPayload(t *testing.T) {
 		Payload:         []byte("fake image data"),
 	}
 
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset error: %v", err.Error)
+		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -91,7 +91,7 @@ func TestToCatenaAsset_WithPayload(t *testing.T) {
 	}
 }
 
-func TestToCatenaAsset_WithUrl(t *testing.T) {
+func TestToAsset_WithUrl(t *testing.T) {
 	dp := DataPayload{
 		Metadata: map[string]string{
 			"content-type": "application/json",
@@ -99,9 +99,9 @@ func TestToCatenaAsset_WithUrl(t *testing.T) {
 		Url: "https://example.com/resource.json",
 	}
 
-	asset, err := ToCatenaAsset(dp, false)
+	asset, err := ToAsset(dp, false)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset error: %v", err.Error)
+		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -121,40 +121,40 @@ func TestToCatenaAsset_WithUrl(t *testing.T) {
 	}
 }
 
-func TestToCatenaAsset_BothPayloadAndUrl_Error(t *testing.T) {
+func TestToAsset_BothPayloadAndUrl_Error(t *testing.T) {
 	dp := DataPayload{
 		Payload: []byte("some data"),
 		Url:     "https://example.com/resource",
 	}
 
-	_, err := ToCatenaAsset(dp, true)
+	_, err := ToAsset(dp, true)
 	if err.Code == OK {
 		t.Error("expected error when both payload and url are provided")
 	}
 }
 
-func TestToCatenaAsset_NeitherPayloadNorUrl_Error(t *testing.T) {
+func TestToAsset_NeitherPayloadNorUrl_Error(t *testing.T) {
 	dp := DataPayload{
 		Metadata: map[string]string{
 			"content-type": "text/plain",
 		},
 	}
 
-	_, err := ToCatenaAsset(dp, true)
+	_, err := ToAsset(dp, true)
 	if err.Code == OK {
 		t.Error("expected error when neither payload nor url are provided")
 	}
 }
 
-func TestToCatenaAsset_WithGzipEncoding(t *testing.T) {
+func TestToAsset_WithGzipEncoding(t *testing.T) {
 	dp := DataPayload{
 		Payload:         []byte("compressed data"),
 		PayloadEncoding: EncodingGzip,
 	}
 
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset error: %v", err.Error)
+		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -171,15 +171,15 @@ func TestToCatenaAsset_WithGzipEncoding(t *testing.T) {
 	}
 }
 
-func TestToCatenaAsset_WithDeflateEncoding(t *testing.T) {
+func TestToAsset_WithDeflateEncoding(t *testing.T) {
 	dp := DataPayload{
 		Payload:         []byte("compressed data"),
 		PayloadEncoding: EncodingDeflate,
 	}
 
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset error: %v", err.Error)
+		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -189,23 +189,23 @@ func TestToCatenaAsset_WithDeflateEncoding(t *testing.T) {
 	}
 }
 
-func TestCatenaAsset_GetProtoAsset_Nil(t *testing.T) {
-	asset := CatenaAsset{asset: nil}
+func TestAsset_GetProtoAsset_Nil(t *testing.T) {
+	asset := Asset{asset: nil}
 	if asset.GetProtoAsset() != nil {
 		t.Error("expected nil proto asset")
 	}
 }
 
-func TestToCatenaAsset_WithDigest(t *testing.T) {
+func TestToAsset_WithDigest(t *testing.T) {
 	digest := []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33}
 	dp := DataPayload{
 		Digest:  digest,
 		Payload: []byte("data with digest"),
 	}
 
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset error: %v", err.Error)
+		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -224,16 +224,16 @@ func TestToCatenaAsset_WithDigest(t *testing.T) {
 	}
 }
 
-func TestToCatenaAsset_EmptyPayload_WithUrl(t *testing.T) {
+func TestToAsset_EmptyPayload_WithUrl(t *testing.T) {
 	// Test that empty payload slice with valid URL works
 	dp := DataPayload{
 		Payload: []byte{}, // explicitly empty
 		Url:     "https://example.com/data",
 	}
 
-	asset, err := ToCatenaAsset(dp, false)
+	asset, err := ToAsset(dp, false)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset error: %v", err.Error)
+		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
 	proto := asset.GetProtoAsset()
@@ -636,9 +636,9 @@ func TestTranscodeAssetPayload(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  original,
 	}
-	asset, res := ToCatenaAsset(dp, true)
+	asset, res := ToAsset(dp, true)
 	if res.Code != OK {
-		t.Fatalf("ToCatenaAsset: %v", res.Error)
+		t.Fatalf("ToAsset: %v", res.Error)
 	}
 
 	// Transcode to GZIP
@@ -692,9 +692,9 @@ func TestTranscodeAssetPayload_RecomputesDigest(t *testing.T) {
 	original := []byte("digest recompute test data")
 	dp := ToPayload(original, "text/plain", "test.txt")
 
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset: %v", err.Error)
+		t.Fatalf("ToAsset: %v", err.Error)
 	}
 
 	originalDigest := make([]byte, len(asset.GetProtoAsset().GetPayload().GetDigest()))
@@ -738,7 +738,7 @@ func TestTranscodeAssetPayload_SameEncoding_Noop(t *testing.T) {
 	dp := DataPayload{
 		Payload: []byte("data"),
 	}
-	asset, _ := ToCatenaAsset(dp, true)
+	asset, _ := ToAsset(dp, true)
 	originalBytes := asset.GetProtoAsset().GetPayload().GetPayload()
 
 	if res := TranscodeAssetPayload(&asset, EncodingUncompressed); res.Code != OK {
@@ -755,9 +755,9 @@ func TestTranscodeAssetPayload_DoesNotMutateOriginalProto(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  original,
 	}
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset: %v", err.Error)
+		t.Fatalf("ToAsset: %v", err.Error)
 	}
 
 	originalProto := asset.GetProtoAsset()
@@ -782,7 +782,7 @@ func TestTranscodeAssetPayload_DoesNotMutateOriginalProto(t *testing.T) {
 }
 
 func TestTranscodeAssetPayload_NilAsset(t *testing.T) {
-	asset := CatenaAsset{}
+	asset := Asset{}
 	err := TranscodeAssetPayload(&asset, EncodingGzip)
 	if err.Code == OK {
 		t.Error("expected error for nil asset")
@@ -790,7 +790,7 @@ func TestTranscodeAssetPayload_NilAsset(t *testing.T) {
 }
 
 func TestTranscodeAssetPayload_NilPayload(t *testing.T) {
-	asset := CatenaAsset{asset: &protos.ExternalObjectPayload{Payload: nil}}
+	asset := Asset{asset: &protos.ExternalObjectPayload{Payload: nil}}
 	err := TranscodeAssetPayload(&asset, EncodingGzip)
 	if err.Code == OK {
 		t.Error("expected error for nil payload on non-nil asset")
@@ -802,9 +802,9 @@ func TestTranscodeAssetPayload_DecodeError(t *testing.T) {
 		Payload:         []byte("not valid gzip"),
 		PayloadEncoding: EncodingGzip,
 	}
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset: %v", err.Error)
+		t.Fatalf("ToAsset: %v", err.Error)
 	}
 
 	err = TranscodeAssetPayload(&asset, EncodingUncompressed)
@@ -817,9 +817,9 @@ func TestTranscodeAssetPayload_EncodeError(t *testing.T) {
 	dp := DataPayload{
 		Payload: []byte("valid data"),
 	}
-	asset, err := ToCatenaAsset(dp, true)
+	asset, err := ToAsset(dp, true)
 	if err.Code != OK {
-		t.Fatalf("ToCatenaAsset: %v", err.Error)
+		t.Fatalf("ToAsset: %v", err.Error)
 	}
 
 	err = TranscodeAssetPayload(&asset, Encoding(99))

--- a/sdks/go/pkg/catena/command.go
+++ b/sdks/go/pkg/catena/command.go
@@ -95,7 +95,7 @@ func (r CommandResult) GetProtoResponse() *protos.CommandResponse {
 }
 
 // CommandReply returns a successful command response wrapping a value.
-func CommandReply(value CatenaValue) (CommandResult, StatusResult) {
+func CommandReply(value Value) (CommandResult, StatusResult) {
 	return CommandResult{
 		response: &protos.CommandResponse{
 			Kind: &protos.CommandResponse_Response{Response: value.Value},

--- a/sdks/go/pkg/catena/command_test.go
+++ b/sdks/go/pkg/catena/command_test.go
@@ -79,7 +79,7 @@ func TestPolyglotText_Get_MissingFallback(t *testing.T) {
 }
 
 func TestCommandReply(t *testing.T) {
-	val, _ := ToCatenaValue(int32(42))
+	val, _ := ToValue(int32(42))
 	result, status := CommandReply(val)
 
 	if status.Code != OK {
@@ -222,7 +222,7 @@ func TestCommandError_NilResponse(t *testing.T) {
 }
 
 func TestCommandResult_GetProtoResponse_Response(t *testing.T) {
-	val, _ := ToCatenaValue("hello")
+	val, _ := ToValue("hello")
 	result, _ := CommandReply(val)
 	proto := result.GetProtoResponse()
 

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -62,19 +62,19 @@ const (
 	DetailLevelUnset         DetailLevel = protos.Device_UNSET
 )
 
-// CatenaDevice wraps protos.Device for device model handling
-type CatenaDevice struct {
+// Device wraps protos.Device for device model handling
+type Device struct {
 	device *protos.Device
 }
 
-// ToCatenaDevice converts a Go map/struct to CatenaDevice
+// ToDevice converts a Go map/struct to Device
 // This allows developers to work with native Go types and convert to the protobuf format
-func ToCatenaDevice(m map[string]any) (CatenaDevice, error) {
+func ToDevice(m map[string]any) (Device, error) {
 	device, err := toProtoDevice(m)
 	if err != nil {
-		return CatenaDevice{}, fmt.Errorf("ToCatenaDevice: %w", err)
+		return Device{}, fmt.Errorf("ToDevice: %w", err)
 	}
-	return CatenaDevice{device: device}, nil
+	return Device{device: device}, nil
 }
 
 // toProtoDevice converts native Go types to protos.Device
@@ -95,6 +95,6 @@ func toProtoDevice(m map[string]any) (*protos.Device, error) {
 }
 
 // GetProtoDevice returns the underlying protos.Device
-func (cd CatenaDevice) GetProtoDevice() *protos.Device {
+func (cd Device) GetProtoDevice() *protos.Device {
 	return cd.device
 }

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -42,22 +42,22 @@ import (
 	"testing"
 )
 
-func TestToCatenaDevice_Basic(t *testing.T) {
+func TestToDevice_Basic(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	if cd.GetProtoDevice() == nil {
 		t.Error("expected non-nil proto device")
 	}
 }
 
-func TestToCatenaDevice_WithParams(t *testing.T) {
+func TestToDevice_WithParams(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
@@ -75,9 +75,9 @@ func TestToCatenaDevice_WithParams(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -98,7 +98,7 @@ func TestToCatenaDevice_WithParams(t *testing.T) {
 	}
 }
 
-func TestToCatenaDevice_WithConstraints(t *testing.T) {
+func TestToDevice_WithConstraints(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
@@ -117,9 +117,9 @@ func TestToCatenaDevice_WithConstraints(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -162,7 +162,7 @@ func TestToCatenaDevice_WithConstraints(t *testing.T) {
 	}
 }
 
-func TestToCatenaDevice_WithLanguagePacks(t *testing.T) {
+func TestToDevice_WithLanguagePacks(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
@@ -186,9 +186,9 @@ func TestToCatenaDevice_WithLanguagePacks(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -216,7 +216,7 @@ func TestToCatenaDevice_WithLanguagePacks(t *testing.T) {
 	}
 }
 
-func TestToCatenaDevice_WithMenuGroups(t *testing.T) {
+func TestToDevice_WithMenuGroups(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
@@ -241,9 +241,9 @@ func TestToCatenaDevice_WithMenuGroups(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -276,7 +276,7 @@ func TestToCatenaDevice_WithMenuGroups(t *testing.T) {
 	}
 }
 
-func TestToCatenaDevice_WithCommands(t *testing.T) {
+func TestToDevice_WithCommands(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
@@ -292,9 +292,9 @@ func TestToCatenaDevice_WithCommands(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {
@@ -315,8 +315,8 @@ func TestToCatenaDevice_WithCommands(t *testing.T) {
 	}
 }
 
-func TestCatenaDevice_GetProtoDevice_Nil(t *testing.T) {
-	cd := CatenaDevice{device: nil}
+func TestDevice_GetProtoDevice_Nil(t *testing.T) {
+	cd := Device{device: nil}
 	if cd.GetProtoDevice() != nil {
 		t.Error("expected nil proto device")
 	}
@@ -345,7 +345,7 @@ func TestDetailLevelConstants(t *testing.T) {
 	}
 }
 
-func TestToCatenaDevice_CompleteDevice(t *testing.T) {
+func TestToDevice_CompleteDevice(t *testing.T) {
 	// This test verifies a complete device configuration like the example
 	deviceMap := map[string]any{
 		"slot":              uint32(0),
@@ -418,9 +418,9 @@ func TestToCatenaDevice_CompleteDevice(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 
 	proto := cd.GetProtoDevice()
@@ -449,7 +449,7 @@ func TestToCatenaDevice_CompleteDevice(t *testing.T) {
 	}
 }
 
-func TestToCatenaDevice_FloatRangeConstraint(t *testing.T) {
+func TestToDevice_FloatRangeConstraint(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
@@ -463,9 +463,9 @@ func TestToCatenaDevice_FloatRangeConstraint(t *testing.T) {
 		},
 	}
 
-	cd, err := ToCatenaDevice(deviceMap)
+	cd, err := ToDevice(deviceMap)
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 	proto := cd.GetProtoDevice()
 	if proto == nil {

--- a/sdks/go/pkg/catena/param_info.go
+++ b/sdks/go/pkg/catena/param_info.go
@@ -47,17 +47,17 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-// CatenaParamInfo wraps protos.ParamInfoResponse for parameter info handling.
+// ParamInfo wraps protos.ParamInfoResponse for parameter info handling.
 // It carries both a ParamInfo descriptor and, for array parameters, the
 // current array length.
-type CatenaParamInfo struct {
+type ParamInfo struct {
 	response *protos.ParamInfoResponse
 }
 
-// NewParamInfo creates a CatenaParamInfo with the specified fields.
+// NewParamInfo creates a ParamInfo with the specified fields.
 // name may be nil if no display name is required.
 // arrayLength should be 0 for non-array parameters.
-func NewParamInfo(oid string, name PolyglotText, paramType ParamType, templateOid string, arrayLength uint32) CatenaParamInfo {
+func NewParamInfo(oid string, name PolyglotText, paramType ParamType, templateOid string, arrayLength uint32) ParamInfo {
 	info := &protos.ParamInfo{
 		Oid:         oid,
 		Type:        paramType,
@@ -66,7 +66,7 @@ func NewParamInfo(oid string, name PolyglotText, paramType ParamType, templateOi
 	if name != nil {
 		info.Name = &protos.PolyglotText{DisplayStrings: name}
 	}
-	return CatenaParamInfo{
+	return ParamInfo{
 		response: &protos.ParamInfoResponse{
 			Info:        info,
 			ArrayLength: arrayLength,
@@ -74,28 +74,28 @@ func NewParamInfo(oid string, name PolyglotText, paramType ParamType, templateOi
 	}
 }
 
-// ToCatenaParamInfo converts a Go map to a CatenaParamInfo by marshalling
+// ToParamInfo converts a Go map to a ParamInfo by marshalling
 // through protojson. The map keys mirror the protos.ParamInfoResponse schema
-func ToCatenaParamInfo(m map[string]any) (CatenaParamInfo, error) {
+func ToParamInfo(m map[string]any) (ParamInfo, error) {
 	jsonData, err := json.Marshal(m)
 	if err != nil {
-		return CatenaParamInfo{}, fmt.Errorf("ToCatenaParamInfo: marshal map: %w", err)
+		return ParamInfo{}, fmt.Errorf("ToParamInfo: marshal map: %w", err)
 	}
 
 	resp := &protos.ParamInfoResponse{}
 	if err := protojson.Unmarshal(jsonData, resp); err != nil {
-		return CatenaParamInfo{}, fmt.Errorf("ToCatenaParamInfo: unmarshal to proto: %w", err)
+		return ParamInfo{}, fmt.Errorf("ToParamInfo: unmarshal to proto: %w", err)
 	}
-	return CatenaParamInfo{response: resp}, nil
+	return ParamInfo{response: resp}, nil
 }
 
 // GetProtoResponse returns the underlying protos.ParamInfoResponse.
-func (p CatenaParamInfo) GetProtoResponse() *protos.ParamInfoResponse {
+func (p ParamInfo) GetProtoResponse() *protos.ParamInfoResponse {
 	return p.response
 }
 
 // GetProtoInfo returns the underlying protos.ParamInfo, or nil if unset.
-func (p CatenaParamInfo) GetProtoInfo() *protos.ParamInfo {
+func (p ParamInfo) GetProtoInfo() *protos.ParamInfo {
 	if p.response == nil {
 		return nil
 	}
@@ -103,22 +103,22 @@ func (p CatenaParamInfo) GetProtoInfo() *protos.ParamInfo {
 }
 
 // GetOid returns the parameter's OID, or "" if unset.
-func (p CatenaParamInfo) GetOid() string {
+func (p ParamInfo) GetOid() string {
 	return p.GetProtoInfo().GetOid()
 }
 
 // GetParamType returns the parameter's type, or UNDEFINED if unset.
-func (p CatenaParamInfo) GetParamType() ParamType {
+func (p ParamInfo) GetParamType() ParamType {
 	return p.GetProtoInfo().GetType()
 }
 
 // GetTemplateOid returns the template OID, or "" if unset.
-func (p CatenaParamInfo) GetTemplateOid() string {
+func (p ParamInfo) GetTemplateOid() string {
 	return p.GetProtoInfo().GetTemplateOid()
 }
 
 // GetArrayLength returns the array length for array parameters, or 0 otherwise.
-func (p CatenaParamInfo) GetArrayLength() uint32 {
+func (p ParamInfo) GetArrayLength() uint32 {
 	if p.response == nil {
 		return 0
 	}

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -83,7 +83,7 @@ func TestNewParamInfo_ArrayLength(t *testing.T) {
 	}
 }
 
-func TestToCatenaParamInfo_FromMap(t *testing.T) {
+func TestToParamInfo_FromMap(t *testing.T) {
 	m := map[string]any{
 		"info": map[string]any{
 			"oid":          "brightness",
@@ -98,9 +98,9 @@ func TestToCatenaParamInfo_FromMap(t *testing.T) {
 		"array_length": 0,
 	}
 
-	pi, err := ToCatenaParamInfo(m)
+	pi, err := ToParamInfo(m)
 	if err != nil {
-		t.Fatalf("ToCatenaParamInfo error: %v", err)
+		t.Fatalf("ToParamInfo error: %v", err)
 	}
 	if pi.GetOid() != "brightness" {
 		t.Errorf("expected oid 'brightness', got %s", pi.GetOid())
@@ -113,19 +113,19 @@ func TestToCatenaParamInfo_FromMap(t *testing.T) {
 	}
 }
 
-func TestToCatenaParamInfo_InvalidProto(t *testing.T) {
+func TestToParamInfo_InvalidProto(t *testing.T) {
 	m := map[string]any{
 		"info": map[string]any{
 			"type": "NOT_A_TYPE",
 		},
 	}
-	if _, err := ToCatenaParamInfo(m); err == nil {
+	if _, err := ToParamInfo(m); err == nil {
 		t.Error("expected error for invalid ParamType, got nil")
 	}
 }
 
-func TestCatenaParamInfo_ZeroValue(t *testing.T) {
-	var pi CatenaParamInfo
+func TestParamInfo_ZeroValue(t *testing.T) {
+	var pi ParamInfo
 	if pi.GetProtoResponse() != nil {
 		t.Error("expected nil proto response for zero value")
 	}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -54,12 +54,12 @@ import (
 )
 
 // Handler function types used by both REST and gRPC servers.
-type DeviceHandler func() (CatenaDevice, StatusResult)
-type GetValueHandler func(slot uint16, fqoid string) (CatenaValue, StatusResult)
+type DeviceHandler func() (Device, StatusResult)
+type GetValueHandler func(slot uint16, fqoid string) (Value, StatusResult)
 type SetValueHandler func(value any, slot uint16, fqoid string) StatusResult
-type GetAssetHandler func(slot uint16, fqoid string) (CatenaAsset, StatusResult)
+type GetAssetHandler func(slot uint16, fqoid string) (Asset, StatusResult)
 type ExecuteCommandHandler func(slot uint16, commandFqoid string, payload any) (CommandResult, StatusResult)
-type ParamInfoHandler func(slot uint16, oidPrefix string, recursive bool) ([]CatenaParamInfo, StatusResult)
+type ParamInfoHandler func(slot uint16, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult)
 type HeartbeatHandler func(slot uint16)
 
 var ErrServerStopped = errors.New("server is stopped")
@@ -125,12 +125,12 @@ type Server interface {
 // interface of funcs that Transports use to interact with the server without circular imports
 type ServerRuntime interface {
 	GetSlots() []uint16
-	InvokeGetDeviceHandler(slot uint16) (CatenaDevice, StatusResult)
-	InvokeGetValueHandler(slot uint16, fqoid string) (CatenaValue, StatusResult)
+	InvokeGetDeviceHandler(slot uint16) (Device, StatusResult)
+	InvokeGetValueHandler(slot uint16, fqoid string) (Value, StatusResult)
 	InvokeSetValueHandler(value any, slot uint16, fqoid string) StatusResult
-	InvokeGetAssetHandler(slot uint16, fqoid string) (CatenaAsset, StatusResult)
+	InvokeGetAssetHandler(slot uint16, fqoid string) (Asset, StatusResult)
 	InvokeExecuteCommandHandler(slot uint16, commandFqoid string, payload any) (CommandResult, StatusResult)
-	InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool) ([]CatenaParamInfo, StatusResult)
+	InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult)
 	RegisterTransportConnection(transport Transport) (int, *Connection)
 	ShutdownTransportConnections(ctx context.Context, transport Transport)
 	DeregisterConnection(connID int)
@@ -401,7 +401,7 @@ func (s *server) RegisterHeartbeatHandler(slot uint16, handler HeartbeatHandler)
 	}
 }
 
-func (s *server) InvokeGetDeviceHandler(slot uint16) (CatenaDevice, StatusResult) {
+func (s *server) InvokeGetDeviceHandler(slot uint16) (Device, StatusResult) {
 	s.mu.Lock()
 	handler, ok := s.getDeviceHandlers[slot]
 	s.mu.Unlock()
@@ -411,10 +411,10 @@ func (s *server) InvokeGetDeviceHandler(slot uint16) (CatenaDevice, StatusResult
 	}
 	// TODO: lookup default handler for slot
 	logger.Warning("GetDeviceHandler called - no handler registered for this slot")
-	return ReplyError[CatenaDevice](NOT_FOUND, "No device defined at slot")
+	return ReplyError[Device](NOT_FOUND, "No device defined at slot")
 }
 
-func (s *server) InvokeGetValueHandler(slot uint16, fqoid string) (CatenaValue, StatusResult) {
+func (s *server) InvokeGetValueHandler(slot uint16, fqoid string) (Value, StatusResult) {
 	s.mu.Lock()
 	handler, ok := s.getValueHandlers[slot]
 	s.mu.Unlock()
@@ -424,7 +424,7 @@ func (s *server) InvokeGetValueHandler(slot uint16, fqoid string) (CatenaValue, 
 	}
 	// TODO: lookup default handler for slot
 	logger.Warning("GetValueHandler called - no handler registered for this slot", "slot", slot, "fqoid", fqoid)
-	return ReplyError[CatenaValue](NOT_FOUND, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
+	return ReplyError[Value](NOT_FOUND, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
 }
 
 func (s *server) InvokeSetValueHandler(value any, slot uint16, fqoid string) StatusResult {
@@ -440,7 +440,7 @@ func (s *server) InvokeSetValueHandler(value any, slot uint16, fqoid string) Sta
 	return StatusWithCode(NOT_FOUND, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
 }
 
-func (s *server) InvokeGetAssetHandler(slot uint16, fqoid string) (CatenaAsset, StatusResult) {
+func (s *server) InvokeGetAssetHandler(slot uint16, fqoid string) (Asset, StatusResult) {
 	s.mu.Lock()
 	handler, ok := s.getAssetHandlers[slot]
 	s.mu.Unlock()
@@ -450,7 +450,7 @@ func (s *server) InvokeGetAssetHandler(slot uint16, fqoid string) (CatenaAsset, 
 	}
 	// TODO: lookup default handler for slot
 	logger.Warning("GetAssetHandler called - no handler registered for this slot", "slot", slot, "fqoid", fqoid)
-	return ReplyError[CatenaAsset](NOT_FOUND, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
+	return ReplyError[Asset](NOT_FOUND, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
 }
 
 func (s *server) InvokeExecuteCommandHandler(slot uint16, commandFqoid string, payload any) (CommandResult, StatusResult) {
@@ -466,7 +466,7 @@ func (s *server) InvokeExecuteCommandHandler(slot uint16, commandFqoid string, p
 	return CommandError(NOT_FOUND, "ExecuteCommand "+commandFqoid+" not found at slot "+strconv.Itoa(int(slot)))
 }
 
-func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool) ([]CatenaParamInfo, StatusResult) {
+func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult) {
 	s.mu.Lock()
 	handler, ok := s.paramInfoHandlers[slot]
 	s.mu.Unlock()

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -474,12 +474,12 @@ func TestServer_Shutdown_Idempotent(t *testing.T) {
 func TestServer_RegisterGetDeviceHandler(t *testing.T) {
 	srv := NewServer(100).(*server)
 
-	expected := CatenaDevice{
+	expected := Device{
 		device: &protos.Device{},
 	}
 
 	handlerCalled := false
-	srv.RegisterGetDeviceHandler(0, func() (CatenaDevice, StatusResult) {
+	srv.RegisterGetDeviceHandler(0, func() (Device, StatusResult) {
 		handlerCalled = true
 		return expected, StatusResult{Code: OK}
 	})
@@ -510,8 +510,8 @@ func TestServer_RegisterGetDeviceHandler_SendsSlotsAdded(t *testing.T) {
 		},
 	}
 
-	srv.RegisterGetDeviceHandler(0, func() (CatenaDevice, StatusResult) {
-		return CatenaDevice{}, StatusResult{Code: OK}
+	srv.RegisterGetDeviceHandler(0, func() (Device, StatusResult) {
+		return Device{}, StatusResult{Code: OK}
 	})
 
 	if len(updates) != 1 {
@@ -532,10 +532,10 @@ func TestServer_RegisterGetDeviceHandler_SendsSlotsAdded(t *testing.T) {
 func TestServer_RegisterGetValueHandler(t *testing.T) {
 	srv := NewServer(100).(*server)
 
-	expected := CatenaValue{}
+	expected := Value{}
 
 	handlerCalled := false
-	srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string) (CatenaValue, StatusResult) {
+	srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string) (Value, StatusResult) {
 		handlerCalled = true
 		if slot != 0 {
 			t.Errorf("expected slot 0, got %d", slot)
@@ -595,10 +595,10 @@ func TestServer_RegisterGetAssetHandler(t *testing.T) {
 		Metadata: map[string]string{"content-type": "image/png"},
 		Payload:  []byte("fake image"),
 	}
-	expected, _ := ToCatenaAsset(dp, false)
+	expected, _ := ToAsset(dp, false)
 
 	handlerCalled := false
-	srv.RegisterGetAssetHandler(0, func(slot uint16, fqoid string) (CatenaAsset, StatusResult) {
+	srv.RegisterGetAssetHandler(0, func(slot uint16, fqoid string) (Asset, StatusResult) {
 		handlerCalled = true
 		return expected, StatusResult{Code: OK}
 	})
@@ -649,12 +649,12 @@ func TestServer_RegisterParamInfoHandler(t *testing.T) {
 	srv := NewServer(100).(*server)
 
 	handlerCalled := false
-	srv.RegisterParamInfoHandler(0, func(slot uint16, oidPrefix string, recursive bool) ([]CatenaParamInfo, StatusResult) {
+	srv.RegisterParamInfoHandler(0, func(slot uint16, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult) {
 		handlerCalled = true
 		if oidPrefix != "test/param" {
 			t.Errorf("expected oidPrefix 'test/param', got %s", oidPrefix)
 		}
-		return []CatenaParamInfo{}, StatusResult{Code: OK}
+		return []ParamInfo{}, StatusResult{Code: OK}
 	})
 
 	actual, _ := srv.InvokeParamInfoHandler(0, "test/param", false)

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -145,7 +145,7 @@ const (
 
 // ResponseType is a constraint for types that can be returned from handlers
 type ResponseType interface {
-	CatenaValue | CatenaAsset | CatenaDevice
+	Value | Asset | Device
 }
 
 // Reply returns a successful response (OK) with the given value.
@@ -162,7 +162,7 @@ func ReplyWithCode[T ResponseType](value T, code StatusCode) (T, StatusResult) {
 
 // ReplyError returns an error response with the given status code and message.
 // The value returned is the zero value of T.
-// Usage: catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "not found")
+// Usage: catena.ReplyError[catena.Value](catena.NOT_FOUND, "not found")
 func ReplyError[T ResponseType](code StatusCode, msg string) (T, StatusResult) {
 	var zero T
 	return zero, StatusResult{Code: code, Error: msg}

--- a/sdks/go/pkg/catena/status_code_test.go
+++ b/sdks/go/pkg/catena/status_code_test.go
@@ -72,8 +72,8 @@ func TestStatusCodeConstants(t *testing.T) {
 	}
 }
 
-func TestReply_CatenaValue(t *testing.T) {
-	value, _ := ToCatenaValue(int32(42))
+func TestReply_Value(t *testing.T) {
+	value, _ := ToValue(int32(42))
 	result, status := Reply(value)
 
 	if status.Code != OK {
@@ -87,12 +87,12 @@ func TestReply_CatenaValue(t *testing.T) {
 	}
 }
 
-func TestReply_CatenaDevice(t *testing.T) {
+func TestReply_Device(t *testing.T) {
 	deviceMap := map[string]any{
 		"slot":         uint32(0),
 		"detail_level": DetailLevelFull,
 	}
-	device, _ := ToCatenaDevice(deviceMap)
+	device, _ := ToDevice(deviceMap)
 	result, status := Reply(device)
 
 	if status.Code != OK {
@@ -103,11 +103,11 @@ func TestReply_CatenaDevice(t *testing.T) {
 	}
 }
 
-func TestReply_CatenaAsset(t *testing.T) {
+func TestReply_Asset(t *testing.T) {
 	dp := DataPayload{
 		Payload: []byte("test"),
 	}
-	asset, _ := ToCatenaAsset(dp, true)
+	asset, _ := ToAsset(dp, true)
 	result, status := Reply(asset)
 
 	if status.Code != OK {
@@ -119,7 +119,7 @@ func TestReply_CatenaAsset(t *testing.T) {
 }
 
 func TestReplyWithCode(t *testing.T) {
-	value, _ := ToCatenaValue(int32(42))
+	value, _ := ToValue(int32(42))
 	result, status := ReplyWithCode(value, CREATED)
 
 	if status.Code != CREATED {
@@ -133,8 +133,8 @@ func TestReplyWithCode(t *testing.T) {
 	}
 }
 
-func TestReplyError_CatenaValue(t *testing.T) {
-	result, status := ReplyError[CatenaValue](NOT_FOUND, "resource not found")
+func TestReplyError_Value(t *testing.T) {
+	result, status := ReplyError[Value](NOT_FOUND, "resource not found")
 
 	if status.Code != NOT_FOUND {
 		t.Errorf("ReplyError status code = %d, want %d", status.Code, NOT_FOUND)
@@ -147,8 +147,8 @@ func TestReplyError_CatenaValue(t *testing.T) {
 	}
 }
 
-func TestReplyError_CatenaDevice(t *testing.T) {
-	result, status := ReplyError[CatenaDevice](INTERNAL, "internal error")
+func TestReplyError_Device(t *testing.T) {
+	result, status := ReplyError[Device](INTERNAL, "internal error")
 
 	if status.Code != INTERNAL {
 		t.Errorf("ReplyError status code = %d, want %d", status.Code, INTERNAL)
@@ -161,8 +161,8 @@ func TestReplyError_CatenaDevice(t *testing.T) {
 	}
 }
 
-func TestReplyError_CatenaAsset(t *testing.T) {
-	result, status := ReplyError[CatenaAsset](UNAVAILABLE, "service unavailable")
+func TestReplyError_Asset(t *testing.T) {
+	result, status := ReplyError[Asset](UNAVAILABLE, "service unavailable")
 
 	if status.Code != UNAVAILABLE {
 		t.Errorf("ReplyError status code = %d, want %d", status.Code, UNAVAILABLE)
@@ -233,9 +233,9 @@ func TestStatusCode_Values(t *testing.T) {
 // TestResponseType_Constraint verifies the generic constraint works
 func TestResponseType_Constraint(t *testing.T) {
 	// These should all compile and work
-	var _ func(CatenaValue) (CatenaValue, StatusResult) = Reply[CatenaValue]
-	var _ func(CatenaDevice) (CatenaDevice, StatusResult) = Reply[CatenaDevice]
-	var _ func(CatenaAsset) (CatenaAsset, StatusResult) = Reply[CatenaAsset]
+	var _ func(Value) (Value, StatusResult) = Reply[Value]
+	var _ func(Device) (Device, StatusResult) = Reply[Device]
+	var _ func(Asset) (Asset, StatusResult) = Reply[Asset]
 }
 
 func TestReplyError_AllStatusCodes(t *testing.T) {
@@ -248,7 +248,7 @@ func TestReplyError_AllStatusCodes(t *testing.T) {
 
 	for i, code := range codes {
 		t.Run(fmt.Sprintf("StatusCode_%d", code), func(t *testing.T) {
-			result, status := ReplyError[CatenaValue](code, "test error")
+			result, status := ReplyError[Value](code, "test error")
 			if status.Code != code {
 				t.Errorf("test %d: ReplyError code = %d, want %d", i, status.Code, code)
 			}

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -45,7 +45,7 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-type CatenaValue struct {
+type Value struct {
 	Value *protos.Value
 }
 
@@ -95,12 +95,12 @@ const (
 	ConstraintTypeAlarmTable         ConstraintType = protos.Constraint_ALARM_TABLE
 )
 
-func ToCatenaValue(v any) (CatenaValue, StatusResult) {
+func ToValue(v any) (Value, StatusResult) {
 	val, res := ToProto(v)
 	if res.Code != OK {
-		return CatenaValue{}, StatusResult{Code: res.Code, Error: "ToCatenaValue: " + res.Error}
+		return Value{}, StatusResult{Code: res.Code, Error: "ToValue: " + res.Error}
 	}
-	return CatenaValue{Value: val}, StatusResult{Code: OK}
+	return Value{Value: val}, StatusResult{Code: OK}
 }
 
 // ToProto converts native Go types to protos.Value

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-func TestToCatenaValue(t *testing.T) {
+func TestToValue(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   any
@@ -68,19 +68,19 @@ func TestToCatenaValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cv, err := ToCatenaValue(tt.input)
+			cv, err := ToValue(tt.input)
 			if tt.wantErr {
 				if err.Code == OK {
-					t.Errorf("ToCatenaValue(%v) expected error, got nil", tt.input)
+					t.Errorf("ToValue(%v) expected error, got nil", tt.input)
 				}
 				return
 			}
 			if err.Code != OK {
-				t.Errorf("ToCatenaValue(%v) unexpected error: %v", tt.input, err.Error)
+				t.Errorf("ToValue(%v) unexpected error: %v", tt.input, err.Error)
 				return
 			}
 			if cv.Value == nil {
-				t.Errorf("ToCatenaValue(%v) returned nil Value", tt.input)
+				t.Errorf("ToValue(%v) returned nil Value", tt.input)
 			}
 		})
 	}

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -239,15 +239,15 @@ func TestGrpcTransport_DeviceRequest_Success(t *testing.T) {
 
 	// Register mock handler
 	handlerCalled := false
-	runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
+	runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
 		deviceMap := map[string]any{
 			"slot":         uint32(slot),
 			"detail_level": catena.DetailLevelFull,
 		}
-		device, err := catena.ToCatenaDevice(deviceMap)
+		device, err := catena.ToDevice(deviceMap)
 		if err != nil {
-			t.Fatalf("ToCatenaDevice failed: %v", err)
+			t.Fatalf("ToDevice failed: %v", err)
 		}
 		return catena.Reply(device)
 	}
@@ -314,8 +314,8 @@ func TestGrpcTransport_DeviceRequest_HandlerError(t *testing.T) {
 	defer cleanup()
 
 	// Register handler that returns error
-	runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
-		return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
+	runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
+		return catena.ReplyError[catena.Device](catena.NOT_FOUND, "device not found")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -389,11 +389,11 @@ func TestGrpcTransport_GetValue_Success(t *testing.T) {
 			_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 			defer cleanup()
 
-			runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+			runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
 				if fqoid != "device.param1" {
 					t.Errorf("expected fqoid 'device.param1', got %s", fqoid)
 				}
-				value, _ := catena.ToCatenaValue(tt.handlerValue)
+				value, _ := catena.ToValue(tt.handlerValue)
 				return catena.Reply(value)
 			}
 
@@ -424,8 +424,8 @@ func TestGrpcTransport_GetValue_HandlerError(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "param not supported")
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
+		return catena.ReplyError[catena.Value](catena.NOT_FOUND, "param not supported")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -628,13 +628,13 @@ func TestGrpcTransport_ExternalObjectRequest_Success(t *testing.T) {
 	defer cleanup()
 
 	handlerCalled := false
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		handlerCalled = true
 		if fqoid != "device.image1" {
 			t.Errorf("expected fqoid 'device.image1', got %s", fqoid)
 		}
 		payload := catena.ToPayloadFromURL("http://example.com/asset.jpg")
-		asset, _ := catena.ToCatenaAsset(payload, true)
+		asset, _ := catena.ToAsset(payload, true)
 		return catena.Reply(asset)
 	}
 
@@ -678,8 +678,8 @@ func TestGrpcTransport_ExternalObjectRequest_HandlerError(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
-		return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "asset not found")
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
+		return catena.ReplyError[catena.Asset](catena.NOT_FOUND, "asset not found")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -705,7 +705,7 @@ func TestGrpcTransport_ParamInfoRequest_Success(t *testing.T) {
 	defer cleanup()
 
 	handlerCalled := false
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		handlerCalled = true
 		if oidPrefix != "parent" {
 			t.Errorf("expected oidPrefix 'parent', got %s", oidPrefix)
@@ -713,7 +713,7 @@ func TestGrpcTransport_ParamInfoRequest_Success(t *testing.T) {
 		if !recursive {
 			t.Error("expected recursive=true")
 		}
-		return []catena.CatenaParamInfo{
+		return []catena.ParamInfo{
 			catena.NewParamInfo("parent", catena.NewPolyglotText("en", "Parent"), catena.ParamTypeStruct, "", 0),
 			catena.NewParamInfo("parent/child", nil, catena.ParamTypeInt32, "", 0),
 			catena.NewParamInfo("parent/arr", nil, catena.ParamTypeStringArray, "", 5),
@@ -757,14 +757,14 @@ func TestGrpcTransport_ParamInfoRequest_TopLevel(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		if oidPrefix != "" {
 			t.Errorf("expected empty oidPrefix, got %q", oidPrefix)
 		}
 		if recursive {
 			t.Error("expected recursive=false")
 		}
-		return []catena.CatenaParamInfo{
+		return []catena.ParamInfo{
 			catena.NewParamInfo("a", nil, catena.ParamTypeInt32, "", 0),
 			catena.NewParamInfo("b", nil, catena.ParamTypeFloat32, "", 0),
 		}, catena.StatusWithCode(catena.OK, "")
@@ -795,7 +795,7 @@ func TestGrpcTransport_ParamInfoRequest_HandlerError(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		return nil, catena.StatusWithCode(catena.NOT_FOUND, "param not found")
 	}
 
@@ -819,7 +819,7 @@ func TestGrpcTransport_ParamInfoRequest_EmptyResult_NotFound(t *testing.T) {
 		_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 		defer cleanup()
 
-		runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+		runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 			return nil, catena.StatusWithCode(catena.OK, "")
 		}
 
@@ -840,7 +840,7 @@ func TestGrpcTransport_ParamInfoRequest_EmptyResult_NotFound(t *testing.T) {
 		_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 		defer cleanup()
 
-		runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+		runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 			return nil, catena.StatusWithCode(catena.OK, "")
 		}
 
@@ -892,7 +892,7 @@ func TestGrpcTransport_ExecuteCommand_WithResponse(t *testing.T) {
 		if payload == nil {
 			t.Error("expected non-nil payload")
 		}
-		value, _ := catena.ToCatenaValue(string("Command executed"))
+		value, _ := catena.ToValue(string("Command executed"))
 		return catena.CommandReply(value)
 	}
 
@@ -945,7 +945,7 @@ func TestGrpcTransport_ExecuteCommand_NilPayload(t *testing.T) {
 		} else {
 			receivedPayload = "nil"
 		}
-		value, _ := catena.ToCatenaValue(string("OK"))
+		value, _ := catena.ToValue(string("OK"))
 		return catena.CommandReply(value)
 	}
 
@@ -1154,8 +1154,8 @@ func TestGrpcTransport_ErrorMessages_DevVsProd(t *testing.T) {
 			devMessage: "param not supported",
 			grpcCode:   codes.Unimplemented,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-					return catena.ReplyError[catena.CatenaValue](catena.UNIMPLEMENTED, "param not supported")
+				runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
+					return catena.ReplyError[catena.Value](catena.UNIMPLEMENTED, "param not supported")
 				}
 			},
 			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
@@ -1334,8 +1334,8 @@ func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
 			devMessage: "device not found",
 			grpcCode:   codes.NotFound,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
-					return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
+				runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
+					return catena.ReplyError[catena.Device](catena.NOT_FOUND, "device not found")
 				}
 			},
 			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
@@ -1352,8 +1352,8 @@ func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
 			devMessage: "asset not found",
 			grpcCode:   codes.NotFound,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
-					return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "asset not found")
+				runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
+					return catena.ReplyError[catena.Asset](catena.NOT_FOUND, "asset not found")
 				}
 			},
 			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
@@ -1388,7 +1388,7 @@ func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
 			devMessage: "param not found",
 			grpcCode:   codes.NotFound,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+				runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 					return nil, catena.StatusResult{Code: catena.NOT_FOUND, Error: "param not found"}
 				}
 			},
@@ -1674,8 +1674,8 @@ func TestGrpcTransport_ConcurrentClients(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-		value, _ := catena.ToCatenaValue(int32(42))
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
+		value, _ := catena.ToValue(int32(42))
 		return catena.Reply(value)
 	}
 
@@ -1711,16 +1711,16 @@ func TestGrpcTransport_DifferentHandlersPerSlot(t *testing.T) {
 	defer cleanup()
 
 	// Register different handlers for each slot
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
 		if slot == 0 {
-			value, _ := catena.ToCatenaValue(int32(100))
+			value, _ := catena.ToValue(int32(100))
 			return catena.Reply(value)
 		}
 		if slot == 1 {
-			value, _ := catena.ToCatenaValue(int32(200))
+			value, _ := catena.ToValue(int32(200))
 			return catena.Reply(value)
 		}
-		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "slot not found")
+		return catena.ReplyError[catena.Value](catena.NOT_FOUND, "slot not found")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -1767,17 +1767,17 @@ func TestGrpcTransport_Start_EndpointsReachable(t *testing.T) {
 	}
 
 	// Register handlers
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-		value, _ := catena.ToCatenaValue(int32(42))
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
+		value, _ := catena.ToValue(int32(42))
 		return catena.Reply(value)
 	}
 
-	runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
+	runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
 		deviceMap := map[string]any{
 			"slot":         uint32(slot),
 			"detail_level": catena.DetailLevelFull,
 		}
-		device, _ := catena.ToCatenaDevice(deviceMap)
+		device, _ := catena.ToDevice(deviceMap)
 		return catena.Reply(device)
 	}
 
@@ -2038,8 +2038,8 @@ func TestGrpcTransport_MultipleClients_RealNetwork(t *testing.T) {
 	}
 
 	runtime := makeStubServerRuntime(t)
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
-		value, _ := catena.ToCatenaValue(int32(99))
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
+		value, _ := catena.ToValue(int32(99))
 		return catena.Reply(value)
 	}
 

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -555,7 +555,7 @@ func TestInjectJSONField_PushUpdatesSlotZero(t *testing.T) {
 // --- MarshalDeviceJSON tests (migrated from catena/device_test.go) ---
 
 func TestMarshalDeviceJSON(t *testing.T) {
-	cd, err := catena.ToCatenaDevice(map[string]any{
+	cd, err := catena.ToDevice(map[string]any{
 		"slot":         uint32(0),
 		"detail_level": catena.DetailLevelFull,
 		"params": map[string]any{
@@ -570,7 +570,7 @@ func TestMarshalDeviceJSON(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 
 	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
@@ -591,7 +591,7 @@ func TestMarshalDeviceJSON(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
-	cd, err := catena.ToCatenaDevice(map[string]any{
+	cd, err := catena.ToDevice(map[string]any{
 		"slot":         uint32(0),
 		"detail_level": catena.DetailLevelFull,
 		"params": map[string]any{
@@ -604,7 +604,7 @@ func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 
 	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
@@ -635,11 +635,11 @@ func TestMarshalDeviceJSON_Nil(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
-	cd, err := catena.ToCatenaDevice(map[string]any{
+	cd, err := catena.ToDevice(map[string]any{
 		"slot": uint32(5),
 	})
 	if err != nil {
-		t.Fatalf("ToCatenaDevice: %v", err)
+		t.Fatalf("ToDevice: %v", err)
 	}
 	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
 	if err2 != nil {
@@ -652,12 +652,12 @@ func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
-	cd, err := catena.ToCatenaDevice(map[string]any{
+	cd, err := catena.ToDevice(map[string]any{
 		"slot":         uint32(0),
 		"detail_level": catena.DetailLevelFull,
 	})
 	if err != nil {
-		t.Fatalf("ToCatenaDevice: %v", err)
+		t.Fatalf("ToDevice: %v", err)
 	}
 	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
 	if err2 != nil {
@@ -676,7 +676,7 @@ func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
-	cd, err := catena.ToCatenaDevice(map[string]any{
+	cd, err := catena.ToDevice(map[string]any{
 		"slot": uint32(0),
 		"params": map[string]any{
 			"brightness": map[string]any{
@@ -690,7 +690,7 @@ func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("ToCatenaDevice: %v", err)
+		t.Fatalf("ToDevice: %v", err)
 	}
 	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
 	if err2 != nil {
@@ -795,7 +795,7 @@ func TestCleanDeviceJSON(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_CompleteDevice(t *testing.T) {
-	cd, err := catena.ToCatenaDevice(map[string]any{
+	cd, err := catena.ToDevice(map[string]any{
 		"slot":              uint32(0),
 		"detail_level":      catena.DetailLevelFull,
 		"multi_set_enabled": true,
@@ -837,7 +837,7 @@ func TestMarshalDeviceJSON_CompleteDevice(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("ToCatenaDevice error: %v", err)
+		t.Fatalf("ToDevice error: %v", err)
 	}
 
 	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
@@ -988,9 +988,9 @@ func TestMarshalAssetJSON(t *testing.T) {
 		Payload: []byte("binary data"),
 	}
 
-	asset, res := catena.ToCatenaAsset(dp, true)
+	asset, res := catena.ToAsset(dp, true)
 	if res.Code != catena.OK {
-		t.Fatalf("ToCatenaAsset error: %v", res.Error)
+		t.Fatalf("ToAsset error: %v", res.Error)
 	}
 
 	jsonData, err := MarshalAssetJSON(asset.GetProtoAsset())

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -53,7 +53,7 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-type FallbackHandler func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult)
+type FallbackHandler func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult)
 
 type RestTransport struct {
 	mu              sync.Mutex
@@ -175,11 +175,11 @@ func writeHTTPResult(w http.ResponseWriter, result catena.StatusResult, value in
 
 	// Handle different value types (no error case)
 	switch v := value.(type) {
-	case catena.CatenaValue:
+	case catena.Value:
 		writeValueResult(w, v, httpStatus)
-	case catena.CatenaDevice:
+	case catena.Device:
 		writeDeviceResult(w, v, httpStatus)
-	case catena.CatenaAsset:
+	case catena.Asset:
 		writeAssetResult(w, v, httpStatus)
 	default:
 		w.WriteHeader(httpStatus)
@@ -204,8 +204,8 @@ func writeHTTPStatusResult(w http.ResponseWriter, result catena.StatusResult) {
 	}
 }
 
-// writeValueResult writes a CatenaValue as JSON
-func writeValueResult(w http.ResponseWriter, value catena.CatenaValue, httpStatus int) {
+// writeValueResult writes a Value as JSON
+func writeValueResult(w http.ResponseWriter, value catena.Value, httpStatus int) {
 	protoValue := value.Value
 	if protoValue == nil {
 		w.WriteHeader(httpStatus)
@@ -218,8 +218,8 @@ func writeValueResult(w http.ResponseWriter, value catena.CatenaValue, httpStatu
 	}
 }
 
-// writeDeviceResult writes a CatenaDevice as JSON
-func writeDeviceResult(w http.ResponseWriter, device catena.CatenaDevice, httpStatus int) {
+// writeDeviceResult writes a Device as JSON
+func writeDeviceResult(w http.ResponseWriter, device catena.Device, httpStatus int) {
 	if device.GetProtoDevice() == nil {
 		w.WriteHeader(httpStatus)
 		return
@@ -241,8 +241,8 @@ func writeDeviceResult(w http.ResponseWriter, device catena.CatenaDevice, httpSt
 	}
 }
 
-// writeAssetResult writes a CatenaAsset as JSON-encoded ExternalObjectPayload
-func writeAssetResult(w http.ResponseWriter, asset catena.CatenaAsset, httpStatus int) {
+// writeAssetResult writes an Asset as JSON-encoded ExternalObjectPayload
+func writeAssetResult(w http.ResponseWriter, asset catena.Asset, httpStatus int) {
 	protoAsset := asset.GetProtoAsset()
 	if protoAsset == nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -287,7 +287,7 @@ func (t *RestTransport) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher
 func (t *RestTransport) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Check if the request method is GET
 	if r.Method != http.MethodGet {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
+		val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -295,7 +295,7 @@ func (t *RestTransport) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Check if SSE streaming is supported
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "streaming not supported")
+		val, res := catena.ReplyError[catena.Value](catena.INTERNAL, "streaming not supported")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -310,7 +310,7 @@ func (t *RestTransport) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// so one transport can shut down without impacting streams owned by others.
 	connID, conn := t.runtime.RegisterTransportConnection(t)
 	if connID < 0 {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.RESOURCE_EXHAUSTED, "Too many connections to service")
+		val, res := catena.ReplyError[catena.Value](catena.RESOURCE_EXHAUSTED, "Too many connections to service")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -358,7 +358,7 @@ func (t *RestTransport) registerRoutes() {
 		logger.Info("Device endpoint", "path", r.URL.Path, "method", r.Method)
 		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
 		if len(parts) < 3 {
-			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid path format")
+			val, res := catena.ReplyError[catena.Value](catena.INVALID_ARGUMENT, "invalid path format")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -366,7 +366,7 @@ func (t *RestTransport) registerRoutes() {
 		slotStr := parts[2]
 		slot, err := catena.ValidateSlotString(slotStr)
 		if err.Code != catena.OK {
-			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid slot number")
+			val, res := catena.ReplyError[catena.Value](catena.INVALID_ARGUMENT, "invalid slot number")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -391,20 +391,20 @@ func (t *RestTransport) registerRoutes() {
 			case "param-info":
 				t.handleParamInfoEndpoint(w, r, slot, parts[4:])
 			default:
-				val, res := catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "unknown endpoint")
+				val, res := catena.ReplyError[catena.Value](catena.NOT_FOUND, "unknown endpoint")
 				writeHTTPResult(w, res, val)
 			}
 			return
 		}
 
-		val, res := catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
+		val, res := catena.ReplyError[catena.Value](catena.NOT_FOUND, "endpoint not found")
 		writeHTTPResult(w, res, val)
 	})
 
 	// Health endpoint: GET /st2138-api/v1/health
 	t.mux.HandleFunc("/st2138-api/v1/health", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
+			val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -425,7 +425,7 @@ func (t *RestTransport) registerRoutes() {
 			writeHTTPResult(w, res, val)
 			return
 		}
-		val, res := catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "endpoint not found")
+		val, res := catena.ReplyError[catena.Value](catena.NOT_FOUND, "endpoint not found")
 		writeHTTPResult(w, res, val)
 	})
 
@@ -438,7 +438,7 @@ func (t *RestTransport) registerRoutes() {
 // Returns the list of populated slots
 func (t *RestTransport) handleGetPopulatedSlots(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
+		val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -482,7 +482,7 @@ func (t *RestTransport) handleValueEndpoint(w http.ResponseWriter, r *http.Reque
 		nativeValue, errProto := catena.FromProto(reqValue)
 		if errProto.Code != catena.OK {
 			logger.Error("failed to convert proto value to native Go type", "error", errProto.Error)
-			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid request body")
+			val, res := catena.ReplyError[catena.Value](catena.INVALID_ARGUMENT, "invalid request body")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -491,14 +491,14 @@ func (t *RestTransport) handleValueEndpoint(w http.ResponseWriter, r *http.Reque
 		writeHTTPStatusResult(w, res)
 
 	default:
-		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET, PUT, PATCH allowed")
+		val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only GET, PUT, PATCH allowed")
 		writeHTTPResult(w, res, val)
 	}
 }
 
 func (t *RestTransport) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slot uint16, pathParts []string) {
 	if r.Method != http.MethodGet {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
+		val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -510,14 +510,14 @@ func (t *RestTransport) handleAssetEndpoint(w http.ResponseWriter, r *http.Reque
 		if compressionStr := r.URL.Query().Get("compression"); compressionStr != "" {
 			targetEncoding, encRes := catena.ParsePayloadEncoding(compressionStr)
 			if encRes.Code != catena.OK {
-				_, errRes := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, encRes.Error)
-				writeHTTPResult(w, errRes, catena.CatenaValue{})
+				_, errRes := catena.ReplyError[catena.Value](catena.INVALID_ARGUMENT, encRes.Error)
+				writeHTTPResult(w, errRes, catena.Value{})
 				return
 			}
 			if tcRes := catena.TranscodeAssetPayload(&asset, targetEncoding); tcRes.Code != catena.OK {
 				logger.Error("failed to transcode asset payload", "error", tcRes.Error)
-				_, errRes := catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "failed to transcode payload: "+tcRes.Error)
-				writeHTTPResult(w, errRes, catena.CatenaValue{})
+				_, errRes := catena.ReplyError[catena.Value](catena.INTERNAL, "failed to transcode payload: "+tcRes.Error)
+				writeHTTPResult(w, errRes, catena.Value{})
 				return
 			}
 		}
@@ -529,7 +529,7 @@ func (t *RestTransport) handleAssetEndpoint(w http.ResponseWriter, r *http.Reque
 // handleParamInfoEndpoint handles param info requests and streaming (SSE).
 func (t *RestTransport) handleParamInfoEndpoint(w http.ResponseWriter, r *http.Request, slot uint16, pathParts []string) {
 	if r.Method != http.MethodGet {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only GET allowed")
+		val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only GET allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -588,10 +588,10 @@ func (t *RestTransport) handleParamInfoEndpoint(w http.ResponseWriter, r *http.R
 }
 
 // writeParamInfoStream streams the param info entries to the client as Server-Sent Events.
-func (t *RestTransport) writeParamInfoStream(w http.ResponseWriter, r *http.Request, infos []catena.CatenaParamInfo) {
+func (t *RestTransport) writeParamInfoStream(w http.ResponseWriter, r *http.Request, infos []catena.ParamInfo) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.INTERNAL, "streaming not supported")
+		val, res := catena.ReplyError[catena.Value](catena.INTERNAL, "streaming not supported")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -629,7 +629,7 @@ func (t *RestTransport) writeParamInfoStream(w http.ResponseWriter, r *http.Requ
 
 func (t *RestTransport) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, slot uint16, pathParts []string) {
 	if r.Method != http.MethodPost {
-		val, res := catena.ReplyError[catena.CatenaValue](catena.METHOD_NOT_ALLOWED, "only POST allowed")
+		val, res := catena.ReplyError[catena.Value](catena.METHOD_NOT_ALLOWED, "only POST allowed")
 		writeHTTPResult(w, res, val)
 		return
 	}
@@ -647,7 +647,7 @@ func (t *RestTransport) handleCommandEndpoint(w http.ResponseWriter, r *http.Req
 		reqValue, err := ReadRequestJSON(r)
 		if err.Code != catena.OK {
 			logger.Error("failed to read command payload", "error", err)
-			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid command payload")
+			val, res := catena.ReplyError[catena.Value](catena.INVALID_ARGUMENT, "invalid command payload")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -655,7 +655,7 @@ func (t *RestTransport) handleCommandEndpoint(w http.ResponseWriter, r *http.Req
 		payload, errProto = catena.FromProto(reqValue)
 		if errProto.Code != catena.OK {
 			logger.Error("failed to convert proto value to native Go type", "error", errProto.Error)
-			val, res := catena.ReplyError[catena.CatenaValue](catena.INVALID_ARGUMENT, "invalid command payload")
+			val, res := catena.ReplyError[catena.Value](catena.INVALID_ARGUMENT, "invalid command payload")
 			writeHTTPResult(w, res, val)
 			return
 		}
@@ -663,7 +663,7 @@ func (t *RestTransport) handleCommandEndpoint(w http.ResponseWriter, r *http.Req
 
 	cmdResult, res := t.runtime.InvokeExecuteCommandHandler(slot, commandFqoid, payload)
 	if res.Code != catena.OK {
-		writeHTTPResult(w, res, catena.CatenaValue{})
+		writeHTTPResult(w, res, catena.Value{})
 		return
 	}
 

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -94,9 +94,9 @@ func TestRestTransport_GetDevice_Route(t *testing.T) {
 		"slot":         uint32(0),
 		"detail_level": catena.DetailLevelFull,
 	}
-	device, _ := catena.ToCatenaDevice(deviceMap)
+	device, _ := catena.ToDevice(deviceMap)
 
-	runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
+	runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
 		if slot != 0 {
 			t.Errorf("expected slot 0, got %d", slot)
@@ -116,12 +116,12 @@ func TestRestTransport_GetDevice_NotFound(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
+	runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
 		if slot != 99 {
 			t.Errorf("expected slot 99, got %d", slot)
 		}
-		return catena.ReplyError[catena.CatenaDevice](catena.NOT_FOUND, "device not found")
+		return catena.ReplyError[catena.Device](catena.NOT_FOUND, "device not found")
 	}
 
 	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/99", "")
@@ -137,12 +137,12 @@ func TestRestTransport_GetDevice_InvalidSlot(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.getDeviceFn = func(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
+	runtime.getDeviceFn = func(slot uint16) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
 		if slot != 0 {
 			t.Errorf("expected slot 0, got %d", slot)
 		}
-		return catena.ReplyError[catena.CatenaDevice](catena.INVALID_ARGUMENT, "invalid slot")
+		return catena.ReplyError[catena.Device](catena.INVALID_ARGUMENT, "invalid slot")
 	}
 
 	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/invalid", "")
@@ -157,8 +157,8 @@ func TestRestTransport_GetDevice_InvalidSlot(t *testing.T) {
 func TestRestTransport_GetValue_Route(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	value, _ := catena.ToCatenaValue(int32(42))
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+	value, _ := catena.ToValue(int32(42))
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
 		if fqoid != "brightness" {
 			t.Errorf("expected fqoid 'brightness', got %s", fqoid)
 		}
@@ -219,9 +219,9 @@ func TestRestTransport_GetAsset_Route(t *testing.T) {
 		Metadata: map[string]string{"content-type": "image/png"},
 		Payload:  []byte("fake image"),
 	}
-	asset, _ := catena.ToCatenaAsset(dp, true)
+	asset, _ := catena.ToAsset(dp, true)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		return catena.Reply(asset)
 	}
 
@@ -233,9 +233,9 @@ func TestRestTransport_GetAsset_MethodNotAllowed(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		handlerCalled = true
-		return catena.Reply(catena.CatenaAsset{})
+		return catena.Reply(catena.Asset{})
 	}
 
 	makeRequest(t, transport, http.MethodPost, "/st2138-api/v1/0/asset/logo", "")
@@ -277,7 +277,7 @@ func TestRestTransport_ExecuteCommand_WithPayload(t *testing.T) {
 		if payload == nil {
 			t.Error("expected payload to be non-nil")
 		}
-		val, _ := catena.ToCatenaValue(payload)
+		val, _ := catena.ToValue(payload)
 		return catena.CommandReply(val)
 	}
 
@@ -457,9 +457,9 @@ func TestRestTransport_Fallback_Route(t *testing.T) {
 	transport, _ := makeTestRestTransport(t)
 
 	handlerCalled := false
-	transport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
+	transport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult) {
 		handlerCalled = true
-		return catena.ReplyError[catena.CatenaValue](catena.NOT_FOUND, "custom not found")
+		return catena.ReplyError[catena.Value](catena.NOT_FOUND, "custom not found")
 	})
 
 	rec := makeRequest(t, transport, http.MethodGet, "/unknown/path", "")
@@ -472,11 +472,11 @@ func TestRestTransport_Fallback_Route(t *testing.T) {
 func TestRestTransport_NestedValuePath(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.getValueFn = func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+	runtime.getValueFn = func(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
 		if fqoid != "nested/path/to/param" {
 			t.Errorf("expected fqoid 'nested/path/to/param', got %s", fqoid)
 		}
-		value, _ := catena.ToCatenaValue(int32(1))
+		value, _ := catena.ToValue(int32(1))
 		return catena.Reply(value)
 	}
 
@@ -518,7 +518,7 @@ func TestWriteHTTPResult_Error(t *testing.T) {
 		Code:  catena.NOT_FOUND,
 		Error: "test error message",
 	}
-	writeHTTPResult(rec, result, catena.CatenaValue{})
+	writeHTTPResult(rec, result, catena.Value{})
 
 	errMsg := assertHasError(t, rec)
 	if errMsg != "test error message" {
@@ -551,7 +551,7 @@ func TestRestTransport_ErrorMessages_DevVsProd(t *testing.T) {
 
 			rec := httptest.NewRecorder()
 			result := catena.StatusResult{Code: catena.NOT_FOUND, Error: "detailed error"}
-			writeHTTPResult(rec, result, catena.CatenaValue{})
+			writeHTTPResult(rec, result, catena.Value{})
 
 			assertBodyContains(t, rec, tt.expected)
 		})
@@ -564,9 +564,9 @@ func TestWriteFunctions_NilValues(t *testing.T) {
 		fn             func(http.ResponseWriter)
 		expectedStatus int
 	}{
-		{"nil value", func(w http.ResponseWriter) { writeValueResult(w, catena.CatenaValue{}, http.StatusOK) }, http.StatusOK},
-		{"nil device", func(w http.ResponseWriter) { writeDeviceResult(w, catena.CatenaDevice{}, http.StatusOK) }, http.StatusOK},
-		{"nil asset", func(w http.ResponseWriter) { writeAssetResult(w, catena.CatenaAsset{}, http.StatusOK) }, http.StatusInternalServerError},
+		{"nil value", func(w http.ResponseWriter) { writeValueResult(w, catena.Value{}, http.StatusOK) }, http.StatusOK},
+		{"nil device", func(w http.ResponseWriter) { writeDeviceResult(w, catena.Device{}, http.StatusOK) }, http.StatusOK},
+		{"nil asset", func(w http.ResponseWriter) { writeAssetResult(w, catena.Asset{}, http.StatusOK) }, http.StatusInternalServerError},
 	}
 
 	for _, tt := range tests {
@@ -678,13 +678,13 @@ func TestRestTransport_Connect_TooManyConnections(t *testing.T) {
 }
 
 func TestWriteResults_ValidData(t *testing.T) {
-	device, _ := catena.ToCatenaDevice(map[string]any{"slot": int32(0)})
+	device, _ := catena.ToDevice(map[string]any{"slot": int32(0)})
 	rec := httptest.NewRecorder()
 	writeDeviceResult(rec, device, http.StatusOK)
 	assertStatus(t, rec, http.StatusOK)
 	assertContentType(t, rec, "application/json")
 
-	asset, _ := catena.ToCatenaAsset(catena.DataPayload{Payload: []byte("data")}, false)
+	asset, _ := catena.ToAsset(catena.DataPayload{Payload: []byte("data")}, false)
 	rec = httptest.NewRecorder()
 	writeAssetResult(rec, asset, http.StatusOK)
 	assertStatus(t, rec, http.StatusOK)
@@ -711,7 +711,7 @@ func TestCommandEndpoint_FromProtoError(t *testing.T) {
 func TestCommandEndpoint_ResponseValue(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 	runtime.commandFn = func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
-		val, _ := catena.ToCatenaValue("command executed")
+		val, _ := catena.ToValue("command executed")
 		return catena.CommandReply(val)
 	}
 
@@ -781,7 +781,7 @@ func TestCommandEndpoint_RespondFalse(t *testing.T) {
 	handlerCalled := false
 	runtime.commandFn = func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
 		handlerCalled = true
-		val, _ := catena.ToCatenaValue("should be thrown away")
+		val, _ := catena.ToValue("should be thrown away")
 		return catena.CommandReply(val)
 	}
 
@@ -805,7 +805,7 @@ func TestCommandEndpoint_RespondFalse(t *testing.T) {
 func TestCommandEndpoint_RespondTrue(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 	runtime.commandFn = func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
-		val, _ := catena.ToCatenaValue(int32(42))
+		val, _ := catena.ToValue(int32(42))
 		return catena.CommandReply(val)
 	}
 
@@ -821,7 +821,7 @@ func TestCommandEndpoint_RespondTrue(t *testing.T) {
 func TestCommandEndpoint_RespondDefaultIsTrue(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 	runtime.commandFn = func(slot uint16, fqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
-		val, _ := catena.ToCatenaValue(int32(42))
+		val, _ := catena.ToValue(int32(42))
 		return catena.CommandReply(val)
 	}
 
@@ -1032,9 +1032,9 @@ func TestRestTransport_GetAsset_CompressionQueryParam_Gzip(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  []byte("test asset data for compression"),
 	}
-	asset, _ := catena.ToCatenaAsset(dp, true)
+	asset, _ := catena.ToAsset(dp, true)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		return catena.Reply(asset)
 	}
 
@@ -1063,9 +1063,9 @@ func TestRestTransport_GetAsset_CompressionQueryParam_Deflate(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  []byte("test asset data for compression"),
 	}
-	asset, _ := catena.ToCatenaAsset(dp, true)
+	asset, _ := catena.ToAsset(dp, true)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		return catena.Reply(asset)
 	}
 
@@ -1097,9 +1097,9 @@ func TestRestTransport_GetAsset_CompressionQueryParam_Uncompressed(t *testing.T)
 		Payload:         gzData,
 		PayloadEncoding: catena.EncodingGzip,
 	}
-	asset, _ := catena.ToCatenaAsset(dp, true)
+	asset, _ := catena.ToAsset(dp, true)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		return catena.Reply(asset)
 	}
 
@@ -1161,7 +1161,7 @@ func TestRestTransport_Connect_WithOrigin(t *testing.T) {
 }
 
 func TestWriteValueResult_WriteError(t *testing.T) {
-	value, _ := catena.ToCatenaValue(int32(1))
+	value, _ := catena.ToValue(int32(1))
 	rec := httptest.NewRecorder()
 	w := &failWriter{ResponseWriter: rec, failOnWrite: true}
 
@@ -1173,7 +1173,7 @@ func TestWriteValueResult_WriteError(t *testing.T) {
 }
 
 func TestWriteDeviceResult_WriteError(t *testing.T) {
-	device, _ := catena.ToCatenaDevice(map[string]any{"slot": int32(0)})
+	device, _ := catena.ToDevice(map[string]any{"slot": int32(0)})
 	rec := httptest.NewRecorder()
 	w := &failWriter{ResponseWriter: rec, failOnWrite: true}
 
@@ -1183,7 +1183,7 @@ func TestWriteDeviceResult_WriteError(t *testing.T) {
 }
 
 func TestWriteAssetResult_WriteError(t *testing.T) {
-	asset, _ := catena.ToCatenaAsset(catena.DataPayload{Payload: []byte("x")}, false)
+	asset, _ := catena.ToAsset(catena.DataPayload{Payload: []byte("x")}, false)
 	rec := httptest.NewRecorder()
 	w := &failWriter{ResponseWriter: rec, failOnWrite: true}
 
@@ -1199,7 +1199,7 @@ func TestWriteHTTPResult_WithError_NonDev(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	result := catena.StatusResult{Code: catena.NOT_FOUND, Error: "internal detail"}
-	writeHTTPResult(rec, result, catena.CatenaValue{})
+	writeHTTPResult(rec, result, catena.Value{})
 
 	assertBodyNotContains(t, rec, "internal detail")
 }
@@ -1341,9 +1341,9 @@ func TestRestTransport_GetAsset_CompressionQueryParam_Invalid(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  []byte("test data"),
 	}
-	asset, _ := catena.ToCatenaAsset(dp, true)
+	asset, _ := catena.ToAsset(dp, true)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		return catena.Reply(asset)
 	}
 
@@ -1363,9 +1363,9 @@ func TestRestTransport_GetAsset_NoCompressionParam(t *testing.T) {
 		Metadata: map[string]string{"content-type": "text/plain"},
 		Payload:  []byte("uncompressed data"),
 	}
-	asset, _ := catena.ToCatenaAsset(dp, true)
+	asset, _ := catena.ToAsset(dp, true)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 		return catena.Reply(asset)
 	}
 
@@ -1381,8 +1381,8 @@ func TestRestTransport_GetAsset_NoCompressionParam(t *testing.T) {
 func TestRestTransport_GetAsset_CompressionWithError(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
-		return catena.ReplyError[catena.CatenaAsset](catena.NOT_FOUND, "asset not found")
+	runtime.getAssetFn = func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
+		return catena.ReplyError[catena.Asset](catena.NOT_FOUND, "asset not found")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/missing?compression=GZIP", nil)
@@ -1402,7 +1402,7 @@ func TestRestTransport_ParamInfo_UnaryRoute(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		handlerCalled = true
 		// Mirroring the C++ controller, REST builds the fqoid by prepending "/"
 		// to each path segment after the endpoint.
@@ -1412,7 +1412,7 @@ func TestRestTransport_ParamInfo_UnaryRoute(t *testing.T) {
 		if recursive {
 			t.Error("expected recursive=false for unary call")
 		}
-		return []catena.CatenaParamInfo{
+		return []catena.ParamInfo{
 			catena.NewParamInfo("text_box", catena.NewPolyglotText("en", "Text Box"), catena.ParamTypeString, "", 0),
 		}, catena.StatusWithCode(catena.OK, "")
 	}
@@ -1442,9 +1442,9 @@ func TestRestTransport_ParamInfo_NestedFqoid(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	receivedOidPrefix := ""
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		receivedOidPrefix = oidPrefix
-		return []catena.CatenaParamInfo{
+		return []catena.ParamInfo{
 			catena.NewParamInfo(oidPrefix, nil, catena.ParamTypeInt32, "", 0),
 		}, catena.StatusWithCode(catena.OK, "")
 	}
@@ -1459,7 +1459,7 @@ func TestRestTransport_ParamInfo_NestedFqoid(t *testing.T) {
 func TestRestTransport_ParamInfo_NotFound(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		return nil, catena.StatusWithCode(catena.OK, "")
 	}
 
@@ -1473,7 +1473,7 @@ func TestRestTransport_ParamInfo_NotFound(t *testing.T) {
 func TestRestTransport_ParamInfo_HandlerError(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		return nil, catena.StatusWithCode(catena.NOT_FOUND, "param not found")
 	}
 
@@ -1494,7 +1494,7 @@ func TestRestTransport_ParamInfo_UnaryRecursiveRejected(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		handlerCalled = true
 		return nil, catena.StatusWithCode(catena.OK, "")
 	}
@@ -1514,7 +1514,7 @@ func TestRestTransport_ParamInfo_UnaryRecursiveRejected(t *testing.T) {
 func TestRestTransport_ParamInfo_UnaryMissingFqoidRejected(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 	handlerCalled := false
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		handlerCalled = true
 		return nil, catena.StatusWithCode(catena.OK, "")
 	}
@@ -1549,9 +1549,9 @@ func TestRestTransport_ParamInfo_RecursivePresenceOnly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			transport, runtime := makeTestRestTransport(t)
 			var gotRecursive bool
-			runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+			runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 				gotRecursive = recursive
-				return []catena.CatenaParamInfo{
+				return []catena.ParamInfo{
 					catena.NewParamInfo("a", nil, catena.ParamTypeInt32, "", 0),
 				}, catena.StatusWithCode(catena.OK, "")
 			}
@@ -1568,14 +1568,14 @@ func TestRestTransport_ParamInfo_RecursivePresenceOnly(t *testing.T) {
 func TestRestTransport_ParamInfo_StreamRoute(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		if oidPrefix != "/parent" {
 			t.Errorf("expected oidPrefix '/parent', got %s", oidPrefix)
 		}
 		if !recursive {
 			t.Error("expected recursive=true")
 		}
-		return []catena.CatenaParamInfo{
+		return []catena.ParamInfo{
 			catena.NewParamInfo("parent", nil, catena.ParamTypeStruct, "", 0),
 			catena.NewParamInfo("parent/child1", nil, catena.ParamTypeInt32, "", 0),
 			catena.NewParamInfo("parent/child2", nil, catena.ParamTypeStringArray, "", 3),
@@ -1600,11 +1600,11 @@ func TestRestTransport_ParamInfo_StreamRoute(t *testing.T) {
 func TestRestTransport_ParamInfo_TopLevelStreamRoute(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		if oidPrefix != "" {
 			t.Errorf("expected empty oidPrefix for top-level stream, got %q", oidPrefix)
 		}
-		return []catena.CatenaParamInfo{
+		return []catena.ParamInfo{
 			catena.NewParamInfo("a", nil, catena.ParamTypeInt32, "", 0),
 			catena.NewParamInfo("b", nil, catena.ParamTypeFloat32, "", 0),
 		}, catena.StatusWithCode(catena.OK, "")
@@ -1625,7 +1625,7 @@ func TestRestTransport_ParamInfo_TopLevelStreamRoute(t *testing.T) {
 func TestRestTransport_ParamInfo_TopLevelStream_Empty(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
-	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+	runtime.paramInfoFn = func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 		return nil, catena.StatusWithCode(catena.OK, "")
 	}
 

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -49,12 +49,12 @@ import (
 type stubServerRuntime struct {
 	tb                       testing.TB
 	slots                    []uint16
-	getDeviceFn              func(slot uint16) (catena.CatenaDevice, catena.StatusResult)
-	getValueFn               func(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult)
+	getDeviceFn              func(slot uint16) (catena.Device, catena.StatusResult)
+	getValueFn               func(slot uint16, fqoid string) (catena.Value, catena.StatusResult)
 	setValueFn               func(value any, slot uint16, fqoid string) catena.StatusResult
-	getAssetFn               func(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult)
+	getAssetFn               func(slot uint16, fqoid string) (catena.Asset, catena.StatusResult)
 	commandFn                func(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult)
-	paramInfoFn              func(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult)
+	paramInfoFn              func(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult)
 	registerTransportConnFn  func(transport catena.Transport) (int, *catena.Connection)
 	deregisterConnFn         func(connID int)
 	shutdownTransportConnsFn func(ctx context.Context, transport catena.Transport)
@@ -83,20 +83,20 @@ func (s *stubServerRuntime) GetSlots() []uint16 {
 	return s.slots
 }
 
-func (s *stubServerRuntime) InvokeGetDeviceHandler(slot uint16) (catena.CatenaDevice, catena.StatusResult) {
+func (s *stubServerRuntime) InvokeGetDeviceHandler(slot uint16) (catena.Device, catena.StatusResult) {
 	if s.getDeviceFn != nil {
 		return s.getDeviceFn(slot)
 	}
 	s.panicf("GetDevice handler not implemented in stubServerRuntime for slot %d", slot)
-	return catena.CatenaDevice{}, catena.StatusResult{Code: catena.INTERNAL}
+	return catena.Device{}, catena.StatusResult{Code: catena.INTERNAL}
 }
 
-func (s *stubServerRuntime) InvokeGetValueHandler(slot uint16, fqoid string) (catena.CatenaValue, catena.StatusResult) {
+func (s *stubServerRuntime) InvokeGetValueHandler(slot uint16, fqoid string) (catena.Value, catena.StatusResult) {
 	if s.getValueFn != nil {
 		return s.getValueFn(slot, fqoid)
 	}
 	s.panicf("GetValue handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid)
-	return catena.CatenaValue{}, catena.StatusResult{Code: catena.INTERNAL}
+	return catena.Value{}, catena.StatusResult{Code: catena.INTERNAL}
 }
 
 func (s *stubServerRuntime) InvokeSetValueHandler(value any, slot uint16, fqoid string) catena.StatusResult {
@@ -107,12 +107,12 @@ func (s *stubServerRuntime) InvokeSetValueHandler(value any, slot uint16, fqoid 
 	return catena.StatusResult{Code: catena.INTERNAL}
 }
 
-func (s *stubServerRuntime) InvokeGetAssetHandler(slot uint16, fqoid string) (catena.CatenaAsset, catena.StatusResult) {
+func (s *stubServerRuntime) InvokeGetAssetHandler(slot uint16, fqoid string) (catena.Asset, catena.StatusResult) {
 	if s.getAssetFn != nil {
 		return s.getAssetFn(slot, fqoid)
 	}
 	s.panicf("GetAsset handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid)
-	return catena.CatenaAsset{}, catena.StatusResult{Code: catena.INTERNAL}
+	return catena.Asset{}, catena.StatusResult{Code: catena.INTERNAL}
 }
 
 func (s *stubServerRuntime) InvokeExecuteCommandHandler(slot uint16, commandFqoid string, payload any) (catena.CommandResult, catena.StatusResult) {
@@ -123,7 +123,7 @@ func (s *stubServerRuntime) InvokeExecuteCommandHandler(slot uint16, commandFqoi
 	return catena.CommandResult{}, catena.StatusResult{Code: catena.INTERNAL}
 }
 
-func (s *stubServerRuntime) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool) ([]catena.CatenaParamInfo, catena.StatusResult) {
+func (s *stubServerRuntime) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
 	if s.paramInfoFn != nil {
 		return s.paramInfoFn(slot, oidPrefix, recursive)
 	}


### PR DESCRIPTION
## 📖 Description
<!-- A clear, concise summary of what this PR does. -->

Removed the `Catena` prefix from all exported types and converter functions in the Go SDK's `catena` package, aligning with Go naming conventions. 


Example: `catena.CatenaAsset` -> `catena.Asset`  

---

## 🎯 Goal / Outcome
<!-- What should be achieved once this PR is merged? -->

More cohesive, idiomatic Go naming across the SDK. All public API surface reads naturally eliminating the redundant `catena.Catena*` scheme.

---

## ✅ Definition of Done (DoD)
<!-- Checklist derived from the actual changes: -->
- [x] All 5 exported types renamed (`CatenaValue` → `Value`, `CatenaAsset` → `Asset`, `CatenaDevice` → `Device`, `CatenaParamInfo` → `ParamInfo`, `CatenaServer` → `Server`)
- [x] All 4 converter functions renamed (`ToCatenaValue` → `ToValue`, `ToCatenaAsset` → `ToAsset`, `ToCatenaDevice` → `ToDevice`, `ToCatenaParamInfo` → `ToParamInfo`)
- [x] All references updated across consumer packages (`rest`, `grpc`, `internal`)
- [x] All example files updated
- [x] README documentation updated (`rest/README.md`, `grpc/README.md`)
- [x] Test function names updated to match (e.g. `TestToCatenaAsset_*` → `TestToAsset_*`)
- [x] `go build ./...` passes
- [x] `go test ./...` passes 

---

## 🛠️ Implementation Notes (Optional)
<!-- Technical details, architectural decisions, or constraints visible in the diff. -->

- **Protobuf types untouched**: Auto-generated `protos.CatenaServiceClient`, `protos.CatenaServiceServer`, etc. were intentionally left as-is — those names come from the `.proto` service definition (`st2138.CatenaService`) and should not be renamed in Go code.
- **No naming collisions**: `catena.Server` (interface) is always referenced cross-package and does not collide with `rest.Server` or `grpc.Server` (concrete structs in their own packages).
- **Purely mechanical rename**: Every change is a direct string substitution — no logic, signatures, or behavior changed. The diff is 422 insertions / 422 deletions across 39 files.

---

## 🔗 Related Issues / Links
<!-- Issue numbers, Jira tickets, or related PRs extracted from commits/branch name. -->

- Closes issue #1316 

---