### PR TITLE
[GO] ConnectionProps

### DIFF
--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -848,13 +848,10 @@ func main() {
 	}
 	connectionProps := catena.NewConnectionProps(catena.ConnectionPropsOptions{
 		Protocol:        connectionProtocol,
-		Port:            options.Dashboard.Port,
-		ServicePort:     options.Dashboard.ServicePort,
-		Hostname:        options.Dashboard.Hostname,
+		Dashboard:       options.Dashboard,
 		RefreshInterval: 30000,
 		NodeName:        "One of Everything Demo",
 		NodeID:          "one-of-everything-a4:bb:6d:6a:6f:a3",
-		TLSEnabled:      options.Dashboard.TLSEnabled,
 	})
 	connectionPropsURL := fmt.Sprintf("http://localhost:%d%s", options.Dashboard.Port, connectionProps.Endpoint())
 	if err := connectionProps.Start(); err != nil {
@@ -943,7 +940,7 @@ func main() {
 	logger.Info("")
 	logger.Info("[ REST transport ]", "status", status(options.UseRest))
 	if options.UseRest {
-		logger.Info("    web ui", "url", "http://localhost:8080/")
+		logger.Info("    web ui", "url", "http://localhost:9080/")
 	}
 
 	logger.Info("")

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -874,16 +874,6 @@ func main() {
 		restTransport := transports.NewDefaultRestTransport()
 
 		restTransport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult) {
-			// Also serve the DashBoard connection-props XML on the REST port
-			if r.URL.Path == connectionProps.Endpoint() {
-				if r.Method != http.MethodGet {
-					return catena.ReplyError[catena.Value](catena.StatusCodeInvalidArgument, "method not allowed: "+r.Method)
-				}
-				w.Header().Set("Content-Type", "application/xml")
-				w.Write([]byte(connectionProps.Content()))
-				return catena.Reply(catena.Value{})
-			}
-
 			if r.URL.Path == "/assets-list" {
 				var assetList []map[string]any
 				assets.Range(func(key, value any) bool {

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -842,17 +842,15 @@ func main() {
 	// DashBoard "Detect Frame Information" connection-props HTTP server.
 	// Advertises this device so DashBoard can resolve and populate the
 	// connection dialog. Works for both REST and gRPC devices.
-	connectionProtocol := catena.ProtocolST2138Rest
+	dashboardOpts := options.Dashboard
+	dashboardOpts.Protocol = catena.ProtocolST2138Rest
 	if options.UseGrpc {
-		connectionProtocol = catena.ProtocolST2138Grpc
+		dashboardOpts.Protocol = catena.ProtocolST2138Grpc
 	}
-	connectionProps := catena.NewConnectionProps(catena.ConnectionPropsOptions{
-		Protocol:        connectionProtocol,
-		Dashboard:       options.Dashboard,
-		RefreshInterval: 30000,
-		NodeName:        "One of Everything Demo",
-		NodeID:          "one-of-everything-a4:bb:6d:6a:6f:a3",
-	})
+	dashboardOpts.RefreshInterval = 30000
+	dashboardOpts.NodeName = "One of Everything Demo"
+	dashboardOpts.NodeID = "one-of-everything-a4:bb:6d:6a:6f:a3"
+	connectionProps := catena.NewConnectionProps(dashboardOpts)
 	connectionPropsURL := fmt.Sprintf("http://localhost:%d%s", options.Dashboard.Port, connectionProps.Endpoint())
 	if err := connectionProps.Start(); err != nil {
 		logger.Warning("Failed to start connection props server", "port", options.Dashboard.Port, "error", err)

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -839,6 +839,30 @@ func main() {
 		os.Exit(1)
 	}
 
+	// DashBoard "Detect Frame Information" connection-props HTTP server.
+	// Advertises this device so DashBoard can resolve and populate the
+	// connection dialog. Works for both REST and gRPC devices.
+	connectionProtocol := catena.ProtocolST2138Rest
+	if options.UseGrpc {
+		connectionProtocol = catena.ProtocolST2138Grpc
+	}
+	connectionProps := catena.NewConnectionProps(catena.ConnectionPropsOptions{
+		Protocol:        connectionProtocol,
+		Port:            options.Dashboard.Port,
+		ServicePort:     options.Dashboard.ServicePort,
+		Hostname:        options.Dashboard.Hostname,
+		RefreshInterval: 30000,
+		NodeName:        "One of Everything Demo",
+		NodeID:          "one-of-everything-a4:bb:6d:6a:6f:a3",
+		TLSEnabled:      options.Dashboard.TLSEnabled,
+	})
+	if err := connectionProps.Start(); err != nil {
+		logger.Warning("Failed to start connection props server", "port", options.Dashboard.Port, "error", err)
+	} else {
+		logger.Info("Connection props available at:",
+			"url", fmt.Sprintf("http://localhost:%d%s", options.Dashboard.Port, connectionProps.Endpoint()))
+	}
+
 	logger.Info("=======================================================")
 	logger.Info("One of Everything gRPC Example")
 	logger.Info("=======================================================")
@@ -866,6 +890,16 @@ func main() {
 		restTransport := transports.NewDefaultRestTransport()
 
 		restTransport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult) {
+			// Also serve the DashBoard connection-props XML on the REST port
+			if r.URL.Path == connectionProps.Endpoint() {
+				if r.Method != http.MethodGet {
+					return catena.ReplyError[catena.Value](catena.StatusCodeInvalidArgument, "method not allowed: "+r.Method)
+				}
+				w.Header().Set("Content-Type", "application/xml")
+				w.Write([]byte(connectionProps.Content()))
+				return catena.Reply(catena.Value{})
+			}
+
 			if r.URL.Path == "/assets-list" {
 				var assetList []map[string]any
 				assets.Range(func(key, value any) bool {
@@ -926,6 +960,9 @@ func main() {
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
 	defer shutdownCancel()
+	if err := connectionProps.Stop(shutdownCtx); err != nil {
+		logger.Warning("Error stopping connection props server", "error", err)
+	}
 	srv.Shutdown(shutdownCtx)
 	logger.Info("Server shutdown complete")
 }

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -856,37 +856,21 @@ func main() {
 		NodeID:          "one-of-everything-a4:bb:6d:6a:6f:a3",
 		TLSEnabled:      options.Dashboard.TLSEnabled,
 	})
+	connectionPropsURL := fmt.Sprintf("http://localhost:%d%s", options.Dashboard.Port, connectionProps.Endpoint())
 	if err := connectionProps.Start(); err != nil {
 		logger.Warning("Failed to start connection props server", "port", options.Dashboard.Port, "error", err)
-	} else {
-		logger.Info("Connection props available at:",
-			"url", fmt.Sprintf("http://localhost:%d%s", options.Dashboard.Port, connectionProps.Endpoint()))
+		connectionPropsURL = ""
 	}
 
-	logger.Info("=======================================================")
-	logger.Info("One of Everything gRPC Example")
-	logger.Info("=======================================================")
-
-	// register the transports we want to serve on.
+	// Register the enabled transports.
 	if options.UseGrpc {
-		logger.Info("gRPC transport starting")
-		logger.Info("")
-		// Register gRPC transport if enabled in config
 		if err := srv.RegisterTransport(transports.NewDefaultGrpcTransport()); err != nil {
 			logger.Error("Failed to register gRPC transport", "error", err)
 			os.Exit(1)
 		}
-		logger.Info("Use grpcurl or a gRPC client to interact with the server:")
-		logger.Info("  grpcurl -plaintext localhost:6254 list")
-	} else {
-		logger.Info("gRPC transport disabled by config")
 	}
-	logger.Info("")
-	logger.Info("=======================================================")
 
 	if options.UseRest {
-		logger.Info("REST transport starting")
-		logger.Info("")
 		restTransport := transports.NewDefaultRestTransport()
 
 		restTransport.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult) {
@@ -942,12 +926,42 @@ func main() {
 			logger.Error("Failed to register REST transport", "error", err)
 			os.Exit(1)
 		}
-
-		logger.Info("Web UI available at:")
-		logger.Info("  http://localhost:8080/")
-	} else {
-		logger.Info("REST transport disabled by config")
 	}
+
+	// Startup summary: header, then one section per transport/service with an
+	// ENABLED/DISABLED indicator and its endpoints.
+	status := func(on bool) string {
+		if on {
+			return "ENABLED"
+		}
+		return "DISABLED"
+	}
+
+	logger.Info("")
+	logger.Info("=======================================================")
+	logger.Info("One of Everything Example")
+	logger.Info("=======================================================")
+
+	logger.Info("")
+	logger.Info("[ gRPC transport ]", "status", status(options.UseGrpc))
+	if options.UseGrpc {
+		grpcAddr := fmt.Sprintf("localhost:%d", options.Dashboard.ServicePort)
+		logger.Info("    address", "value", grpcAddr)
+		logger.Info("    query", "command", "grpcurl -plaintext "+grpcAddr+" list")
+	}
+
+	logger.Info("")
+	logger.Info("[ REST transport ]", "status", status(options.UseRest))
+	if options.UseRest {
+		logger.Info("    web ui", "url", "http://localhost:8080/")
+	}
+
+	logger.Info("")
+	logger.Info("[ DashBoard connection props ]", "status", status(connectionPropsURL != ""))
+	if connectionPropsURL != "" {
+		logger.Info("    endpoint", "url", connectionPropsURL)
+	}
+
 	logger.Info("")
 	logger.Info("=======================================================")
 

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Lightweight HTTP server that serves DashBoard connection properties.
+ * @file connection_props.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-06-08
+ */
+
+package catena
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
+)
+
+// ConnectionProtocol identifies the Catena transport advertised to DashBoard.
+type ConnectionProtocol int
+
+const (
+	// ProtocolST2138Rest advertises a ST 2138 REST device.
+	ProtocolST2138Rest ConnectionProtocol = iota
+	// ProtocolST2138Grpc advertises a ST 2138 gRPC device.
+	ProtocolST2138Grpc
+)
+
+// String returns the canonical protocol identifier used in logs.
+func (p ConnectionProtocol) String() string {
+	switch p {
+	case ProtocolST2138Rest:
+		return "st2138-rest"
+	case ProtocolST2138Grpc:
+		return "st2138-grpc"
+	default:
+		return ""
+	}
+}
+
+// Default values
+const (
+	defaultConnectionPropsEndpoint    = "/connect/connection-props.xml"
+	defaultConnectionPropsService     = "service:catena-device"
+	defaultConnectionPropsEquipment   = "catena"
+	defaultConnectionPropsRefreshMs   = 30000
+	defaultConnectionPropsHostname    = "0.0.0.0"
+	defaultConnectionPropsPort        = 80
+	defaultConnectionPropsServicePort = 6254
+)
+
+// ConnectionPropsOptions configures a ConnectionProps server
+type ConnectionPropsOptions struct {
+	// Protocol is the transport being advertised (used for logging).
+	Protocol ConnectionProtocol
+	// Port is the port the connection-props HTTP server listens on (default 80).
+	Port int
+	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
+	ServicePort int
+	// Hostname is the address advertised to DashBoard (default "0.0.0.0").
+	Hostname string
+	// RefreshInterval is the DashBoard refresh interval in milliseconds (default 30000).
+	RefreshInterval uint32
+	// NodeName is the optional human-readable node name.
+	NodeName string
+	// NodeID is the optional unique node identifier.
+	NodeID string
+	// ServiceName is the advertised service URL (default "service:catena-device").
+	ServiceName string
+	// EquipmentType is the DashBoard equipment type (default "catena").
+	EquipmentType string
+	// Endpoint is the path served (default "/connect/connection-props.xml").
+	Endpoint string
+	// TLSEnabled controls whether the advertised connection uses TLS/SSL.
+	TLSEnabled bool
+}
+
+// ConnectionProps is a lightweight HTTP server that serves a single endpoint
+// (/connect/connection-props.xml) with the connection properties consumed by
+// the DashBoard "Detect Frame Information" workflow. It is transport-agnostic
+// and can front either a REST or gRPC Catena device.
+type ConnectionProps struct {
+	opts ConnectionPropsOptions
+
+	mu      sync.Mutex
+	server  *http.Server
+	content string
+	running bool
+}
+
+// NewConnectionProps builds a ConnectionProps server, applying defaults for any
+// unset option. The XML payload is generated once at construction time.
+func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
+	if opts.Port == 0 {
+		opts.Port = defaultConnectionPropsPort
+	}
+	if opts.ServicePort == 0 {
+		opts.ServicePort = defaultConnectionPropsServicePort
+	}
+	if opts.Hostname == "" {
+		opts.Hostname = defaultConnectionPropsHostname
+	}
+	if opts.RefreshInterval == 0 {
+		opts.RefreshInterval = defaultConnectionPropsRefreshMs
+	}
+	if opts.ServiceName == "" {
+		opts.ServiceName = defaultConnectionPropsService
+	}
+	if opts.EquipmentType == "" {
+		opts.EquipmentType = defaultConnectionPropsEquipment
+	}
+	if opts.Endpoint == "" {
+		opts.Endpoint = defaultConnectionPropsEndpoint
+	}
+	if !strings.HasPrefix(opts.Endpoint, "/") {
+		opts.Endpoint = "/" + opts.Endpoint
+	}
+
+	c := &ConnectionProps{opts: opts}
+	c.content = c.generateXML()
+	logger.Info("Connection props server constructed",
+		"endpoint", opts.Endpoint, "port", opts.Port, "protocol", opts.Protocol.String())
+	return c
+}
+
+// Endpoint returns the path this server responds to.
+func (c *ConnectionProps) Endpoint() string {
+	return c.opts.Endpoint
+}
+
+// IsRunning reports whether the server is currently listening.
+func (c *ConnectionProps) IsRunning() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.running
+}
+
+// Content returns the generated XML payload served at the endpoint.
+func (c *ConnectionProps) Content() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.content
+}
+
+// Start begins serving connection props in a background goroutine. It returns
+// an error if the server is already running or the listener cannot be created.
+func (c *ConnectionProps) Start() error {
+	c.mu.Lock()
+	if c.running {
+		c.mu.Unlock()
+		logger.Warning("Connection props server already running", "port", c.opts.Port)
+		return fmt.Errorf("connection props server already running")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", c.handle)
+
+	c.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", c.opts.Port),
+		Handler: mux,
+	}
+	c.running = true
+	srv := c.server
+	c.mu.Unlock()
+
+	go func() {
+		logger.Info("Connection props server listening",
+			"address", srv.Addr, "endpoint", c.opts.Endpoint)
+		err := srv.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			logger.Error("Connection props server error", "error", err)
+		}
+		c.mu.Lock()
+		c.running = false
+		c.mu.Unlock()
+	}()
+	return nil
+}
+
+// Stop gracefully shuts down the server, honoring the provided context deadline.
+// It is safe to call when the server is not running.
+func (c *ConnectionProps) Stop(ctx context.Context) error {
+	c.mu.Lock()
+	srv := c.server
+	running := c.running
+	c.mu.Unlock()
+
+	if !running || srv == nil {
+		return nil
+	}
+
+	logger.Info("Stopping connection props server", "port", c.opts.Port)
+	err := srv.Shutdown(ctx)
+	if err != nil {
+		// Best-effort hard close so we never leak the listener.
+		_ = srv.Close()
+	}
+
+	c.mu.Lock()
+	c.running = false
+	c.mu.Unlock()
+
+	logger.Info("Connection props server stopped")
+	return err
+}
+
+// handle serves the connection-props endpoint and a /health probe; everything
+// else returns 404. Only GET is permitted on the props endpoint.
+func (c *ConnectionProps) handle(w http.ResponseWriter, r *http.Request) {
+	logger.Debug("Connection props request", "method", r.Method, "path", r.URL.Path)
+
+	switch r.URL.Path {
+	case c.opts.Endpoint:
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		c.mu.Lock()
+		body := c.content
+		c.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	case "/health":
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	default:
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}
+}
+
+// generateXML renders the DashBoard connection-props XML payload.
+func (c *ConnectionProps) generateXML() string {
+	scheme := "http"
+	connectionType := "TCP"
+	if c.opts.TLSEnabled {
+		scheme = "https"
+		connectionType = "SSL"
+	}
+
+	var b strings.Builder
+	b.WriteString("<properties version=\"1.0\">\n")
+	b.WriteString("    <comment>DashBoard Device Connection Settings</comment>\n")
+	writeEntry(&b, "base-url", fmt.Sprintf("%s://%s/", scheme, c.opts.Hostname))
+	writeEntry(&b, "serviceUrl", c.opts.ServiceName)
+	writeEntry(&b, "equipmentType", c.opts.EquipmentType)
+	writeEntry(&b, "address", c.opts.Hostname)
+	writeEntry(&b, "port", fmt.Sprintf("%d", c.opts.ServicePort))
+	writeEntry(&b, "connectionType", connectionType)
+	if c.opts.NodeID != "" {
+		writeEntry(&b, "node-id", c.opts.NodeID)
+	}
+	if c.opts.NodeName != "" {
+		writeEntry(&b, "node-name", c.opts.NodeName)
+	}
+	writeEntry(&b, "index-url", "connect/connection-props.xml")
+	writeEntry(&b, "refresh-interval", fmt.Sprintf("%d", c.opts.RefreshInterval))
+	b.WriteString("</properties>")
+	return b.String()
+}
+
+// writeEntry appends a single <entry> line with an XML-escaped value.
+func writeEntry(b *strings.Builder, key, value string) {
+	b.WriteString("    <entry key=\"")
+	b.WriteString(key)
+	b.WriteString("\">")
+	b.WriteString(xmlEscape(value))
+	b.WriteString("</entry>\n")
+}
+
+// xmlEscape escapes the characters that are illegal in XML text content.
+func xmlEscape(s string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"\"", "&quot;",
+		"'", "&apos;",
+	)
+	return replacer.Replace(s)
+}

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -76,7 +76,7 @@ const (
 	defaultConnectionPropsService     = "service:catena-device"
 	defaultConnectionPropsRefreshMs   = 30000
 	defaultConnectionPropsHostname    = "0.0.0.0"
-	defaultConnectionPropsPort        = 80
+	defaultConnectionPropsPort        = 8080
 	defaultConnectionPropsServicePort = 6254
 )
 
@@ -84,7 +84,7 @@ const (
 type ConnectionPropsOptions struct {
 	// Protocol is the transport being advertised (used for logging).
 	Protocol ConnectionProtocol
-	// Port is the port the connection-props HTTP server listens on (default 80).
+	// Port is the port the connection-props HTTP server listens on (default 8080).
 	Port int
 	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
 	ServicePort int

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -161,13 +161,6 @@ func (c *ConnectionProps) IsRunning() bool {
 	return c.running
 }
 
-// Content returns the generated XML payload served at the endpoint.
-func (c *ConnectionProps) Content() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.content
-}
-
 // Start begins serving connection props in a background goroutine. It returns
 // an error if the server is already running or the listener cannot be created.
 func (c *ConnectionProps) Start() error {

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -40,6 +40,7 @@ package catena
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
 	"net"
 	"net/http"
@@ -49,23 +50,6 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/config"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 )
-
-// ConnectionProtocol identifies the Catena transport advertised to DashBoard.
-type ConnectionProtocol string
-
-const (
-	// ProtocolST2138Rest advertises a ST 2138 REST device.
-	ProtocolST2138Rest ConnectionProtocol = "st2138-rest"
-	// ProtocolST2138Grpc advertises a ST 2138 gRPC device.
-	ProtocolST2138Grpc ConnectionProtocol = "st2138-grpc"
-	// ProtocolST2138Catena advertises a legacy "catena" device.
-	ProtocolST2138Catena ConnectionProtocol = "catena"
-)
-
-// String returns the canonical protocol identifier used in logs.
-func (p ConnectionProtocol) String() string {
-	return string(p)
-}
 
 // Default values
 const (
@@ -77,33 +61,12 @@ const (
 	defaultConnectionPropsServicePort = 6254
 )
 
-// ConnectionPropsOptions configures a ConnectionProps server
-type ConnectionPropsOptions struct {
-	// Protocol is the transport being advertised (used for logging and the
-	// advertised equipmentType).
-	Protocol ConnectionProtocol
-	// Dashboard carries the shared connection settings advertised to DashBoard
-	// (listen port, service host/port, TLS). These typically come from the
-	// loaded runtime configuration.
-	Dashboard config.DashboardOptions
-	// RefreshInterval is the DashBoard refresh interval in milliseconds (default 30000).
-	RefreshInterval uint32
-	// NodeName is the optional human-readable node name.
-	NodeName string
-	// NodeID is the optional unique node identifier.
-	NodeID string
-	// ServiceName is the advertised service URL (default "service:catena-device").
-	ServiceName string
-	// Endpoint is the path served (default "/connect/connection-props.xml").
-	Endpoint string
-}
-
 // ConnectionProps is a lightweight HTTP server that serves a single endpoint
 // (/connect/connection-props.xml) with the connection properties consumed by
 // the DashBoard "Detect Frame Information" workflow. It is transport-agnostic
 // and can front either a REST or gRPC Catena device.
 type ConnectionProps struct {
-	opts ConnectionPropsOptions
+	opts config.DashboardOptions
 
 	mu      sync.Mutex
 	server  *http.Server
@@ -113,18 +76,18 @@ type ConnectionProps struct {
 
 // NewConnectionProps builds a ConnectionProps server, applying defaults for any
 // unset option. The XML payload is generated once at construction time.
-func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
+func NewConnectionProps(opts config.DashboardOptions) *ConnectionProps {
 	if opts.Protocol == "" {
-		opts.Protocol = ProtocolST2138Rest
+		opts.Protocol = config.ProtocolST2138Rest
 	}
-	if opts.Dashboard.Port == 0 {
-		opts.Dashboard.Port = defaultConnectionPropsPort
+	if opts.Port == 0 {
+		opts.Port = defaultConnectionPropsPort
 	}
-	if opts.Dashboard.ServicePort == 0 {
-		opts.Dashboard.ServicePort = defaultConnectionPropsServicePort
+	if opts.ServicePort == 0 {
+		opts.ServicePort = defaultConnectionPropsServicePort
 	}
-	if opts.Dashboard.ServiceHostname == "" {
-		opts.Dashboard.ServiceHostname = defaultConnectionPropsHostname
+	if opts.ServiceHostname == "" {
+		opts.ServiceHostname = defaultConnectionPropsHostname
 	}
 	if opts.RefreshInterval == 0 {
 		opts.RefreshInterval = defaultConnectionPropsRefreshMs
@@ -142,7 +105,7 @@ func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
 	c := &ConnectionProps{opts: opts}
 	c.content = c.generateXML()
 	logger.Info("Connection props server constructed",
-		"endpoint", opts.Endpoint, "port", opts.Dashboard.Port, "protocol", opts.Protocol.String())
+		"endpoint", opts.Endpoint, "port", opts.Port, "protocol", string(opts.Protocol))
 	return c
 }
 
@@ -164,17 +127,23 @@ func (c *ConnectionProps) Start() error {
 	c.mu.Lock()
 	if c.running {
 		c.mu.Unlock()
-		logger.Warning("Connection props server already running", "port", c.opts.Dashboard.Port)
+		logger.Warning("Connection props server already running", "port", c.opts.Port)
 		return fmt.Errorf("connection props server already running")
 	}
 
+	// Endpoint is known up front, so register explicit handlers for the
+	// props endpoint and the health probe; ServeMux returns 404 for anything
+	// else.
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", c.handle)
+	mux.HandleFunc(c.opts.Endpoint, c.handleProps)
+	mux.HandleFunc("/health", c.handleHealth)
 
-	addr := fmt.Sprintf(":%d", c.opts.Dashboard.Port)
+	addr := fmt.Sprintf(":%d", c.opts.Port)
 	// Bind synchronously so that errors (privileged port, address already in
 	// use, etc.) are returned to the caller instead of only being logged
 	// asynchronously after Start has already reported success.
+	// TODO: replicate this synchronous-listener startup routine in RestTransport
+	// (sdks/go/pkg/transports/rest_transport.go) so its errors surface to the caller too.
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		c.mu.Unlock()
@@ -217,11 +186,15 @@ func (c *ConnectionProps) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	logger.Info("Stopping connection props server", "port", c.opts.Dashboard.Port)
+	logger.Info("Stopping connection props server", "port", c.opts.Port)
 	err := srv.Shutdown(ctx)
 	if err != nil {
 		// Best-effort hard close so we never leak the listener.
-		_ = srv.Close()
+		logger.Warning("HTTP server shutdown timed out, forcing close")
+		closeErr := srv.Close()
+		if closeErr != nil {
+			logger.Error("failed to force close HTTP server", "error", closeErr)
+		}
 	}
 
 	c.mu.Lock()
@@ -232,84 +205,85 @@ func (c *ConnectionProps) Stop(ctx context.Context) error {
 	return err
 }
 
-// handle serves the connection-props endpoint and a /health probe; everything
-// else returns 404. Only GET is permitted on the props endpoint.
-func (c *ConnectionProps) handle(w http.ResponseWriter, r *http.Request) {
+// handleProps serves the connection-props endpoint. Only GET is permitted.
+func (c *ConnectionProps) handleProps(w http.ResponseWriter, r *http.Request) {
 	logger.Debug("Connection props request", "method", r.Method, "path", r.URL.Path)
 
-	switch r.URL.Path {
-	case c.opts.Endpoint:
-		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", "GET")
-			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		c.mu.Lock()
-		body := c.content
-		c.mu.Unlock()
-
-		w.Header().Set("Content-Type", "application/xml")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(body))
-	case "/health":
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
-	default:
-		http.Error(w, "Not Found", http.StatusNotFound)
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
 	}
+	c.mu.Lock()
+	body := c.content
+	c.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(body))
 }
 
-// generateXML renders the DashBoard connection-props XML payload.
+// handleHealth serves the /health probe.
+func (c *ConnectionProps) handleHealth(w http.ResponseWriter, r *http.Request) {
+	logger.Debug("Connection props request", "method", r.Method, "path", r.URL.Path)
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
+}
+
+// generateXML renders the DashBoard connection-props XML payload using the
+// standard library marshaller.
 func (c *ConnectionProps) generateXML() string {
+	// DashBoard does not recognize the "https" scheme, so the advertised
+	// base-url always uses "http"; TLS is signalled via connectionType=SSL.
 	scheme := "http"
 	connectionType := "TCP"
-	if c.opts.Dashboard.ServiceTLS {
-		scheme = "https"
+	if c.opts.ServiceTLS {
 		connectionType = "SSL"
 	}
 
-	var b strings.Builder
-	b.WriteString("<properties version=\"1.0\">\n")
-	b.WriteString("    <comment>DashBoard Device Connection Settings</comment>\n")
-	writeEntry(&b, "base-url", fmt.Sprintf("%s://%s/", scheme, c.opts.Dashboard.ServiceHostname))
-	writeEntry(&b, "serviceUrl", c.opts.ServiceName)
-	writeEntry(&b, "equipmentType", c.opts.Protocol.String())
-	writeEntry(&b, "address", c.opts.Dashboard.ServiceHostname)
-	writeEntry(&b, "port", fmt.Sprintf("%d", c.opts.Dashboard.ServicePort))
-	writeEntry(&b, "connectionType", connectionType)
+	type entry struct {
+		Key   string `xml:"key,attr"`
+		Value string `xml:",chardata"`
+	}
+
+	entries := []entry{
+		{Key: "base-url", Value: fmt.Sprintf("%s://%s/", scheme, c.opts.ServiceHostname)},
+		{Key: "serviceUrl", Value: c.opts.ServiceName},
+		{Key: "equipmentType", Value: string(c.opts.Protocol)},
+		{Key: "address", Value: c.opts.ServiceHostname},
+		{Key: "port", Value: fmt.Sprintf("%d", c.opts.ServicePort)},
+		{Key: "connectionType", Value: connectionType},
+	}
 	if c.opts.NodeID != "" {
-		writeEntry(&b, "node-id", c.opts.NodeID)
+		entries = append(entries, entry{Key: "node-id", Value: c.opts.NodeID})
 	}
 	if c.opts.NodeName != "" {
-		writeEntry(&b, "node-name", c.opts.NodeName)
+		entries = append(entries, entry{Key: "node-name", Value: c.opts.NodeName})
 	}
-	writeEntry(&b, "index-url", "connect/connection-props.xml")
-	writeEntry(&b, "refresh-interval", fmt.Sprintf("%d", c.opts.RefreshInterval))
-	b.WriteString("</properties>")
-	return b.String()
-}
-
-// writeEntry appends a single <entry> line with an XML-escaped value.
-func writeEntry(b *strings.Builder, key, value string) {
-	b.WriteString("    <entry key=\"")
-	b.WriteString(key)
-	b.WriteString("\">")
-	b.WriteString(xmlEscape(value))
-	b.WriteString("</entry>\n")
-}
-
-// xmlEscape escapes the characters that are illegal in XML text content.
-func xmlEscape(s string) string {
-	replacer := strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		">", "&gt;",
-		"\"", "&quot;",
-		"'", "&apos;",
+	entries = append(entries,
+		entry{Key: "index-url", Value: "connect/connection-props.xml"},
+		entry{Key: "refresh-interval", Value: fmt.Sprintf("%d", c.opts.RefreshInterval)},
 	)
-	return replacer.Replace(s)
+
+	doc := struct {
+		XMLName xml.Name `xml:"properties"`
+		Version string   `xml:"version,attr"`
+		Comment string   `xml:"comment"`
+		Entries []entry  `xml:"entry"`
+	}{
+		Version: "1.0",
+		Comment: "DashBoard Device Connection Settings",
+		Entries: entries,
+	}
+
+	out, err := xml.MarshalIndent(doc, "", "    ")
+	if err != nil {
+		logger.Error("Failed to marshal connection props XML", "error", err)
+		return ""
+	}
+	return string(out)
 }

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -41,6 +41,7 @@ package catena
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -174,8 +175,20 @@ func (c *ConnectionProps) Start() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", c.handle)
 
+	addr := fmt.Sprintf(":%d", c.opts.Port)
+	// Bind synchronously so that errors (privileged port, address already in
+	// use, etc.) are returned to the caller instead of only being logged
+	// asynchronously after Start has already reported success.
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		c.mu.Unlock()
+		logger.Error("Connection props server failed to listen",
+			"address", addr, "error", err)
+		return fmt.Errorf("connection props server failed to listen on %s: %w", addr, err)
+	}
+
 	c.server = &http.Server{
-		Addr:    fmt.Sprintf(":%d", c.opts.Port),
+		Addr:    addr,
 		Handler: mux,
 	}
 	c.running = true
@@ -185,7 +198,7 @@ func (c *ConnectionProps) Start() error {
 	go func() {
 		logger.Info("Connection props server listening",
 			"address", srv.Addr, "endpoint", c.opts.Endpoint)
-		err := srv.ListenAndServe()
+		err := srv.Serve(listener)
 		if err != nil && err != http.ErrServerClosed {
 			logger.Error("Connection props server error", "error", err)
 		}

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -47,18 +47,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/rossvideo/catena/sdks/go/pkg/config"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
-)
-
-// Default values
-const (
-	defaultConnectionPropsEndpoint    = "/connect/connection-props.xml"
-	defaultConnectionPropsService     = "service:catena-device"
-	defaultConnectionPropsRefreshMs   = 30000
-	defaultConnectionPropsHostname    = "localhost"
-	defaultConnectionPropsPort        = 8080
-	defaultConnectionPropsServicePort = 6254
 )
 
 // ConnectionProps is a lightweight HTTP server that serves a single endpoint
@@ -66,7 +55,7 @@ const (
 // the DashBoard "Detect Frame Information" workflow. It is transport-agnostic
 // and can front either a REST or gRPC Catena device.
 type ConnectionProps struct {
-	opts config.DashboardOptions
+	opts DashboardOptions
 
 	mu      sync.Mutex
 	server  *http.Server
@@ -74,30 +63,10 @@ type ConnectionProps struct {
 	running bool
 }
 
-// NewConnectionProps builds a ConnectionProps server, applying defaults for any
-// unset option. The XML payload is generated once at construction time.
-func NewConnectionProps(opts config.DashboardOptions) *ConnectionProps {
-	if opts.Protocol == "" {
-		opts.Protocol = config.ProtocolST2138Rest
-	}
-	if opts.Port == 0 {
-		opts.Port = defaultConnectionPropsPort
-	}
-	if opts.ServicePort == 0 {
-		opts.ServicePort = defaultConnectionPropsServicePort
-	}
-	if opts.ServiceHostname == "" {
-		opts.ServiceHostname = defaultConnectionPropsHostname
-	}
-	if opts.RefreshInterval == 0 {
-		opts.RefreshInterval = defaultConnectionPropsRefreshMs
-	}
-	if opts.ServiceName == "" {
-		opts.ServiceName = defaultConnectionPropsService
-	}
-	if opts.Endpoint == "" {
-		opts.Endpoint = defaultConnectionPropsEndpoint
-	}
+// NewConnectionProps builds a ConnectionProps server from the supplied options,
+// which are expected to be initialized (see config.DefaultDashboardOptions). The
+// XML payload is generated once at construction time.
+func NewConnectionProps(opts DashboardOptions) *ConnectionProps {
 	if !strings.HasPrefix(opts.Endpoint, "/") {
 		opts.Endpoint = "/" + opts.Endpoint
 	}

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -76,7 +76,7 @@ const (
 	defaultConnectionPropsEndpoint    = "/connect/connection-props.xml"
 	defaultConnectionPropsService     = "service:catena-device"
 	defaultConnectionPropsRefreshMs   = 30000
-	defaultConnectionPropsHostname    = "0.0.0.0"
+	defaultConnectionPropsHostname    = "localhost"
 	defaultConnectionPropsPort        = 8080
 	defaultConnectionPropsServicePort = 6254
 )
@@ -89,7 +89,7 @@ type ConnectionPropsOptions struct {
 	Port int
 	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
 	ServicePort int
-	// Hostname is the address advertised to DashBoard (default "0.0.0.0").
+	// Hostname is the address advertised to DashBoard (default "localhost").
 	Hostname string
 	// RefreshInterval is the DashBoard refresh interval in milliseconds (default 30000).
 	RefreshInterval uint32

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -51,25 +51,20 @@ import (
 )
 
 // ConnectionProtocol identifies the Catena transport advertised to DashBoard.
-type ConnectionProtocol int
+type ConnectionProtocol string
 
 const (
 	// ProtocolST2138Rest advertises a ST 2138 REST device.
-	ProtocolST2138Rest ConnectionProtocol = iota
+	ProtocolST2138Rest ConnectionProtocol = "st2138-rest"
 	// ProtocolST2138Grpc advertises a ST 2138 gRPC device.
-	ProtocolST2138Grpc
+	ProtocolST2138Grpc ConnectionProtocol = "st2138-grpc"
+	// ProtocolST2138Catena advertises a legacy "catena" device.
+	ProtocolST2138Catena ConnectionProtocol = "catena"
 )
 
 // String returns the canonical protocol identifier used in logs.
 func (p ConnectionProtocol) String() string {
-	switch p {
-	case ProtocolST2138Rest:
-		return "st2138-rest"
-	case ProtocolST2138Grpc:
-		return "st2138-grpc"
-	default:
-		return ""
-	}
+	return string(p)
 }
 
 // Default values
@@ -119,6 +114,9 @@ type ConnectionProps struct {
 // NewConnectionProps builds a ConnectionProps server, applying defaults for any
 // unset option. The XML payload is generated once at construction time.
 func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
+	if opts.Protocol == "" {
+		opts.Protocol = ProtocolST2138Rest
+	}
 	if opts.Dashboard.Port == 0 {
 		opts.Dashboard.Port = defaultConnectionPropsPort
 	}

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -46,6 +46,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/rossvideo/catena/sdks/go/pkg/config"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 )
 
@@ -83,14 +84,13 @@ const (
 
 // ConnectionPropsOptions configures a ConnectionProps server
 type ConnectionPropsOptions struct {
-	// Protocol is the transport being advertised (used for logging).
+	// Protocol is the transport being advertised (used for logging and the
+	// advertised equipmentType).
 	Protocol ConnectionProtocol
-	// Port is the port the connection-props HTTP server listens on (default 8080).
-	Port int
-	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
-	ServicePort int
-	// Hostname is the address advertised to DashBoard (default "localhost").
-	Hostname string
+	// Dashboard carries the shared connection settings advertised to DashBoard
+	// (listen port, service host/port, TLS). These typically come from the
+	// loaded runtime configuration.
+	Dashboard config.DashboardOptions
 	// RefreshInterval is the DashBoard refresh interval in milliseconds (default 30000).
 	RefreshInterval uint32
 	// NodeName is the optional human-readable node name.
@@ -101,8 +101,6 @@ type ConnectionPropsOptions struct {
 	ServiceName string
 	// Endpoint is the path served (default "/connect/connection-props.xml").
 	Endpoint string
-	// TLSEnabled controls whether the advertised connection uses TLS/SSL.
-	TLSEnabled bool
 }
 
 // ConnectionProps is a lightweight HTTP server that serves a single endpoint
@@ -121,14 +119,14 @@ type ConnectionProps struct {
 // NewConnectionProps builds a ConnectionProps server, applying defaults for any
 // unset option. The XML payload is generated once at construction time.
 func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
-	if opts.Port == 0 {
-		opts.Port = defaultConnectionPropsPort
+	if opts.Dashboard.Port == 0 {
+		opts.Dashboard.Port = defaultConnectionPropsPort
 	}
-	if opts.ServicePort == 0 {
-		opts.ServicePort = defaultConnectionPropsServicePort
+	if opts.Dashboard.ServicePort == 0 {
+		opts.Dashboard.ServicePort = defaultConnectionPropsServicePort
 	}
-	if opts.Hostname == "" {
-		opts.Hostname = defaultConnectionPropsHostname
+	if opts.Dashboard.ServiceHostname == "" {
+		opts.Dashboard.ServiceHostname = defaultConnectionPropsHostname
 	}
 	if opts.RefreshInterval == 0 {
 		opts.RefreshInterval = defaultConnectionPropsRefreshMs
@@ -146,7 +144,7 @@ func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
 	c := &ConnectionProps{opts: opts}
 	c.content = c.generateXML()
 	logger.Info("Connection props server constructed",
-		"endpoint", opts.Endpoint, "port", opts.Port, "protocol", opts.Protocol.String())
+		"endpoint", opts.Endpoint, "port", opts.Dashboard.Port, "protocol", opts.Protocol.String())
 	return c
 }
 
@@ -168,14 +166,14 @@ func (c *ConnectionProps) Start() error {
 	c.mu.Lock()
 	if c.running {
 		c.mu.Unlock()
-		logger.Warning("Connection props server already running", "port", c.opts.Port)
+		logger.Warning("Connection props server already running", "port", c.opts.Dashboard.Port)
 		return fmt.Errorf("connection props server already running")
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", c.handle)
 
-	addr := fmt.Sprintf(":%d", c.opts.Port)
+	addr := fmt.Sprintf(":%d", c.opts.Dashboard.Port)
 	// Bind synchronously so that errors (privileged port, address already in
 	// use, etc.) are returned to the caller instead of only being logged
 	// asynchronously after Start has already reported success.
@@ -221,7 +219,7 @@ func (c *ConnectionProps) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	logger.Info("Stopping connection props server", "port", c.opts.Port)
+	logger.Info("Stopping connection props server", "port", c.opts.Dashboard.Port)
 	err := srv.Shutdown(ctx)
 	if err != nil {
 		// Best-effort hard close so we never leak the listener.
@@ -271,7 +269,7 @@ func (c *ConnectionProps) handle(w http.ResponseWriter, r *http.Request) {
 func (c *ConnectionProps) generateXML() string {
 	scheme := "http"
 	connectionType := "TCP"
-	if c.opts.TLSEnabled {
+	if c.opts.Dashboard.ServiceTLS {
 		scheme = "https"
 		connectionType = "SSL"
 	}
@@ -279,11 +277,11 @@ func (c *ConnectionProps) generateXML() string {
 	var b strings.Builder
 	b.WriteString("<properties version=\"1.0\">\n")
 	b.WriteString("    <comment>DashBoard Device Connection Settings</comment>\n")
-	writeEntry(&b, "base-url", fmt.Sprintf("%s://%s/", scheme, c.opts.Hostname))
+	writeEntry(&b, "base-url", fmt.Sprintf("%s://%s/", scheme, c.opts.Dashboard.ServiceHostname))
 	writeEntry(&b, "serviceUrl", c.opts.ServiceName)
-	writeEntry(&b, "equipmentType", "catena")
-	writeEntry(&b, "address", c.opts.Hostname)
-	writeEntry(&b, "port", fmt.Sprintf("%d", c.opts.ServicePort))
+	writeEntry(&b, "equipmentType", c.opts.Protocol.String())
+	writeEntry(&b, "address", c.opts.Dashboard.ServiceHostname)
+	writeEntry(&b, "port", fmt.Sprintf("%d", c.opts.Dashboard.ServicePort))
 	writeEntry(&b, "connectionType", connectionType)
 	if c.opts.NodeID != "" {
 		writeEntry(&b, "node-id", c.opts.NodeID)

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -234,7 +234,7 @@ func (c *ConnectionProps) generateXML() string {
 		entries = append(entries, entry{Key: "node-name", Value: c.opts.NodeName})
 	}
 	entries = append(entries,
-		entry{Key: "index-url", Value: "connect/connection-props.xml"},
+		entry{Key: "index-url", Value: c.opts.Endpoint},
 		entry{Key: "refresh-interval", Value: fmt.Sprintf("%d", c.opts.RefreshInterval)},
 	)
 

--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -74,7 +74,6 @@ func (p ConnectionProtocol) String() string {
 const (
 	defaultConnectionPropsEndpoint    = "/connect/connection-props.xml"
 	defaultConnectionPropsService     = "service:catena-device"
-	defaultConnectionPropsEquipment   = "catena"
 	defaultConnectionPropsRefreshMs   = 30000
 	defaultConnectionPropsHostname    = "0.0.0.0"
 	defaultConnectionPropsPort        = 80
@@ -99,8 +98,6 @@ type ConnectionPropsOptions struct {
 	NodeID string
 	// ServiceName is the advertised service URL (default "service:catena-device").
 	ServiceName string
-	// EquipmentType is the DashBoard equipment type (default "catena").
-	EquipmentType string
 	// Endpoint is the path served (default "/connect/connection-props.xml").
 	Endpoint string
 	// TLSEnabled controls whether the advertised connection uses TLS/SSL.
@@ -137,9 +134,6 @@ func NewConnectionProps(opts ConnectionPropsOptions) *ConnectionProps {
 	}
 	if opts.ServiceName == "" {
 		opts.ServiceName = defaultConnectionPropsService
-	}
-	if opts.EquipmentType == "" {
-		opts.EquipmentType = defaultConnectionPropsEquipment
 	}
 	if opts.Endpoint == "" {
 		opts.Endpoint = defaultConnectionPropsEndpoint
@@ -281,7 +275,7 @@ func (c *ConnectionProps) generateXML() string {
 	b.WriteString("    <comment>DashBoard Device Connection Settings</comment>\n")
 	writeEntry(&b, "base-url", fmt.Sprintf("%s://%s/", scheme, c.opts.Hostname))
 	writeEntry(&b, "serviceUrl", c.opts.ServiceName)
-	writeEntry(&b, "equipmentType", c.opts.EquipmentType)
+	writeEntry(&b, "equipmentType", "catena")
 	writeEntry(&b, "address", c.opts.Hostname)
 	writeEntry(&b, "port", fmt.Sprintf("%d", c.opts.ServicePort))
 	writeEntry(&b, "connectionType", connectionType)

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -49,8 +49,8 @@ func TestConnectionProtocolString(t *testing.T) {
 	if got := ProtocolST2138Grpc.String(); got != "st2138-grpc" {
 		t.Errorf("ProtocolST2138Grpc.String() = %q, want %q", got, "st2138-grpc")
 	}
-	if got := ConnectionProtocol(99).String(); got != "" {
-		t.Errorf("unknown protocol String() = %q, want empty", got)
+	if got := ProtocolST2138Catena.String(); got != "catena" {
+		t.Errorf("ProtocolST2138Catena.String() = %q, want %q", got, "catena")
 	}
 }
 

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -42,24 +42,12 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/config"
 )
 
-func TestConnectionProtocolString(t *testing.T) {
-	if got := ProtocolST2138Rest.String(); got != "st2138-rest" {
-		t.Errorf("ProtocolST2138Rest.String() = %q, want %q", got, "st2138-rest")
-	}
-	if got := ProtocolST2138Grpc.String(); got != "st2138-grpc" {
-		t.Errorf("ProtocolST2138Grpc.String() = %q, want %q", got, "st2138-grpc")
-	}
-	if got := ProtocolST2138Catena.String(); got != "catena" {
-		t.Errorf("ProtocolST2138Catena.String() = %q, want %q", got, "catena")
-	}
-}
-
 func TestConnectionPropsDefaults(t *testing.T) {
-	c := NewConnectionProps(ConnectionPropsOptions{})
+	c := NewConnectionProps(config.DashboardOptions{})
 	if c.Endpoint() != "/connect/connection-props.xml" {
 		t.Errorf("default endpoint = %q", c.Endpoint())
 	}
-	xml := fetchPropsXML(t, ConnectionPropsOptions{})
+	xml := fetchPropsXML(t, config.DashboardOptions{})
 
 	wants := []string{
 		"<properties version=\"1.0\">",
@@ -87,12 +75,10 @@ func TestConnectionPropsDefaults(t *testing.T) {
 }
 
 func TestConnectionPropsCustomValues(t *testing.T) {
-	xml := fetchPropsXML(t, ConnectionPropsOptions{
-		Protocol: ProtocolST2138Grpc,
-		Dashboard: config.DashboardOptions{
-			ServiceHostname: "10.62.251.47",
-			ServicePort:     5254,
-		},
+	xml := fetchPropsXML(t, config.DashboardOptions{
+		Protocol:        ProtocolST2138Grpc,
+		ServiceHostname: "10.62.251.47",
+		ServicePort:     5254,
 		RefreshInterval: 15000,
 		NodeName:        "Enterprise Management SSG",
 		NodeID:          "Enterprise Management SSG-a4:bb:6d:6a:6f:a3",
@@ -117,14 +103,13 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 }
 
 func TestConnectionPropsTLSScheme(t *testing.T) {
-	xml := fetchPropsXML(t, ConnectionPropsOptions{
-		Dashboard: config.DashboardOptions{
-			ServiceHostname: "host.example",
-			ServiceTLS:      true,
-		},
+	xml := fetchPropsXML(t, config.DashboardOptions{
+		ServiceHostname: "host.example",
+		ServiceTLS:      true,
 	})
-	if !strings.Contains(xml, "<entry key=\"base-url\">https://host.example/</entry>") {
-		t.Errorf("expected https base-url, got:\n%s", xml)
+	// DashBoard does not recognize "https"; base-url stays http even with TLS.
+	if !strings.Contains(xml, "<entry key=\"base-url\">http://host.example/</entry>") {
+		t.Errorf("expected http base-url, got:\n%s", xml)
 	}
 	if !strings.Contains(xml, "<entry key=\"connectionType\">SSL</entry>") {
 		t.Errorf("expected SSL connectionType, got:\n%s", xml)
@@ -132,15 +117,16 @@ func TestConnectionPropsTLSScheme(t *testing.T) {
 }
 
 func TestConnectionPropsEndpointNormalized(t *testing.T) {
-	c := NewConnectionProps(ConnectionPropsOptions{Endpoint: "connect/foo.xml"})
+	c := NewConnectionProps(config.DashboardOptions{Endpoint: "connect/foo.xml"})
 	if c.Endpoint() != "/connect/foo.xml" {
 		t.Errorf("endpoint not normalized: %q", c.Endpoint())
 	}
 }
 
 func TestConnectionPropsXMLEscaping(t *testing.T) {
-	xml := fetchPropsXML(t, ConnectionPropsOptions{NodeName: `a&b<c>"d'`})
-	if !strings.Contains(xml, "a&amp;b&lt;c&gt;&quot;d&apos;") {
+	xml := fetchPropsXML(t, config.DashboardOptions{NodeName: `a&b<c>"d'`})
+	// encoding/xml escapes quotes as numeric character references.
+	if !strings.Contains(xml, "a&amp;b&lt;c&gt;&#34;d&#39;") {
 		t.Errorf("value not escaped, got:\n%s", xml)
 	}
 }
@@ -148,10 +134,10 @@ func TestConnectionPropsXMLEscaping(t *testing.T) {
 // fetchPropsXML starts a ConnectionProps server on a free port, fetches the
 // served XML over HTTP, and returns the response body. This mirrors how the
 // C++ tests verify content, since there is no in-process content getter.
-func fetchPropsXML(t *testing.T, opts ConnectionPropsOptions) string {
+func fetchPropsXML(t *testing.T, opts config.DashboardOptions) string {
 	t.Helper()
 	port := freePort(t)
-	opts.Dashboard.Port = port
+	opts.Port = port
 	c := NewConnectionProps(opts)
 	if err := c.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
@@ -190,13 +176,11 @@ func freePort(t *testing.T) int {
 
 func TestConnectionPropsServeAndStop(t *testing.T) {
 	port := freePort(t)
-	c := NewConnectionProps(ConnectionPropsOptions{
-		Dashboard: config.DashboardOptions{
-			Port:            port,
-			ServiceHostname: "127.0.0.1",
-		},
-		NodeName: "test-node",
-		NodeID:   "test-node-id",
+	c := NewConnectionProps(config.DashboardOptions{
+		Port:            port,
+		ServiceHostname: "127.0.0.1",
+		NodeName:        "test-node",
+		NodeID:          "test-node-id",
 	})
 
 	if err := c.Start(); err != nil {
@@ -278,7 +262,7 @@ func TestConnectionPropsServeAndStop(t *testing.T) {
 
 func TestConnectionPropsDoubleStart(t *testing.T) {
 	port := freePort(t)
-	c := NewConnectionProps(ConnectionPropsOptions{Dashboard: config.DashboardOptions{Port: port}})
+	c := NewConnectionProps(config.DashboardOptions{Port: port})
 	if err := c.Start(); err != nil {
 		t.Fatalf("first Start() error: %v", err)
 	}
@@ -294,7 +278,7 @@ func TestConnectionPropsDoubleStart(t *testing.T) {
 }
 
 func TestConnectionPropsStopWhenNotRunning(t *testing.T) {
-	c := NewConnectionProps(ConnectionPropsOptions{})
+	c := NewConnectionProps(config.DashboardOptions{})
 	if err := c.Stop(context.Background()); err != nil {
 		t.Errorf("Stop() on idle server error: %v", err)
 	}

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package catena
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestConnectionProtocolString(t *testing.T) {
+	if got := ProtocolST2138Rest.String(); got != "st2138-rest" {
+		t.Errorf("ProtocolST2138Rest.String() = %q, want %q", got, "st2138-rest")
+	}
+	if got := ProtocolST2138Grpc.String(); got != "st2138-grpc" {
+		t.Errorf("ProtocolST2138Grpc.String() = %q, want %q", got, "st2138-grpc")
+	}
+	if got := ConnectionProtocol(99).String(); got != "" {
+		t.Errorf("unknown protocol String() = %q, want empty", got)
+	}
+}
+
+func TestConnectionPropsDefaults(t *testing.T) {
+	c := NewConnectionProps(ConnectionPropsOptions{})
+	if c.Endpoint() != "/connect/connection-props.xml" {
+		t.Errorf("default endpoint = %q", c.Endpoint())
+	}
+	xml := c.Content()
+
+	wants := []string{
+		"<properties version=\"1.0\">",
+		"<comment>DashBoard Device Connection Settings</comment>",
+		"<entry key=\"base-url\">http://0.0.0.0/</entry>",
+		"<entry key=\"serviceUrl\">service:catena-device</entry>",
+		"<entry key=\"equipmentType\">catena</entry>",
+		"<entry key=\"address\">0.0.0.0</entry>",
+		"<entry key=\"port\">6254</entry>",
+		"<entry key=\"connectionType\">TCP</entry>",
+		"<entry key=\"index-url\">connect/connection-props.xml</entry>",
+		"<entry key=\"refresh-interval\">30000</entry>",
+		"</properties>",
+	}
+	for _, w := range wants {
+		if !strings.Contains(xml, w) {
+			t.Errorf("XML missing %q\nGot:\n%s", w, xml)
+		}
+	}
+
+	// node-id / node-name omitted when unset.
+	if strings.Contains(xml, "node-id") || strings.Contains(xml, "node-name") {
+		t.Errorf("expected node-id/node-name to be omitted, got:\n%s", xml)
+	}
+}
+
+func TestConnectionPropsCustomValues(t *testing.T) {
+	c := NewConnectionProps(ConnectionPropsOptions{
+		Protocol:        ProtocolST2138Grpc,
+		Hostname:        "10.62.251.47",
+		ServicePort:     5254,
+		RefreshInterval: 15000,
+		NodeName:        "Enterprise Management SSG",
+		NodeID:          "Enterprise Management SSG-a4:bb:6d:6a:6f:a3",
+		ServiceName:     "service:broadcast-equipment",
+		EquipmentType:   "opengear-json",
+	})
+	xml := c.Content()
+
+	wants := []string{
+		"<entry key=\"base-url\">http://10.62.251.47/</entry>",
+		"<entry key=\"serviceUrl\">service:broadcast-equipment</entry>",
+		"<entry key=\"equipmentType\">opengear-json</entry>",
+		"<entry key=\"address\">10.62.251.47</entry>",
+		"<entry key=\"port\">5254</entry>",
+		"<entry key=\"node-id\">Enterprise Management SSG-a4:bb:6d:6a:6f:a3</entry>",
+		"<entry key=\"node-name\">Enterprise Management SSG</entry>",
+		"<entry key=\"refresh-interval\">15000</entry>",
+	}
+	for _, w := range wants {
+		if !strings.Contains(xml, w) {
+			t.Errorf("XML missing %q\nGot:\n%s", w, xml)
+		}
+	}
+}
+
+func TestConnectionPropsTLSScheme(t *testing.T) {
+	c := NewConnectionProps(ConnectionPropsOptions{
+		Hostname:   "host.example",
+		TLSEnabled: true,
+	})
+	xml := c.Content()
+	if !strings.Contains(xml, "<entry key=\"base-url\">https://host.example/</entry>") {
+		t.Errorf("expected https base-url, got:\n%s", xml)
+	}
+	if !strings.Contains(xml, "<entry key=\"connectionType\">SSL</entry>") {
+		t.Errorf("expected SSL connectionType, got:\n%s", xml)
+	}
+}
+
+func TestConnectionPropsEndpointNormalized(t *testing.T) {
+	c := NewConnectionProps(ConnectionPropsOptions{Endpoint: "connect/foo.xml"})
+	if c.Endpoint() != "/connect/foo.xml" {
+		t.Errorf("endpoint not normalized: %q", c.Endpoint())
+	}
+}
+
+func TestConnectionPropsXMLEscaping(t *testing.T) {
+	c := NewConnectionProps(ConnectionPropsOptions{NodeName: `a&b<c>"d'`})
+	xml := c.Content()
+	if !strings.Contains(xml, "a&amp;b&lt;c&gt;&quot;d&apos;") {
+		t.Errorf("value not escaped, got:\n%s", xml)
+	}
+}
+
+// freePort returns an available TCP port for tests.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func TestConnectionPropsServeAndStop(t *testing.T) {
+	port := freePort(t)
+	c := NewConnectionProps(ConnectionPropsOptions{
+		Port:     port,
+		Hostname: "127.0.0.1",
+		NodeName: "test-node",
+		NodeID:   "test-node-id",
+	})
+
+	if err := c.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = c.Stop(ctx)
+	})
+
+	if !c.IsRunning() {
+		t.Fatalf("expected server to be running")
+	}
+
+	base := "http://127.0.0.1:" + itoa(port)
+
+	// Wait until the listener is accepting connections.
+	waitForServer(t, base+"/health")
+
+	// Endpoint returns the XML body.
+	resp, err := http.Get(base + "/connect/connection-props.xml")
+	if err != nil {
+		t.Fatalf("GET endpoint: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("endpoint status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/xml" {
+		t.Errorf("Content-Type = %q, want application/xml", ct)
+	}
+	if !strings.Contains(string(body), "<entry key=\"node-name\">test-node</entry>") {
+		t.Errorf("body missing node-name:\n%s", body)
+	}
+
+	// Health probe.
+	hResp, err := http.Get(base + "/health")
+	if err != nil {
+		t.Fatalf("GET health: %v", err)
+	}
+	hResp.Body.Close()
+	if hResp.StatusCode != http.StatusOK {
+		t.Errorf("health status = %d, want 200", hResp.StatusCode)
+	}
+
+	// Unknown path 404.
+	nfResp, err := http.Get(base + "/nope")
+	if err != nil {
+		t.Fatalf("GET unknown: %v", err)
+	}
+	nfResp.Body.Close()
+	if nfResp.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown path status = %d, want 404", nfResp.StatusCode)
+	}
+
+	// Non-GET method on endpoint -> 405.
+	req, _ := http.NewRequest(http.MethodPost, base+"/connect/connection-props.xml", nil)
+	mResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST endpoint: %v", err)
+	}
+	mResp.Body.Close()
+	if mResp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("POST status = %d, want 405", mResp.StatusCode)
+	}
+
+	// Stop and verify it is no longer running.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := c.Stop(ctx); err != nil {
+		t.Errorf("Stop() error: %v", err)
+	}
+	if c.IsRunning() {
+		t.Errorf("expected server to be stopped")
+	}
+}
+
+func TestConnectionPropsDoubleStart(t *testing.T) {
+	port := freePort(t)
+	c := NewConnectionProps(ConnectionPropsOptions{Port: port})
+	if err := c.Start(); err != nil {
+		t.Fatalf("first Start() error: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = c.Stop(ctx)
+	})
+
+	if err := c.Start(); err == nil {
+		t.Errorf("expected error on second Start()")
+	}
+}
+
+func TestConnectionPropsStopWhenNotRunning(t *testing.T) {
+	c := NewConnectionProps(ConnectionPropsOptions{})
+	if err := c.Stop(context.Background()); err != nil {
+		t.Errorf("Stop() on idle server error: %v", err)
+	}
+}
+
+// waitForServer polls url until it responds or the timeout elapses.
+func waitForServer(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server did not become ready: %s", url)
+}
+
+// itoa is a tiny helper to avoid importing strconv in this test file.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -54,7 +54,7 @@ func TestConnectionPropsDefaults(t *testing.T) {
 		"<comment>DashBoard Device Connection Settings</comment>",
 		"<entry key=\"base-url\">http://localhost/</entry>",
 		"<entry key=\"serviceUrl\">service:catena-device</entry>",
-		"<entry key=\"equipmentType\">st2138-rest</entry>",
+		"<entry key=\"equipmentType\">st2138-grpc</entry>",
 		"<entry key=\"address\">localhost</entry>",
 		"<entry key=\"port\">6254</entry>",
 		"<entry key=\"connectionType\">TCP</entry>",

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -38,6 +38,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/config"
 )
 
 func TestConnectionProtocolString(t *testing.T) {
@@ -64,7 +66,7 @@ func TestConnectionPropsDefaults(t *testing.T) {
 		"<comment>DashBoard Device Connection Settings</comment>",
 		"<entry key=\"base-url\">http://localhost/</entry>",
 		"<entry key=\"serviceUrl\">service:catena-device</entry>",
-		"<entry key=\"equipmentType\">catena</entry>",
+		"<entry key=\"equipmentType\">st2138-rest</entry>",
 		"<entry key=\"address\">localhost</entry>",
 		"<entry key=\"port\">6254</entry>",
 		"<entry key=\"connectionType\">TCP</entry>",
@@ -86,9 +88,11 @@ func TestConnectionPropsDefaults(t *testing.T) {
 
 func TestConnectionPropsCustomValues(t *testing.T) {
 	xml := fetchPropsXML(t, ConnectionPropsOptions{
-		Protocol:        ProtocolST2138Grpc,
-		Hostname:        "10.62.251.47",
-		ServicePort:     5254,
+		Protocol: ProtocolST2138Grpc,
+		Dashboard: config.DashboardOptions{
+			ServiceHostname: "10.62.251.47",
+			ServicePort:     5254,
+		},
 		RefreshInterval: 15000,
 		NodeName:        "Enterprise Management SSG",
 		NodeID:          "Enterprise Management SSG-a4:bb:6d:6a:6f:a3",
@@ -98,7 +102,7 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 	wants := []string{
 		"<entry key=\"base-url\">http://10.62.251.47/</entry>",
 		"<entry key=\"serviceUrl\">service:broadcast-equipment</entry>",
-		"<entry key=\"equipmentType\">catena</entry>",
+		"<entry key=\"equipmentType\">st2138-grpc</entry>",
 		"<entry key=\"address\">10.62.251.47</entry>",
 		"<entry key=\"port\">5254</entry>",
 		"<entry key=\"node-id\">Enterprise Management SSG-a4:bb:6d:6a:6f:a3</entry>",
@@ -114,8 +118,10 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 
 func TestConnectionPropsTLSScheme(t *testing.T) {
 	xml := fetchPropsXML(t, ConnectionPropsOptions{
-		Hostname:   "host.example",
-		TLSEnabled: true,
+		Dashboard: config.DashboardOptions{
+			ServiceHostname: "host.example",
+			ServiceTLS:      true,
+		},
 	})
 	if !strings.Contains(xml, "<entry key=\"base-url\">https://host.example/</entry>") {
 		t.Errorf("expected https base-url, got:\n%s", xml)
@@ -145,7 +151,7 @@ func TestConnectionPropsXMLEscaping(t *testing.T) {
 func fetchPropsXML(t *testing.T, opts ConnectionPropsOptions) string {
 	t.Helper()
 	port := freePort(t)
-	opts.Port = port
+	opts.Dashboard.Port = port
 	c := NewConnectionProps(opts)
 	if err := c.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
@@ -185,8 +191,10 @@ func freePort(t *testing.T) int {
 func TestConnectionPropsServeAndStop(t *testing.T) {
 	port := freePort(t)
 	c := NewConnectionProps(ConnectionPropsOptions{
-		Port:     port,
-		Hostname: "127.0.0.1",
+		Dashboard: config.DashboardOptions{
+			Port:            port,
+			ServiceHostname: "127.0.0.1",
+		},
 		NodeName: "test-node",
 		NodeID:   "test-node-id",
 	})
@@ -270,7 +278,7 @@ func TestConnectionPropsServeAndStop(t *testing.T) {
 
 func TestConnectionPropsDoubleStart(t *testing.T) {
 	port := freePort(t)
-	c := NewConnectionProps(ConnectionPropsOptions{Port: port})
+	c := NewConnectionProps(ConnectionPropsOptions{Dashboard: config.DashboardOptions{Port: port}})
 	if err := c.Start(); err != nil {
 		t.Fatalf("first Start() error: %v", err)
 	}

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -93,14 +93,13 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 		NodeName:        "Enterprise Management SSG",
 		NodeID:          "Enterprise Management SSG-a4:bb:6d:6a:6f:a3",
 		ServiceName:     "service:broadcast-equipment",
-		EquipmentType:   "opengear-json",
 	})
 	xml := c.Content()
 
 	wants := []string{
 		"<entry key=\"base-url\">http://10.62.251.47/</entry>",
 		"<entry key=\"serviceUrl\">service:broadcast-equipment</entry>",
-		"<entry key=\"equipmentType\">opengear-json</entry>",
+		"<entry key=\"equipmentType\">catena</entry>",
 		"<entry key=\"address\">10.62.251.47</entry>",
 		"<entry key=\"port\">5254</entry>",
 		"<entry key=\"node-id\">Enterprise Management SSG-a4:bb:6d:6a:6f:a3</entry>",

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -43,11 +43,11 @@ import (
 )
 
 func TestConnectionPropsDefaults(t *testing.T) {
-	c := NewConnectionProps(config.DashboardOptions{})
+	c := NewConnectionProps(config.DefaultDashboardOptions())
 	if c.Endpoint() != "/connect/connection-props.xml" {
 		t.Errorf("default endpoint = %q", c.Endpoint())
 	}
-	xml := fetchPropsXML(t, config.DashboardOptions{})
+	xml := fetchPropsXML(t, config.DefaultDashboardOptions())
 
 	wants := []string{
 		"<properties version=\"1.0\">",
@@ -75,15 +75,15 @@ func TestConnectionPropsDefaults(t *testing.T) {
 }
 
 func TestConnectionPropsCustomValues(t *testing.T) {
-	xml := fetchPropsXML(t, config.DashboardOptions{
-		Protocol:        ProtocolST2138Grpc,
-		ServiceHostname: "10.62.251.47",
-		ServicePort:     5254,
-		RefreshInterval: 15000,
-		NodeName:        "Enterprise Management SSG",
-		NodeID:          "Enterprise Management SSG-a4:bb:6d:6a:6f:a3",
-		ServiceName:     "service:broadcast-equipment",
-	})
+	opts := config.DefaultDashboardOptions()
+	opts.Protocol = ProtocolST2138Grpc
+	opts.ServiceHostname = "10.62.251.47"
+	opts.ServicePort = 5254
+	opts.RefreshInterval = 15000
+	opts.NodeName = "Enterprise Management SSG"
+	opts.NodeID = "Enterprise Management SSG-a4:bb:6d:6a:6f:a3"
+	opts.ServiceName = "service:broadcast-equipment"
+	xml := fetchPropsXML(t, opts)
 
 	wants := []string{
 		"<entry key=\"base-url\">http://10.62.251.47/</entry>",
@@ -103,10 +103,10 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 }
 
 func TestConnectionPropsTLSScheme(t *testing.T) {
-	xml := fetchPropsXML(t, config.DashboardOptions{
-		ServiceHostname: "host.example",
-		ServiceTLS:      true,
-	})
+	opts := config.DefaultDashboardOptions()
+	opts.ServiceHostname = "host.example"
+	opts.ServiceTLS = true
+	xml := fetchPropsXML(t, opts)
 	// DashBoard does not recognize "https"; base-url stays http even with TLS.
 	if !strings.Contains(xml, "<entry key=\"base-url\">http://host.example/</entry>") {
 		t.Errorf("expected http base-url, got:\n%s", xml)
@@ -117,14 +117,18 @@ func TestConnectionPropsTLSScheme(t *testing.T) {
 }
 
 func TestConnectionPropsEndpointNormalized(t *testing.T) {
-	c := NewConnectionProps(config.DashboardOptions{Endpoint: "connect/foo.xml"})
+	opts := config.DefaultDashboardOptions()
+	opts.Endpoint = "connect/foo.xml"
+	c := NewConnectionProps(opts)
 	if c.Endpoint() != "/connect/foo.xml" {
 		t.Errorf("endpoint not normalized: %q", c.Endpoint())
 	}
 }
 
 func TestConnectionPropsXMLEscaping(t *testing.T) {
-	xml := fetchPropsXML(t, config.DashboardOptions{NodeName: `a&b<c>"d'`})
+	opts := config.DefaultDashboardOptions()
+	opts.NodeName = `a&b<c>"d'`
+	xml := fetchPropsXML(t, opts)
 	// encoding/xml escapes quotes as numeric character references.
 	if !strings.Contains(xml, "a&amp;b&lt;c&gt;&#34;d&#39;") {
 		t.Errorf("value not escaped, got:\n%s", xml)
@@ -176,12 +180,12 @@ func freePort(t *testing.T) int {
 
 func TestConnectionPropsServeAndStop(t *testing.T) {
 	port := freePort(t)
-	c := NewConnectionProps(config.DashboardOptions{
-		Port:            port,
-		ServiceHostname: "127.0.0.1",
-		NodeName:        "test-node",
-		NodeID:          "test-node-id",
-	})
+	opts := config.DefaultDashboardOptions()
+	opts.Port = port
+	opts.ServiceHostname = "127.0.0.1"
+	opts.NodeName = "test-node"
+	opts.NodeID = "test-node-id"
+	c := NewConnectionProps(opts)
 
 	if err := c.Start(); err != nil {
 		t.Fatalf("Start() error: %v", err)
@@ -262,7 +266,9 @@ func TestConnectionPropsServeAndStop(t *testing.T) {
 
 func TestConnectionPropsDoubleStart(t *testing.T) {
 	port := freePort(t)
-	c := NewConnectionProps(config.DashboardOptions{Port: port})
+	opts := config.DefaultDashboardOptions()
+	opts.Port = port
+	c := NewConnectionProps(opts)
 	if err := c.Start(); err != nil {
 		t.Fatalf("first Start() error: %v", err)
 	}
@@ -278,7 +284,7 @@ func TestConnectionPropsDoubleStart(t *testing.T) {
 }
 
 func TestConnectionPropsStopWhenNotRunning(t *testing.T) {
-	c := NewConnectionProps(config.DashboardOptions{})
+	c := NewConnectionProps(config.DefaultDashboardOptions())
 	if err := c.Stop(context.Background()); err != nil {
 		t.Errorf("Stop() on idle server error: %v", err)
 	}

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -58,7 +58,7 @@ func TestConnectionPropsDefaults(t *testing.T) {
 		"<entry key=\"address\">localhost</entry>",
 		"<entry key=\"port\">6254</entry>",
 		"<entry key=\"connectionType\">TCP</entry>",
-		"<entry key=\"index-url\">connect/connection-props.xml</entry>",
+		"<entry key=\"index-url\">/connect/connection-props.xml</entry>",
 		"<entry key=\"refresh-interval\">30000</entry>",
 		"</properties>",
 	}

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -57,7 +57,7 @@ func TestConnectionPropsDefaults(t *testing.T) {
 	if c.Endpoint() != "/connect/connection-props.xml" {
 		t.Errorf("default endpoint = %q", c.Endpoint())
 	}
-	xml := c.Content()
+	xml := fetchPropsXML(t, ConnectionPropsOptions{})
 
 	wants := []string{
 		"<properties version=\"1.0\">",
@@ -85,7 +85,7 @@ func TestConnectionPropsDefaults(t *testing.T) {
 }
 
 func TestConnectionPropsCustomValues(t *testing.T) {
-	c := NewConnectionProps(ConnectionPropsOptions{
+	xml := fetchPropsXML(t, ConnectionPropsOptions{
 		Protocol:        ProtocolST2138Grpc,
 		Hostname:        "10.62.251.47",
 		ServicePort:     5254,
@@ -94,7 +94,6 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 		NodeID:          "Enterprise Management SSG-a4:bb:6d:6a:6f:a3",
 		ServiceName:     "service:broadcast-equipment",
 	})
-	xml := c.Content()
 
 	wants := []string{
 		"<entry key=\"base-url\">http://10.62.251.47/</entry>",
@@ -114,11 +113,10 @@ func TestConnectionPropsCustomValues(t *testing.T) {
 }
 
 func TestConnectionPropsTLSScheme(t *testing.T) {
-	c := NewConnectionProps(ConnectionPropsOptions{
+	xml := fetchPropsXML(t, ConnectionPropsOptions{
 		Hostname:   "host.example",
 		TLSEnabled: true,
 	})
-	xml := c.Content()
 	if !strings.Contains(xml, "<entry key=\"base-url\">https://host.example/</entry>") {
 		t.Errorf("expected https base-url, got:\n%s", xml)
 	}
@@ -135,11 +133,42 @@ func TestConnectionPropsEndpointNormalized(t *testing.T) {
 }
 
 func TestConnectionPropsXMLEscaping(t *testing.T) {
-	c := NewConnectionProps(ConnectionPropsOptions{NodeName: `a&b<c>"d'`})
-	xml := c.Content()
+	xml := fetchPropsXML(t, ConnectionPropsOptions{NodeName: `a&b<c>"d'`})
 	if !strings.Contains(xml, "a&amp;b&lt;c&gt;&quot;d&apos;") {
 		t.Errorf("value not escaped, got:\n%s", xml)
 	}
+}
+
+// fetchPropsXML starts a ConnectionProps server on a free port, fetches the
+// served XML over HTTP, and returns the response body. This mirrors how the
+// C++ tests verify content, since there is no in-process content getter.
+func fetchPropsXML(t *testing.T, opts ConnectionPropsOptions) string {
+	t.Helper()
+	port := freePort(t)
+	opts.Port = port
+	c := NewConnectionProps(opts)
+	if err := c.Start(); err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = c.Stop(ctx)
+	})
+
+	base := "http://127.0.0.1:" + itoa(port)
+	waitForServer(t, base+"/health")
+
+	resp, err := http.Get(base + c.Endpoint())
+	if err != nil {
+		t.Fatalf("GET endpoint: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("endpoint status = %d, want 200", resp.StatusCode)
+	}
+	return string(body)
 }
 
 // freePort returns an available TCP port for tests.

--- a/sdks/go/pkg/catena/connection_props_test.go
+++ b/sdks/go/pkg/catena/connection_props_test.go
@@ -62,10 +62,10 @@ func TestConnectionPropsDefaults(t *testing.T) {
 	wants := []string{
 		"<properties version=\"1.0\">",
 		"<comment>DashBoard Device Connection Settings</comment>",
-		"<entry key=\"base-url\">http://0.0.0.0/</entry>",
+		"<entry key=\"base-url\">http://localhost/</entry>",
 		"<entry key=\"serviceUrl\">service:catena-device</entry>",
 		"<entry key=\"equipmentType\">catena</entry>",
-		"<entry key=\"address\">0.0.0.0</entry>",
+		"<entry key=\"address\">localhost</entry>",
 		"<entry key=\"port\">6254</entry>",
 		"<entry key=\"connectionType\">TCP</entry>",
 		"<entry key=\"index-url\">connect/connection-props.xml</entry>",

--- a/sdks/go/pkg/catena/types.go
+++ b/sdks/go/pkg/catena/types.go
@@ -43,8 +43,17 @@ import "github.com/rossvideo/catena/sdks/go/pkg/config"
 type RuntimeOptions = config.RuntimeOptions
 type ServerOptions = config.ServerOptions
 type JwtValidationOptions = config.JwtValidationOptions
+type DashboardOptions = config.DashboardOptions
+type ConnectionProtocol = config.ConnectionProtocol
+
+const (
+	ProtocolST2138Rest   = config.ProtocolST2138Rest
+	ProtocolST2138Grpc   = config.ProtocolST2138Grpc
+	ProtocolST2138Catena = config.ProtocolST2138Catena
+)
 
 var (
 	DefaultServerOptions        = config.DefaultServerOptions
 	DefaultJwtValidationOptions = config.DefaultJwtValidationOptions
+	DefaultDashboardOptions     = config.DefaultDashboardOptions
 )

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -109,6 +109,9 @@ const (
 // DashboardOptions configures the DashBoard connection-props HTTP server that
 // advertises this device for the "Detect Frame Information" workflow. It is
 // transport-agnostic and can front either a REST or gRPC Catena device.
+//
+// DashboardOptions must be initialized before use.
+// Prefer config.InitOptions or config.DefaultDashboardOptions().
 type DashboardOptions struct {
 	// ServiceHostname is the address advertised to DashBoard (default "localhost").
 	ServiceHostname string `env:"DASHBOARD_SERVICE_HOSTNAME" flag:"dashboard-service-hostname"`
@@ -120,7 +123,7 @@ type DashboardOptions struct {
 	ServiceTLS bool `env:"DASHBOARD_SERVICE_TLS_ENABLED" flag:"dashboard-service-tls-enabled"`
 	// Protocol is the transport being advertised (used for logging and the
 	// advertised equipmentType).
-	Protocol ConnectionProtocol
+	Protocol ConnectionProtocol `env:"DASHBOARD_PROTOCOL" flag:"dashboard-protocol"`
 	// RefreshInterval is the DashBoard refresh interval in milliseconds (default 30000).
 	RefreshInterval uint32
 	// NodeName is the optional human-readable node name.
@@ -168,6 +171,10 @@ func DefaultDashboardOptions() DashboardOptions {
 		Port:            8080,
 		ServicePort:     6254,
 		ServiceTLS:      false,
+		Protocol:        ProtocolST2138Rest,
+		RefreshInterval: 30000,
+		ServiceName:     "service:catena-device",
+		Endpoint:        "/connect/connection-props.xml",
 	}
 }
 

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -94,18 +94,43 @@ func (o JwtValidationOptions) ResolvedAllowedAlgs() []string {
 	return append([]string(nil), o.AllowedAlgs...)
 }
 
+// ConnectionProtocol identifies the Catena transport advertised to DashBoard.
+type ConnectionProtocol string
+
+const (
+	// ProtocolST2138Rest advertises a ST 2138 REST device.
+	ProtocolST2138Rest ConnectionProtocol = "st2138-rest"
+	// ProtocolST2138Grpc advertises a ST 2138 gRPC device.
+	ProtocolST2138Grpc ConnectionProtocol = "st2138-grpc"
+	// ProtocolST2138Catena advertises a legacy "catena" device.
+	ProtocolST2138Catena ConnectionProtocol = "catena"
+)
+
 // DashboardOptions configures the DashBoard connection-props HTTP server that
 // advertises this device for the "Detect Frame Information" workflow. It is
 // transport-agnostic and can front either a REST or gRPC Catena device.
 type DashboardOptions struct {
 	// ServiceHostname is the address advertised to DashBoard (default "localhost").
-	ServiceHostname string `env:"DASHBOARD_HOSTNAME" flag:"dashboard-hostname"`
+	ServiceHostname string `env:"DASHBOARD_SERVICE_HOSTNAME" flag:"dashboard-service-hostname"`
 	// Port is the port the connection-props HTTP server listens on (default 8080).
 	Port int `env:"DASHBOARD_PORT" flag:"dashboard-port"`
 	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
 	ServicePort int `env:"DASHBOARD_SERVICE_PORT" flag:"dashboard-service-port"`
 	// ServiceTLS controls whether the advertised connection uses TLS/SSL (default false).
-	ServiceTLS bool `env:"DASHBOARD_TLS_ENABLED" flag:"dashboard-tls-enabled"`
+	ServiceTLS bool `env:"DASHBOARD_SERVICE_TLS_ENABLED" flag:"dashboard-service-tls-enabled"`
+	// Protocol is the transport being advertised (used for logging and the
+	// advertised equipmentType).
+	Protocol ConnectionProtocol
+	// RefreshInterval is the DashBoard refresh interval in milliseconds (default 30000).
+	RefreshInterval uint32
+	// NodeName is the optional human-readable node name.
+	NodeName string `env:"DASHBOARD_NODE_NAME" flag:"dashboard-node-name"`
+	// NodeID is the optional unique node identifier.
+	NodeID string `env:"DASHBOARD_NODE_ID" flag:"dashboard-node-id"`
+	// ServiceName is the advertised service URL (default "service:catena-device").
+	ServiceName string `env:"DASHBOARD_SERVICE_NAME" flag:"dashboard-service-name"`
+	// Endpoint is the path served (default "/connect/connection-props.xml").
+	Endpoint string `env:"DASHBOARD_ENDPOINT" flag:"dashboard-endpoint"`
 }
 
 type LoggerOptions struct {

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -98,14 +98,14 @@ func (o JwtValidationOptions) ResolvedAllowedAlgs() []string {
 // advertises this device for the "Detect Frame Information" workflow. It is
 // transport-agnostic and can front either a REST or gRPC Catena device.
 type DashboardOptions struct {
-	// Hostname is the address advertised to DashBoard (default "localhost").
-	Hostname string `env:"HOSTNAME" flag:"hostname"`
+	// ServiceHostname is the address advertised to DashBoard (default "localhost").
+	ServiceHostname string `env:"DASHBOARD_HOSTNAME" flag:"dashboard-hostname"`
 	// Port is the port the connection-props HTTP server listens on (default 8080).
 	Port int `env:"DASHBOARD_PORT" flag:"dashboard-port"`
 	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
-	ServicePort int `env:"SERVICE_PORT" flag:"service-port"`
-	// TLSEnabled controls whether the advertised connection uses TLS/SSL (default false).
-	TLSEnabled bool `env:"DASHBOARD_TLS_ENABLED" flag:"dashboard-tls-enabled"`
+	ServicePort int `env:"DASHBOARD_SERVICE_PORT" flag:"dashboard-service-port"`
+	// ServiceTLS controls whether the advertised connection uses TLS/SSL (default false).
+	ServiceTLS bool `env:"DASHBOARD_TLS_ENABLED" flag:"dashboard-tls-enabled"`
 }
 
 type LoggerOptions struct {
@@ -139,10 +139,10 @@ func defaultRuntimeOptions() RuntimeOptions {
 // connection-props server.
 func DefaultDashboardOptions() DashboardOptions {
 	return DashboardOptions{
-		Hostname:    "localhost",
-		Port:        8080,
-		ServicePort: 6254,
-		TLSEnabled:  false,
+		ServiceHostname: "localhost",
+		Port:            8080,
+		ServicePort:     6254,
+		ServiceTLS:      false,
 	}
 }
 

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -98,7 +98,7 @@ func (o JwtValidationOptions) ResolvedAllowedAlgs() []string {
 // advertises this device for the "Detect Frame Information" workflow. It is
 // transport-agnostic and can front either a REST or gRPC Catena device.
 type DashboardOptions struct {
-	// Hostname is the address advertised to DashBoard (default "0.0.0.0").
+	// Hostname is the address advertised to DashBoard (default "localhost").
 	Hostname string `env:"HOSTNAME" flag:"hostname"`
 	// Port is the port the connection-props HTTP server listens on (default 8080).
 	Port int `env:"DASHBOARD_PORT" flag:"dashboard-port"`
@@ -150,7 +150,7 @@ func DefaultServerOptions() ServerOptions {
 	return ServerOptions{
 		IsDev:          false,
 		MaxConnections: 100,
-		AuthzEnabled:   false,
+		AuthzEnabled:   true,
 		JwtOptions:     DefaultJwtValidationOptions(),
 	}
 }

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -98,9 +98,9 @@ func (o JwtValidationOptions) ResolvedAllowedAlgs() []string {
 // advertises this device for the "Detect Frame Information" workflow. It is
 // transport-agnostic and can front either a REST or gRPC Catena device.
 type DashboardOptions struct {
-	// Hostname is the address advertised to DashBoard (default "localhost").
+	// Hostname is the address advertised to DashBoard (default "0.0.0.0").
 	Hostname string `env:"HOSTNAME" flag:"hostname"`
-	// Port is the port the connection-props HTTP server listens on (default 80).
+	// Port is the port the connection-props HTTP server listens on (default 8080).
 	Port int `env:"DASHBOARD_PORT" flag:"dashboard-port"`
 	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
 	ServicePort int `env:"SERVICE_PORT" flag:"service-port"`
@@ -140,7 +140,7 @@ func defaultRuntimeOptions() RuntimeOptions {
 func DefaultDashboardOptions() DashboardOptions {
 	return DashboardOptions{
 		Hostname:    "localhost",
-		Port:        80,
+		Port:        8080,
 		ServicePort: 6254,
 		TLSEnabled:  false,
 	}
@@ -150,7 +150,7 @@ func DefaultServerOptions() ServerOptions {
 	return ServerOptions{
 		IsDev:          false,
 		MaxConnections: 100,
-		AuthzEnabled:   true,
+		AuthzEnabled:   false,
 		JwtOptions:     DefaultJwtValidationOptions(),
 	}
 }

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -48,10 +48,11 @@ import (
 )
 
 type RuntimeOptions struct {
-	UseGrpc bool `env:"USE_GRPC" flag:"use-grpc"`
-	UseRest bool `env:"USE_REST" flag:"use-rest"`
-	Server  ServerOptions
-	Logger  LoggerOptions
+	UseGrpc   bool `env:"USE_GRPC" flag:"use-grpc"`
+	UseRest   bool `env:"USE_REST" flag:"use-rest"`
+	Server    ServerOptions
+	Logger    LoggerOptions
+	Dashboard DashboardOptions
 }
 
 type ServerOptions struct {
@@ -93,6 +94,20 @@ func (o JwtValidationOptions) ResolvedAllowedAlgs() []string {
 	return append([]string(nil), o.AllowedAlgs...)
 }
 
+// DashboardOptions configures the DashBoard connection-props HTTP server that
+// advertises this device for the "Detect Frame Information" workflow. It is
+// transport-agnostic and can front either a REST or gRPC Catena device.
+type DashboardOptions struct {
+	// Hostname is the address advertised to DashBoard (default "localhost").
+	Hostname string `env:"HOSTNAME" flag:"hostname"`
+	// Port is the port the connection-props HTTP server listens on (default 80).
+	Port int `env:"DASHBOARD_PORT" flag:"dashboard-port"`
+	// ServicePort is the Catena service port advertised to DashBoard (default 6254).
+	ServicePort int `env:"SERVICE_PORT" flag:"service-port"`
+	// TLSEnabled controls whether the advertised connection uses TLS/SSL (default false).
+	TLSEnabled bool `env:"DASHBOARD_TLS_ENABLED" flag:"dashboard-tls-enabled"`
+}
+
 type LoggerOptions struct {
 	// AppName is used in log file naming
 	AppName string
@@ -112,10 +127,22 @@ type LoggerOptions struct {
 
 func defaultRuntimeOptions() RuntimeOptions {
 	return RuntimeOptions{
-		UseGrpc: false,
-		UseRest: false,
-		Server:  DefaultServerOptions(),
-		Logger:  DefaultLoggerOptions(),
+		UseGrpc:   false,
+		UseRest:   false,
+		Server:    DefaultServerOptions(),
+		Logger:    DefaultLoggerOptions(),
+		Dashboard: DefaultDashboardOptions(),
+	}
+}
+
+// DefaultDashboardOptions returns sensible defaults for the DashBoard
+// connection-props server.
+func DefaultDashboardOptions() DashboardOptions {
+	return DashboardOptions{
+		Hostname:    "localhost",
+		Port:        80,
+		ServicePort: 6254,
+		TLSEnabled:  false,
 	}
 }
 

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -171,7 +171,7 @@ func DefaultDashboardOptions() DashboardOptions {
 		Port:            8080,
 		ServicePort:     6254,
 		ServiceTLS:      false,
-		Protocol:        ProtocolST2138Rest,
+		Protocol:        ProtocolST2138Grpc,
 		RefreshInterval: 30000,
 		ServiceName:     "service:catena-device",
 		Endpoint:        "/connect/connection-props.xml",
@@ -216,6 +216,7 @@ var _ slog.LogValuer = RuntimeOptions{}
 var _ slog.LogValuer = ServerOptions{}
 var _ slog.LogValuer = JwtValidationOptions{}
 var _ slog.LogValuer = LoggerOptions{}
+var _ slog.LogValuer = DashboardOptions{}
 
 func (o JwtValidationOptions) LogValue() slog.Value {
 	return slog.GroupValue(
@@ -248,11 +249,27 @@ func (o LoggerOptions) LogValue() slog.Value {
 	)
 }
 
+func (o DashboardOptions) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("service_hostname", o.ServiceHostname),
+		slog.Int("port", o.Port),
+		slog.Int("service_port", o.ServicePort),
+		slog.Bool("service_tls", o.ServiceTLS),
+		slog.String("protocol", string(o.Protocol)),
+		slog.Uint64("refresh_interval", uint64(o.RefreshInterval)),
+		slog.String("node_name", o.NodeName),
+		slog.String("node_id", o.NodeID),
+		slog.String("service_name", o.ServiceName),
+		slog.String("endpoint", o.Endpoint),
+	)
+}
+
 func (o RuntimeOptions) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Bool("use_grpc", o.UseGrpc),
 		slog.Bool("use_rest", o.UseRest),
 		slog.Any("server", o.Server),
 		slog.Any("logger", o.Logger),
+		slog.Any("dashboard", o.Dashboard),
 	)
 }

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -72,10 +72,10 @@ func TestDefaultOptions(t *testing.T) {
 			UseJSON:        false,
 		},
 		Dashboard: DashboardOptions{
-			Hostname:    "localhost",
-			Port:        8080,
-			ServicePort: 6254,
-			TLSEnabled:  false,
+			ServiceHostname: "localhost",
+			Port:            8080,
+			ServicePort:     6254,
+			ServiceTLS:      false,
 		},
 	}) {
 		t.Errorf("defaultRuntimeOptions() returned unexpected value: %+v", opts)

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -71,6 +71,12 @@ func TestDefaultOptions(t *testing.T) {
 			WriteToConsole: true,
 			UseJSON:        false,
 		},
+		Dashboard: DashboardOptions{
+			Hostname:    "localhost",
+			Port:        80,
+			ServicePort: 6254,
+			TLSEnabled:  false,
+		},
 	}) {
 		t.Errorf("defaultRuntimeOptions() returned unexpected value: %+v", opts)
 	}

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -72,8 +72,8 @@ func TestDefaultOptions(t *testing.T) {
 			UseJSON:        false,
 		},
 		Dashboard: DashboardOptions{
-			Hostname:    "localhost",
-			Port:        80,
+			Hostname:    "0.0.0.0",
+			Port:        8080,
 			ServicePort: 6254,
 			TLSEnabled:  false,
 		},

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -72,7 +72,7 @@ func TestDefaultOptions(t *testing.T) {
 			UseJSON:        false,
 		},
 		Dashboard: DashboardOptions{
-			Hostname:    "0.0.0.0",
+			Hostname:    "localhost",
 			Port:        8080,
 			ServicePort: 6254,
 			TLSEnabled:  false,

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -76,6 +76,10 @@ func TestDefaultOptions(t *testing.T) {
 			Port:            8080,
 			ServicePort:     6254,
 			ServiceTLS:      false,
+			Protocol:        ProtocolST2138Rest,
+			RefreshInterval: 30000,
+			ServiceName:     "service:catena-device",
+			Endpoint:        "/connect/connection-props.xml",
 		},
 	}) {
 		t.Errorf("defaultRuntimeOptions() returned unexpected value: %+v", opts)

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -76,7 +76,7 @@ func TestDefaultOptions(t *testing.T) {
 			Port:            8080,
 			ServicePort:     6254,
 			ServiceTLS:      false,
-			Protocol:        ProtocolST2138Rest,
+			Protocol:        ProtocolST2138Grpc,
 			RefreshInterval: 30000,
 			ServiceName:     "service:catena-device",
 			Endpoint:        "/connect/connection-props.xml",
@@ -108,6 +108,18 @@ func TestRuntimeOptions_LogValuer(t *testing.T) {
 			WriteToFile:    true,
 			WriteToConsole: true,
 			UseJSON:        true,
+		},
+		Dashboard: DashboardOptions{
+			ServiceHostname: "test-host",
+			Port:            8080,
+			ServicePort:     6254,
+			ServiceTLS:      true,
+			Protocol:        ProtocolST2138Grpc,
+			RefreshInterval: 30000,
+			NodeName:        "test-node",
+			NodeID:          "test-id",
+			ServiceName:     "service:test",
+			Endpoint:        "/connect/connection-props.xml",
 		},
 	}
 
@@ -155,6 +167,18 @@ func TestRuntimeOptions_LogValuer(t *testing.T) {
 			"write_to_file":    true,
 			"write_to_console": true,
 			"use_json":         true,
+		},
+		"dashboard": map[string]any{
+			"service_hostname": "test-host",
+			"port":             json.Number("8080"),
+			"service_port":     json.Number("6254"),
+			"service_tls":      true,
+			"protocol":         "st2138-grpc",
+			"refresh_interval": json.Number("30000"),
+			"node_name":        "test-node",
+			"node_id":          "test-id",
+			"service_name":     "service:test",
+			"endpoint":         "/connect/connection-props.xml",
 		},
 	}
 

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -103,6 +103,7 @@ func InitOptionsPrefix(appName, prefix string, args []string) (RuntimeOptions, e
 		extractInt("DASHBOARD_PORT", "dashboard-port", "Port for the DashBoard connection-props HTTP server", &opts.Dashboard.Port).
 		extractInt("DASHBOARD_SERVICE_PORT", "dashboard-service-port", "Catena service port advertised to DashBoard", &opts.Dashboard.ServicePort).
 		extractBool("DASHBOARD_SERVICE_TLS_ENABLED", "dashboard-service-tls-enabled", "Whether the advertised DashBoard connection uses TLS", &opts.Dashboard.ServiceTLS).
+		extractConnectionProtocol("DASHBOARD_PROTOCOL", "dashboard-protocol", "Transport advertised to DashBoard (st2138-rest, st2138-grpc, catena)", &opts.Dashboard.Protocol).
 		extractString("DASHBOARD_SERVICE_NAME", "dashboard-service-name", "Advertised service URL for DashBoard connection props", &opts.Dashboard.ServiceName).
 		extractString("DASHBOARD_NODE_NAME", "dashboard-node-name", "Human-readable node name advertised to DashBoard", &opts.Dashboard.NodeName).
 		extractString("DASHBOARD_NODE_ID", "dashboard-node-id", "Unique node identifier advertised to DashBoard", &opts.Dashboard.NodeID).
@@ -201,6 +202,20 @@ func (l *configLoader) extractString(envName, cliName, usage string, val *string
 	// dummy passthrough parser func
 	l.err = loadParser(l.err, l.flags, l.prefixEnv(envName), cliName, usage, val, func(s string) (string, error) {
 		return s, nil
+	})
+	return l
+}
+
+func (l *configLoader) extractConnectionProtocol(envName, cliName, usage string, val *ConnectionProtocol) *configLoader {
+	// custom parser that validates the protocol against the known values
+	l.err = loadParser(l.err, l.flags, l.prefixEnv(envName), cliName, usage, val, func(s string) (ConnectionProtocol, error) {
+		switch ConnectionProtocol(s) {
+		case ProtocolST2138Rest, ProtocolST2138Grpc, ProtocolST2138Catena:
+			return ConnectionProtocol(s), nil
+		default:
+			return "", fmt.Errorf("%q is not a valid protocol (valid: %s, %s, %s)", s,
+				ProtocolST2138Rest, ProtocolST2138Grpc, ProtocolST2138Catena)
+		}
 	})
 	return l
 }

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -98,6 +98,11 @@ func InitOptionsPrefix(appName, prefix string, args []string) (RuntimeOptions, e
 		extractString("JWT_ISSUER", "jwt-issuer", "Expected JWT issuer for validating incoming requests", &opts.Server.JwtOptions.Issuer).
 		extractString("JWT_AUDIENCE", "jwt-audience", "Expected JWT audience for validating incoming requests", &opts.Server.JwtOptions.Audience).
 		extractBool("JWT_VALIDATE_SIGNATURE", "jwt-validate-signature", "Whether to validate the JWT signature or just the claims", &opts.Server.JwtOptions.ValidateSignature).
+		// DashBoard connection-props options
+		extractString("HOSTNAME", "hostname", "Advertised hostname/address for DashBoard connection props", &opts.Dashboard.Hostname).
+		extractInt("DASHBOARD_PORT", "dashboard-port", "Port for the DashBoard connection-props HTTP server", &opts.Dashboard.Port).
+		extractInt("SERVICE_PORT", "service-port", "Catena service port advertised to DashBoard", &opts.Dashboard.ServicePort).
+		extractBool("DASHBOARD_TLS_ENABLED", "dashboard-tls-enabled", "Whether the advertised DashBoard connection uses TLS", &opts.Dashboard.TLSEnabled).
 		// logging options
 		extractBool("SILENT", "silent", "Suppress all log output", &opts.Logger.Silent).
 		extractString("LOG_DIR", "log-dir", "Directory for log files", &opts.Logger.LogDir).

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -99,10 +99,10 @@ func InitOptionsPrefix(appName, prefix string, args []string) (RuntimeOptions, e
 		extractString("JWT_AUDIENCE", "jwt-audience", "Expected JWT audience for validating incoming requests", &opts.Server.JwtOptions.Audience).
 		extractBool("JWT_VALIDATE_SIGNATURE", "jwt-validate-signature", "Whether to validate the JWT signature or just the claims", &opts.Server.JwtOptions.ValidateSignature).
 		// DashBoard connection-props options
-		extractString("HOSTNAME", "hostname", "Advertised hostname/address for DashBoard connection props", &opts.Dashboard.Hostname).
+		extractString("DASHBOARD_HOSTNAME", "dashboard-hostname", "Advertised hostname/address for DashBoard connection props", &opts.Dashboard.ServiceHostname).
 		extractInt("DASHBOARD_PORT", "dashboard-port", "Port for the DashBoard connection-props HTTP server", &opts.Dashboard.Port).
-		extractInt("SERVICE_PORT", "service-port", "Catena service port advertised to DashBoard", &opts.Dashboard.ServicePort).
-		extractBool("DASHBOARD_TLS_ENABLED", "dashboard-tls-enabled", "Whether the advertised DashBoard connection uses TLS", &opts.Dashboard.TLSEnabled).
+		extractInt("DASHBOARD_SERVICE_PORT", "dashboard-service-port", "Catena service port advertised to DashBoard", &opts.Dashboard.ServicePort).
+		extractBool("DASHBOARD_TLS_ENABLED", "dashboard-tls-enabled", "Whether the advertised DashBoard connection uses TLS", &opts.Dashboard.ServiceTLS).
 		// logging options
 		extractBool("SILENT", "silent", "Suppress all log output", &opts.Logger.Silent).
 		extractString("LOG_DIR", "log-dir", "Directory for log files", &opts.Logger.LogDir).

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -99,10 +99,14 @@ func InitOptionsPrefix(appName, prefix string, args []string) (RuntimeOptions, e
 		extractString("JWT_AUDIENCE", "jwt-audience", "Expected JWT audience for validating incoming requests", &opts.Server.JwtOptions.Audience).
 		extractBool("JWT_VALIDATE_SIGNATURE", "jwt-validate-signature", "Whether to validate the JWT signature or just the claims", &opts.Server.JwtOptions.ValidateSignature).
 		// DashBoard connection-props options
-		extractString("DASHBOARD_HOSTNAME", "dashboard-hostname", "Advertised hostname/address for DashBoard connection props", &opts.Dashboard.ServiceHostname).
+		extractString("DASHBOARD_SERVICE_HOSTNAME", "dashboard-service-hostname", "Advertised hostname/address for DashBoard connection props", &opts.Dashboard.ServiceHostname).
 		extractInt("DASHBOARD_PORT", "dashboard-port", "Port for the DashBoard connection-props HTTP server", &opts.Dashboard.Port).
 		extractInt("DASHBOARD_SERVICE_PORT", "dashboard-service-port", "Catena service port advertised to DashBoard", &opts.Dashboard.ServicePort).
-		extractBool("DASHBOARD_TLS_ENABLED", "dashboard-tls-enabled", "Whether the advertised DashBoard connection uses TLS", &opts.Dashboard.ServiceTLS).
+		extractBool("DASHBOARD_SERVICE_TLS_ENABLED", "dashboard-service-tls-enabled", "Whether the advertised DashBoard connection uses TLS", &opts.Dashboard.ServiceTLS).
+		extractString("DASHBOARD_SERVICE_NAME", "dashboard-service-name", "Advertised service URL for DashBoard connection props", &opts.Dashboard.ServiceName).
+		extractString("DASHBOARD_NODE_NAME", "dashboard-node-name", "Human-readable node name advertised to DashBoard", &opts.Dashboard.NodeName).
+		extractString("DASHBOARD_NODE_ID", "dashboard-node-id", "Unique node identifier advertised to DashBoard", &opts.Dashboard.NodeID).
+		extractString("DASHBOARD_ENDPOINT", "dashboard-endpoint", "Path served by the DashBoard connection-props HTTP server", &opts.Dashboard.Endpoint).
 		// logging options
 		extractBool("SILENT", "silent", "Suppress all log output", &opts.Logger.Silent).
 		extractString("LOG_DIR", "log-dir", "Directory for log files", &opts.Logger.LogDir).

--- a/sdks/go/pkg/config/load_test.go
+++ b/sdks/go/pkg/config/load_test.go
@@ -310,6 +310,44 @@ func TestLoader_LogLevel(t *testing.T) {
 	})
 }
 
+func TestLoader_ConnectionProtocol(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected ConnectionProtocol
+	}{
+		{"st2138-rest", ProtocolST2138Rest},
+		{"st2138-grpc", ProtocolST2138Grpc},
+		{"catena", ProtocolST2138Catena},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			loader := makeTestLoader(t)
+			val := ProtocolST2138Rest
+			t.Setenv("TEST_PROTOCOL", tt.input)
+			loader.extractConnectionProtocol("TEST_PROTOCOL", "test-protocol", "Test protocol flag", &val)
+			if loader.err != nil {
+				t.Errorf("Expected no error got: %v", loader.err)
+			}
+			if val != tt.expected {
+				t.Errorf("Expected val to be %v got: %v", tt.expected, val)
+			}
+		})
+	}
+
+	t.Run("invalid protocol", func(t *testing.T) {
+		loader := makeTestLoader(t)
+		val := ProtocolST2138Rest
+		t.Setenv("TEST_PROTOCOL", "notaprotocol")
+		loader.extractConnectionProtocol("TEST_PROTOCOL", "test-protocol", "Test protocol flag", &val)
+		if loader.err == nil {
+			t.Errorf("Expected error got nil")
+		}
+		if val != ProtocolST2138Rest {
+			t.Errorf("Expected val to be unchanged at ProtocolST2138Rest got: %v", val)
+		}
+	})
+}
+
 func TestLoadParser(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		flags := flag.NewFlagSet("TEST", flag.ContinueOnError)

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -137,7 +137,7 @@ Caller guidance:
 
 ## Defaults
 
-- REST default port: `8080`
+- REST default port: `9080`
 - gRPC default port: `6254`
 - gRPC reflection default: disabled
 

--- a/sdks/go/pkg/transports/REST.md
+++ b/sdks/go/pkg/transports/REST.md
@@ -5,9 +5,9 @@
 ## Constructor
 
 ```go
-rest := transports.NewRestTransport(8080)
+rest := transports.NewRestTransport(9080)
 // or
-rest := transports.NewDefaultRestTransport() // 8080
+rest := transports.NewDefaultRestTransport() // 9080
 ```
 
 Register it on the shared server:
@@ -75,7 +75,7 @@ srv.BroadcastUpdate(slot, "product/version", "1.2.3")
 Client side:
 
 ```javascript
-const source = new EventSource("http://localhost:8080/st2138-api/v1/connect");
+const source = new EventSource("http://localhost:9080/st2138-api/v1/connect");
 source.onmessage = (event) => {
   const update = JSON.parse(event.data);
   console.log(update);

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -82,7 +82,7 @@ func NewRestTransport(port int) *RestTransport {
 
 func NewDefaultRestTransport() *RestTransport {
 	return NewRestTransport(
-		8080, // port
+		9080, // port
 	)
 }
 

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -82,8 +82,8 @@ func TestRestTransport_NewDefaultTransport(t *testing.T) {
 	if transport == nil {
 		t.Fatal("NewDefaultRestTransport returned nil")
 	}
-	if transport.port != 8080 {
-		t.Errorf("expected default port 8080, got %d", transport.port)
+	if transport.port != 9080 {
+		t.Errorf("expected default port 9080, got %d", transport.port)
 	}
 }
 


### PR DESCRIPTION
## 📖 Description

Adds a **DashBoard connection-props HTTP server** to the Go SDK. The new `catena.ConnectionProps` type runs a lightweight HTTP server that serves a single `/connect/connection-props.xml` endpoint, advertising the device so DashBoard's "Detect Frame Information" can resolve and auto-populate its connection dialog. It works in front of both REST and gRPC Catena devices.

The change wires this into the configuration system (new `DashboardOptions` with env/flag support), integrates it into the `oneOfEverything` example.

---

## 🎯 Goal / Outcome

Once merged, a Go-based Catena device can advertise its connection properties over HTTP so DashBoard can automatically discover and connect to it, matching behavior already available in the C++ SDK.

---

## ✅ Definition of Done (DoD)

- [x] `catena.ConnectionProps` server implemented synchronous bind for early error reporting and graceful shutdown,
- [x] Configuration support added (`DashboardOptions`, defaults, env/flag wiring in `load.go`)
- [x] `oneOfEverything` example integrated with start/stop lifecycle and improved startup summary
- [x] Unit tests added (`connection_props_test.go`) and existing `config` tests updated
- [x] All `pkg/` tests pass (`catena`, `config`, `logger`, `transports`); `run_coverage.sh` green
- [x] Committed `oneOfEverything` binary removed from the repo

---

## 🛠️ Implementation Notes (Optional)

- **Synchronous listener bind**: `Start()` calls `net.Listen` before launching the serving goroutine, so failures (privileged port, address in use) are returned to the caller rather than only being logged asynchronously after `Start` already reported success.
- **Transport-agnostic**: a `ConnectionProtocol` enum (`st2138-rest` / `st2138-grpc`) selects what gets advertised; the same server fronts either transport.
- **Defaults**: advertised hostname `localhost`, HTTP server on port `8080`, advertised Catena service port `6254`, refresh interval `30000ms`, endpoint `/connect/connection-props.xml`.
- **XML generation** happens once at construction; values are XML-escaped via `strings.NewReplacer`.
- During development the port moved `80` → `8080`, an early fallback REST handler approach was removed in favor of the dedicated server, and a round of Bugbot findings were addressed.

---

## 🔗 Related Issues / Links

- Closes issue #1336 
