### PR TITLE
[GO] Menu Creation Helpers

### DIFF
--- a/sdks/go/pkg/catena/command.go
+++ b/sdks/go/pkg/catena/command.go
@@ -42,28 +42,6 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-// PolyglotText maps BCP-47 language codes to display strings.
-type PolyglotText map[string]string
-
-// NewPolyglotText creates a PolyglotText with a single language entry.
-func NewPolyglotText(lang, text string) PolyglotText {
-	return PolyglotText{lang: text}
-}
-
-// With returns the PolyglotText with an additional language entry added.
-func (p PolyglotText) With(lang, text string) PolyglotText {
-	p[lang] = text
-	return p
-}
-
-// Get returns the display string for lang, falling back to fallback if not present.
-func (p PolyglotText) Get(lang, fallback string) string {
-	if s, ok := p[lang]; ok {
-		return s
-	}
-	return p[fallback]
-}
-
 // CommandResult wraps protos.CommandResponse, representing the three possible
 // outcomes of ExecuteCommand: no_response, response, or exception.
 type CommandResult struct {

--- a/sdks/go/pkg/catena/command_test.go
+++ b/sdks/go/pkg/catena/command_test.go
@@ -44,40 +44,6 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-func TestNewPolyglotText(t *testing.T) {
-	pt := NewPolyglotText("en", "Hello")
-	if pt["en"] != "Hello" {
-		t.Errorf("expected 'Hello', got %s", pt["en"])
-	}
-}
-
-func TestPolyglotText_With(t *testing.T) {
-	pt := NewPolyglotText("en", "Hello").With("fr", "Bonjour")
-	if pt["en"] != "Hello" {
-		t.Errorf("expected 'Hello', got %s", pt["en"])
-	}
-	if pt["fr"] != "Bonjour" {
-		t.Errorf("expected 'Bonjour', got %s", pt["fr"])
-	}
-}
-
-func TestPolyglotText_Get(t *testing.T) {
-	pt := NewPolyglotText("en", "Hello").With("fr", "Bonjour")
-	if pt.Get("fr", "en") != "Bonjour" {
-		t.Errorf("expected 'Bonjour', got %s", pt.Get("fr", "en"))
-	}
-	if pt.Get("de", "en") != "Hello" {
-		t.Errorf("expected fallback 'Hello', got %s", pt.Get("de", "en"))
-	}
-}
-
-func TestPolyglotText_Get_MissingFallback(t *testing.T) {
-	pt := NewPolyglotText("en", "Hello")
-	if pt.Get("de", "fr") != "" {
-		t.Errorf("expected empty string for missing fallback, got %s", pt.Get("de", "fr"))
-	}
-}
-
 func TestCommandReply(t *testing.T) {
 	val, _ := ToValue(int32(42))
 	result, status := CommandReply(val)

--- a/sdks/go/pkg/catena/menu.go
+++ b/sdks/go/pkg/catena/menu.go
@@ -39,6 +39,8 @@
 package catena
 
 import (
+	"google.golang.org/protobuf/proto"
+
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
@@ -67,6 +69,9 @@ func (mg *MenuGroup) WithName(name PolyglotText) *MenuGroup {
 
 // WithMenu inserts menu into the menu group's menus map, keyed by oid.
 // Replaces any existing menu at that oid. A nil menu is ignored.
+// The menu's proto is deep-copied so that later builder mutations on the
+// caller's Menu (or reusing it under another oid) do not affect entries that
+// were already added.
 func (mg *MenuGroup) WithMenu(oid string, menu *Menu) *MenuGroup {
 	if menu == nil {
 		logger.Warning("WithMenu called with nil menu; ignoring", "oid", oid)
@@ -75,7 +80,7 @@ func (mg *MenuGroup) WithMenu(oid string, menu *Menu) *MenuGroup {
 	if mg.Proto.Menus == nil {
 		mg.Proto.Menus = map[string]*protos.Menu{}
 	}
-	mg.Proto.Menus[oid] = menu.Proto
+	mg.Proto.Menus[oid] = proto.Clone(menu.Proto).(*protos.Menu)
 	return mg
 }
 

--- a/sdks/go/pkg/catena/menu.go
+++ b/sdks/go/pkg/catena/menu.go
@@ -39,95 +39,109 @@
 package catena
 
 import (
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
 // MenuGroup wraps a protos.MenuGroup and exposes a fluent builder API.
+// The group's oid is supplied by its parent when the group is attached, so it
+// is not stored here.
 type MenuGroup struct {
-	Oid   string
 	Proto *protos.MenuGroup
 }
 
-// NewMenuGroup creates a MenuGroup with the given oid and an initialized proto.
-func NewMenuGroup(oid string) *MenuGroup {
+// NewMenuGroup creates a MenuGroup with an initialized proto.
+func NewMenuGroup() *MenuGroup {
 	return &MenuGroup{
-		Oid: oid,
 		Proto: &protos.MenuGroup{
 			Menus: make(map[string]*protos.Menu),
 		},
 	}
 }
 
-// WithMenuGroupName sets the menu group's display name, replacing any existing name.
-func (mg *MenuGroup) WithMenuGroupName(name PolyglotText) *MenuGroup {
+// WithName sets the menu group's display name, replacing any existing name.
+func (mg *MenuGroup) WithName(name PolyglotText) *MenuGroup {
 	mg.Proto.Name = &protos.PolyglotText{DisplayStrings: name}
 	return mg
 }
 
-// AddMenuGroupName merges entries from name into the menu group's existing display name.
-// If no name exists yet, it is created.
-func (mg *MenuGroup) AddMenuGroupName(name PolyglotText) *MenuGroup {
-	if mg.Proto.Name == nil {
-		mg.Proto.Name = &protos.PolyglotText{DisplayStrings: make(map[string]string)}
+// WithMenu inserts menu into the menu group's menus map, keyed by oid.
+// Replaces any existing menu at that oid. A nil menu is ignored.
+func (mg *MenuGroup) WithMenu(oid string, menu *Menu) *MenuGroup {
+	if menu == nil {
+		logger.Warning("WithMenu called with nil menu; ignoring", "oid", oid)
+		return mg
 	}
-	if mg.Proto.Name.DisplayStrings == nil {
-		mg.Proto.Name.DisplayStrings = make(map[string]string)
+	if mg.Proto.Menus == nil {
+		mg.Proto.Menus = map[string]*protos.Menu{}
 	}
-	for k, v := range name {
-		mg.Proto.Name.DisplayStrings[k] = v
-	}
+	mg.Proto.Menus[oid] = menu.Proto
 	return mg
 }
 
-// WithMenu creates a new menu with the given name and inserts it into the
-// menu group's menus map, keyed by oid. Replaces any existing menu at that oid.
-func (mg *MenuGroup) WithMenu(oid string, name PolyglotText) *MenuGroup {
-	mg.Proto.Menus[oid] = &protos.Menu{
-		Name: &protos.PolyglotText{DisplayStrings: name},
-	}
-	return mg
-}
-
-// AddMenu creates a new menu with the given name and inserts it into the
-// menu group's menus map, keyed by oid. Replaces any existing menu at that oid.
-func (mg *MenuGroup) AddMenu(oid string, name PolyglotText) *MenuGroup {
-	mg.Proto.Menus[oid] = &protos.Menu{
-		Name: &protos.PolyglotText{DisplayStrings: name},
-	}
+// WithOrder sets the menu group's display order.
+func (mg *MenuGroup) WithOrder(order uint32) *MenuGroup {
+	mg.Proto.Order = order
 	return mg
 }
 
 // Menu wraps a protos.Menu and exposes a fluent builder API.
+// The menu's oid is supplied by its parent when the menu is attached, so it is
+// not stored here.
 type Menu struct {
-	Oid   string
 	Proto *protos.Menu
 }
 
-// NewMenu creates a Menu with the given oid and an initialized proto.
-func NewMenu(oid string) *Menu {
+// NewMenu creates a Menu with an initialized proto.
+func NewMenu() *Menu {
 	return &Menu{
-		Oid:   oid,
 		Proto: &protos.Menu{},
 	}
 }
 
-// WithMenuName sets the menu's display name, replacing any existing name.
-func (m *Menu) WithMenuName(name PolyglotText) *Menu {
+// WithName sets the menu's display name, replacing any existing name.
+func (m *Menu) WithName(name PolyglotText) *Menu {
 	m.Proto.Name = &protos.PolyglotText{DisplayStrings: name}
 	return m
 }
 
-// AddMenuName merges entries from name into the menu's existing display name.
-// If no name exists yet, it is created.
-func (m *Menu) AddMenuName(name PolyglotText) *Menu {
-	if m.Proto.Name == nil {
-		m.Proto.Name = &protos.PolyglotText{DisplayStrings: make(map[string]string)}
+// WithHidden sets whether the menu should be hidden in the client GUI.
+func (m *Menu) WithHidden(hidden bool) *Menu {
+	m.Proto.Hidden = hidden
+	return m
+}
+
+// WithDisabled sets whether the menu should be disabled (shown as read-only)
+// in the client GUI.
+func (m *Menu) WithDisabled(disabled bool) *Menu {
+	m.Proto.Disabled = disabled
+	return m
+}
+
+// WithParamOids sets the menu's parameter members, replacing any existing oids.
+func (m *Menu) WithParamOids(oids ...string) *Menu {
+	m.Proto.ParamOids = oids
+	return m
+}
+
+// WithCommandOids sets the menu's command members, replacing any existing oids.
+func (m *Menu) WithCommandOids(oids ...string) *Menu {
+	m.Proto.CommandOids = oids
+	return m
+}
+
+// WithClientHint sets a single client hint key/value pair, creating the map if
+// it does not yet exist.
+func (m *Menu) WithClientHint(key, value string) *Menu {
+	if m.Proto.ClientHints == nil {
+		m.Proto.ClientHints = map[string]string{}
 	}
-	if m.Proto.Name.DisplayStrings == nil {
-		m.Proto.Name.DisplayStrings = make(map[string]string)
-	}
-	for k, v := range name {
-		m.Proto.Name.DisplayStrings[k] = v
-	}
+	m.Proto.ClientHints[key] = value
+	return m
+}
+
+// WithOrder sets the menu's display order.
+func (m *Menu) WithOrder(order uint32) *Menu {
+	m.Proto.Order = order
 	return m
 }

--- a/sdks/go/pkg/catena/menu.go
+++ b/sdks/go/pkg/catena/menu.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Menu and MenuGroup builder types for the Catena SDK.
+ * @file menu.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-06-01
+ */
+
+package catena
+
+import (
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// MenuGroup wraps a protos.MenuGroup and exposes a fluent builder API.
+type MenuGroup struct {
+	Oid   string
+	Proto *protos.MenuGroup
+}
+
+// NewMenuGroup creates a MenuGroup with the given oid and an initialized proto.
+func NewMenuGroup(oid string) *MenuGroup {
+	return &MenuGroup{
+		Oid: oid,
+		Proto: &protos.MenuGroup{
+			Menus: make(map[string]*protos.Menu),
+		},
+	}
+}
+
+// WithMenuGroupName sets the menu group's display name, replacing any existing name.
+func (mg *MenuGroup) WithMenuGroupName(name PolyglotText) *MenuGroup {
+	mg.Proto.Name = &protos.PolyglotText{DisplayStrings: name}
+	return mg
+}
+
+// AddMenuGroupName merges entries from name into the menu group's existing display name.
+// If no name exists yet, it is created.
+func (mg *MenuGroup) AddMenuGroupName(name PolyglotText) *MenuGroup {
+	if mg.Proto.Name == nil {
+		mg.Proto.Name = &protos.PolyglotText{DisplayStrings: make(map[string]string)}
+	}
+	for k, v := range name {
+		mg.Proto.Name.DisplayStrings[k] = v
+	}
+	return mg
+}
+
+// WithMenu creates a new menu with the given name and inserts it into the
+// menu group's menus map, keyed by oid. Replaces any existing menu at that oid.
+func (mg *MenuGroup) WithMenu(oid string, name PolyglotText) *MenuGroup {
+	mg.Proto.Menus[oid] = &protos.Menu{
+		Name: &protos.PolyglotText{DisplayStrings: name},
+	}
+	return mg
+}
+
+// AddMenu creates a new menu with the given name and inserts it into the
+// menu group's menus map, keyed by oid. Replaces any existing menu at that oid.
+func (mg *MenuGroup) AddMenu(oid string, name PolyglotText) *MenuGroup {
+	mg.Proto.Menus[oid] = &protos.Menu{
+		Name: &protos.PolyglotText{DisplayStrings: name},
+	}
+	return mg
+}
+
+// Menu wraps a protos.Menu and exposes a fluent builder API.
+type Menu struct {
+	Oid   string
+	Proto *protos.Menu
+}
+
+// NewMenu creates a Menu with the given oid and an initialized proto.
+func NewMenu(oid string) *Menu {
+	return &Menu{
+		Oid:   oid,
+		Proto: &protos.Menu{},
+	}
+}
+
+// WithMenuName sets the menu's display name, replacing any existing name.
+func (m *Menu) WithMenuName(name PolyglotText) *Menu {
+	m.Proto.Name = &protos.PolyglotText{DisplayStrings: name}
+	return m
+}
+
+// AddMenuName merges entries from name into the menu's existing display name.
+// If no name exists yet, it is created.
+func (m *Menu) AddMenuName(name PolyglotText) *Menu {
+	if m.Proto.Name == nil {
+		m.Proto.Name = &protos.PolyglotText{DisplayStrings: make(map[string]string)}
+	}
+	for k, v := range name {
+		m.Proto.Name.DisplayStrings[k] = v
+	}
+	return m
+}

--- a/sdks/go/pkg/catena/menu.go
+++ b/sdks/go/pkg/catena/menu.go
@@ -70,6 +70,9 @@ func (mg *MenuGroup) AddMenuGroupName(name PolyglotText) *MenuGroup {
 	if mg.Proto.Name == nil {
 		mg.Proto.Name = &protos.PolyglotText{DisplayStrings: make(map[string]string)}
 	}
+	if mg.Proto.Name.DisplayStrings == nil {
+		mg.Proto.Name.DisplayStrings = make(map[string]string)
+	}
 	for k, v := range name {
 		mg.Proto.Name.DisplayStrings[k] = v
 	}
@@ -119,6 +122,9 @@ func (m *Menu) WithMenuName(name PolyglotText) *Menu {
 func (m *Menu) AddMenuName(name PolyglotText) *Menu {
 	if m.Proto.Name == nil {
 		m.Proto.Name = &protos.PolyglotText{DisplayStrings: make(map[string]string)}
+	}
+	if m.Proto.Name.DisplayStrings == nil {
+		m.Proto.Name.DisplayStrings = make(map[string]string)
 	}
 	for k, v := range name {
 		m.Proto.Name.DisplayStrings[k] = v

--- a/sdks/go/pkg/catena/menu_test.go
+++ b/sdks/go/pkg/catena/menu_test.go
@@ -40,6 +40,8 @@ package catena
 
 import (
 	"testing"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
 func TestNewMenuGroup(t *testing.T) {
@@ -117,6 +119,22 @@ func TestMenuGroup_WithMenu_Replaces(t *testing.T) {
 	ds := mg.Proto.Menus["video"].Name.GetDisplayStrings()
 	if ds["en"] != "New Video" {
 		t.Errorf("expected 'New Video', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_WithMenu_NilMapInitialized(t *testing.T) {
+	mg := &MenuGroup{Proto: &protos.MenuGroup{}}
+	if mg.Proto.Menus != nil {
+		t.Fatal("expected nil menus map before WithMenu")
+	}
+
+	mg.WithMenu("video", NewMenu().WithName(NewPolyglotText("en", "Video")))
+
+	if mg.Proto.Menus == nil {
+		t.Fatal("expected menus map to be initialized by WithMenu")
+	}
+	if _, ok := mg.Proto.Menus["video"]; !ok {
+		t.Error("expected menu 'video' to exist")
 	}
 }
 

--- a/sdks/go/pkg/catena/menu_test.go
+++ b/sdks/go/pkg/catena/menu_test.go
@@ -43,10 +43,7 @@ import (
 )
 
 func TestNewMenuGroup(t *testing.T) {
-	mg := NewMenuGroup("group1")
-	if mg.Oid != "group1" {
-		t.Errorf("expected oid 'group1', got %s", mg.Oid)
-	}
+	mg := NewMenuGroup()
 	if mg.Proto == nil {
 		t.Fatal("expected non-nil proto")
 	}
@@ -58,18 +55,18 @@ func TestNewMenuGroup(t *testing.T) {
 	}
 }
 
-func TestMenuGroup_WithMenuGroupName(t *testing.T) {
-	mg := NewMenuGroup("g1").WithMenuGroupName(NewPolyglotText("en", "Settings"))
+func TestMenuGroup_WithName(t *testing.T) {
+	mg := NewMenuGroup().WithName(NewPolyglotText("en", "Settings"))
 	ds := mg.Proto.Name.GetDisplayStrings()
 	if ds["en"] != "Settings" {
 		t.Errorf("expected 'Settings', got %s", ds["en"])
 	}
 }
 
-func TestMenuGroup_WithMenuGroupName_Replaces(t *testing.T) {
-	mg := NewMenuGroup("g1").
-		WithMenuGroupName(NewPolyglotText("en", "Old").With("fr", "Ancien")).
-		WithMenuGroupName(NewPolyglotText("en", "New"))
+func TestMenuGroup_WithName_Replaces(t *testing.T) {
+	mg := NewMenuGroup().
+		WithName(NewPolyglotText("en", "Old").With("fr", "Ancien")).
+		WithName(NewPolyglotText("en", "New"))
 
 	ds := mg.Proto.Name.GetDisplayStrings()
 	if ds["en"] != "New" {
@@ -80,18 +77,15 @@ func TestMenuGroup_WithMenuGroupName_Replaces(t *testing.T) {
 	}
 }
 
-func TestMenuGroup_AddMenuGroupName_CreatesIfNil(t *testing.T) {
-	mg := NewMenuGroup("g1").AddMenuGroupName(NewPolyglotText("en", "Settings"))
-	ds := mg.Proto.Name.GetDisplayStrings()
-	if ds["en"] != "Settings" {
-		t.Errorf("expected 'Settings', got %s", ds["en"])
+// TestMenuGroup_WithName_LoopBuiltName demonstrates building a name up in a
+// loop via an empty PolyglotText and passing it in, replacing the old
+// AddMenuGroupName merge helper.
+func TestMenuGroup_WithName_LoopBuiltName(t *testing.T) {
+	name := NewPolyglotText()
+	for lang, text := range map[string]string{"en": "Settings", "fr": "Paramètres"} {
+		name.With(lang, text)
 	}
-}
-
-func TestMenuGroup_AddMenuGroupName_Merges(t *testing.T) {
-	mg := NewMenuGroup("g1").
-		WithMenuGroupName(NewPolyglotText("en", "Settings")).
-		AddMenuGroupName(NewPolyglotText("fr", "Paramètres"))
+	mg := NewMenuGroup().WithName(name)
 
 	ds := mg.Proto.Name.GetDisplayStrings()
 	if ds["en"] != "Settings" {
@@ -102,19 +96,8 @@ func TestMenuGroup_AddMenuGroupName_Merges(t *testing.T) {
 	}
 }
 
-func TestMenuGroup_AddMenuGroupName_OverwritesExisting(t *testing.T) {
-	mg := NewMenuGroup("g1").
-		WithMenuGroupName(NewPolyglotText("en", "Old")).
-		AddMenuGroupName(NewPolyglotText("en", "New"))
-
-	ds := mg.Proto.Name.GetDisplayStrings()
-	if ds["en"] != "New" {
-		t.Errorf("expected 'New', got %s", ds["en"])
-	}
-}
-
 func TestMenuGroup_WithMenu(t *testing.T) {
-	mg := NewMenuGroup("g1").WithMenu("video", NewPolyglotText("en", "Video"))
+	mg := NewMenuGroup().WithMenu("video", NewMenu().WithName(NewPolyglotText("en", "Video")))
 
 	menu, ok := mg.Proto.Menus["video"]
 	if !ok {
@@ -127,9 +110,9 @@ func TestMenuGroup_WithMenu(t *testing.T) {
 }
 
 func TestMenuGroup_WithMenu_Replaces(t *testing.T) {
-	mg := NewMenuGroup("g1").
-		WithMenu("video", NewPolyglotText("en", "Old Video")).
-		WithMenu("video", NewPolyglotText("en", "New Video"))
+	mg := NewMenuGroup().
+		WithMenu("video", NewMenu().WithName(NewPolyglotText("en", "Old Video"))).
+		WithMenu("video", NewMenu().WithName(NewPolyglotText("en", "New Video")))
 
 	ds := mg.Proto.Menus["video"].Name.GetDisplayStrings()
 	if ds["en"] != "New Video" {
@@ -137,23 +120,17 @@ func TestMenuGroup_WithMenu_Replaces(t *testing.T) {
 	}
 }
 
-func TestMenuGroup_AddMenu(t *testing.T) {
-	mg := NewMenuGroup("g1").AddMenu("audio", NewPolyglotText("en", "Audio"))
-
-	menu, ok := mg.Proto.Menus["audio"]
-	if !ok {
-		t.Fatal("expected menu 'audio' to exist")
-	}
-	ds := menu.Name.GetDisplayStrings()
-	if ds["en"] != "Audio" {
-		t.Errorf("expected 'Audio', got %s", ds["en"])
+func TestMenuGroup_WithMenu_NilIgnored(t *testing.T) {
+	mg := NewMenuGroup().WithMenu("video", nil)
+	if len(mg.Proto.Menus) != 0 {
+		t.Errorf("expected nil menu to be ignored, got %d entries", len(mg.Proto.Menus))
 	}
 }
 
 func TestMenuGroup_MultipleMenus(t *testing.T) {
-	mg := NewMenuGroup("g1").
-		WithMenu("video", NewPolyglotText("en", "Video")).
-		AddMenu("audio", NewPolyglotText("en", "Audio"))
+	mg := NewMenuGroup().
+		WithMenu("video", NewMenu().WithName(NewPolyglotText("en", "Video"))).
+		WithMenu("audio", NewMenu().WithName(NewPolyglotText("en", "Audio")))
 
 	if len(mg.Proto.Menus) != 2 {
 		t.Errorf("expected 2 menus, got %d", len(mg.Proto.Menus))
@@ -166,16 +143,19 @@ func TestMenuGroup_MultipleMenus(t *testing.T) {
 	}
 }
 
-func TestMenuGroup_FullChaining(t *testing.T) {
-	mg := NewMenuGroup("main").
-		WithMenuGroupName(NewPolyglotText("en", "Main Group")).
-		AddMenuGroupName(NewPolyglotText("fr", "Groupe Principal")).
-		WithMenu("video", NewPolyglotText("en", "Video")).
-		AddMenu("audio", NewPolyglotText("en", "Audio").With("fr", "Son"))
-
-	if mg.Oid != "main" {
-		t.Errorf("expected oid 'main', got %s", mg.Oid)
+func TestMenuGroup_WithOrder(t *testing.T) {
+	mg := NewMenuGroup().WithOrder(3)
+	if mg.Proto.GetOrder() != 3 {
+		t.Errorf("expected order 3, got %d", mg.Proto.GetOrder())
 	}
+}
+
+func TestMenuGroup_FullChaining(t *testing.T) {
+	mg := NewMenuGroup().
+		WithName(NewPolyglotText("en", "Main Group").With("fr", "Groupe Principal")).
+		WithOrder(1).
+		WithMenu("video", NewMenu().WithName(NewPolyglotText("en", "Video"))).
+		WithMenu("audio", NewMenu().WithName(NewPolyglotText("en", "Audio").With("fr", "Son")))
 
 	ds := mg.Proto.Name.GetDisplayStrings()
 	if ds["en"] != "Main Group" {
@@ -183,6 +163,9 @@ func TestMenuGroup_FullChaining(t *testing.T) {
 	}
 	if ds["fr"] != "Groupe Principal" {
 		t.Errorf("expected 'Groupe Principal', got %s", ds["fr"])
+	}
+	if mg.Proto.GetOrder() != 1 {
+		t.Errorf("expected order 1, got %d", mg.Proto.GetOrder())
 	}
 
 	if len(mg.Proto.Menus) != 2 {
@@ -194,27 +177,24 @@ func TestMenuGroup_FullChaining(t *testing.T) {
 }
 
 func TestNewMenu(t *testing.T) {
-	m := NewMenu("video")
-	if m.Oid != "video" {
-		t.Errorf("expected oid 'video', got %s", m.Oid)
-	}
+	m := NewMenu()
 	if m.Proto == nil {
 		t.Fatal("expected non-nil proto")
 	}
 }
 
-func TestMenu_WithMenuName(t *testing.T) {
-	m := NewMenu("video").WithMenuName(NewPolyglotText("en", "Video Settings"))
+func TestMenu_WithName(t *testing.T) {
+	m := NewMenu().WithName(NewPolyglotText("en", "Video Settings"))
 	ds := m.Proto.Name.GetDisplayStrings()
 	if ds["en"] != "Video Settings" {
 		t.Errorf("expected 'Video Settings', got %s", ds["en"])
 	}
 }
 
-func TestMenu_WithMenuName_Replaces(t *testing.T) {
-	m := NewMenu("video").
-		WithMenuName(NewPolyglotText("en", "Old").With("fr", "Ancien")).
-		WithMenuName(NewPolyglotText("en", "New"))
+func TestMenu_WithName_Replaces(t *testing.T) {
+	m := NewMenu().
+		WithName(NewPolyglotText("en", "Old").With("fr", "Ancien")).
+		WithName(NewPolyglotText("en", "New"))
 
 	ds := m.Proto.Name.GetDisplayStrings()
 	if ds["en"] != "New" {
@@ -225,35 +205,43 @@ func TestMenu_WithMenuName_Replaces(t *testing.T) {
 	}
 }
 
-func TestMenu_AddMenuName_CreatesIfNil(t *testing.T) {
-	m := NewMenu("video").AddMenuName(NewPolyglotText("en", "Video"))
-	ds := m.Proto.Name.GetDisplayStrings()
-	if ds["en"] != "Video" {
-		t.Errorf("expected 'Video', got %s", ds["en"])
+func TestMenu_WithFields(t *testing.T) {
+	m := NewMenu().
+		WithName(NewPolyglotText("en", "Video")).
+		WithHidden(true).
+		WithDisabled(true).
+		WithParamOids("brightness", "contrast").
+		WithCommandOids("reboot").
+		WithClientHint("ui-url", "https://example.com").
+		WithOrder(2)
+
+	if !m.Proto.GetHidden() {
+		t.Error("expected hidden to be true")
+	}
+	if !m.Proto.GetDisabled() {
+		t.Error("expected disabled to be true")
+	}
+	if got := m.Proto.GetParamOids(); len(got) != 2 || got[0] != "brightness" || got[1] != "contrast" {
+		t.Errorf("expected param_oids [brightness contrast], got %v", got)
+	}
+	if got := m.Proto.GetCommandOids(); len(got) != 1 || got[0] != "reboot" {
+		t.Errorf("expected command_oids [reboot], got %v", got)
+	}
+	if m.Proto.GetClientHints()["ui-url"] != "https://example.com" {
+		t.Errorf("expected client hint ui-url, got %v", m.Proto.GetClientHints())
+	}
+	if m.Proto.GetOrder() != 2 {
+		t.Errorf("expected order 2, got %d", m.Proto.GetOrder())
 	}
 }
 
-func TestMenu_AddMenuName_Merges(t *testing.T) {
-	m := NewMenu("video").
-		WithMenuName(NewPolyglotText("en", "Video")).
-		AddMenuName(NewPolyglotText("fr", "Vidéo"))
+func TestMenu_WithClientHint_Multiple(t *testing.T) {
+	m := NewMenu().
+		WithClientHint("a", "1").
+		WithClientHint("b", "2")
 
-	ds := m.Proto.Name.GetDisplayStrings()
-	if ds["en"] != "Video" {
-		t.Errorf("expected 'Video', got %s", ds["en"])
-	}
-	if ds["fr"] != "Vidéo" {
-		t.Errorf("expected 'Vidéo', got %s", ds["fr"])
-	}
-}
-
-func TestMenu_AddMenuName_OverwritesExisting(t *testing.T) {
-	m := NewMenu("video").
-		WithMenuName(NewPolyglotText("en", "Old")).
-		AddMenuName(NewPolyglotText("en", "New"))
-
-	ds := m.Proto.Name.GetDisplayStrings()
-	if ds["en"] != "New" {
-		t.Errorf("expected 'New', got %s", ds["en"])
+	hints := m.Proto.GetClientHints()
+	if hints["a"] != "1" || hints["b"] != "2" {
+		t.Errorf("expected both client hints, got %v", hints)
 	}
 }

--- a/sdks/go/pkg/catena/menu_test.go
+++ b/sdks/go/pkg/catena/menu_test.go
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for Menu and MenuGroup builder types.
+ * @file menu_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-06-01
+ */
+
+package catena
+
+import (
+	"testing"
+)
+
+func TestNewMenuGroup(t *testing.T) {
+	mg := NewMenuGroup("group1")
+	if mg.Oid != "group1" {
+		t.Errorf("expected oid 'group1', got %s", mg.Oid)
+	}
+	if mg.Proto == nil {
+		t.Fatal("expected non-nil proto")
+	}
+	if mg.Proto.Menus == nil {
+		t.Fatal("expected initialized menus map")
+	}
+	if len(mg.Proto.Menus) != 0 {
+		t.Errorf("expected empty menus map, got %d entries", len(mg.Proto.Menus))
+	}
+}
+
+func TestMenuGroup_WithMenuGroupName(t *testing.T) {
+	mg := NewMenuGroup("g1").WithMenuGroupName(NewPolyglotText("en", "Settings"))
+	ds := mg.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Settings" {
+		t.Errorf("expected 'Settings', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_WithMenuGroupName_Replaces(t *testing.T) {
+	mg := NewMenuGroup("g1").
+		WithMenuGroupName(NewPolyglotText("en", "Old").With("fr", "Ancien")).
+		WithMenuGroupName(NewPolyglotText("en", "New"))
+
+	ds := mg.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "New" {
+		t.Errorf("expected 'New', got %s", ds["en"])
+	}
+	if _, ok := ds["fr"]; ok {
+		t.Errorf("expected fr to be absent after replacement, got %s", ds["fr"])
+	}
+}
+
+func TestMenuGroup_AddMenuGroupName_CreatesIfNil(t *testing.T) {
+	mg := NewMenuGroup("g1").AddMenuGroupName(NewPolyglotText("en", "Settings"))
+	ds := mg.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Settings" {
+		t.Errorf("expected 'Settings', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_AddMenuGroupName_Merges(t *testing.T) {
+	mg := NewMenuGroup("g1").
+		WithMenuGroupName(NewPolyglotText("en", "Settings")).
+		AddMenuGroupName(NewPolyglotText("fr", "Paramètres"))
+
+	ds := mg.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Settings" {
+		t.Errorf("expected 'Settings', got %s", ds["en"])
+	}
+	if ds["fr"] != "Paramètres" {
+		t.Errorf("expected 'Paramètres', got %s", ds["fr"])
+	}
+}
+
+func TestMenuGroup_AddMenuGroupName_OverwritesExisting(t *testing.T) {
+	mg := NewMenuGroup("g1").
+		WithMenuGroupName(NewPolyglotText("en", "Old")).
+		AddMenuGroupName(NewPolyglotText("en", "New"))
+
+	ds := mg.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "New" {
+		t.Errorf("expected 'New', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_WithMenu(t *testing.T) {
+	mg := NewMenuGroup("g1").WithMenu("video", NewPolyglotText("en", "Video"))
+
+	menu, ok := mg.Proto.Menus["video"]
+	if !ok {
+		t.Fatal("expected menu 'video' to exist")
+	}
+	ds := menu.Name.GetDisplayStrings()
+	if ds["en"] != "Video" {
+		t.Errorf("expected 'Video', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_WithMenu_Replaces(t *testing.T) {
+	mg := NewMenuGroup("g1").
+		WithMenu("video", NewPolyglotText("en", "Old Video")).
+		WithMenu("video", NewPolyglotText("en", "New Video"))
+
+	ds := mg.Proto.Menus["video"].Name.GetDisplayStrings()
+	if ds["en"] != "New Video" {
+		t.Errorf("expected 'New Video', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_AddMenu(t *testing.T) {
+	mg := NewMenuGroup("g1").AddMenu("audio", NewPolyglotText("en", "Audio"))
+
+	menu, ok := mg.Proto.Menus["audio"]
+	if !ok {
+		t.Fatal("expected menu 'audio' to exist")
+	}
+	ds := menu.Name.GetDisplayStrings()
+	if ds["en"] != "Audio" {
+		t.Errorf("expected 'Audio', got %s", ds["en"])
+	}
+}
+
+func TestMenuGroup_MultipleMenus(t *testing.T) {
+	mg := NewMenuGroup("g1").
+		WithMenu("video", NewPolyglotText("en", "Video")).
+		AddMenu("audio", NewPolyglotText("en", "Audio"))
+
+	if len(mg.Proto.Menus) != 2 {
+		t.Errorf("expected 2 menus, got %d", len(mg.Proto.Menus))
+	}
+	if mg.Proto.Menus["video"].Name.GetDisplayStrings()["en"] != "Video" {
+		t.Error("expected video menu name 'Video'")
+	}
+	if mg.Proto.Menus["audio"].Name.GetDisplayStrings()["en"] != "Audio" {
+		t.Error("expected audio menu name 'Audio'")
+	}
+}
+
+func TestMenuGroup_FullChaining(t *testing.T) {
+	mg := NewMenuGroup("main").
+		WithMenuGroupName(NewPolyglotText("en", "Main Group")).
+		AddMenuGroupName(NewPolyglotText("fr", "Groupe Principal")).
+		WithMenu("video", NewPolyglotText("en", "Video")).
+		AddMenu("audio", NewPolyglotText("en", "Audio").With("fr", "Son"))
+
+	if mg.Oid != "main" {
+		t.Errorf("expected oid 'main', got %s", mg.Oid)
+	}
+
+	ds := mg.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Main Group" {
+		t.Errorf("expected 'Main Group', got %s", ds["en"])
+	}
+	if ds["fr"] != "Groupe Principal" {
+		t.Errorf("expected 'Groupe Principal', got %s", ds["fr"])
+	}
+
+	if len(mg.Proto.Menus) != 2 {
+		t.Fatalf("expected 2 menus, got %d", len(mg.Proto.Menus))
+	}
+	if mg.Proto.Menus["audio"].Name.GetDisplayStrings()["fr"] != "Son" {
+		t.Errorf("expected audio fr='Son', got %s", mg.Proto.Menus["audio"].Name.GetDisplayStrings()["fr"])
+	}
+}
+
+func TestNewMenu(t *testing.T) {
+	m := NewMenu("video")
+	if m.Oid != "video" {
+		t.Errorf("expected oid 'video', got %s", m.Oid)
+	}
+	if m.Proto == nil {
+		t.Fatal("expected non-nil proto")
+	}
+}
+
+func TestMenu_WithMenuName(t *testing.T) {
+	m := NewMenu("video").WithMenuName(NewPolyglotText("en", "Video Settings"))
+	ds := m.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Video Settings" {
+		t.Errorf("expected 'Video Settings', got %s", ds["en"])
+	}
+}
+
+func TestMenu_WithMenuName_Replaces(t *testing.T) {
+	m := NewMenu("video").
+		WithMenuName(NewPolyglotText("en", "Old").With("fr", "Ancien")).
+		WithMenuName(NewPolyglotText("en", "New"))
+
+	ds := m.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "New" {
+		t.Errorf("expected 'New', got %s", ds["en"])
+	}
+	if _, ok := ds["fr"]; ok {
+		t.Errorf("expected fr to be absent after replacement, got %s", ds["fr"])
+	}
+}
+
+func TestMenu_AddMenuName_CreatesIfNil(t *testing.T) {
+	m := NewMenu("video").AddMenuName(NewPolyglotText("en", "Video"))
+	ds := m.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Video" {
+		t.Errorf("expected 'Video', got %s", ds["en"])
+	}
+}
+
+func TestMenu_AddMenuName_Merges(t *testing.T) {
+	m := NewMenu("video").
+		WithMenuName(NewPolyglotText("en", "Video")).
+		AddMenuName(NewPolyglotText("fr", "Vidéo"))
+
+	ds := m.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "Video" {
+		t.Errorf("expected 'Video', got %s", ds["en"])
+	}
+	if ds["fr"] != "Vidéo" {
+		t.Errorf("expected 'Vidéo', got %s", ds["fr"])
+	}
+}
+
+func TestMenu_AddMenuName_OverwritesExisting(t *testing.T) {
+	m := NewMenu("video").
+		WithMenuName(NewPolyglotText("en", "Old")).
+		AddMenuName(NewPolyglotText("en", "New"))
+
+	ds := m.Proto.Name.GetDisplayStrings()
+	if ds["en"] != "New" {
+		t.Errorf("expected 'New', got %s", ds["en"])
+	}
+}

--- a/sdks/go/pkg/catena/polyglot_text.go
+++ b/sdks/go/pkg/catena/polyglot_text.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief PolyglotText type for multilingual display strings.
+ * @file polyglot_text.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-10
+ */
+
+package catena
+
+// PolyglotText maps BCP-47 language codes to display strings.
+type PolyglotText map[string]string
+
+// NewPolyglotText creates a PolyglotText with a single language entry.
+func NewPolyglotText(lang, text string) PolyglotText {
+	return PolyglotText{lang: text}
+}
+
+// With returns the PolyglotText with an additional language entry added.
+func (p PolyglotText) With(lang, text string) PolyglotText {
+	p[lang] = text
+	return p
+}
+
+// Add returns the PolyglotText with an additional language entry added.
+func (p PolyglotText) Add(lang, text string) PolyglotText {
+	p[lang] = text
+	return p
+}
+
+// Get returns the display string for lang, falling back to fallback if not present.
+func (p PolyglotText) Get(lang, fallback string) string {
+	if s, ok := p[lang]; ok {
+		return s
+	}
+	return p[fallback]
+}

--- a/sdks/go/pkg/catena/polyglot_text.go
+++ b/sdks/go/pkg/catena/polyglot_text.go
@@ -38,22 +38,35 @@
 
 package catena
 
+import (
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
+)
+
 // PolyglotText maps BCP-47 language codes to display strings.
 type PolyglotText map[string]string
 
-// NewPolyglotText creates a PolyglotText with a single language entry.
-func NewPolyglotText(lang, text string) PolyglotText {
-	return PolyglotText{lang: text}
+// NewPolyglotText creates a PolyglotText from zero or more (lang, text) pairs.
+// Calling it with no arguments yields an empty PolyglotText, which is useful
+// for building entries up in a loop before passing the result to a builder:
+//
+//	name := NewPolyglotText()
+//	for lang := range langs {
+//		name.With(lang, translate(lang, "Hello"))
+//	}
+func NewPolyglotText(pairs ...string) PolyglotText {
+	p := PolyglotText{}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		p[pairs[i]] = pairs[i+1]
+	}
+	if len(pairs)%2 != 0 {
+		logger.Warning("NewPolyglotText: odd number of arguments; ignoring trailing lang with no text",
+			"lang", pairs[len(pairs)-1])
+	}
+	return p
 }
 
 // With returns the PolyglotText with an additional language entry added.
 func (p PolyglotText) With(lang, text string) PolyglotText {
-	p[lang] = text
-	return p
-}
-
-// Add returns the PolyglotText with an additional language entry added.
-func (p PolyglotText) Add(lang, text string) PolyglotText {
 	p[lang] = text
 	return p
 }

--- a/sdks/go/pkg/catena/polyglot_text_test.go
+++ b/sdks/go/pkg/catena/polyglot_text_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for PolyglotText type.
+ * @file polyglot_text_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-03-10
+ */
+
+package catena
+
+import (
+	"testing"
+)
+
+func TestNewPolyglotText(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello")
+	if pt["en"] != "Hello" {
+		t.Errorf("expected 'Hello', got %s", pt["en"])
+	}
+}
+
+func TestPolyglotText_With(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello").With("fr", "Bonjour")
+	if pt["en"] != "Hello" {
+		t.Errorf("expected 'Hello', got %s", pt["en"])
+	}
+	if pt["fr"] != "Bonjour" {
+		t.Errorf("expected 'Bonjour', got %s", pt["fr"])
+	}
+}
+
+func TestPolyglotText_Add(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello").Add("fr", "Bonjour")
+	if pt["en"] != "Hello" {
+		t.Errorf("expected 'Hello', got %s", pt["en"])
+	}
+	if pt["fr"] != "Bonjour" {
+		t.Errorf("expected 'Bonjour', got %s", pt["fr"])
+	}
+}
+
+func TestPolyglotText_Get(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello").With("fr", "Bonjour")
+	if pt.Get("fr", "en") != "Bonjour" {
+		t.Errorf("expected 'Bonjour', got %s", pt.Get("fr", "en"))
+	}
+	if pt.Get("de", "en") != "Hello" {
+		t.Errorf("expected fallback 'Hello', got %s", pt.Get("de", "en"))
+	}
+}
+
+func TestPolyglotText_Get_MissingFallback(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello")
+	if pt.Get("de", "fr") != "" {
+		t.Errorf("expected empty string for missing fallback, got %s", pt.Get("de", "fr"))
+	}
+}

--- a/sdks/go/pkg/catena/polyglot_text_test.go
+++ b/sdks/go/pkg/catena/polyglot_text_test.go
@@ -59,13 +59,38 @@ func TestPolyglotText_With(t *testing.T) {
 	}
 }
 
-func TestPolyglotText_Add(t *testing.T) {
-	pt := NewPolyglotText("en", "Hello").Add("fr", "Bonjour")
+func TestNewPolyglotText_Empty(t *testing.T) {
+	pt := NewPolyglotText()
+	if pt == nil {
+		t.Fatal("expected non-nil PolyglotText")
+	}
+	if len(pt) != 0 {
+		t.Errorf("expected empty PolyglotText, got %d entries", len(pt))
+	}
+
+	pt.With("en", "Hello").With("fr", "Bonjour")
+	if pt["en"] != "Hello" || pt["fr"] != "Bonjour" {
+		t.Errorf("expected entries to be added, got %v", pt)
+	}
+}
+
+func TestNewPolyglotText_MultiplePairs(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello", "fr", "Bonjour")
 	if pt["en"] != "Hello" {
 		t.Errorf("expected 'Hello', got %s", pt["en"])
 	}
 	if pt["fr"] != "Bonjour" {
 		t.Errorf("expected 'Bonjour', got %s", pt["fr"])
+	}
+}
+
+func TestNewPolyglotText_OddArgs(t *testing.T) {
+	pt := NewPolyglotText("en", "Hello", "fr")
+	if pt["en"] != "Hello" {
+		t.Errorf("expected 'Hello', got %s", pt["en"])
+	}
+	if _, ok := pt["fr"]; ok {
+		t.Errorf("expected unpaired trailing lang to be ignored, got %v", pt)
 	}
 }
 


### PR DESCRIPTION
## 📖 Description
Introduces `Menu` and `MenuGroup` fluent builder types for the Go Catena SDK and extracts the `PolyglotText` type into its own dedicated file. This refactors `PolyglotText` out of `command.go` into `polyglot_text.go`, adds a new `Add` alias method, and creates a new `menu.go` module with `MenuGroup` and `Menu` builders that wrap the corresponding protobuf types with a chainable API.

---

## 🎯 Goal / Outcome
Provide Go SDK users with builder helpers for constructing `Menu` and `MenuGroup` protobuf objects.

---

## ✅ Definition of Done (DoD)
- [x] `PolyglotText` extracted from `command.go` into `polyglot_text.go` with no behavioral changes
- [x] New `Add` method added to `PolyglotText` for API consistency
- [x] `MenuGroup` builder implemented with `NewMenuGroup`, `WithMenuGroupName`, `AddMenuGroupName`, `WithMenu`, `AddMenu`
- [x] `Menu` builder implemented with `NewMenu`, `WithMenuName`, `AddMenuName`
- [x] All builders expose a fluent API
- [x] Comprehensive unit tests added for `PolyglotText`
- [x] Comprehensive unit tests added for `Menu`/`MenuGroup`

---

## 🛠️ Implementation Notes (Optional)
- `MenuGroup` and `Menu` are thin wrappers around `protos.MenuGroup` and `protos.Menu` respectively, exposing the underlying `Proto` field for direct access when needed.
- The "With" methods (e.g. `WithMenuGroupName`, `WithMenuName`) **replace** the entire name, while the "Add" methods (e.g. `AddMenuGroupName`, `AddMenuName`) **merge** new language entries into an existing name.
- `PolyglotText` is a `map[string]string` type alias, which means `With` and `Add` mutate in place — callers sharing references should be aware of this.
- Tests were moved from `command_test.go` to `polyglot_text_test.go` for the `PolyglotText` tests, keeping test organization aligned with source files.

---

## 🔗 Related Issues / Links

Closes issue #1307 

