### PR TITLE
[GO] MultiSetValue Endpoint

### DIFF
--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -684,80 +684,48 @@ func main() {
 	for _, slot := range slotList {
 		p := slotParams[slot]
 
-		srv.RegisterSetValueHandler(slot, func(value any, slot uint16, fqoid string, ctx catena.HandlerContext) catena.StatusResult {
-			logger.Info("SetValue", "slot", slot, "fqoid", fqoid, "value", value)
-			key := normalizeFqoid(fqoid)
-
-			if value == nil {
-				logger.Error("SetValue nil value received", "slot", slot, "fqoid", fqoid)
-				return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "nil value received")
-			}
-
-			// "running" is driven by start/stop commands, not direct writes,
-			// so reject SetValue with a clear hint to avoid silent drift
-			// between CounterState and the slot-param cache.
-			if slot == 0 && key == "running" {
-				logger.Warning("SetValue rejected for running param", "slot", slot, "fqoid", fqoid)
-				return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "use start/stop commands to change running state")
-			}
-
-			val, ok := p.Load(key)
-			if !ok {
-				logger.Error("SetValue param not found", "slot", slot, "fqoid", fqoid)
-				return catena.StatusWithCode(catena.StatusCodeNotFound, "param not found: "+fqoid)
-			}
-
-			if reflect.TypeOf(val) != reflect.TypeOf(value) {
-				logger.Error("SetValue type mismatch", "slot", slot, "fqoid", fqoid,
-					"expected", reflect.TypeOf(val), "got", reflect.TypeOf(value))
-				return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "type mismatch")
-			}
-
-			p.Store(key, value)
-			logger.Info("Parameter updated", "fqoid", fqoid, "value", value)
-			srv.BroadcastUpdate(slot, fqoid, value, catena.ScopeMon)
-			return catena.StatusWithCode(catena.StatusCodeOk, "")
-		})
-	}
-
-	for _, slot := range []uint16{0, 2} {
-		p := slotParams[slot]
-
-		srv.RegisterMultiSetValueHandler(slot, func(values []catena.SetValueEntry, slot uint16, ctx catena.HandlerContext) catena.StatusResult {
-			logger.Info("MultiSetValue", "slot", slot, "count", len(values))
+		// A single SetValueHandler covers both single and multi set requests:
+		// single endpoints deliver a one-element slice, multi endpoints deliver
+		// the full slice. Validate every entry before applying any so the batch
+		// is all-or-nothing.
+		srv.RegisterSetValueHandler(slot, func(slot uint16, entries []catena.SetValueEntry, ctx catena.HandlerContext) catena.StatusResult {
+			logger.Info("SetValue", "slot", slot, "count", len(entries))
 
 			// Validate pass: check every entry before applying any changes.
-			for _, entry := range values {
+			for _, entry := range entries {
 				key := normalizeFqoid(entry.Fqoid)
 
 				if entry.Value == nil {
-					logger.Error("MultiSetValue nil value", "slot", slot, "fqoid", entry.Fqoid)
+					logger.Error("SetValue nil value", "slot", slot, "fqoid", entry.Fqoid)
 					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "nil value for "+entry.Fqoid)
 				}
 
+				// "running" is driven by start/stop commands, not direct writes,
+				// so reject SetValue with a clear hint to avoid silent drift
+				// between CounterState and the slot-param cache.
 				if slot == 0 && key == "running" {
-					logger.Warning("MultiSetValue rejected for running param", "slot", slot, "fqoid", entry.Fqoid)
+					logger.Warning("SetValue rejected for running param", "slot", slot, "fqoid", entry.Fqoid)
 					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "use start/stop commands to change running state")
 				}
 
 				existing, ok := p.Load(key)
 				if !ok {
-					logger.Error("MultiSetValue param not found", "slot", slot, "fqoid", entry.Fqoid)
+					logger.Error("SetValue param not found", "slot", slot, "fqoid", entry.Fqoid)
 					return catena.StatusWithCode(catena.StatusCodeNotFound, "param not found: "+entry.Fqoid)
 				}
 
 				if reflect.TypeOf(existing) != reflect.TypeOf(entry.Value) {
-					logger.Error("MultiSetValue type mismatch", "slot", slot, "fqoid", entry.Fqoid,
+					logger.Error("SetValue type mismatch", "slot", slot, "fqoid", entry.Fqoid,
 						"expected", reflect.TypeOf(existing), "got", reflect.TypeOf(entry.Value))
 					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "type mismatch for "+entry.Fqoid)
 				}
 			}
 
 			// Apply pass: all entries validated, store and broadcast.
-			for _, entry := range values {
+			for _, entry := range entries {
 				key := normalizeFqoid(entry.Fqoid)
 				p.Store(key, entry.Value)
-				logger.Info("Parameter updated (multi)", "fqoid", entry.Fqoid, "value", entry.Value)
+				logger.Info("Parameter updated", "fqoid", entry.Fqoid, "value", entry.Value)
 				srv.BroadcastUpdate(slot, entry.Fqoid, entry.Value, catena.ScopeMon)
 			}
 

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -720,6 +720,51 @@ func main() {
 		})
 	}
 
+	for _, slot := range []uint16{0, 2} {
+		p := slotParams[slot]
+
+		srv.RegisterMultiSetValueHandler(slot, func(values []catena.SetValueEntry, slot uint16, ctx catena.HandlerContext) catena.StatusResult {
+			logger.Info("MultiSetValue", "slot", slot, "count", len(values))
+
+			// Validate pass: check every entry before applying any changes.
+			for _, entry := range values {
+				key := normalizeFqoid(entry.Fqoid)
+
+				if entry.Value == nil {
+					logger.Error("MultiSetValue nil value", "slot", slot, "fqoid", entry.Fqoid)
+					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "nil value for "+entry.Fqoid)
+				}
+
+				if slot == 0 && key == "running" {
+					logger.Warning("MultiSetValue rejected for running param", "slot", slot, "fqoid", entry.Fqoid)
+					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "use start/stop commands to change running state")
+				}
+
+				existing, ok := p.Load(key)
+				if !ok {
+					logger.Error("MultiSetValue param not found", "slot", slot, "fqoid", entry.Fqoid)
+					return catena.StatusWithCode(catena.StatusCodeNotFound, "param not found: "+entry.Fqoid)
+				}
+
+				if reflect.TypeOf(existing) != reflect.TypeOf(entry.Value) {
+					logger.Error("MultiSetValue type mismatch", "slot", slot, "fqoid", entry.Fqoid,
+						"expected", reflect.TypeOf(existing), "got", reflect.TypeOf(entry.Value))
+					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "type mismatch for "+entry.Fqoid)
+				}
+			}
+
+			// Apply pass: all entries validated, store and broadcast.
+			for _, entry := range values {
+				key := normalizeFqoid(entry.Fqoid)
+				p.Store(key, entry.Value)
+				logger.Info("Parameter updated (multi)", "fqoid", entry.Fqoid, "value", entry.Value)
+				srv.BroadcastUpdate(slot, entry.Fqoid, entry.Value, catena.ScopeMon)
+			}
+
+			return catena.StatusWithCode(catena.StatusCodeOk, "")
+		})
+	}
+
 	srv.RegisterExecuteCommandHandler(0, func(slot uint16, commandFqoid string, payload any, ctx catena.HandlerContext) (catena.CommandResult, catena.StatusResult) {
 		logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid)
 		key := normalizeFqoid(commandFqoid)

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -63,6 +63,7 @@ const (
 	EndpointGetDevice
 	EndpointGetValue
 	EndpointSetValue
+	EndpointMultiSetValue
 	EndpointGetAsset
 	EndpointExecuteCommand
 	EndpointParamInfo
@@ -122,6 +123,15 @@ func (ctx HandlerContext) HasAnyReadScope() bool {
 type DeviceHandler func(slot uint16, ctx HandlerContext) (Device, StatusResult)
 type GetValueHandler func(slot uint16, fqoid string, ctx HandlerContext) (Value, StatusResult)
 type SetValueHandler func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult
+
+// SetValueEntry is a single fqoid/value pair within a MultiSetValue request.
+type SetValueEntry struct {
+	Fqoid string
+	Value any
+}
+
+// MultiSetValueHandler applies multiple parameter values atomically (all-or-nothing).
+type MultiSetValueHandler func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult
 type GetAssetHandler func(slot uint16, fqoid string, ctx HandlerContext) (Asset, StatusResult)
 type ExecuteCommandHandler func(slot uint16, commandFqoid string, payload any, ctx HandlerContext) (CommandResult, StatusResult)
 type ParamInfoHandler func(slot uint16, oidPrefix string, recursive bool, ctx HandlerContext) ([]ParamInfo, StatusResult)
@@ -177,6 +187,7 @@ type Server interface {
 	RegisterGetDeviceHandler(slot uint16, handler DeviceHandler)
 	RegisterGetValueHandler(slot uint16, handler GetValueHandler)
 	RegisterSetValueHandler(slot uint16, handler SetValueHandler)
+	RegisterMultiSetValueHandler(slot uint16, handler MultiSetValueHandler)
 	RegisterGetAssetHandler(slot uint16, handler GetAssetHandler)
 	RegisterExecuteCommandHandler(slot uint16, handler ExecuteCommandHandler)
 	RegisterParamInfoHandler(slot uint16, handler ParamInfoHandler)
@@ -198,6 +209,7 @@ type ServerRuntime interface {
 	InvokeGetDeviceHandler(slot uint16, transportContext TransportContext) (Device, StatusResult)
 	InvokeGetValueHandler(slot uint16, fqoid string, transportContext TransportContext) (Value, StatusResult)
 	InvokeSetValueHandler(value any, slot uint16, fqoid string, transportContext TransportContext) StatusResult
+	InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16, transportContext TransportContext) StatusResult
 	InvokeGetAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (Asset, StatusResult)
 	InvokeExecuteCommandHandler(slot uint16, commandFqoid string, payload any, transportContext TransportContext) (CommandResult, StatusResult)
 	InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool, transportContext TransportContext) ([]ParamInfo, StatusResult)
@@ -223,6 +235,7 @@ type server struct {
 	getDeviceHandlers      map[uint16]DeviceHandler
 	getValueHandlers       map[uint16]GetValueHandler
 	setValueHandlers       map[uint16]SetValueHandler
+	multiSetValueHandlers  map[uint16]MultiSetValueHandler
 	getAssetHandlers       map[uint16]GetAssetHandler
 	executeCommandHandlers map[uint16]ExecuteCommandHandler
 	paramInfoHandlers      map[uint16]ParamInfoHandler
@@ -259,6 +272,7 @@ func NewServer(opts config.ServerOptions) (Server, error) {
 		getDeviceHandlers:      make(map[uint16]DeviceHandler),
 		getValueHandlers:       make(map[uint16]GetValueHandler),
 		setValueHandlers:       make(map[uint16]SetValueHandler),
+		multiSetValueHandlers:  make(map[uint16]MultiSetValueHandler),
 		getAssetHandlers:       make(map[uint16]GetAssetHandler),
 		executeCommandHandlers: make(map[uint16]ExecuteCommandHandler),
 		paramInfoHandlers:      make(map[uint16]ParamInfoHandler),
@@ -532,6 +546,17 @@ func (s *server) RegisterSetValueHandler(slot uint16, handler SetValueHandler) {
 	}
 }
 
+func (s *server) RegisterMultiSetValueHandler(slot uint16, handler MultiSetValueHandler) {
+	s.mu.Lock()
+	s.multiSetValueHandlers[slot] = handler
+	newSlot := s.registerSlotLocked(slot)
+	s.mu.Unlock()
+
+	if newSlot {
+		s.notifySlotsAdded(slot)
+	}
+}
+
 func (s *server) RegisterGetAssetHandler(slot uint16, handler GetAssetHandler) {
 	s.mu.Lock()
 	s.getAssetHandlers[slot] = handler
@@ -658,6 +683,50 @@ func (s *server) InvokeSetValueHandler(value any, slot uint16, fqoid string, tra
 	// TODO: lookup default handler for slot
 	logger.Warning("SetValueHandler called - no handler registered for this slot", "slot", slot, "fqoid", fqoid)
 	return StatusWithCode(StatusCodeNotFound, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
+}
+
+// InvokeMultiSetValueHandler applies multiple parameter values for a slot.
+// If a dedicated MultiSetValueHandler is registered for the slot, it is used to
+// guarantee all-or-nothing (atomic) semantics. Otherwise, it falls back to
+// looping over the single SetValueHandler per entry, returning on the first
+// error. This fallback is NOT atomic; partial application can occur if a later
+// entry fails. Apps requiring true all-or-nothing behavior must register a
+// MultiSetValueHandler.
+func (s *server) InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16, transportContext TransportContext) StatusResult {
+	handlerContext, res := s.resolveHandlerContext(transportContext)
+	if res.Code != StatusCodeOk {
+		return res
+	}
+
+	if !s.hasWriteAccess(handlerContext) {
+		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+	}
+	if !s.isAccessAllowed(EndpointMultiSetValue, handlerContext) {
+		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+	}
+
+	s.mu.Lock()
+	multiHandler, hasMulti := s.multiSetValueHandlers[slot]
+	singleHandler, hasSingle := s.setValueHandlers[slot]
+	s.mu.Unlock()
+
+	if hasMulti {
+		return multiHandler(values, slot, handlerContext)
+	}
+
+	// Non-atomic fallback: apply each entry via the single SetValue handler.
+	if hasSingle {
+		for _, entry := range values {
+			res := singleHandler(entry.Value, slot, entry.Fqoid, handlerContext)
+			if res.Code != StatusCodeOk {
+				return res
+			}
+		}
+		return StatusWithCode(StatusCodeOk, "")
+	}
+
+	logger.Warning("MultiSetValueHandler called - no handler registered for this slot", "slot", slot)
+	return StatusWithCode(StatusCodeNotFound, "no value handler registered at slot "+strconv.Itoa(int(slot)))
 }
 
 func (s *server) InvokeGetAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (Asset, StatusResult) {

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -700,9 +700,6 @@ func (s *server) InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16,
 	if !s.hasWriteAccess(handlerContext) {
 		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
 	}
-	if !s.isAccessAllowed(EndpointMultiSetValue, handlerContext) {
-		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
-	}
 
 	s.mu.Lock()
 	multiHandler, hasMulti := s.multiSetValueHandlers[slot]
@@ -710,11 +707,19 @@ func (s *server) InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16,
 	s.mu.Unlock()
 
 	if hasMulti {
+		if !s.isAccessAllowed(EndpointMultiSetValue, handlerContext) {
+			return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+		}
 		return multiHandler(values, slot, handlerContext)
 	}
 
 	// Non-atomic fallback: apply each entry via the single SetValue handler.
+	// The fallback uses the single SetValueHandler, so it is gated by
+	// EndpointSetValue access to preserve the documented fallback semantics
 	if hasSingle {
+		if !s.isAccessAllowed(EndpointSetValue, handlerContext) {
+			return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+		}
 		for _, entry := range values {
 			res := singleHandler(entry.Value, slot, entry.Fqoid, handlerContext)
 			if res.Code != StatusCodeOk {

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -689,9 +689,8 @@ func (s *server) InvokeSetValueHandler(value any, slot uint16, fqoid string, tra
 // If a dedicated MultiSetValueHandler is registered for the slot, it is used to
 // guarantee all-or-nothing (atomic) semantics. Otherwise, it falls back to
 // looping over the single SetValueHandler per entry, returning on the first
-// error. This fallback is NOT atomic; partial application can occur if a later
-// entry fails. Apps requiring true all-or-nothing behavior must register a
-// MultiSetValueHandler.
+// error, however it is not atomic; partial application can occur if a later
+// entry fails.
 func (s *server) InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16, transportContext TransportContext) StatusResult {
 	handlerContext, res := s.resolveHandlerContext(transportContext)
 	if res.Code != StatusCodeOk {

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -63,7 +63,6 @@ const (
 	EndpointGetDevice
 	EndpointGetValue
 	EndpointSetValue
-	EndpointMultiSetValue
 	EndpointGetAsset
 	EndpointExecuteCommand
 	EndpointParamInfo
@@ -122,16 +121,17 @@ func (ctx HandlerContext) HasAnyReadScope() bool {
 // Handler function types used by both REST and gRPC servers.
 type DeviceHandler func(slot uint16, ctx HandlerContext) (Device, StatusResult)
 type GetValueHandler func(slot uint16, fqoid string, ctx HandlerContext) (Value, StatusResult)
-type SetValueHandler func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult
 
-// SetValueEntry is a single fqoid/value pair within a MultiSetValue request.
+// SetValueEntry is a single fqoid/value pair within a SetValue request.
 type SetValueEntry struct {
 	Fqoid string
 	Value any
 }
 
-// MultiSetValueHandler applies multiple parameter values atomically (all-or-nothing).
-type MultiSetValueHandler func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult
+// SetValueHandler applies one or more parameter values for a slot. Single-value
+// endpoints invoke it with a one-element slice; multi-value endpoints pass the
+// full slice so the handler can apply them atomically (all-or-nothing).
+type SetValueHandler func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult
 type GetAssetHandler func(slot uint16, fqoid string, ctx HandlerContext) (Asset, StatusResult)
 type ExecuteCommandHandler func(slot uint16, commandFqoid string, payload any, ctx HandlerContext) (CommandResult, StatusResult)
 type ParamInfoHandler func(slot uint16, oidPrefix string, recursive bool, ctx HandlerContext) ([]ParamInfo, StatusResult)
@@ -187,7 +187,6 @@ type Server interface {
 	RegisterGetDeviceHandler(slot uint16, handler DeviceHandler)
 	RegisterGetValueHandler(slot uint16, handler GetValueHandler)
 	RegisterSetValueHandler(slot uint16, handler SetValueHandler)
-	RegisterMultiSetValueHandler(slot uint16, handler MultiSetValueHandler)
 	RegisterGetAssetHandler(slot uint16, handler GetAssetHandler)
 	RegisterExecuteCommandHandler(slot uint16, handler ExecuteCommandHandler)
 	RegisterParamInfoHandler(slot uint16, handler ParamInfoHandler)
@@ -208,8 +207,7 @@ type ServerRuntime interface {
 	GetSlots(transportContext TransportContext) ([]uint16, StatusResult)
 	InvokeGetDeviceHandler(slot uint16, transportContext TransportContext) (Device, StatusResult)
 	InvokeGetValueHandler(slot uint16, fqoid string, transportContext TransportContext) (Value, StatusResult)
-	InvokeSetValueHandler(value any, slot uint16, fqoid string, transportContext TransportContext) StatusResult
-	InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16, transportContext TransportContext) StatusResult
+	InvokeSetValueHandler(slot uint16, entries []SetValueEntry, transportContext TransportContext) StatusResult
 	InvokeGetAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (Asset, StatusResult)
 	InvokeExecuteCommandHandler(slot uint16, commandFqoid string, payload any, transportContext TransportContext) (CommandResult, StatusResult)
 	InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool, transportContext TransportContext) ([]ParamInfo, StatusResult)
@@ -235,7 +233,6 @@ type server struct {
 	getDeviceHandlers      map[uint16]DeviceHandler
 	getValueHandlers       map[uint16]GetValueHandler
 	setValueHandlers       map[uint16]SetValueHandler
-	multiSetValueHandlers  map[uint16]MultiSetValueHandler
 	getAssetHandlers       map[uint16]GetAssetHandler
 	executeCommandHandlers map[uint16]ExecuteCommandHandler
 	paramInfoHandlers      map[uint16]ParamInfoHandler
@@ -272,7 +269,6 @@ func NewServer(opts config.ServerOptions) (Server, error) {
 		getDeviceHandlers:      make(map[uint16]DeviceHandler),
 		getValueHandlers:       make(map[uint16]GetValueHandler),
 		setValueHandlers:       make(map[uint16]SetValueHandler),
-		multiSetValueHandlers:  make(map[uint16]MultiSetValueHandler),
 		getAssetHandlers:       make(map[uint16]GetAssetHandler),
 		executeCommandHandlers: make(map[uint16]ExecuteCommandHandler),
 		paramInfoHandlers:      make(map[uint16]ParamInfoHandler),
@@ -546,17 +542,6 @@ func (s *server) RegisterSetValueHandler(slot uint16, handler SetValueHandler) {
 	}
 }
 
-func (s *server) RegisterMultiSetValueHandler(slot uint16, handler MultiSetValueHandler) {
-	s.mu.Lock()
-	s.multiSetValueHandlers[slot] = handler
-	newSlot := s.registerSlotLocked(slot)
-	s.mu.Unlock()
-
-	if newSlot {
-		s.notifySlotsAdded(slot)
-	}
-}
-
 func (s *server) RegisterGetAssetHandler(slot uint16, handler GetAssetHandler) {
 	s.mu.Lock()
 	s.getAssetHandlers[slot] = handler
@@ -660,7 +645,11 @@ func (s *server) InvokeGetValueHandler(slot uint16, fqoid string, transportConte
 	return ReplyError[Value](StatusCodeNotFound, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
 }
 
-func (s *server) InvokeSetValueHandler(value any, slot uint16, fqoid string, transportContext TransportContext) StatusResult {
+// InvokeSetValueHandler applies one or more parameter values for a slot. The
+// registered SetValueHandler receives the full slice of entries so it can apply
+// them atomically; single-value endpoints pass a one-element slice. Access
+// checks run once for the whole batch.
+func (s *server) InvokeSetValueHandler(slot uint16, entries []SetValueEntry, transportContext TransportContext) StatusResult {
 	handlerContext, res := s.resolveHandlerContext(transportContext)
 	if res.Code != StatusCodeOk {
 		return res
@@ -678,59 +667,11 @@ func (s *server) InvokeSetValueHandler(value any, slot uint16, fqoid string, tra
 	s.mu.Unlock()
 
 	if ok {
-		return handler(value, slot, fqoid, handlerContext)
+		return handler(slot, entries, handlerContext)
 	}
 	// TODO: lookup default handler for slot
-	logger.Warning("SetValueHandler called - no handler registered for this slot", "slot", slot, "fqoid", fqoid)
-	return StatusWithCode(StatusCodeNotFound, "fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)))
-}
-
-// InvokeMultiSetValueHandler applies multiple parameter values for a slot.
-// If a dedicated MultiSetValueHandler is registered for the slot, it is used to
-// guarantee all-or-nothing (atomic) semantics. Otherwise, it falls back to
-// looping over the single SetValueHandler per entry, returning on the first
-// error, however it is not atomic; partial application can occur if a later
-// entry fails.
-func (s *server) InvokeMultiSetValueHandler(values []SetValueEntry, slot uint16, transportContext TransportContext) StatusResult {
-	handlerContext, res := s.resolveHandlerContext(transportContext)
-	if res.Code != StatusCodeOk {
-		return res
-	}
-
-	if !s.hasWriteAccess(handlerContext) {
-		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
-	}
-
-	s.mu.Lock()
-	multiHandler, hasMulti := s.multiSetValueHandlers[slot]
-	singleHandler, hasSingle := s.setValueHandlers[slot]
-	s.mu.Unlock()
-
-	if hasMulti {
-		if !s.isAccessAllowed(EndpointMultiSetValue, handlerContext) {
-			return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
-		}
-		return multiHandler(values, slot, handlerContext)
-	}
-
-	// Non-atomic fallback: apply each entry via the single SetValue handler.
-	// The fallback uses the single SetValueHandler, so it is gated by
-	// EndpointSetValue access to preserve the documented fallback semantics
-	if hasSingle {
-		if !s.isAccessAllowed(EndpointSetValue, handlerContext) {
-			return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
-		}
-		for _, entry := range values {
-			res := singleHandler(entry.Value, slot, entry.Fqoid, handlerContext)
-			if res.Code != StatusCodeOk {
-				return res
-			}
-		}
-		return StatusWithCode(StatusCodeOk, "")
-	}
-
-	logger.Warning("MultiSetValueHandler called - no handler registered for this slot", "slot", slot)
-	return StatusWithCode(StatusCodeNotFound, "no value handler registered at slot "+strconv.Itoa(int(slot)))
+	logger.Warning("SetValueHandler called - no handler registered for this slot", "slot", slot, "count", len(entries))
+	return StatusWithCode(StatusCodeNotFound, "no SetValue handler registered for slot "+strconv.Itoa(int(slot)))
 }
 
 func (s *server) InvokeGetAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (Asset, StatusResult) {

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -1127,6 +1127,16 @@ func TestServer_EndpointsReturnResolveHandlerContextError(t *testing.T) {
 			},
 		},
 		{
+			name: "multi set value",
+			invoke: func(srv *server, handlerCalled *bool) StatusResult {
+				srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+					*handlerCalled = true
+					return StatusWithCode(StatusCodeOk, "")
+				})
+				return srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, 0, invalidContext)
+			},
+		},
+		{
 			name: "get asset",
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
 				srv.RegisterGetAssetHandler(0, func(slot uint16, fqoid string, ctx HandlerContext) (Asset, StatusResult) {
@@ -1249,6 +1259,17 @@ func TestServer_EndpointsReturnPermissionDeniedWhenAccessHandlerDenies(t *testin
 					return StatusWithCode(StatusCodeOk, "")
 				})
 				return srv.InvokeSetValueHandler(int32(42), 0, "test/param", transportContext)
+			},
+		},
+		{
+			name:     "multi set value",
+			endpoint: EndpointMultiSetValue,
+			invoke: func(srv *server, handlerCalled *bool) StatusResult {
+				srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+					*handlerCalled = true
+					return StatusWithCode(StatusCodeOk, "")
+				})
+				return srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, 0, transportContext)
 			},
 		},
 		{

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -736,10 +736,13 @@ func TestServer_RegisterSetValueHandler(t *testing.T) {
 	transportContext := validTestTransportContext(nil)
 
 	handlerCalled := false
-	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+	srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 		handlerCalled = true
-		if value != int32(42) {
-			t.Errorf("expected value int32(42), got %v", value)
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Value != int32(42) {
+			t.Errorf("expected value int32(42), got %v", entries[0].Value)
 		}
 		if ctx.Token == nil || ctx.Token.Raw != transportContext.AccessToken {
 			t.Errorf("expected parsed token from access token")
@@ -750,7 +753,7 @@ func TestServer_RegisterSetValueHandler(t *testing.T) {
 		return StatusResult{Code: StatusCodeOk}
 	})
 
-	status := srv.InvokeSetValueHandler(int32(42), 0, "test/param", transportContext)
+	status := srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, transportContext)
 
 	if !handlerCalled {
 		t.Error("registered handler was not called")
@@ -769,16 +772,15 @@ func TestServer_RegisterSetValueHandler(t *testing.T) {
 	}
 }
 
-func TestServer_RegisterMultiSetValueHandler(t *testing.T) {
+func TestServer_InvokeSetValueHandler_MultipleEntries(t *testing.T) {
 	srv := newTestServer(t, true)
 	transportContext := validTestTransportContext(nil)
 
-	handlerCalled := false
-	srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
-		handlerCalled = true
-		if len(values) != 2 {
-			t.Errorf("expected 2 values, got %d", len(values))
-		}
+	callCount := 0
+	var got []SetValueEntry
+	srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
+		callCount++
+		got = entries
 		if !ctx.HasReadScope("all") {
 			t.Errorf("expected parsed token read scopes to include all, got %v", ctx.readScopes)
 		}
@@ -789,13 +791,16 @@ func TestServer_RegisterMultiSetValueHandler(t *testing.T) {
 		{Fqoid: "a", Value: int32(1)},
 		{Fqoid: "b", Value: int32(2)},
 	}
-	status := srv.InvokeMultiSetValueHandler(entries, 0, transportContext)
+	status := srv.InvokeSetValueHandler(0, entries, transportContext)
 
-	if !handlerCalled {
-		t.Error("registered multi-set handler was not called")
-	}
 	if status.Code != StatusCodeOk {
 		t.Errorf("expected OK status, got %v", status.Code)
+	}
+	if callCount != 1 {
+		t.Errorf("expected handler called once with the full batch, got %d", callCount)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries delivered to handler, got %d", len(got))
 	}
 
 	slots, status := srv.GetSlots(validTestTransportContext(nil))
@@ -807,109 +812,20 @@ func TestServer_RegisterMultiSetValueHandler(t *testing.T) {
 	}
 }
 
-func TestServer_InvokeMultiSetValueHandler_Fallback(t *testing.T) {
+func TestServer_InvokeSetValueHandler_HandlerError(t *testing.T) {
 	srv := newTestServer(t, true)
 
-	callCount := 0
-	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
-		callCount++
-		return StatusResult{Code: StatusCodeOk}
+	srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
+		return StatusWithCode(StatusCodeInvalidArgument, "bad value")
 	})
 
 	entries := []SetValueEntry{
 		{Fqoid: "a", Value: int32(1)},
 		{Fqoid: "b", Value: int32(2)},
 	}
-	status := srv.InvokeMultiSetValueHandler(entries, 0, validTestTransportContext(nil))
-	if status.Code != StatusCodeOk {
-		t.Errorf("expected OK status, got %v", status.Code)
-	}
-	if callCount != 2 {
-		t.Errorf("expected single handler called 2 times via fallback, got %d", callCount)
-	}
-}
-
-func TestServer_InvokeMultiSetValueHandler_FallbackStopsOnError(t *testing.T) {
-	srv := newTestServer(t, true)
-
-	callCount := 0
-	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
-		callCount++
-		if callCount == 2 {
-			return StatusWithCode(StatusCodeInvalidArgument, "bad value")
-		}
-		return StatusResult{Code: StatusCodeOk}
-	})
-
-	entries := []SetValueEntry{
-		{Fqoid: "a", Value: int32(1)},
-		{Fqoid: "b", Value: int32(2)},
-		{Fqoid: "c", Value: int32(3)},
-	}
-	status := srv.InvokeMultiSetValueHandler(entries, 0, validTestTransportContext(nil))
+	status := srv.InvokeSetValueHandler(0, entries, validTestTransportContext(nil))
 	if status.Code != StatusCodeInvalidArgument {
 		t.Errorf("expected InvalidArgument status, got %v", status.Code)
-	}
-	if callCount != 2 {
-		t.Errorf("expected handler called 2 times (stopped at error), got %d", callCount)
-	}
-}
-
-func TestServer_InvokeMultiSetValueHandler_NoHandler(t *testing.T) {
-	srv := newTestServer(t, true)
-
-	status := srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "a", Value: int32(1)}}, 0, validTestTransportContext(nil))
-	if status.Code != StatusCodeNotFound {
-		t.Errorf("expected StatusCodeNotFound status, got %v", status.Code)
-	}
-}
-
-func TestServer_InvokeMultiSetValueHandler_FallbackUsesSetValueAccess(t *testing.T) {
-	srv := newTestServer(t, true)
-
-	callCount := 0
-	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
-		callCount++
-		return StatusResult{Code: StatusCodeOk}
-	})
-
-	srv.RegisterAccessHandler(func(endpointType EndpointType, ctx HandlerContext) bool {
-		return endpointType == EndpointSetValue
-	})
-
-	entries := []SetValueEntry{
-		{Fqoid: "a", Value: int32(1)},
-		{Fqoid: "b", Value: int32(2)},
-	}
-	status := srv.InvokeMultiSetValueHandler(entries, 0, validTestTransportContext(nil))
-	if status.Code != StatusCodeOk {
-		t.Errorf("expected OK status from SetValue-gated fallback, got %v", status.Code)
-	}
-	if callCount != 2 {
-		t.Errorf("expected single handler called 2 times via fallback, got %d", callCount)
-	}
-}
-
-// A dedicated multi handler must still be gated by EndpointMultiSetValue access.
-func TestServer_InvokeMultiSetValueHandler_DedicatedRequiresMultiAccess(t *testing.T) {
-	srv := newTestServer(t, true)
-
-	handlerCalled := false
-	srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
-		handlerCalled = true
-		return StatusResult{Code: StatusCodeOk}
-	})
-
-	srv.RegisterAccessHandler(func(endpointType EndpointType, ctx HandlerContext) bool {
-		return endpointType == EndpointSetValue
-	})
-
-	status := srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "a", Value: int32(1)}}, 0, validTestTransportContext(nil))
-	if status.Code != StatusCodePermissionDenied {
-		t.Errorf("expected StatusCodePermissionDenied for dedicated handler without multi access, got %v", status.Code)
-	}
-	if handlerCalled {
-		t.Error("multi handler should not run when EndpointMultiSetValue access is denied")
 	}
 }
 
@@ -1061,22 +977,22 @@ func TestServer_EndpointsReturnPermissionDeniedWhenScopeCheckFails(t *testing.T)
 			name:      "set value",
 			scopeKind: "write",
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeSetValueHandler(int32(42), 0, "test/param", noWriteContext)
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, noWriteContext)
 			},
 		},
 		{
 			name:      "multi set value",
 			scopeKind: "write",
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, 0, noWriteContext)
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "a", Value: int32(1)}, {Fqoid: "b", Value: int32(2)}}, noWriteContext)
 			},
 		},
 		{
@@ -1168,21 +1084,21 @@ func TestServer_EndpointsReturnResolveHandlerContextError(t *testing.T) {
 		{
 			name: "set value",
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeSetValueHandler(int32(42), 0, "test/param", invalidContext)
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, invalidContext)
 			},
 		},
 		{
 			name: "multi set value",
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, 0, invalidContext)
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "a", Value: int32(1)}, {Fqoid: "b", Value: int32(2)}}, invalidContext)
 			},
 		},
 		{
@@ -1303,22 +1219,22 @@ func TestServer_EndpointsReturnPermissionDeniedWhenAccessHandlerDenies(t *testin
 			name:     "set value",
 			endpoint: EndpointSetValue,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeSetValueHandler(int32(42), 0, "test/param", transportContext)
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, transportContext)
 			},
 		},
 		{
 			name:     "multi set value",
-			endpoint: EndpointMultiSetValue,
+			endpoint: EndpointSetValue,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, 0, transportContext)
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "a", Value: int32(1)}, {Fqoid: "b", Value: int32(2)}}, transportContext)
 			},
 		},
 		{
@@ -1501,7 +1417,7 @@ func TestServer_InvokeSetValueHandler_NoHandler(t *testing.T) {
 		t.Errorf("expected 0 slots, got %d", len(slots))
 	}
 
-	status = srv.InvokeSetValueHandler(42, 0, "test/param", validTestTransportContext(nil))
+	status = srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, validTestTransportContext(nil))
 
 	// no handler should return StatusCodeNotFound status
 	if status.Code != StatusCodeNotFound {
@@ -1724,11 +1640,11 @@ func TestServer_AuthzDisabledAllowsRequestsWithoutToken(t *testing.T) {
 			name:              "set value",
 			expectHandlerCall: true,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+				srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
 					*handlerCalled = true
 					return StatusWithCode(StatusCodeOk, "")
 				})
-				return srv.InvokeSetValueHandler(int32(42), 0, "test/param", TransportContext{})
+				return srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, TransportContext{})
 			},
 		},
 		{

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -864,6 +864,55 @@ func TestServer_InvokeMultiSetValueHandler_NoHandler(t *testing.T) {
 	}
 }
 
+func TestServer_InvokeMultiSetValueHandler_FallbackUsesSetValueAccess(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	callCount := 0
+	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+		callCount++
+		return StatusResult{Code: StatusCodeOk}
+	})
+
+	srv.RegisterAccessHandler(func(endpointType EndpointType, ctx HandlerContext) bool {
+		return endpointType == EndpointSetValue
+	})
+
+	entries := []SetValueEntry{
+		{Fqoid: "a", Value: int32(1)},
+		{Fqoid: "b", Value: int32(2)},
+	}
+	status := srv.InvokeMultiSetValueHandler(entries, 0, validTestTransportContext(nil))
+	if status.Code != StatusCodeOk {
+		t.Errorf("expected OK status from SetValue-gated fallback, got %v", status.Code)
+	}
+	if callCount != 2 {
+		t.Errorf("expected single handler called 2 times via fallback, got %d", callCount)
+	}
+}
+
+// A dedicated multi handler must still be gated by EndpointMultiSetValue access.
+func TestServer_InvokeMultiSetValueHandler_DedicatedRequiresMultiAccess(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	handlerCalled := false
+	srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+		handlerCalled = true
+		return StatusResult{Code: StatusCodeOk}
+	})
+
+	srv.RegisterAccessHandler(func(endpointType EndpointType, ctx HandlerContext) bool {
+		return endpointType == EndpointSetValue
+	})
+
+	status := srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "a", Value: int32(1)}}, 0, validTestTransportContext(nil))
+	if status.Code != StatusCodePermissionDenied {
+		t.Errorf("expected StatusCodePermissionDenied for dedicated handler without multi access, got %v", status.Code)
+	}
+	if handlerCalled {
+		t.Error("multi handler should not run when EndpointMultiSetValue access is denied")
+	}
+}
+
 func TestServer_RegisterGetAssetHandler(t *testing.T) {
 	srv := newTestServer(t, true)
 

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -769,6 +769,101 @@ func TestServer_RegisterSetValueHandler(t *testing.T) {
 	}
 }
 
+func TestServer_RegisterMultiSetValueHandler(t *testing.T) {
+	srv := newTestServer(t, true)
+	transportContext := validTestTransportContext(nil)
+
+	handlerCalled := false
+	srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+		handlerCalled = true
+		if len(values) != 2 {
+			t.Errorf("expected 2 values, got %d", len(values))
+		}
+		if !ctx.HasReadScope("all") {
+			t.Errorf("expected parsed token read scopes to include all, got %v", ctx.readScopes)
+		}
+		return StatusResult{Code: StatusCodeOk}
+	})
+
+	entries := []SetValueEntry{
+		{Fqoid: "a", Value: int32(1)},
+		{Fqoid: "b", Value: int32(2)},
+	}
+	status := srv.InvokeMultiSetValueHandler(entries, 0, transportContext)
+
+	if !handlerCalled {
+		t.Error("registered multi-set handler was not called")
+	}
+	if status.Code != StatusCodeOk {
+		t.Errorf("expected OK status, got %v", status.Code)
+	}
+
+	slots, status := srv.GetSlots(validTestTransportContext(nil))
+	if status.Code != StatusCodeOk {
+		t.Errorf("expected OK status from GetSlots, got %v", status.Code)
+	}
+	if !slices.Contains(slots, uint16(0)) {
+		t.Error("slot 0 should be registered in server slots")
+	}
+}
+
+func TestServer_InvokeMultiSetValueHandler_Fallback(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	callCount := 0
+	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+		callCount++
+		return StatusResult{Code: StatusCodeOk}
+	})
+
+	entries := []SetValueEntry{
+		{Fqoid: "a", Value: int32(1)},
+		{Fqoid: "b", Value: int32(2)},
+	}
+	status := srv.InvokeMultiSetValueHandler(entries, 0, validTestTransportContext(nil))
+	if status.Code != StatusCodeOk {
+		t.Errorf("expected OK status, got %v", status.Code)
+	}
+	if callCount != 2 {
+		t.Errorf("expected single handler called 2 times via fallback, got %d", callCount)
+	}
+}
+
+func TestServer_InvokeMultiSetValueHandler_FallbackStopsOnError(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	callCount := 0
+	srv.RegisterSetValueHandler(0, func(value any, slot uint16, fqoid string, ctx HandlerContext) StatusResult {
+		callCount++
+		if callCount == 2 {
+			return StatusWithCode(StatusCodeInvalidArgument, "bad value")
+		}
+		return StatusResult{Code: StatusCodeOk}
+	})
+
+	entries := []SetValueEntry{
+		{Fqoid: "a", Value: int32(1)},
+		{Fqoid: "b", Value: int32(2)},
+		{Fqoid: "c", Value: int32(3)},
+	}
+	status := srv.InvokeMultiSetValueHandler(entries, 0, validTestTransportContext(nil))
+	if status.Code != StatusCodeInvalidArgument {
+		t.Errorf("expected InvalidArgument status, got %v", status.Code)
+	}
+	if callCount != 2 {
+		t.Errorf("expected handler called 2 times (stopped at error), got %d", callCount)
+	}
+}
+
+func TestServer_InvokeMultiSetValueHandler_NoHandler(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	status := srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "a", Value: int32(1)}}, 0, validTestTransportContext(nil))
+	if status.Code != StatusCodeNotFound {
+		t.Errorf("expected StatusCodeNotFound status, got %v", status.Code)
+	}
+}
+
 func TestServer_RegisterGetAssetHandler(t *testing.T) {
 	srv := newTestServer(t, true)
 
@@ -922,6 +1017,17 @@ func TestServer_EndpointsReturnPermissionDeniedWhenScopeCheckFails(t *testing.T)
 					return StatusWithCode(StatusCodeOk, "")
 				})
 				return srv.InvokeSetValueHandler(int32(42), 0, "test/param", noWriteContext)
+			},
+		},
+		{
+			name:      "multi set value",
+			scopeKind: "write",
+			invoke: func(srv *server, handlerCalled *bool) StatusResult {
+				srv.RegisterMultiSetValueHandler(0, func(values []SetValueEntry, slot uint16, ctx HandlerContext) StatusResult {
+					*handlerCalled = true
+					return StatusWithCode(StatusCodeOk, "")
+				})
+				return srv.InvokeMultiSetValueHandler([]SetValueEntry{{Fqoid: "test/param", Value: int32(42)}}, 0, noWriteContext)
 			},
 		},
 		{

--- a/sdks/go/pkg/transports/GRPC.md
+++ b/sdks/go/pkg/transports/GRPC.md
@@ -48,7 +48,7 @@ Currently unimplemented (returns `Unimplemented`):
 RPC methods invoke the same handlers registered on `catena.Server`:
 
 - `DeviceRequest` -> `RegisterGetDeviceHandler`
-- `GetValue` / `SetValue` / `MultiSetValue` -> `RegisterGetValueHandler`, `RegisterSetValueHandler`
+- `GetValue` / `SetValue` / `MultiSetValue` -> `RegisterGetValueHandler`, `RegisterSetValueHandler`, `RegisterMultiSetValueHandler`
 - `ExternalObjectRequest` -> `RegisterGetAssetHandler`
 - `ExecuteCommand` -> `RegisterExecuteCommandHandler`
 - `ParamInfoRequest` -> `RegisterParamInfoHandler`

--- a/sdks/go/pkg/transports/GRPC.md
+++ b/sdks/go/pkg/transports/GRPC.md
@@ -48,7 +48,8 @@ Currently unimplemented (returns `Unimplemented`):
 RPC methods invoke the same handlers registered on `catena.Server`:
 
 - `DeviceRequest` -> `RegisterGetDeviceHandler`
-- `GetValue` / `SetValue` / `MultiSetValue` -> `RegisterGetValueHandler`, `RegisterSetValueHandler`, `RegisterMultiSetValueHandler`
+- `GetValue` -> `RegisterGetValueHandler`
+- `SetValue` / `MultiSetValue` -> `RegisterSetValueHandler` (the handler receives `[]SetValueEntry`; `SetValue` delivers a one-element slice, `MultiSetValue` delivers the full slice for atomic application)
 - `ExternalObjectRequest` -> `RegisterGetAssetHandler`
 - `ExecuteCommand` -> `RegisterExecuteCommandHandler`
 - `ParamInfoRequest` -> `RegisterParamInfoHandler`

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -76,8 +76,7 @@ Both transports invoke the same registered handlers from `catena.ServerRuntime`:
 
 - `RegisterGetDeviceHandler`
 - `RegisterGetValueHandler`
-- `RegisterSetValueHandler`
-- `RegisterMultiSetValueHandler`
+- `RegisterSetValueHandler` (handles both single and multi set requests; single endpoints deliver a one-element `[]SetValueEntry`, multi endpoints deliver the full slice)
 - `RegisterGetAssetHandler`
 - `RegisterExecuteCommandHandler`
 - `RegisterParamInfoHandler`

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -77,6 +77,7 @@ Both transports invoke the same registered handlers from `catena.ServerRuntime`:
 - `RegisterGetDeviceHandler`
 - `RegisterGetValueHandler`
 - `RegisterSetValueHandler`
+- `RegisterMultiSetValueHandler`
 - `RegisterGetAssetHandler`
 - `RegisterExecuteCommandHandler`
 - `RegisterParamInfoHandler`

--- a/sdks/go/pkg/transports/REST.md
+++ b/sdks/go/pkg/transports/REST.md
@@ -45,8 +45,8 @@ Fallback and root behavior:
 REST routes invoke handlers registered on `catena.Server`:
 
 - Device route -> `RegisterGetDeviceHandler`
-- Value routes -> `RegisterGetValueHandler`, `RegisterSetValueHandler`
-- Values route -> `RegisterMultiSetValueHandler`
+- Value routes -> `RegisterGetValueHandler`, `RegisterSetValueHandler` (the set route delivers a one-element `[]SetValueEntry`)
+- Values route -> `RegisterSetValueHandler` (delivers the full `[]SetValueEntry` for atomic application)
 - Asset route -> `RegisterGetAssetHandler`
 - Command route -> `RegisterExecuteCommandHandler`
 - Param-info routes -> `RegisterParamInfoHandler`

--- a/sdks/go/pkg/transports/REST.md
+++ b/sdks/go/pkg/transports/REST.md
@@ -26,6 +26,7 @@ Core routes:
 - `GET /st2138-api/v1/{slot}` - DeviceRequest equivalent
 - `GET /st2138-api/v1/{slot}/value/{oid}` - GetValue
 - `PUT /st2138-api/v1/{slot}/value/{oid}` - SetValue
+- `PUT /st2138-api/v1/{slot}/values` - SetValues (MultiSetValue)
 - `GET /st2138-api/v1/{slot}/asset/{oid}` - ExternalObjectRequest equivalent
 - `POST /st2138-api/v1/{slot}/command/{oid}` - ExecuteCommand
 - `GET /st2138-api/v1/{slot}/param-info/{oid...}` - unary param info
@@ -45,6 +46,7 @@ REST routes invoke handlers registered on `catena.Server`:
 
 - Device route -> `RegisterGetDeviceHandler`
 - Value routes -> `RegisterGetValueHandler`, `RegisterSetValueHandler`
+- Values route -> `RegisterMultiSetValueHandler`
 - Asset route -> `RegisterGetAssetHandler`
 - Command route -> `RegisterExecuteCommandHandler`
 - Param-info routes -> `RegisterParamInfoHandler`

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -336,7 +336,8 @@ func (s *catenaService) SetValue(ctx context.Context, req *protos.SingleSetValue
 	}
 
 	transportContext := s.transport.retrieveMetadataFromContext(ctx)
-	result := s.transport.runtime.InvokeSetValueHandler(nativeValue, slot, fqoid, transportContext)
+	entries := []catena.SetValueEntry{{Fqoid: fqoid, Value: nativeValue}}
+	result := s.transport.runtime.InvokeSetValueHandler(slot, entries, transportContext)
 	if result.Error != "" {
 		logger.Error("SetValue handler error", "slot", slot, "fqoid", fqoid, "error", result.Error)
 		return nil, status.Error(ToGRPCCode(result.Code), result.Error)
@@ -368,7 +369,7 @@ func (s *catenaService) MultiSetValue(ctx context.Context, req *protos.MultiSetV
 		entries = append(entries, catena.SetValueEntry{Fqoid: fqoid, Value: nativeValue})
 	}
 
-	result := s.transport.runtime.InvokeMultiSetValueHandler(entries, slot, transportContext)
+	result := s.transport.runtime.InvokeSetValueHandler(slot, entries, transportContext)
 	if result.Error != "" {
 		logger.Error("MultiSetValue handler error", "slot", slot, "error", result.Error)
 		return nil, status.Error(ToGRPCCode(result.Code), result.Error)

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -352,11 +352,10 @@ func (s *catenaService) MultiSetValue(ctx context.Context, req *protos.MultiSetV
 		return nil, status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	// TODO server should get a direct handler for this to make it a atomic operation, rather than looping and invoking the single set handler multiple times
-
 	logger.Info("MultiSetValue", "slot", slot, "count", len(req.Values))
 	transportContext := s.transport.retrieveMetadataFromContext(ctx)
 
+	entries := make([]catena.SetValueEntry, 0, len(req.Values))
 	for _, setValue := range req.Values {
 		fqoid := setValue.Oid
 
@@ -366,11 +365,13 @@ func (s *catenaService) MultiSetValue(ctx context.Context, req *protos.MultiSetV
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid value for %s: %v", fqoid, errProto.Error))
 		}
 
-		result := s.transport.runtime.InvokeSetValueHandler(nativeValue, slot, fqoid, transportContext)
-		if result.Error != "" {
-			logger.Error("MultiSetValue handler error", "slot", slot, "fqoid", fqoid, "error", result.Error)
-			return nil, status.Error(ToGRPCCode(result.Code), result.Error)
-		}
+		entries = append(entries, catena.SetValueEntry{Fqoid: fqoid, Value: nativeValue})
+	}
+
+	result := s.transport.runtime.InvokeMultiSetValueHandler(entries, slot, transportContext)
+	if result.Error != "" {
+		logger.Error("MultiSetValue handler error", "slot", slot, "error", result.Error)
+		return nil, status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
 	return &protos.Empty{}, nil

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -771,6 +771,31 @@ func TestGrpcTransport_MultiSetValue_EmptyValues(t *testing.T) {
 	}
 }
 
+func TestGrpcTransport_MultiSetValue_DedicatedHandler(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
+	defer cleanup()
+
+	var got []catena.SetValueEntry
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+		got = values
+		return catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	_, err := makeMultiSetValueRequest(t, client, ctx, 0, map[string]any{
+		"param1": int32(10),
+		"param2": "test",
+	})
+	assertNoError(t, err)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries delivered to dedicated handler, got %d", len(got))
+	}
+}
+
 // =============================================================================
 // Test: ExternalObjectRequest
 // =============================================================================

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -248,7 +248,7 @@ func TestGrpcTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "multi set value",
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
-				runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+				runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
 					assertContext(t, ctx)
 					return catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
@@ -678,8 +678,10 @@ func TestGrpcTransport_MultiSetValue_Success(t *testing.T) {
 	defer cleanup()
 
 	callCount := 0
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	var got []catena.SetValueEntry
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
+		got = values
 		return catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
@@ -693,8 +695,11 @@ func TestGrpcTransport_MultiSetValue_Success(t *testing.T) {
 	})
 	assertNoError(t, err)
 
-	if callCount != 3 {
-		t.Errorf("expected handler to be called 3 times, got %d", callCount)
+	if callCount != 1 {
+		t.Errorf("expected handler to be called once, got %d", callCount)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 entries delivered to handler, got %d", len(got))
 	}
 }
 
@@ -718,13 +723,9 @@ func TestGrpcTransport_MultiSetValue_HandlerError(t *testing.T) {
 	defer cleanup()
 
 	callCount := 0
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
-		// Fail on second value
-		if callCount == 2 {
-			return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "second value invalid")
-		}
-		return catena.StatusWithCode(catena.StatusCodeOk, "")
+		return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "value invalid")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -737,9 +738,8 @@ func TestGrpcTransport_MultiSetValue_HandlerError(t *testing.T) {
 	})
 	assertGRPCCode(t, err, codes.InvalidArgument, "handler error")
 
-	// Verify processing stopped at second value
-	if callCount != 2 {
-		t.Errorf("expected handler called 2 times (stopped at error), got %d", callCount)
+	if callCount != 1 {
+		t.Errorf("expected handler called once, got %d", callCount)
 	}
 }
 
@@ -749,8 +749,10 @@ func TestGrpcTransport_MultiSetValue_EmptyValues(t *testing.T) {
 	defer cleanup()
 
 	callCount := 0
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	var got []catena.SetValueEntry
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
+		got = values
 		return catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
@@ -766,8 +768,11 @@ func TestGrpcTransport_MultiSetValue_EmptyValues(t *testing.T) {
 		t.Fatalf("MultiSetValue with empty values failed: %v", err)
 	}
 
-	if callCount != 0 {
-		t.Errorf("expected handler not to be called, got %d calls", callCount)
+	if callCount != 1 {
+		t.Errorf("expected handler to be called once, got %d calls", callCount)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 entries delivered to handler, got %d", len(got))
 	}
 }
 
@@ -1374,7 +1379,7 @@ func TestGrpcTransport_ErrorMessages_DevVsProd(t *testing.T) {
 			devMessage: "multi set failed",
 			grpcCode:   codes.FailedPrecondition,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+				runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
 					return catena.StatusWithCode(catena.StatusCodeFailedPrecondition, "multi set failed")
 				}
 			},

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -248,7 +248,7 @@ func TestGrpcTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "multi set value",
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
-				runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+				runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 					assertContext(t, ctx)
 					return catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
@@ -598,10 +598,13 @@ func TestGrpcTransport_SetValue_Success(t *testing.T) {
 	defer cleanup()
 
 	receivedValue := any(nil)
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
-		receivedValue = value
-		if fqoid != "device.param1" {
-			t.Errorf("expected fqoid 'device.param1', got %s", fqoid)
+	runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		receivedValue = entries[0].Value
+		if entries[0].Fqoid != "device.param1" {
+			t.Errorf("expected fqoid 'device.param1', got %s", entries[0].Fqoid)
 		}
 		return catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
@@ -657,7 +660,7 @@ func TestGrpcTransport_SetValue_HandlerError(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "value out of range")
 	}
 
@@ -679,7 +682,7 @@ func TestGrpcTransport_MultiSetValue_Success(t *testing.T) {
 
 	callCount := 0
 	var got []catena.SetValueEntry
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
 		got = values
 		return catena.StatusWithCode(catena.StatusCodeOk, "")
@@ -723,7 +726,7 @@ func TestGrpcTransport_MultiSetValue_HandlerError(t *testing.T) {
 	defer cleanup()
 
 	callCount := 0
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
 		return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "value invalid")
 	}
@@ -750,7 +753,7 @@ func TestGrpcTransport_MultiSetValue_EmptyValues(t *testing.T) {
 
 	callCount := 0
 	var got []catena.SetValueEntry
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
 		got = values
 		return catena.StatusWithCode(catena.StatusCodeOk, "")
@@ -773,31 +776,6 @@ func TestGrpcTransport_MultiSetValue_EmptyValues(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("expected 0 entries delivered to handler, got %d", len(got))
-	}
-}
-
-func TestGrpcTransport_MultiSetValue_DedicatedHandler(t *testing.T) {
-	ctx := context.Background()
-	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
-	defer cleanup()
-
-	var got []catena.SetValueEntry
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
-		got = values
-		return catena.StatusWithCode(catena.StatusCodeOk, "")
-	}
-
-	client, cleanup := setupGRPCClient(t, ctx, lis)
-	defer cleanup()
-
-	_, err := makeMultiSetValueRequest(t, client, ctx, 0, map[string]any{
-		"param1": int32(10),
-		"param2": "test",
-	})
-	assertNoError(t, err)
-
-	if len(got) != 2 {
-		t.Fatalf("expected 2 entries delivered to dedicated handler, got %d", len(got))
 	}
 }
 
@@ -1358,7 +1336,7 @@ func TestGrpcTransport_ErrorMessages_DevVsProd(t *testing.T) {
 			devMessage: "value out of range",
 			grpcCode:   codes.InvalidArgument,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+				runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 					return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "value out of range")
 				}
 			},
@@ -1379,7 +1357,7 @@ func TestGrpcTransport_ErrorMessages_DevVsProd(t *testing.T) {
 			devMessage: "multi set failed",
 			grpcCode:   codes.FailedPrecondition,
 			setupHandlers: func(runtime *stubServerRuntime) {
-				runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+				runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 					return catena.StatusWithCode(catena.StatusCodeFailedPrecondition, "multi set failed")
 				}
 			},

--- a/sdks/go/pkg/transports/json_utils.go
+++ b/sdks/go/pkg/transports/json_utils.go
@@ -202,6 +202,60 @@ func ReadRequestJSON(r *http.Request) (*protos.Value, catena.StatusResult) {
 	return v, catena.StatusResult{Code: catena.StatusCodeOk}
 }
 
+// ReadMultiSetValuesRequestJSON reads and unmarshals a SetValues request body of
+// the form {"values":[{"fqoid":"...","value":{<Value oneof>}}, ...]} into a
+// slice of catena.SetValueEntry. It validates the Content-Type header and
+// converts each proto Value into its native Go type.
+func ReadMultiSetValuesRequestJSON(r *http.Request) ([]catena.SetValueEntry, catena.StatusResult) {
+	defer r.Body.Close()
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: "missing Content-Type header"}
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("invalid content type: %s", contentType)}
+	}
+	if mediaType != "application/json" {
+		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("unsupported content type: %s, expected application/json", mediaType)}
+	}
+
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("failed to read request body: %v", err)}
+	}
+
+	var body struct {
+		Values []struct {
+			Fqoid string          `json:"fqoid"`
+			Value json.RawMessage `json:"value"`
+		} `json:"values"`
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("failed to unmarshal request body: %v", err)}
+	}
+
+	entries := make([]catena.SetValueEntry, 0, len(body.Values))
+	for i, item := range body.Values {
+		pv := &protos.Value{}
+		if err := (protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		}).Unmarshal(item.Value, pv); err != nil {
+			return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("failed to unmarshal value at index %d: %v", i, err)}
+		}
+
+		nativeValue, convErr := catena.FromProto(pv)
+		if convErr.Code != catena.StatusCodeOk {
+			return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("invalid value at index %d: %v", i, convErr.Error)}
+		}
+
+		entries = append(entries, catena.SetValueEntry{Fqoid: item.Fqoid, Value: nativeValue})
+	}
+
+	return entries, catena.StatusResult{Code: catena.StatusCodeOk}
+}
+
 // --- Device JSON cleanup via fastjson AST ---
 
 // zeroFields lists device fields that the SMPTE schema forbids when at their

--- a/sdks/go/pkg/transports/json_utils.go
+++ b/sdks/go/pkg/transports/json_utils.go
@@ -203,9 +203,7 @@ func ReadRequestJSON(r *http.Request) (*protos.Value, catena.StatusResult) {
 }
 
 // ReadMultiSetValuesRequestJSON reads and unmarshals a SetValues request body of
-// the form {"values":[{"fqoid":"...","value":{<Value oneof>}}, ...]} into a
-// slice of catena.SetValueEntry. It validates the Content-Type header and
-// converts each proto Value into its native Go type.
+// the form {"values":[{"fqoid":"...","value":{<Value oneof>}}, ...]} into a slice of catena.SetValueEntry.
 func ReadMultiSetValuesRequestJSON(r *http.Request) ([]catena.SetValueEntry, catena.StatusResult) {
 	defer r.Body.Close()
 

--- a/sdks/go/pkg/transports/json_utils.go
+++ b/sdks/go/pkg/transports/json_utils.go
@@ -203,7 +203,10 @@ func ReadRequestJSON(r *http.Request) (*protos.Value, catena.StatusResult) {
 }
 
 // ReadMultiSetValuesRequestJSON reads and unmarshals a SetValues request body of
-// the form {"values":[{"fqoid":"...","value":{<Value oneof>}}, ...]} into a slice of catena.SetValueEntry.
+// the form {"values":[{"oid":"...","value":{<Value oneof>}}, ...]} into a slice
+// of catena.SetValueEntry. The body is parsed directly into a
+// protos.MultiSetValuePayload; the body's slot field (if present) is ignored
+// since the slot is taken from the request path.
 func ReadMultiSetValuesRequestJSON(r *http.Request) ([]catena.SetValueEntry, catena.StatusResult) {
 	defer r.Body.Close()
 
@@ -224,31 +227,21 @@ func ReadMultiSetValuesRequestJSON(r *http.Request) ([]catena.SetValueEntry, cat
 		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("failed to read request body: %v", err)}
 	}
 
-	var body struct {
-		Values []struct {
-			Fqoid string          `json:"fqoid"`
-			Value json.RawMessage `json:"value"`
-		} `json:"values"`
-	}
-	if err := json.Unmarshal(data, &body); err != nil {
+	payload := &protos.MultiSetValuePayload{}
+	if err := (protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}).Unmarshal(data, payload); err != nil {
 		return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("failed to unmarshal request body: %v", err)}
 	}
 
-	entries := make([]catena.SetValueEntry, 0, len(body.Values))
-	for i, item := range body.Values {
-		pv := &protos.Value{}
-		if err := (protojson.UnmarshalOptions{
-			DiscardUnknown: true,
-		}).Unmarshal(item.Value, pv); err != nil {
-			return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("failed to unmarshal value at index %d: %v", i, err)}
-		}
-
-		nativeValue, convErr := catena.FromProto(pv)
+	entries := make([]catena.SetValueEntry, 0, len(payload.GetValues()))
+	for i, sv := range payload.GetValues() {
+		nativeValue, convErr := catena.FromProto(sv.GetValue())
 		if convErr.Code != catena.StatusCodeOk {
 			return nil, catena.StatusResult{Code: catena.StatusCodeInvalidArgument, Error: fmt.Sprintf("invalid value at index %d: %v", i, convErr.Error)}
 		}
 
-		entries = append(entries, catena.SetValueEntry{Fqoid: item.Fqoid, Value: nativeValue})
+		entries = append(entries, catena.SetValueEntry{Fqoid: sv.GetOid(), Value: nativeValue})
 	}
 
 	return entries, catena.StatusResult{Code: catena.StatusCodeOk}

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -176,6 +176,102 @@ func TestReadRequestJSON_EmptyBody(t *testing.T) {
 	}
 }
 
+func TestReadMultiSetValuesRequestJSON_Valid(t *testing.T) {
+	body := `{"values":[{"oid":"a","value":{"int32_value":1}},{"oid":"b","value":{"string_value":"two"}}]}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	entries, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeOk {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Fqoid != "a" {
+		t.Errorf("expected entry[0] oid 'a', got %q", entries[0].Fqoid)
+	}
+	if v, ok := entries[0].Value.(int32); !ok || v != 1 {
+		t.Errorf("expected entry[0] value int32(1), got %v (%T)", entries[0].Value, entries[0].Value)
+	}
+	if entries[1].Fqoid != "b" {
+		t.Errorf("expected entry[1] oid 'b', got %q", entries[1].Fqoid)
+	}
+	if v, ok := entries[1].Value.(string); !ok || v != "two" {
+		t.Errorf("expected entry[1] value 'two', got %v (%T)", entries[1].Value, entries[1].Value)
+	}
+}
+
+func TestReadMultiSetValuesRequestJSON_MissingContentType(t *testing.T) {
+	body := `{"values":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	// No Content-Type header
+
+	_, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected BAD_REQUEST error for missing Content-Type")
+	}
+	if err.Error != "missing Content-Type header" {
+		t.Errorf("expected 'missing Content-Type header' error, got: %v", err)
+	}
+}
+
+func TestReadMultiSetValuesRequestJSON_MalformedContentType(t *testing.T) {
+	body := `{"values":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "invalid;;;type")
+
+	_, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected error for malformed Content-Type")
+	}
+	if err.Error != "invalid content type: invalid;;;type" {
+		t.Errorf("expected 'invalid content type' error, got: %v", err)
+	}
+}
+
+func TestReadMultiSetValuesRequestJSON_UnsupportedContentType(t *testing.T) {
+	body := `{"values":[]}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "text/plain")
+
+	_, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected error for unsupported Content-Type")
+	}
+	if err.Error != "unsupported content type: text/plain, expected application/json" {
+		t.Errorf("expected 'unsupported content type' error, got: %v", err)
+	}
+}
+
+func TestReadMultiSetValuesRequestJSON_MalformedBody(t *testing.T) {
+	body := `{"values": not-json}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected BAD_REQUEST error for malformed body")
+	}
+	if !strings.Contains(err.Error, "failed to unmarshal request body") {
+		t.Errorf("expected error to contain 'failed to unmarshal request body', got: %v", err.Error)
+	}
+}
+
+func TestReadMultiSetValuesRequestJSON_InvalidValue(t *testing.T) {
+	body := `{"values":[{"oid":"param","value":{"struct_variant_value":{"variant_name":"test"}}}]}`
+	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected BAD_REQUEST error for invalid value")
+	}
+	if !strings.Contains(err.Error, "invalid value at index 0") {
+		t.Errorf("expected error to contain 'invalid value at index 0', got: %v", err.Error)
+	}
+}
+
 func TestWriteProtoJSON_ValidValue(t *testing.T) {
 	w := httptest.NewRecorder()
 	val := &protos.Value{

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -42,14 +42,25 @@ package transports
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/valyala/fastjson"
+
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
+
+// errReader is an io.Reader that always fails, used to exercise body-read
+// error paths in the request readers.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("simulated read error")
+}
 
 func TestReadRequestJSON_ValidInt32(t *testing.T) {
 	body := `{"int32_value": 42}`
@@ -1113,5 +1124,89 @@ func TestMarshalAssetJSON_Nil(t *testing.T) {
 	}
 	if jsonData != nil {
 		t.Error("expected nil JSON data for nil asset")
+	}
+}
+
+func TestInjectJSONField_Float32(t *testing.T) {
+	input := []byte(`{"type":"FLOAT32"}`)
+	got := injectJSONField(input, "value", float32(1.5))
+	body := string(got)
+	if !strings.Contains(body, `"value":1.5`) {
+		t.Errorf("expected value:1.5, got %s", body)
+	}
+}
+
+func TestReadRequestJSON_BodyReadError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", errReader{})
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err := ReadRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected BAD_REQUEST error when reading the body fails")
+	}
+	if !strings.Contains(err.Error, "failed to read request body") {
+		t.Errorf("expected error to contain 'failed to read request body', got: %v", err.Error)
+	}
+}
+
+func TestReadMultiSetValuesRequestJSON_BodyReadError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "/", errReader{})
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err := ReadMultiSetValuesRequestJSON(req)
+	if err.Code != catena.StatusCodeInvalidArgument {
+		t.Fatal("expected BAD_REQUEST error when reading the body fails")
+	}
+	if !strings.Contains(err.Error, "failed to read request body") {
+		t.Errorf("expected error to contain 'failed to read request body', got: %v", err.Error)
+	}
+}
+
+func TestCleanDeviceJSON_ParseError(t *testing.T) {
+	_, err := cleanDeviceJSON([]byte(`{not valid json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON input")
+	}
+	if !strings.Contains(err.Error(), "cleanDeviceJSON parse") {
+		t.Errorf("expected 'cleanDeviceJSON parse' error, got: %v", err)
+	}
+}
+
+func TestDeleteResponseFromParams_NonObject(t *testing.T) {
+	var p fastjson.Parser
+	v, parseErr := p.Parse(`[1,2,3]`)
+	if parseErr != nil {
+		t.Fatalf("failed to parse test JSON: %v", parseErr)
+	}
+	// Should early-return without panicking when the root is not an object.
+	deleteResponseFromParams(v)
+	if v.Type() != fastjson.TypeArray {
+		t.Errorf("expected array value to be left untouched, got %v", v.Type())
+	}
+}
+
+func TestDeleteResponseFromParams_ParamsNotObject(t *testing.T) {
+	var p fastjson.Parser
+	v, parseErr := p.Parse(`{"params":"not-an-object"}`)
+	if parseErr != nil {
+		t.Fatalf("failed to parse test JSON: %v", parseErr)
+	}
+	// "params" present but not an object should also early-return.
+	deleteResponseFromParams(v)
+	if v.Get("params").Type() != fastjson.TypeString {
+		t.Errorf("expected params string to be left untouched, got %v", v.Get("params").Type())
+	}
+}
+
+func TestDeleteResponseFalse_NonObject(t *testing.T) {
+	var p fastjson.Parser
+	v, parseErr := p.Parse(`"just a string"`)
+	if parseErr != nil {
+		t.Fatalf("failed to parse test JSON: %v", parseErr)
+	}
+	// Should early-return without panicking when the value is not an object.
+	deleteResponseFalse(v)
+	if v.Type() != fastjson.TypeString {
+		t.Errorf("expected string value to be left untouched, got %v", v.Type())
 	}
 }

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -426,6 +426,8 @@ func (t *RestTransport) registerRoutes() {
 			switch endpoint {
 			case "value":
 				t.handleValueEndpoint(w, r, slot, parts[4:])
+			case "values":
+				t.handleValuesEndpoint(w, r, slot)
 			case "asset":
 				t.handleAssetEndpoint(w, r, slot, parts[4:])
 			case "command":
@@ -541,6 +543,28 @@ func (t *RestTransport) handleValueEndpoint(w http.ResponseWriter, r *http.Reque
 	default:
 		t.writeHTTPMethodNotAllowed(w, "only GET, PUT, PATCH allowed")
 	}
+}
+
+// handleValuesEndpoint handles PUT /st2138-api/v1/{slot}/values (SetValues).
+// The values are applied via the runtime's MultiSetValue handler, which is
+// atomic when a dedicated handler is registered. On success it returns 204 No
+// Content per ST 2138-12.
+func (t *RestTransport) handleValuesEndpoint(w http.ResponseWriter, r *http.Request, slot uint16) {
+	if r.Method != http.MethodPut {
+		t.writeHTTPMethodNotAllowed(w, "only PUT allowed")
+		return
+	}
+
+	entries, err := ReadMultiSetValuesRequestJSON(r)
+	if err.Code != catena.StatusCodeOk {
+		logger.Error("failed to read request", "error", err)
+		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInvalidArgument, "invalid request body"))
+		return
+	}
+
+	transportContext := t.retrieveMetadataFromRequest(r)
+	res := t.runtime.InvokeMultiSetValueHandler(entries, slot, transportContext)
+	t.writeHTTPStatusResultNoBody(w, res)
 }
 
 func (t *RestTransport) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slot uint16, pathParts []string) {

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -537,7 +537,8 @@ func (t *RestTransport) handleValueEndpoint(w http.ResponseWriter, r *http.Reque
 		}
 
 		transportContext := t.retrieveMetadataFromRequest(r)
-		res := t.runtime.InvokeSetValueHandler(nativeValue, slot, fqoid, transportContext)
+		entries := []catena.SetValueEntry{{Fqoid: fqoid, Value: nativeValue}}
+		res := t.runtime.InvokeSetValueHandler(slot, entries, transportContext)
 		t.writeHTTPStatusResultNoBody(w, res)
 
 	default:
@@ -546,7 +547,7 @@ func (t *RestTransport) handleValueEndpoint(w http.ResponseWriter, r *http.Reque
 }
 
 // handleValuesEndpoint handles PUT /st2138-api/v1/{slot}/values (SetValues).
-// The values are applied via the runtime's MultiSetValue handler.
+// The full set of values is applied via the runtime's SetValue handler.
 // On success it returns 204
 func (t *RestTransport) handleValuesEndpoint(w http.ResponseWriter, r *http.Request, slot uint16) {
 	if r.Method != http.MethodPut {
@@ -562,7 +563,7 @@ func (t *RestTransport) handleValuesEndpoint(w http.ResponseWriter, r *http.Requ
 	}
 
 	transportContext := t.retrieveMetadataFromRequest(r)
-	res := t.runtime.InvokeMultiSetValueHandler(entries, slot, transportContext)
+	res := t.runtime.InvokeSetValueHandler(slot, entries, transportContext)
 	t.writeHTTPStatusResultNoBody(w, res)
 }
 

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -546,9 +546,8 @@ func (t *RestTransport) handleValueEndpoint(w http.ResponseWriter, r *http.Reque
 }
 
 // handleValuesEndpoint handles PUT /st2138-api/v1/{slot}/values (SetValues).
-// The values are applied via the runtime's MultiSetValue handler, which is
-// atomic when a dedicated handler is registered. On success it returns 204 No
-// Content per ST 2138-12.
+// The values are applied via the runtime's MultiSetValue handler.
+// On success it returns 204
 func (t *RestTransport) handleValuesEndpoint(w http.ResponseWriter, r *http.Request, slot uint16) {
 	if r.Method != http.MethodPut {
 		t.writeHTTPMethodNotAllowed(w, "only PUT allowed")

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -166,6 +166,20 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 			},
 		},
 		{
+			name: "set values",
+			setup: func(t *testing.T, runtime *stubServerRuntime) {
+				runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+					assertContext(t, ctx)
+					return catena.StatusWithCode(catena.StatusCodeOk, "")
+				}
+			},
+			run: func(t *testing.T, transport *RestTransport) {
+				rec := makeRequestWithHeaders(t, transport, http.MethodPut, "/st2138-api/v1/0/values",
+					`{"values":[{"fqoid":"a","value":{"int32_value":1}}]}`, headers)
+				assertStatus(t, rec, http.StatusNoContent)
+			},
+		},
+		{
 			name: "get asset",
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
 				runtime.getAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (catena.Asset, catena.StatusResult) {

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -175,7 +175,7 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 			},
 			run: func(t *testing.T, transport *RestTransport) {
 				rec := makeRequestWithHeaders(t, transport, http.MethodPut, "/st2138-api/v1/0/values",
-					`{"values":[{"fqoid":"a","value":{"int32_value":1}}]}`, headers)
+					`{"values":[{"oid":"a","value":{"int32_value":1}}]}`, headers)
 				assertStatus(t, rec, http.StatusNoContent)
 			},
 		},
@@ -395,7 +395,7 @@ func TestRestTransport_SetValues_Route(t *testing.T) {
 		return catena.StatusResult{Code: catena.StatusCodeOk}
 	}
 
-	body := `{"values":[{"fqoid":"ipv4","value":{"string_value":"192.168.1.1"}},{"fqoid":"brightness","value":{"int32_value":42}}]}`
+	body := `{"values":[{"oid":"ipv4","value":{"string_value":"192.168.1.1"}},{"oid":"brightness","value":{"int32_value":42}}]}`
 	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
 	assertStatus(t, rec, http.StatusNoContent)
 
@@ -416,20 +416,25 @@ func TestRestTransport_SetValues_Route(t *testing.T) {
 	}
 }
 
-func TestRestTransport_SetValues_Fallback(t *testing.T) {
+func TestRestTransport_SetValues_DeliversAllEntries(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	callCount := 0
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	var got []catena.SetValueEntry
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
+		got = values
 		return catena.StatusResult{Code: catena.StatusCodeOk}
 	}
 
-	body := `{"values":[{"fqoid":"a","value":{"int32_value":1}},{"fqoid":"b","value":{"int32_value":2}}]}`
+	body := `{"values":[{"oid":"a","value":{"int32_value":1}},{"oid":"b","value":{"int32_value":2}}]}`
 	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
 	assertStatus(t, rec, http.StatusNoContent)
-	if callCount != 2 {
-		t.Errorf("expected single handler called 2 times via fallback, got %d", callCount)
+	if callCount != 1 {
+		t.Errorf("expected handler called once, got %d", callCount)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries delivered to handler, got %d", len(got))
 	}
 }
 
@@ -461,7 +466,7 @@ func TestRestTransport_SetValues_MalformedBody(t *testing.T) {
 
 func TestRestTransport_SetValues_FromProtoError(t *testing.T) {
 	transport, _ := makeTestRestTransport(t)
-	body := `{"values":[{"fqoid":"param","value":{"struct_variant_value":{"variant_name":"test"}}}]}`
+	body := `{"values":[{"oid":"param","value":{"struct_variant_value":{"variant_name":"test"}}}]}`
 	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
 	assertStatus(t, rec, http.StatusBadRequest)
 }
@@ -478,7 +483,7 @@ func TestRestTransport_SetValues_HandlerError(t *testing.T) {
 		return catena.StatusWithCode(catena.StatusCodeNotFound, "not found")
 	}
 
-	body := `{"values":[{"fqoid":"a","value":{"int32_value":1}}]}`
+	body := `{"values":[{"oid":"a","value":{"int32_value":1}}]}`
 	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
 	assertStatus(t, rec, http.StatusNotFound)
 }

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -155,7 +155,7 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "set value",
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
-				runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+				runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 					assertContext(t, ctx)
 					return catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
@@ -168,7 +168,7 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "set values",
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
-				runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+				runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 					assertContext(t, ctx)
 					return catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
@@ -344,13 +344,16 @@ func TestRestTransport_SetValue_Route(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		handlerCalled = true
-		if v, ok := value.(int32); !ok || v != 42 {
-			t.Errorf("expected value int32(42), got %v (%T)", value, value)
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
 		}
-		if fqoid != "brightness" {
-			t.Errorf("expected fqoid 'brightness', got %s", fqoid)
+		if v, ok := entries[0].Value.(int32); !ok || v != 42 {
+			t.Errorf("expected value int32(42), got %v (%T)", entries[0].Value, entries[0].Value)
+		}
+		if entries[0].Fqoid != "brightness" {
+			t.Errorf("expected fqoid 'brightness', got %s", entries[0].Fqoid)
 		}
 		return catena.StatusResult{Code: catena.StatusCodeOk}
 	}
@@ -366,7 +369,7 @@ func TestRestTransport_SetValue_InvalidContentType(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		handlerCalled = true
 		return catena.StatusResult{Code: catena.StatusCodeOk}
 	}
@@ -387,7 +390,7 @@ func TestRestTransport_SetValues_Route(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	var got []catena.SetValueEntry
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		got = values
 		if slot != 0 {
 			t.Errorf("expected slot 0, got %d", slot)
@@ -421,7 +424,7 @@ func TestRestTransport_SetValues_DeliversAllEntries(t *testing.T) {
 
 	callCount := 0
 	var got []catena.SetValueEntry
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		callCount++
 		got = values
 		return catena.StatusResult{Code: catena.StatusCodeOk}
@@ -442,7 +445,7 @@ func TestRestTransport_SetValues_InvalidContentType(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		handlerCalled = true
 		return catena.StatusResult{Code: catena.StatusCodeOk}
 	}
@@ -479,7 +482,7 @@ func TestRestTransport_SetValues_MethodNotAllowed(t *testing.T) {
 
 func TestRestTransport_SetValues_HandlerError(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
-	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, values []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		return catena.StatusWithCode(catena.StatusCodeNotFound, "not found")
 	}
 
@@ -947,7 +950,7 @@ func TestRouting_EdgeCases(t *testing.T) {
 
 func TestValueEndpoint_Methods(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
-	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+	runtime.setValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 		return catena.StatusResult{Code: catena.StatusCodeOk}
 	}
 

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -369,6 +369,106 @@ func TestRestTransport_SetValue_InvalidContentType(t *testing.T) {
 	}
 }
 
+func TestRestTransport_SetValues_Route(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	var got []catena.SetValueEntry
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+		got = values
+		if slot != 0 {
+			t.Errorf("expected slot 0, got %d", slot)
+		}
+		return catena.StatusResult{Code: catena.StatusCodeOk}
+	}
+
+	body := `{"values":[{"fqoid":"ipv4","value":{"string_value":"192.168.1.1"}},{"fqoid":"brightness","value":{"int32_value":42}}]}`
+	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
+	assertStatus(t, rec, http.StatusNoContent)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[0].Fqoid != "ipv4" {
+		t.Errorf("expected entry[0] fqoid 'ipv4', got %s", got[0].Fqoid)
+	}
+	if v, ok := got[0].Value.(string); !ok || v != "192.168.1.1" {
+		t.Errorf("expected entry[0] value '192.168.1.1', got %v (%T)", got[0].Value, got[0].Value)
+	}
+	if got[1].Fqoid != "brightness" {
+		t.Errorf("expected entry[1] fqoid 'brightness', got %s", got[1].Fqoid)
+	}
+	if v, ok := got[1].Value.(int32); !ok || v != 42 {
+		t.Errorf("expected entry[1] value int32(42), got %v (%T)", got[1].Value, got[1].Value)
+	}
+}
+
+func TestRestTransport_SetValues_Fallback(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	callCount := 0
+	runtime.setValueFn = func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+		callCount++
+		return catena.StatusResult{Code: catena.StatusCodeOk}
+	}
+
+	body := `{"values":[{"fqoid":"a","value":{"int32_value":1}},{"fqoid":"b","value":{"int32_value":2}}]}`
+	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
+	assertStatus(t, rec, http.StatusNoContent)
+	if callCount != 2 {
+		t.Errorf("expected single handler called 2 times via fallback, got %d", callCount)
+	}
+}
+
+func TestRestTransport_SetValues_InvalidContentType(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	handlerCalled := false
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+		handlerCalled = true
+		return catena.StatusResult{Code: catena.StatusCodeOk}
+	}
+
+	rec := makeRequestWithHeaders(t, transport, http.MethodPut, "/st2138-api/v1/0/values",
+		`{"values":[]}`, map[string]string{"Content-Type": "text/plain"})
+	assertStatus(t, rec, http.StatusBadRequest)
+	if errMsg := assertHasError(t, rec); errMsg != "invalid request body" {
+		t.Errorf("expected error 'invalid request body', got %s", errMsg)
+	}
+	if handlerCalled {
+		t.Error("handler should not have been called")
+	}
+}
+
+func TestRestTransport_SetValues_MalformedBody(t *testing.T) {
+	transport, _ := makeTestRestTransport(t)
+	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", `{"values": not-json}`)
+	assertStatus(t, rec, http.StatusBadRequest)
+}
+
+func TestRestTransport_SetValues_FromProtoError(t *testing.T) {
+	transport, _ := makeTestRestTransport(t)
+	body := `{"values":[{"fqoid":"param","value":{"struct_variant_value":{"variant_name":"test"}}}]}`
+	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
+	assertStatus(t, rec, http.StatusBadRequest)
+}
+
+func TestRestTransport_SetValues_MethodNotAllowed(t *testing.T) {
+	transport, _ := makeTestRestTransport(t)
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/values", "")
+	assertStatus(t, rec, http.StatusMethodNotAllowed)
+}
+
+func TestRestTransport_SetValues_HandlerError(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+	runtime.multiSetValueFn = func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+		return catena.StatusWithCode(catena.StatusCodeNotFound, "not found")
+	}
+
+	body := `{"values":[{"fqoid":"a","value":{"int32_value":1}}]}`
+	rec := makeRequest(t, transport, http.MethodPut, "/st2138-api/v1/0/values", body)
+	assertStatus(t, rec, http.StatusNotFound)
+}
+
 func TestRestTransport_GetAsset_Route(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -123,17 +123,6 @@ func (s *stubServerRuntime) InvokeMultiSetValueHandler(values []catena.SetValueE
 	if s.multiSetValueFn != nil {
 		return s.multiSetValueFn(values, slot, ctx)
 	}
-	// Mirror the real server's non-atomic fallback: apply each entry via the
-	// single SetValue handler so tests that only wire setValueFn still work.
-	if s.setValueFn != nil {
-		for _, entry := range values {
-			res := s.setValueFn(entry.Value, slot, entry.Fqoid, ctx)
-			if res.Code != catena.StatusCodeOk {
-				return res
-			}
-		}
-		return catena.StatusWithCode(catena.StatusCodeOk, "")
-	}
 	s.panicf("MultiSetValue handler not implemented in stubServerRuntime for slot %d", slot)
 	return catena.StatusResult{Code: catena.StatusCodeInternal}
 }

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -123,6 +123,14 @@ func (s *stubServerRuntime) InvokeMultiSetValueHandler(values []catena.SetValueE
 	if s.multiSetValueFn != nil {
 		return s.multiSetValueFn(values, slot, ctx)
 	}
+	if s.setValueFn != nil {
+		for _, entry := range values {
+			if res := s.setValueFn(entry.Value, slot, entry.Fqoid, ctx); res.Code != catena.StatusCodeOk {
+				return res
+			}
+		}
+		return catena.StatusResult{Code: catena.StatusCodeOk}
+	}
 	s.panicf("MultiSetValue handler not implemented in stubServerRuntime for slot %d", slot)
 	return catena.StatusResult{Code: catena.StatusCodeInternal}
 }

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -56,6 +56,7 @@ type stubServerRuntime struct {
 	getDeviceFn              func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult)
 	getValueFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (catena.Value, catena.StatusResult)
 	setValueFn               func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult
+	multiSetValueFn          func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult
 	getAssetFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (catena.Asset, catena.StatusResult)
 	commandFn                func(slot uint16, commandFqoid string, payload any, ctx catena.TransportContext) (catena.CommandResult, catena.StatusResult)
 	paramInfoFn              func(slot uint16, oidPrefix string, recursive bool, ctx catena.TransportContext) ([]catena.ParamInfo, catena.StatusResult)
@@ -115,6 +116,25 @@ func (s *stubServerRuntime) InvokeSetValueHandler(value any, slot uint16, fqoid 
 		return s.setValueFn(value, slot, fqoid, ctx)
 	}
 	s.panicf("SetValue handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid)
+	return catena.StatusResult{Code: catena.StatusCodeInternal}
+}
+
+func (s *stubServerRuntime) InvokeMultiSetValueHandler(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
+	if s.multiSetValueFn != nil {
+		return s.multiSetValueFn(values, slot, ctx)
+	}
+	// Mirror the real server's non-atomic fallback: apply each entry via the
+	// single SetValue handler so tests that only wire setValueFn still work.
+	if s.setValueFn != nil {
+		for _, entry := range values {
+			res := s.setValueFn(entry.Value, slot, entry.Fqoid, ctx)
+			if res.Code != catena.StatusCodeOk {
+				return res
+			}
+		}
+		return catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+	s.panicf("MultiSetValue handler not implemented in stubServerRuntime for slot %d", slot)
 	return catena.StatusResult{Code: catena.StatusCodeInternal}
 }
 

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -55,8 +55,7 @@ type stubServerRuntime struct {
 	getSlotsFn               func(ctx catena.TransportContext) ([]uint16, catena.StatusResult)
 	getDeviceFn              func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult)
 	getValueFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (catena.Value, catena.StatusResult)
-	setValueFn               func(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult
-	multiSetValueFn          func(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult
+	setValueFn               func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult
 	getAssetFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (catena.Asset, catena.StatusResult)
 	commandFn                func(slot uint16, commandFqoid string, payload any, ctx catena.TransportContext) (catena.CommandResult, catena.StatusResult)
 	paramInfoFn              func(slot uint16, oidPrefix string, recursive bool, ctx catena.TransportContext) ([]catena.ParamInfo, catena.StatusResult)
@@ -111,27 +110,11 @@ func (s *stubServerRuntime) InvokeGetValueHandler(slot uint16, fqoid string, ctx
 	return catena.ReplyError[catena.Value](catena.StatusCodeInternal, "GetValue handler not implemented")
 }
 
-func (s *stubServerRuntime) InvokeSetValueHandler(value any, slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult {
+func (s *stubServerRuntime) InvokeSetValueHandler(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
 	if s.setValueFn != nil {
-		return s.setValueFn(value, slot, fqoid, ctx)
+		return s.setValueFn(slot, entries, ctx)
 	}
-	s.panicf("SetValue handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid)
-	return catena.StatusResult{Code: catena.StatusCodeInternal}
-}
-
-func (s *stubServerRuntime) InvokeMultiSetValueHandler(values []catena.SetValueEntry, slot uint16, ctx catena.TransportContext) catena.StatusResult {
-	if s.multiSetValueFn != nil {
-		return s.multiSetValueFn(values, slot, ctx)
-	}
-	if s.setValueFn != nil {
-		for _, entry := range values {
-			if res := s.setValueFn(entry.Value, slot, entry.Fqoid, ctx); res.Code != catena.StatusCodeOk {
-				return res
-			}
-		}
-		return catena.StatusResult{Code: catena.StatusCodeOk}
-	}
-	s.panicf("MultiSetValue handler not implemented in stubServerRuntime for slot %d", slot)
+	s.panicf("SetValue handler not implemented in stubServerRuntime for slot %d, count %d", slot, len(entries))
 	return catena.StatusResult{Code: catena.StatusCodeInternal}
 }
 


### PR DESCRIPTION
## 📖 Description

Implements the `MultiSetValue` endpoint for the Go SDK, exposed over REST as `PUT /st2138-api/v1/{slot}/values`. The change introduces a new dedicated runtime handler for applying multiple parameter values, and wires both the REST and gRPC transports to use it. When a dedicated handler is registered the operation is atomic. Otherwise it falls back to the existing single-value handler applied per value.

---

## 🎯 Goal / Outcome

Clients can set multiple parameters in a single request per the ST 2138 spec, with a path for true all-or-nothing semantics. 

---

## ✅ Definition of Done (DoD)

- [x] `PUT /st2138-api/v1/{slot}/values` implemented in the REST transport, returning `204 No Content` on success
- [x] New runtime handler surface added: `SetValueEntry`, `MultiSetValueHandler`, `RegisterMultiSetValueHandler`, `InvokeMultiSetValueHandler`, `EndpointMultiSetValue`
- [x] gRPC `MultiSetValue` rewired to the new runtime handler (removed per-value loop + TODO)
- [x] Atomic path via a dedicated handler; non-atomic fallback over the single `SetValueHandler` for backward compatibility
- [x] Edge cases handled: invalid content type, malformed body, value conversion error, wrong method, handler errors, no handler registered
- [x] Tests added across REST, gRPC, and runtime layers (success, fallback, fallback-stops-on-error, NotFound, write-access denial)
- [x] Documentation updated (REST.md, README.md, GRPC.md)

---

## 🛠️ Implementation Notes (Optional)

- `catena/server.go`: adds `EndpointMultiSetValue`, the `SetValueEntry` type, `MultiSetValueHandler`, a `multiSetValueHandlers` map, plus `RegisterMultiSetValueHandler` / `InvokeMultiSetValueHandler`. `InvokeMultiSetValueHandler` performs the same write + access-control checks as single SetValue, then: uses the dedicated handler if registered (atomic); else loops the single handler per entry and stops on first error (non-atomic); else returns `NotFound`.
- `transports/json_utils.go`: adds `ReadMultiSetValuesRequestJSON`, which validates `application/json`, parses `{"values":[{"fqoid","value"}]}` (note the body uses `fqoid`, not the proto `oid`), unmarshals each value via protojson, and converts via `catena.FromProto`.
- `transports/rest_transport.go`: adds the `values` route case and `handleValuesEndpoint` (PUT only, 204 on success, errors mapped via `ToHTTPStatus`).
- `transports/grpc_transport.go`: `MultiSetValue` now builds `[]catena.SetValueEntry` and calls the shared handler.
- The test stub mirrors the runtime's fallback so pre-existing gRPC MultiSetValue tests remain valid.

---

## 🔗 Related Issues / Links

Closes issue #1363 and #1364 

---
