### PR TITLE
[GO] Reserved Update Command

### DIFF
--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -91,6 +91,12 @@ func toProtoDevice(m map[string]any) (*protos.Device, error) {
 		return nil, fmt.Errorf("failed to unmarshal JSON to Device proto: %w", err)
 	}
 
+	// Reserved software-update commands are auto-injected into every device so
+	// upload_update / apply_update are always present and cannot be removed.
+	if err := injectReservedCommands(device); err != nil {
+		return nil, fmt.Errorf("failed to inject reserved commands: %w", err)
+	}
+
 	return device, nil
 }
 

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -228,15 +228,12 @@ type server struct {
 	connectionQueue        connectionQueueInterface
 	heartbeat              *Heartbeat
 	transports             []Transport
-	updateManager          *updateManager
 }
 
 type ServerOptions struct {
-	MaxConnections   int
-	AuthzEnabled     bool
-	JwtOptions       JwtValidationOptions
-	UpdateStorageDir string
-	ApplyUpdateFunc  ApplyUpdateFunc
+	MaxConnections int
+	AuthzEnabled   bool
+	JwtOptions     JwtValidationOptions
 }
 
 func NewServer(opts ServerOptions) (Server, error) {
@@ -271,7 +268,6 @@ func NewServer(opts ServerOptions) (Server, error) {
 		accessHandler:          allowAllAccessHandler,
 		connectionQueue:        newConnectionQueue(opts.MaxConnections),
 		transports:             []Transport{},
-		updateManager:          newUpdateManager(opts.UpdateStorageDir, opts.ApplyUpdateFunc),
 	}, nil
 }
 
@@ -698,12 +694,6 @@ func (s *server) InvokeExecuteCommandHandler(slot uint16, commandFqoid string, p
 	}
 	if !s.isAccessAllowed(EndpointExecuteCommand, handlerContext) {
 		return CommandError(PERMISSION_DENIED, "Permission denied")
-	}
-
-	// Reserved software-update commands are owned by the SDK and take
-	// precedence over any application-registered handler.
-	if isReservedUpdateOid(commandFqoid) && s.updateManager != nil {
-		return s.updateManager.execute(commandFqoid, payload)
 	}
 
 	s.mu.Lock()

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -228,12 +228,15 @@ type server struct {
 	connectionQueue        connectionQueueInterface
 	heartbeat              *Heartbeat
 	transports             []Transport
+	updateManager          *updateManager
 }
 
 type ServerOptions struct {
-	MaxConnections int
-	AuthzEnabled   bool
-	JwtOptions     JwtValidationOptions
+	MaxConnections   int
+	AuthzEnabled     bool
+	JwtOptions       JwtValidationOptions
+	UpdateStorageDir string
+	ApplyUpdateFunc  ApplyUpdateFunc
 }
 
 func NewServer(opts ServerOptions) (Server, error) {
@@ -268,6 +271,7 @@ func NewServer(opts ServerOptions) (Server, error) {
 		accessHandler:          allowAllAccessHandler,
 		connectionQueue:        newConnectionQueue(opts.MaxConnections),
 		transports:             []Transport{},
+		updateManager:          newUpdateManager(opts.UpdateStorageDir, opts.ApplyUpdateFunc),
 	}, nil
 }
 
@@ -694,6 +698,12 @@ func (s *server) InvokeExecuteCommandHandler(slot uint16, commandFqoid string, p
 	}
 	if !s.isAccessAllowed(EndpointExecuteCommand, handlerContext) {
 		return CommandError(PERMISSION_DENIED, "Permission denied")
+	}
+
+	// Reserved software-update commands are owned by the SDK and take
+	// precedence over any application-registered handler.
+	if isReservedUpdateOid(commandFqoid) && s.updateManager != nil {
+		return s.updateManager.execute(commandFqoid, payload)
 	}
 
 	s.mu.Lock()

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -696,6 +696,13 @@ func (s *server) InvokeExecuteCommandHandler(slot uint16, commandFqoid string, p
 		return CommandError(PERMISSION_DENIED, "Permission denied")
 	}
 
+	// Reserved software-update commands are owned by the SDK. They currently
+	// return a placeholder response and take precedence over any user handler.
+	if result, status, handled := executeReservedCommand(commandFqoid, payload); handled {
+		logger.Info("ExecuteCommand handled reserved command", "slot", slot, "commandFqoid", commandFqoid)
+		return result, status
+	}
+
 	s.mu.Lock()
 	handler, ok := s.executeCommandHandlers[slot]
 	s.mu.Unlock()

--- a/sdks/go/pkg/catena/update.go
+++ b/sdks/go/pkg/catena/update.go
@@ -41,6 +41,8 @@ package catena
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -131,6 +133,48 @@ func injectReservedCommands(device *protos.Device) error {
 		device.Commands[oid] = param
 	}
 	return nil
+}
+
+// reservedCommandOid extracts the trailing OID segment from a (possibly
+// fully-qualified) command OID so it can be matched against the reserved
+// software-update OIDs. It tolerates a leading "/" and dotted prefixes such
+// as "device.upload_update".
+func reservedCommandOid(commandFqoid string) string {
+	oid := strings.TrimPrefix(commandFqoid, "/")
+	if idx := strings.LastIndex(oid, "."); idx >= 0 {
+		oid = oid[idx+1:]
+	}
+	return oid
+}
+
+// executeReservedCommand handles execution of the reserved software-update
+// commands. These are not yet implemented, so for now each returns a unique,
+// recognizable placeholder response so the commands can be demonstrated
+// end-to-end before the real update pipeline lands. The boolean return reports
+// whether commandFqoid matched a reserved command and was handled here.
+func executeReservedCommand(commandFqoid string, payload any) (CommandResult, StatusResult, bool) {
+	token := fmt.Sprintf("%d", time.Now().UnixNano())
+	switch reservedCommandOid(commandFqoid) {
+	case ReservedOidUploadUpdate:
+		msg := fmt.Sprintf("PLACEHOLDER upload_update [%s]: update upload received, not yet implemented", token)
+		result, status := reservedCommandReply(msg)
+		return result, status, true
+	case ReservedOidApplyUpdate:
+		msg := fmt.Sprintf("PLACEHOLDER apply_update [%s]: update apply scheduled, not yet implemented", token)
+		result, status := reservedCommandReply(msg)
+		return result, status, true
+	}
+	return CommandResult{}, StatusResult{}, false
+}
+
+// reservedCommandReply wraps a placeholder string into a successful command
+// response, surfacing any conversion error as a transport-level error.
+func reservedCommandReply(msg string) (CommandResult, StatusResult) {
+	val, res := ToValue(msg)
+	if res.Code != OK {
+		return CommandError(res.Code, res.Error)
+	}
+	return CommandReply(val)
 }
 
 // descriptorToParam converts a Go descriptor map into a protos.Param using the

--- a/sdks/go/pkg/catena/update.go
+++ b/sdks/go/pkg/catena/update.go
@@ -41,38 +41,18 @@ package catena
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
 // Reserved command OIDs owned by the SDK for software updates. They are
-// auto-injected into every device model and intercepted by the built-in
-// update manager, so applications do not register handlers for them.
+// auto-injected into every device model and cannot be defined by a device.
 const (
 	ReservedOidUploadUpdate = "upload_update"
 	ReservedOidApplyUpdate  = "apply_update"
 )
-
-// Update describes an uploaded software update awaiting application.
-type Update struct {
-	ID       int32
-	Metadata map[string]string
-	DataPath string // local path to the uploaded bytes (empty when URL-based)
-	URL      string // external URL reference (empty when bytes were uploaded)
-}
-
-// ApplyUpdateFunc applies a previously uploaded update. The default reference
-// implementation only validates that the uploaded data is reachable; real
-// bootloader/firmware apply logic is device-specific and should be supplied
-// via ServerOptions.ApplyUpdateFunc.
-type ApplyUpdateFunc func(update *Update) error
 
 // reservedUpdateCommands holds the descriptor layout for the reserved
 // software-update commands. The data field uses ParamType "DATA" (not the
@@ -131,11 +111,17 @@ var reservedUpdateCommands = map[string]any{
 }
 
 // injectReservedCommands adds the reserved software-update commands to the
-// device's command map, creating the map when necessary. The reserved
-// commands always take precedence so they cannot be removed by applications.
+// device's command map. A device may not define these OIDs itself; doing so is
+// an error. The reserved commands are otherwise present in every device by
+// default.
 func injectReservedCommands(device *protos.Device) error {
 	if device.Commands == nil {
 		device.Commands = make(map[string]*protos.Param)
+	}
+	for oid := range reservedUpdateCommands {
+		if _, exists := device.Commands[oid]; exists {
+			return fmt.Errorf("command %q is reserved by the SDK and cannot be defined by a device", oid)
+		}
 	}
 	for oid, descriptor := range reservedUpdateCommands {
 		param, err := descriptorToParam(descriptor)
@@ -159,206 +145,4 @@ func descriptorToParam(descriptor any) (*protos.Param, error) {
 		return nil, fmt.Errorf("unmarshal descriptor: %w", err)
 	}
 	return param, nil
-}
-
-// normalizeReservedOid strips a leading slash so REST (/upload_update) and
-// gRPC (upload_update) OID forms compare equal.
-func normalizeReservedOid(fqoid string) string {
-	return strings.TrimPrefix(fqoid, "/")
-}
-
-// isReservedUpdateOid reports whether fqoid targets one of the reserved
-// software-update commands.
-func isReservedUpdateOid(fqoid string) bool {
-	switch normalizeReservedOid(fqoid) {
-	case ReservedOidUploadUpdate, ReservedOidApplyUpdate:
-		return true
-	default:
-		return false
-	}
-}
-
-// updateManager owns the lifecycle of uploaded software updates.
-type updateManager struct {
-	mu      sync.Mutex
-	dir     string
-	nextID  int32
-	updates map[int32]*Update
-	applyFn ApplyUpdateFunc
-}
-
-func newUpdateManager(dir string, applyFn ApplyUpdateFunc) *updateManager {
-	if dir == "" {
-		dir = filepath.Join(os.TempDir(), "catena-updates")
-	}
-	if applyFn == nil {
-		applyFn = defaultApplyUpdate
-	}
-	return &updateManager{
-		dir:     dir,
-		updates: make(map[int32]*Update),
-		applyFn: applyFn,
-	}
-}
-
-// defaultApplyUpdate is the reference implementation: it validates that the
-// uploaded update data is reachable. Device-specific apply logic should be
-// supplied via ServerOptions.ApplyUpdateFunc.
-func defaultApplyUpdate(update *Update) error {
-	if update == nil {
-		return fmt.Errorf("nil update")
-	}
-	if update.DataPath != "" {
-		if _, err := os.Stat(update.DataPath); err != nil {
-			return fmt.Errorf("update data not found: %w", err)
-		}
-		return nil
-	}
-	if update.URL != "" {
-		return nil
-	}
-	return fmt.Errorf("update %d has no data", update.ID)
-}
-
-// execute dispatches a reserved update command to its handler.
-func (m *updateManager) execute(fqoid string, payload any) (CommandResult, StatusResult) {
-	switch normalizeReservedOid(fqoid) {
-	case ReservedOidUploadUpdate:
-		return m.handleUpload(payload)
-	case ReservedOidApplyUpdate:
-		return m.handleApply(payload)
-	default:
-		return CommandError(NOT_FOUND, "unknown reserved command: "+fqoid)
-	}
-}
-
-// handleUpload stores the uploaded update data and metadata, returning the
-// newly assigned update ID so apply_update can reference it.
-func (m *updateManager) handleUpload(payload any) (CommandResult, StatusResult) {
-	fields, ok := payload.(map[string]any)
-	if !ok {
-		return CommandExceptionResult("InvalidPayload", "upload_update expects a STRUCT payload",
-			NewPolyglotText("en", "Invalid update payload"))
-	}
-
-	data, ok := fields["data"].(DataPayload)
-	if !ok {
-		return CommandExceptionResult("InvalidPayload", "upload_update requires a 'data' DATA field",
-			NewPolyglotText("en", "Missing update data"))
-	}
-	if len(data.Payload) == 0 && data.Url == "" {
-		return CommandExceptionResult("InvalidPayload", "upload_update 'data' has neither payload nor url",
-			NewPolyglotText("en", "Empty update data"))
-	}
-
-	metadata := parseUpdateMetadata(fields["metadata"])
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.nextID++
-	id := m.nextID
-	update := &Update{ID: id, Metadata: metadata}
-
-	if len(data.Payload) > 0 {
-		if err := os.MkdirAll(m.dir, 0o755); err != nil {
-			m.nextID--
-			return CommandExceptionResult("StorageError", err.Error(),
-				NewPolyglotText("en", "Failed to store update"))
-		}
-		dataPath := filepath.Join(m.dir, fmt.Sprintf("%d.bin", id))
-		if err := os.WriteFile(dataPath, data.Payload, 0o644); err != nil {
-			m.nextID--
-			return CommandExceptionResult("StorageError", err.Error(),
-				NewPolyglotText("en", "Failed to store update"))
-		}
-		update.DataPath = dataPath
-	} else {
-		update.URL = data.Url
-	}
-
-	m.updates[id] = update
-	logger.Info("upload_update stored", "id", id, "path", update.DataPath, "url", update.URL, "bytes", len(data.Payload))
-
-	val, res := ToValue(id)
-	if res.Code != OK {
-		return CommandError(res.Code, res.Error)
-	}
-	return CommandReply(val)
-}
-
-// handleApply applies a previously uploaded update identified by its ID.
-func (m *updateManager) handleApply(payload any) (CommandResult, StatusResult) {
-	fields, ok := payload.(map[string]any)
-	if !ok {
-		return CommandExceptionResult("InvalidPayload", "apply_update expects a STRUCT payload",
-			NewPolyglotText("en", "Invalid update payload"))
-	}
-
-	id, ok := toInt32(fields["id"])
-	if !ok {
-		return CommandExceptionResult("InvalidPayload", "apply_update requires an 'id' INT32 field",
-			NewPolyglotText("en", "Missing update id"))
-	}
-
-	m.mu.Lock()
-	update, found := m.updates[id]
-	applyFn := m.applyFn
-	m.mu.Unlock()
-
-	if !found {
-		return CommandExceptionResult("UnknownUpdate", fmt.Sprintf("no update with id %d", id),
-			NewPolyglotText("en", "Unknown update id"))
-	}
-
-	if err := applyFn(update); err != nil {
-		return CommandExceptionResult("UpdateFailed", err.Error(),
-			NewPolyglotText("en", "Update failed"))
-	}
-
-	logger.Info("apply_update applied", "id", id)
-
-	// Single-response progress: report completion. True streamed 0-100 progress
-	// is a follow-up that requires a streaming command handler + transport.
-	val, res := ToValue(int32(100))
-	if res.Code != OK {
-		return CommandError(res.Code, res.Error)
-	}
-	return CommandReply(val)
-}
-
-// parseUpdateMetadata flattens the STRUCT_ARRAY of {key, value} entries into a
-// plain string map. Unrecognized shapes yield an empty map.
-func parseUpdateMetadata(v any) map[string]string {
-	out := make(map[string]string)
-	arr, ok := v.([]map[string]any)
-	if !ok {
-		return out
-	}
-	for _, entry := range arr {
-		key, _ := entry["key"].(string)
-		value, _ := entry["value"].(string)
-		if key != "" {
-			out[key] = value
-		}
-	}
-	return out
-}
-
-// toInt32 coerces the numeric forms FromProto / JSON decoding may produce.
-func toInt32(v any) (int32, bool) {
-	switch n := v.(type) {
-	case int32:
-		return n, true
-	case int:
-		return int32(n), true
-	case int64:
-		return int32(n), true
-	case float64:
-		return int32(n), true
-	case float32:
-		return int32(n), true
-	default:
-		return 0, false
-	}
 }

--- a/sdks/go/pkg/catena/update.go
+++ b/sdks/go/pkg/catena/update.go
@@ -135,23 +135,14 @@ func injectReservedCommands(device *protos.Device) error {
 	return nil
 }
 
-// reservedCommandOid extracts the trailing OID segment from a (possibly
-// fully-qualified) command OID so it can be matched against the reserved
-// software-update OIDs. It tolerates a leading "/" and dotted prefixes such
-// as "device.upload_update".
+// reservedCommandOid normalizes a command OID for matching against the reserved
+// software-update OIDs. The reserved commands are injected as top-level commands
 func reservedCommandOid(commandFqoid string) string {
-	oid := strings.TrimPrefix(commandFqoid, "/")
-	if idx := strings.LastIndex(oid, "."); idx >= 0 {
-		oid = oid[idx+1:]
-	}
-	return oid
+	return strings.TrimPrefix(commandFqoid, "/")
 }
 
 // executeReservedCommand handles execution of the reserved software-update
-// commands. These are not yet implemented, so for now each returns a unique,
-// recognizable placeholder response so the commands can be demonstrated
-// end-to-end before the real update pipeline lands. The boolean return reports
-// whether commandFqoid matched a reserved command and was handled here.
+// commands. These are not yet implemented, so for now each returns a placeholder response.
 func executeReservedCommand(commandFqoid string, payload any) (CommandResult, StatusResult, bool) {
 	token := fmt.Sprintf("%d", time.Now().UnixNano())
 	switch reservedCommandOid(commandFqoid) {

--- a/sdks/go/pkg/catena/update.go
+++ b/sdks/go/pkg/catena/update.go
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Reserved software-update commands for the Catena SDK.
+ * @file update.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-06-02
+ */
+
+package catena
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// Reserved command OIDs owned by the SDK for software updates. They are
+// auto-injected into every device model and intercepted by the built-in
+// update manager, so applications do not register handlers for them.
+const (
+	ReservedOidUploadUpdate = "upload_update"
+	ReservedOidApplyUpdate  = "apply_update"
+)
+
+// Update describes an uploaded software update awaiting application.
+type Update struct {
+	ID       int32
+	Metadata map[string]string
+	DataPath string // local path to the uploaded bytes (empty when URL-based)
+	URL      string // external URL reference (empty when bytes were uploaded)
+}
+
+// ApplyUpdateFunc applies a previously uploaded update. The default reference
+// implementation only validates that the uploaded data is reachable; real
+// bootloader/firmware apply logic is device-specific and should be supplied
+// via ServerOptions.ApplyUpdateFunc.
+type ApplyUpdateFunc func(update *Update) error
+
+// reservedUpdateCommands holds the descriptor layout for the reserved
+// software-update commands. The data field uses ParamType "DATA" (not the
+// non-existent "DATA_PAYLOAD") so protojson can unmarshal it.
+var reservedUpdateCommands = map[string]any{
+	ReservedOidUploadUpdate: map[string]any{
+		"name": map[string]any{
+			"display_strings": map[string]string{"en": "Update Software"},
+		},
+		"type": "STRUCT",
+		"params": map[string]any{
+			"metadata": map[string]any{
+				"name": map[string]any{
+					"display_strings": map[string]string{"en": "Metadata"},
+				},
+				"type": "STRUCT_ARRAY",
+				"params": map[string]any{
+					"key": map[string]any{
+						"type": "STRING",
+						"name": map[string]any{
+							"display_strings": map[string]string{"en": "Key"},
+						},
+					},
+					"value": map[string]any{
+						"type": "STRING",
+						"name": map[string]any{
+							"display_strings": map[string]string{"en": "Value"},
+						},
+					},
+				},
+			},
+			"data": map[string]any{
+				"name": map[string]any{
+					"display_strings": map[string]string{"en": "Update Data"},
+				},
+				"type": "DATA",
+			},
+		},
+		"response": true,
+	},
+	ReservedOidApplyUpdate: map[string]any{
+		"name": map[string]any{
+			"display_strings": map[string]string{"en": "Update Software"},
+		},
+		"type": "STRUCT",
+		"params": map[string]any{
+			"id": map[string]any{
+				"name": map[string]any{
+					"display_strings": map[string]string{"en": "Update ID"},
+				},
+				"type": "INT32",
+			},
+		},
+		"response": true,
+	},
+}
+
+// injectReservedCommands adds the reserved software-update commands to the
+// device's command map, creating the map when necessary. The reserved
+// commands always take precedence so they cannot be removed by applications.
+func injectReservedCommands(device *protos.Device) error {
+	if device.Commands == nil {
+		device.Commands = make(map[string]*protos.Param)
+	}
+	for oid, descriptor := range reservedUpdateCommands {
+		param, err := descriptorToParam(descriptor)
+		if err != nil {
+			return fmt.Errorf("inject reserved command %q: %w", oid, err)
+		}
+		device.Commands[oid] = param
+	}
+	return nil
+}
+
+// descriptorToParam converts a Go descriptor map into a protos.Param using the
+// same JSON path that toProtoDevice relies on.
+func descriptorToParam(descriptor any) (*protos.Param, error) {
+	jsonData, err := json.Marshal(descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("marshal descriptor: %w", err)
+	}
+	param := &protos.Param{}
+	if err := protojson.Unmarshal(jsonData, param); err != nil {
+		return nil, fmt.Errorf("unmarshal descriptor: %w", err)
+	}
+	return param, nil
+}
+
+// normalizeReservedOid strips a leading slash so REST (/upload_update) and
+// gRPC (upload_update) OID forms compare equal.
+func normalizeReservedOid(fqoid string) string {
+	return strings.TrimPrefix(fqoid, "/")
+}
+
+// isReservedUpdateOid reports whether fqoid targets one of the reserved
+// software-update commands.
+func isReservedUpdateOid(fqoid string) bool {
+	switch normalizeReservedOid(fqoid) {
+	case ReservedOidUploadUpdate, ReservedOidApplyUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
+// updateManager owns the lifecycle of uploaded software updates.
+type updateManager struct {
+	mu      sync.Mutex
+	dir     string
+	nextID  int32
+	updates map[int32]*Update
+	applyFn ApplyUpdateFunc
+}
+
+func newUpdateManager(dir string, applyFn ApplyUpdateFunc) *updateManager {
+	if dir == "" {
+		dir = filepath.Join(os.TempDir(), "catena-updates")
+	}
+	if applyFn == nil {
+		applyFn = defaultApplyUpdate
+	}
+	return &updateManager{
+		dir:     dir,
+		updates: make(map[int32]*Update),
+		applyFn: applyFn,
+	}
+}
+
+// defaultApplyUpdate is the reference implementation: it validates that the
+// uploaded update data is reachable. Device-specific apply logic should be
+// supplied via ServerOptions.ApplyUpdateFunc.
+func defaultApplyUpdate(update *Update) error {
+	if update == nil {
+		return fmt.Errorf("nil update")
+	}
+	if update.DataPath != "" {
+		if _, err := os.Stat(update.DataPath); err != nil {
+			return fmt.Errorf("update data not found: %w", err)
+		}
+		return nil
+	}
+	if update.URL != "" {
+		return nil
+	}
+	return fmt.Errorf("update %d has no data", update.ID)
+}
+
+// execute dispatches a reserved update command to its handler.
+func (m *updateManager) execute(fqoid string, payload any) (CommandResult, StatusResult) {
+	switch normalizeReservedOid(fqoid) {
+	case ReservedOidUploadUpdate:
+		return m.handleUpload(payload)
+	case ReservedOidApplyUpdate:
+		return m.handleApply(payload)
+	default:
+		return CommandError(NOT_FOUND, "unknown reserved command: "+fqoid)
+	}
+}
+
+// handleUpload stores the uploaded update data and metadata, returning the
+// newly assigned update ID so apply_update can reference it.
+func (m *updateManager) handleUpload(payload any) (CommandResult, StatusResult) {
+	fields, ok := payload.(map[string]any)
+	if !ok {
+		return CommandExceptionResult("InvalidPayload", "upload_update expects a STRUCT payload",
+			NewPolyglotText("en", "Invalid update payload"))
+	}
+
+	data, ok := fields["data"].(DataPayload)
+	if !ok {
+		return CommandExceptionResult("InvalidPayload", "upload_update requires a 'data' DATA field",
+			NewPolyglotText("en", "Missing update data"))
+	}
+	if len(data.Payload) == 0 && data.Url == "" {
+		return CommandExceptionResult("InvalidPayload", "upload_update 'data' has neither payload nor url",
+			NewPolyglotText("en", "Empty update data"))
+	}
+
+	metadata := parseUpdateMetadata(fields["metadata"])
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.nextID++
+	id := m.nextID
+	update := &Update{ID: id, Metadata: metadata}
+
+	if len(data.Payload) > 0 {
+		if err := os.MkdirAll(m.dir, 0o755); err != nil {
+			m.nextID--
+			return CommandExceptionResult("StorageError", err.Error(),
+				NewPolyglotText("en", "Failed to store update"))
+		}
+		dataPath := filepath.Join(m.dir, fmt.Sprintf("%d.bin", id))
+		if err := os.WriteFile(dataPath, data.Payload, 0o644); err != nil {
+			m.nextID--
+			return CommandExceptionResult("StorageError", err.Error(),
+				NewPolyglotText("en", "Failed to store update"))
+		}
+		update.DataPath = dataPath
+	} else {
+		update.URL = data.Url
+	}
+
+	m.updates[id] = update
+	logger.Info("upload_update stored", "id", id, "path", update.DataPath, "url", update.URL, "bytes", len(data.Payload))
+
+	val, res := ToValue(id)
+	if res.Code != OK {
+		return CommandError(res.Code, res.Error)
+	}
+	return CommandReply(val)
+}
+
+// handleApply applies a previously uploaded update identified by its ID.
+func (m *updateManager) handleApply(payload any) (CommandResult, StatusResult) {
+	fields, ok := payload.(map[string]any)
+	if !ok {
+		return CommandExceptionResult("InvalidPayload", "apply_update expects a STRUCT payload",
+			NewPolyglotText("en", "Invalid update payload"))
+	}
+
+	id, ok := toInt32(fields["id"])
+	if !ok {
+		return CommandExceptionResult("InvalidPayload", "apply_update requires an 'id' INT32 field",
+			NewPolyglotText("en", "Missing update id"))
+	}
+
+	m.mu.Lock()
+	update, found := m.updates[id]
+	applyFn := m.applyFn
+	m.mu.Unlock()
+
+	if !found {
+		return CommandExceptionResult("UnknownUpdate", fmt.Sprintf("no update with id %d", id),
+			NewPolyglotText("en", "Unknown update id"))
+	}
+
+	if err := applyFn(update); err != nil {
+		return CommandExceptionResult("UpdateFailed", err.Error(),
+			NewPolyglotText("en", "Update failed"))
+	}
+
+	logger.Info("apply_update applied", "id", id)
+
+	// Single-response progress: report completion. True streamed 0-100 progress
+	// is a follow-up that requires a streaming command handler + transport.
+	val, res := ToValue(int32(100))
+	if res.Code != OK {
+		return CommandError(res.Code, res.Error)
+	}
+	return CommandReply(val)
+}
+
+// parseUpdateMetadata flattens the STRUCT_ARRAY of {key, value} entries into a
+// plain string map. Unrecognized shapes yield an empty map.
+func parseUpdateMetadata(v any) map[string]string {
+	out := make(map[string]string)
+	arr, ok := v.([]map[string]any)
+	if !ok {
+		return out
+	}
+	for _, entry := range arr {
+		key, _ := entry["key"].(string)
+		value, _ := entry["value"].(string)
+		if key != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+// toInt32 coerces the numeric forms FromProto / JSON decoding may produce.
+func toInt32(v any) (int32, bool) {
+	switch n := v.(type) {
+	case int32:
+		return n, true
+	case int:
+		return int32(n), true
+	case int64:
+		return int32(n), true
+	case float64:
+		return int32(n), true
+	case float32:
+		return int32(n), true
+	default:
+		return 0, false
+	}
+}

--- a/sdks/go/pkg/catena/update.go
+++ b/sdks/go/pkg/catena/update.go
@@ -171,7 +171,7 @@ func executeReservedCommand(commandFqoid string, payload any) (CommandResult, St
 // response, surfacing any conversion error as a transport-level error.
 func reservedCommandReply(msg string) (CommandResult, StatusResult) {
 	val, res := ToValue(msg)
-	if res.Code != OK {
+	if res.Code != StatusCodeOk {
 		return CommandError(res.Code, res.Error)
 	}
 	return CommandReply(val)

--- a/sdks/go/pkg/catena/update_test.go
+++ b/sdks/go/pkg/catena/update_test.go
@@ -100,6 +100,43 @@ func TestToDevice_InjectsReservedCommandsWhenNoneDefined(t *testing.T) {
 	}
 }
 
+func TestExecuteReservedCommand_MatchesTopLevelOnly(t *testing.T) {
+	reserved := []struct {
+		name  string
+		fqoid string
+	}{
+		{"upload_update", ReservedOidUploadUpdate},
+		{"apply_update", ReservedOidApplyUpdate},
+		{"upload_update with leading slash", "/" + ReservedOidUploadUpdate},
+		{"apply_update with leading slash", "/" + ReservedOidApplyUpdate},
+	}
+	for _, tc := range reserved {
+		t.Run("reserved/"+tc.name, func(t *testing.T) {
+			if _, _, handled := executeReservedCommand(tc.fqoid, nil); !handled {
+				t.Errorf("expected %q to be handled as a reserved command", tc.fqoid)
+			}
+		})
+	}
+
+	notReserved := []struct {
+		name  string
+		fqoid string
+	}{
+		{"nested upload_update", "custom.upload_update"},
+		{"nested apply_update", "custom.apply_update"},
+		{"nested upload_update with leading slash", "/custom.upload_update"},
+		{"deeply nested", "device.commands.upload_update"},
+		{"unrelated command", "reboot"},
+	}
+	for _, tc := range notReserved {
+		t.Run("user/"+tc.name, func(t *testing.T) {
+			if _, _, handled := executeReservedCommand(tc.fqoid, nil); handled {
+				t.Errorf("expected %q NOT to be hijacked by the reserved command handler", tc.fqoid)
+			}
+		})
+	}
+}
+
 func TestToDevice_RejectsReservedCommandDefinition(t *testing.T) {
 	for _, reserved := range []string{ReservedOidUploadUpdate, ReservedOidApplyUpdate} {
 		t.Run(reserved, func(t *testing.T) {

--- a/sdks/go/pkg/catena/update_test.go
+++ b/sdks/go/pkg/catena/update_test.go
@@ -31,29 +31,9 @@
 package catena
 
 import (
-	"errors"
-	"os"
+	"strings"
 	"testing"
 )
-
-func uploadPayload(data DataPayload, metadata []map[string]any) map[string]any {
-	return map[string]any{
-		"metadata": metadata,
-		"data":     data,
-	}
-}
-
-func replyInt32(t *testing.T, r CommandResult) int32 {
-	t.Helper()
-	proto := r.GetProtoResponse()
-	if proto == nil {
-		t.Fatal("expected a CommandResponse, got nil")
-	}
-	if r.IsException() {
-		t.Fatalf("expected reply, got exception: %v", r.GetException())
-	}
-	return proto.GetResponse().GetInt32Value()
-}
 
 func TestToDevice_InjectsReservedCommands(t *testing.T) {
 	deviceMap := map[string]any{
@@ -120,180 +100,28 @@ func TestToDevice_InjectsReservedCommandsWhenNoneDefined(t *testing.T) {
 	}
 }
 
-func TestUpdateManager_UploadApplyRoundTrip(t *testing.T) {
-	dir := t.TempDir()
-	m := newUpdateManager(dir, nil)
+func TestToDevice_RejectsReservedCommandDefinition(t *testing.T) {
+	for _, reserved := range []string{ReservedOidUploadUpdate, ReservedOidApplyUpdate} {
+		t.Run(reserved, func(t *testing.T) {
+			deviceMap := map[string]any{
+				"slot": uint32(0),
+				"commands": map[string]any{
+					reserved: map[string]any{
+						"name": map[string]any{
+							"display_strings": map[string]string{"en": "Custom"},
+						},
+						"type": ParamTypeEmpty,
+					},
+				},
+			}
 
-	metadata := []map[string]any{
-		{"key": "version", "value": "1.2.3"},
-		{"key": "vendor", "value": "Ross"},
-	}
-	payload := uploadPayload(DataPayload{Payload: []byte("firmware-bytes")}, metadata)
-
-	uploadResult, status := m.handleUpload(payload)
-	if status.Code != OK {
-		t.Fatalf("handleUpload status: %v", status.Error)
-	}
-	id := replyInt32(t, uploadResult)
-	if id != 1 {
-		t.Fatalf("expected first update id 1, got %d", id)
-	}
-
-	stored := m.updates[id]
-	if stored == nil {
-		t.Fatal("expected update to be stored")
-	}
-	if stored.Metadata["version"] != "1.2.3" {
-		t.Errorf("expected metadata version 1.2.3, got %q", stored.Metadata["version"])
-	}
-	if _, err := os.Stat(stored.DataPath); err != nil {
-		t.Fatalf("expected update file to exist: %v", err)
-	}
-
-	applyResult, status := m.handleApply(map[string]any{"id": id})
-	if status.Code != OK {
-		t.Fatalf("handleApply status: %v", status.Error)
-	}
-	if progress := replyInt32(t, applyResult); progress != 100 {
-		t.Errorf("expected apply progress 100, got %d", progress)
-	}
-}
-
-func TestUpdateManager_UploadAssignsIncrementingIDs(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-	payload := uploadPayload(DataPayload{Payload: []byte("x")}, nil)
-
-	first, _ := m.handleUpload(payload)
-	second, _ := m.handleUpload(payload)
-
-	if replyInt32(t, first) != 1 || replyInt32(t, second) != 2 {
-		t.Error("expected incrementing update ids 1, 2")
-	}
-}
-
-func TestUpdateManager_UploadURLOnly(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-	payload := uploadPayload(DataPayload{Url: "https://example.com/fw.bin"}, nil)
-
-	uploadResult, status := m.handleUpload(payload)
-	if status.Code != OK {
-		t.Fatalf("handleUpload status: %v", status.Error)
-	}
-	id := replyInt32(t, uploadResult)
-	if m.updates[id].URL != "https://example.com/fw.bin" {
-		t.Error("expected URL to be stored")
-	}
-
-	applyResult, _ := m.handleApply(map[string]any{"id": id})
-	if applyResult.IsException() {
-		t.Errorf("expected URL-based apply to succeed, got exception: %v", applyResult.GetException())
-	}
-}
-
-func TestUpdateManager_UploadInvalidPayload(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-
-	result, _ := m.handleUpload("not-a-struct")
-	if !result.IsException() {
-		t.Fatal("expected exception for non-struct payload")
-	}
-	if result.GetException().GetType() != "InvalidPayload" {
-		t.Errorf("expected InvalidPayload, got %q", result.GetException().GetType())
-	}
-}
-
-func TestUpdateManager_UploadEmptyData(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-
-	result, _ := m.handleUpload(uploadPayload(DataPayload{}, nil))
-	if !result.IsException() {
-		t.Fatal("expected exception for empty data")
-	}
-}
-
-func TestUpdateManager_UploadMissingDataField(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-
-	result, _ := m.handleUpload(map[string]any{"metadata": []map[string]any{}})
-	if !result.IsException() {
-		t.Fatal("expected exception when data field is missing")
-	}
-}
-
-func TestUpdateManager_ApplyUnknownID(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-
-	result, _ := m.handleApply(map[string]any{"id": int32(999)})
-	if !result.IsException() {
-		t.Fatal("expected exception for unknown update id")
-	}
-	if result.GetException().GetType() != "UnknownUpdate" {
-		t.Errorf("expected UnknownUpdate, got %q", result.GetException().GetType())
-	}
-}
-
-func TestUpdateManager_ApplyMissingID(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-
-	result, _ := m.handleApply(map[string]any{})
-	if !result.IsException() {
-		t.Fatal("expected exception when id is missing")
-	}
-}
-
-func TestUpdateManager_ApplyCustomFuncError(t *testing.T) {
-	called := false
-	m := newUpdateManager(t.TempDir(), func(u *Update) error {
-		called = true
-		return errors.New("bootloader rejected image")
-	})
-
-	upload, _ := m.handleUpload(uploadPayload(DataPayload{Payload: []byte("fw")}, nil))
-	id := replyInt32(t, upload)
-
-	result, _ := m.handleApply(map[string]any{"id": id})
-	if !called {
-		t.Error("expected custom ApplyUpdateFunc to be invoked")
-	}
-	if !result.IsException() {
-		t.Fatal("expected exception when apply func fails")
-	}
-	if result.GetException().GetType() != "UpdateFailed" {
-		t.Errorf("expected UpdateFailed, got %q", result.GetException().GetType())
-	}
-}
-
-func TestUpdateManager_ExecuteDispatch(t *testing.T) {
-	m := newUpdateManager(t.TempDir(), nil)
-
-	// Leading-slash form (REST) should normalize to the same OID.
-	upload, status := m.execute("/"+ReservedOidUploadUpdate, uploadPayload(DataPayload{Payload: []byte("fw")}, nil))
-	if status.Code != OK {
-		t.Fatalf("execute upload status: %v", status.Error)
-	}
-	id := replyInt32(t, upload)
-
-	apply, status := m.execute(ReservedOidApplyUpdate, map[string]any{"id": id})
-	if status.Code != OK {
-		t.Fatalf("execute apply status: %v", status.Error)
-	}
-	if replyInt32(t, apply) != 100 {
-		t.Error("expected apply progress 100")
-	}
-}
-
-func TestIsReservedUpdateOid(t *testing.T) {
-	cases := map[string]bool{
-		ReservedOidUploadUpdate:       true,
-		ReservedOidApplyUpdate:        true,
-		"/" + ReservedOidUploadUpdate: true,
-		"/" + ReservedOidApplyUpdate:  true,
-		"reboot":                      false,
-		"":                            false,
-	}
-	for oid, want := range cases {
-		if got := isReservedUpdateOid(oid); got != want {
-			t.Errorf("isReservedUpdateOid(%q) = %v, want %v", oid, got, want)
-		}
+			_, err := ToDevice(deviceMap)
+			if err == nil {
+				t.Fatalf("expected error when device defines reserved command %q", reserved)
+			}
+			if !strings.Contains(err.Error(), reserved) {
+				t.Errorf("expected error to name %q, got: %v", reserved, err)
+			}
+		})
 	}
 }

--- a/sdks/go/pkg/catena/update_test.go
+++ b/sdks/go/pkg/catena/update_test.go
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package catena
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func uploadPayload(data DataPayload, metadata []map[string]any) map[string]any {
+	return map[string]any{
+		"metadata": metadata,
+		"data":     data,
+	}
+}
+
+func replyInt32(t *testing.T, r CommandResult) int32 {
+	t.Helper()
+	proto := r.GetProtoResponse()
+	if proto == nil {
+		t.Fatal("expected a CommandResponse, got nil")
+	}
+	if r.IsException() {
+		t.Fatalf("expected reply, got exception: %v", r.GetException())
+	}
+	return proto.GetResponse().GetInt32Value()
+}
+
+func TestToDevice_InjectsReservedCommands(t *testing.T) {
+	deviceMap := map[string]any{
+		"slot":         uint32(0),
+		"detail_level": DetailLevelFull,
+		"commands": map[string]any{
+			"reboot": map[string]any{
+				"name": map[string]any{
+					"display_strings": map[string]string{"en": "Reboot Device"},
+				},
+				"type": ParamTypeEmpty,
+			},
+		},
+	}
+
+	cd, err := ToDevice(deviceMap)
+	if err != nil {
+		t.Fatalf("ToDevice error: %v", err)
+	}
+	commands := cd.GetProtoDevice().GetCommands()
+
+	for _, oid := range []string{"reboot", ReservedOidUploadUpdate, ReservedOidApplyUpdate} {
+		if _, ok := commands[oid]; !ok {
+			t.Errorf("expected command %q to be present", oid)
+		}
+	}
+
+	upload := commands[ReservedOidUploadUpdate]
+	if upload.GetType() != ParamTypeStruct {
+		t.Errorf("upload_update: expected STRUCT, got %v", upload.GetType())
+	}
+	if !upload.GetResponse() {
+		t.Error("upload_update: expected response=true")
+	}
+	dataField, ok := upload.GetParams()["data"]
+	if !ok {
+		t.Fatal("upload_update: expected 'data' sub-param")
+	}
+	if dataField.GetType() != ParamTypeData {
+		t.Errorf("upload_update.data: expected DATA, got %v", dataField.GetType())
+	}
+
+	apply := commands[ReservedOidApplyUpdate]
+	idField, ok := apply.GetParams()["id"]
+	if !ok {
+		t.Fatal("apply_update: expected 'id' sub-param")
+	}
+	if idField.GetType() != ParamTypeInt32 {
+		t.Errorf("apply_update.id: expected INT32, got %v", idField.GetType())
+	}
+}
+
+func TestToDevice_InjectsReservedCommandsWhenNoneDefined(t *testing.T) {
+	cd, err := ToDevice(map[string]any{"slot": uint32(0)})
+	if err != nil {
+		t.Fatalf("ToDevice error: %v", err)
+	}
+	commands := cd.GetProtoDevice().GetCommands()
+	if _, ok := commands[ReservedOidUploadUpdate]; !ok {
+		t.Error("expected upload_update to be injected")
+	}
+	if _, ok := commands[ReservedOidApplyUpdate]; !ok {
+		t.Error("expected apply_update to be injected")
+	}
+}
+
+func TestUpdateManager_UploadApplyRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	m := newUpdateManager(dir, nil)
+
+	metadata := []map[string]any{
+		{"key": "version", "value": "1.2.3"},
+		{"key": "vendor", "value": "Ross"},
+	}
+	payload := uploadPayload(DataPayload{Payload: []byte("firmware-bytes")}, metadata)
+
+	uploadResult, status := m.handleUpload(payload)
+	if status.Code != OK {
+		t.Fatalf("handleUpload status: %v", status.Error)
+	}
+	id := replyInt32(t, uploadResult)
+	if id != 1 {
+		t.Fatalf("expected first update id 1, got %d", id)
+	}
+
+	stored := m.updates[id]
+	if stored == nil {
+		t.Fatal("expected update to be stored")
+	}
+	if stored.Metadata["version"] != "1.2.3" {
+		t.Errorf("expected metadata version 1.2.3, got %q", stored.Metadata["version"])
+	}
+	if _, err := os.Stat(stored.DataPath); err != nil {
+		t.Fatalf("expected update file to exist: %v", err)
+	}
+
+	applyResult, status := m.handleApply(map[string]any{"id": id})
+	if status.Code != OK {
+		t.Fatalf("handleApply status: %v", status.Error)
+	}
+	if progress := replyInt32(t, applyResult); progress != 100 {
+		t.Errorf("expected apply progress 100, got %d", progress)
+	}
+}
+
+func TestUpdateManager_UploadAssignsIncrementingIDs(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+	payload := uploadPayload(DataPayload{Payload: []byte("x")}, nil)
+
+	first, _ := m.handleUpload(payload)
+	second, _ := m.handleUpload(payload)
+
+	if replyInt32(t, first) != 1 || replyInt32(t, second) != 2 {
+		t.Error("expected incrementing update ids 1, 2")
+	}
+}
+
+func TestUpdateManager_UploadURLOnly(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+	payload := uploadPayload(DataPayload{Url: "https://example.com/fw.bin"}, nil)
+
+	uploadResult, status := m.handleUpload(payload)
+	if status.Code != OK {
+		t.Fatalf("handleUpload status: %v", status.Error)
+	}
+	id := replyInt32(t, uploadResult)
+	if m.updates[id].URL != "https://example.com/fw.bin" {
+		t.Error("expected URL to be stored")
+	}
+
+	applyResult, _ := m.handleApply(map[string]any{"id": id})
+	if applyResult.IsException() {
+		t.Errorf("expected URL-based apply to succeed, got exception: %v", applyResult.GetException())
+	}
+}
+
+func TestUpdateManager_UploadInvalidPayload(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+
+	result, _ := m.handleUpload("not-a-struct")
+	if !result.IsException() {
+		t.Fatal("expected exception for non-struct payload")
+	}
+	if result.GetException().GetType() != "InvalidPayload" {
+		t.Errorf("expected InvalidPayload, got %q", result.GetException().GetType())
+	}
+}
+
+func TestUpdateManager_UploadEmptyData(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+
+	result, _ := m.handleUpload(uploadPayload(DataPayload{}, nil))
+	if !result.IsException() {
+		t.Fatal("expected exception for empty data")
+	}
+}
+
+func TestUpdateManager_UploadMissingDataField(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+
+	result, _ := m.handleUpload(map[string]any{"metadata": []map[string]any{}})
+	if !result.IsException() {
+		t.Fatal("expected exception when data field is missing")
+	}
+}
+
+func TestUpdateManager_ApplyUnknownID(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+
+	result, _ := m.handleApply(map[string]any{"id": int32(999)})
+	if !result.IsException() {
+		t.Fatal("expected exception for unknown update id")
+	}
+	if result.GetException().GetType() != "UnknownUpdate" {
+		t.Errorf("expected UnknownUpdate, got %q", result.GetException().GetType())
+	}
+}
+
+func TestUpdateManager_ApplyMissingID(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+
+	result, _ := m.handleApply(map[string]any{})
+	if !result.IsException() {
+		t.Fatal("expected exception when id is missing")
+	}
+}
+
+func TestUpdateManager_ApplyCustomFuncError(t *testing.T) {
+	called := false
+	m := newUpdateManager(t.TempDir(), func(u *Update) error {
+		called = true
+		return errors.New("bootloader rejected image")
+	})
+
+	upload, _ := m.handleUpload(uploadPayload(DataPayload{Payload: []byte("fw")}, nil))
+	id := replyInt32(t, upload)
+
+	result, _ := m.handleApply(map[string]any{"id": id})
+	if !called {
+		t.Error("expected custom ApplyUpdateFunc to be invoked")
+	}
+	if !result.IsException() {
+		t.Fatal("expected exception when apply func fails")
+	}
+	if result.GetException().GetType() != "UpdateFailed" {
+		t.Errorf("expected UpdateFailed, got %q", result.GetException().GetType())
+	}
+}
+
+func TestUpdateManager_ExecuteDispatch(t *testing.T) {
+	m := newUpdateManager(t.TempDir(), nil)
+
+	// Leading-slash form (REST) should normalize to the same OID.
+	upload, status := m.execute("/"+ReservedOidUploadUpdate, uploadPayload(DataPayload{Payload: []byte("fw")}, nil))
+	if status.Code != OK {
+		t.Fatalf("execute upload status: %v", status.Error)
+	}
+	id := replyInt32(t, upload)
+
+	apply, status := m.execute(ReservedOidApplyUpdate, map[string]any{"id": id})
+	if status.Code != OK {
+		t.Fatalf("execute apply status: %v", status.Error)
+	}
+	if replyInt32(t, apply) != 100 {
+		t.Error("expected apply progress 100")
+	}
+}
+
+func TestIsReservedUpdateOid(t *testing.T) {
+	cases := map[string]bool{
+		ReservedOidUploadUpdate:       true,
+		ReservedOidApplyUpdate:        true,
+		"/" + ReservedOidUploadUpdate: true,
+		"/" + ReservedOidApplyUpdate:  true,
+		"reboot":                      false,
+		"":                            false,
+	}
+	for oid, want := range cases {
+		if got := isReservedUpdateOid(oid); got != want {
+			t.Errorf("isReservedUpdateOid(%q) = %v, want %v", oid, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## 📖 Description
Introduces two SDK-reserved command OIDs, `upload_update` and `apply_update`, to the Go SDK. These commands are now auto-injected into **every** device model produced by `ToDevice`, so they are always present without any application or example code declaring them. A device may **not** define either OID itself — attempting to do so now causes `ToDevice` to fail with an explicit error naming the reserved OID.

---

## 🎯 Goal / Outcome
- `upload_update` and `apply_update` exist by default on every Catena device exposed through the Go SDK.
- The two OIDs are owned by the SDK and cannot be overridden or redefined by device authors.
- Device authors get a clear, early error if they accidentally collide with a reserved OID.

---

## ✅ Definition of Done (DoD)
- [x] `upload_update` / `apply_update` auto-injected into every device via `injectReservedCommands` in `toProtoDevice`
- [x] Reserved OIDs cannot be defined by a device — `ToDevice` returns an error naming the offending OID
- [x] Tests cover injection (with and without other commands) and rejection of user-defined reserved OIDs
- [x] `gofmt`, `go vet`, and `./pkg/...` tests pass

---



## 🔗 Related Issues / Links
- Closes issue #1339 

