### PR TITLE
[Go] Default true flags are confusing to disable

### DIFF
--- a/sdks/go/pkg/config/README.md
+++ b/sdks/go/pkg/config/README.md
@@ -153,6 +153,9 @@ If `--log-level` is explicitly set, it takes priority over these shortcuts.
 
 ## Parsing Notes
 
+- bool CLI flags use Go's standard bool parser.
+- for any bool option that defaults to true, disable it with `--flag=false` (for example, `--authz=false`).
+- bool CLI values accepted: `true`, `false`, `1`, `0`, `t`, `f` (case-insensitive)
 - bool env values accepted: `true`, `1`, `yes`, `on`, `false`, `0`, `no`, `off`
 - the loader always registers flags first so help output is complete
 - environment parse failures are surfaced as errors

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -93,7 +93,7 @@ func InitOptionsPrefix(appName, prefix string, args []string) (RuntimeOptions, e
 		//server options
 		extractInt("MAX_CONNECTIONS", "max-connections", "Maximum number of concurrent connections", &opts.Server.MaxConnections).
 		extractBool("DEV_MODE", "dev", "Enable development mode", &opts.Server.IsDev).
-		extractBool("AUTHZ", "authz", "Enable authorization checks (requires auth)", &opts.Server.AuthzEnabled).
+		extractBool("AUTHZ", "authz", "Enable authorization checks (requires auth). Use --authz=false to disable", &opts.Server.AuthzEnabled).
 		// JWT validation options
 		extractString("JWT_ISSUER", "jwt-issuer", "Expected JWT issuer for validating incoming requests", &opts.Server.JwtOptions.Issuer).
 		extractString("JWT_AUDIENCE", "jwt-audience", "Expected JWT audience for validating incoming requests", &opts.Server.JwtOptions.Audience).

--- a/sdks/go/pkg/config/load_test.go
+++ b/sdks/go/pkg/config/load_test.go
@@ -142,6 +142,16 @@ func TestInitOptions(t *testing.T) {
 			t.Errorf("Expected log level to be %v got: %v", slog.LevelError, opts.Logger.Level)
 		}
 	})
+
+	t.Run("authz can be disabled with explicit false", func(t *testing.T) {
+		opts, err := InitOptions("test_app", []string{"--authz=false"})
+		if err != nil {
+			t.Errorf("Expected no error got: %v", err)
+		}
+		if opts.Server.AuthzEnabled {
+			t.Errorf("Expected AuthzEnabled to be false")
+		}
+	})
 }
 
 func makeTestLoader(t *testing.T) *configLoader {


### PR DESCRIPTION
<!-- please continue to update this as work is being done to add context, links, scope creep, and any other useful info -->

## 📖 Description
<!-- A clear and concise explanation of what this pull request is about and what it accomplishes. -->
For bool settings that default true, it can be confusing how to turn them off, as the standard `--flag` just turns them on again. Turns out go flags does support this already with `--flag=false` so I've updated the documentation to include this reminder
