### PR TITLE
[C++] Fix unit tests colliding with hardcoded ports

### DIFF
--- a/sdks/cpp/connections/REST/include/ServiceImpl.h
+++ b/sdks/cpp/connections/REST/include/ServiceImpl.h
@@ -185,6 +185,10 @@ class ServiceImpl : public catena::REST::IServiceImpl {
      */
     const std::string& version() const override { return version_; }
     /**
+     * @brief Returns the actual port the service is bound to.
+     */
+    uint16_t listeningPort() const { return port_; }
+    /**
      * @brief Starts the API.
      */
     void run() override;

--- a/sdks/cpp/connections/REST/src/ServiceImpl.cpp
+++ b/sdks/cpp/connections/REST/src/ServiceImpl.cpp
@@ -41,6 +41,9 @@ ServiceImpl::ServiceImpl(const ServiceConfig& config)
       router_{Router::getInstance()},
       connectionQueue_{config.maxConnections} {
 
+    // Preserve the actual bound port value reported by the acceptor.
+    port_ = acceptor_.local_endpoint().port();
+
     if (authorizationEnabled_) { LOG(INFO) <<"Authorization enabled."; }
     // Adding dms to slotMap.
     for (auto dm : config.dms) {

--- a/unittests/cpp/REST/tests/ServiceImpl_test.cpp
+++ b/unittests/cpp/REST/tests/ServiceImpl_test.cpp
@@ -46,9 +46,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-// std
-#include <atomic>
-
 // mock classes
 #include "MockDevice.h"
 #include "MockConnect.h"
@@ -75,15 +72,14 @@ class RESTServiceImplTests : public testing::Test {
     void SetUp() override {
         oldCout_ = std::cout.rdbuf(MockConsole_.rdbuf());
         EXPECT_CALL(dm_, slot()).WillRepeatedly(testing::Return(0));
-        // Assign a unique port per test instance
-        port_ = s_next_port.fetch_add(1);
         ServiceConfig config = ServiceConfig()
             .add_dm(&dm_)
             .set_EOPath(EOPath_)
             .set_authz(authzEnabled_)
             .set_maxConnections(1)
-            .set_port(port_);
+            .set_port(0);
         service_.reset(new ServiceImpl(config));
+        port_ = service_->listeningPort();
     }
 
     /*
@@ -126,11 +122,7 @@ class RESTServiceImplTests : public testing::Test {
 
     // We really don't care about uninteresting function errors here.
     testing::NiceMock<MockDevice> dm_;
-
-    static std::atomic<uint16_t> s_next_port;
 };
-
-std::atomic<uint16_t> RESTServiceImplTests::s_next_port{50050};
 
 /*
  * TEST 1 - Test ServiceConfig set_dms() and add_dm()
@@ -167,7 +159,7 @@ TEST_F(RESTServiceImplTests, ServiceImpl_CreateDuplicateSlot) {
     config.dms.push_back(&dm1);
     EXPECT_CALL(dm2, slot()).WillRepeatedly(testing::Return(0));
     config.dms.push_back(&dm2);
-    config.port = port_ + 2;
+    config.port = 0;
     // Creating a service with a duplicate slot.
     EXPECT_THROW(ServiceImpl newService{config}, std::runtime_error) << "Creating a service with two devices sharing a slot should throw an error.";
 }

--- a/unittests/cpp/gRPC/GRPCTest.h
+++ b/unittests/cpp/gRPC/GRPCTest.h
@@ -102,10 +102,13 @@ class GRPCTest : public ::testing::Test {
         oldCout_ = std::cout.rdbuf(MockConsole_.rdbuf());
         
         // Creating the gRPC server.
-        builder_.AddListeningPort(serverAddr_, grpc::InsecureServerCredentials());
+        builder_.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials(), &selectedPort_);
         cq_ = builder_.AddCompletionQueue();
         builder_.RegisterService(&service_);
         server_ = builder_.BuildAndStart();
+
+        // Build the client address from the actual bound server port.
+        serverAddr_ = "127.0.0.1:" + std::to_string(selectedPort_);
 
         // Creating the gRPC client.
         channel_ = grpc::CreateChannel(serverAddr_, grpc::InsecureChannelCredentials());
@@ -159,7 +162,8 @@ class GRPCTest : public ::testing::Test {
     catena::exception_with_status expRc_{"", catena::StatusCode::OK};
 
     // Address used for gRPC tests.
-    std::string serverAddr_ = "0.0.0.0:50051";
+    std::string serverAddr_ = "";
+    int selectedPort_ = 0;
     // Server and service variables.
     grpc::ServerBuilder builder_;
     std::unique_ptr<grpc::Server> server_ = nullptr;

--- a/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
+++ b/unittests/cpp/gRPC/tests/ServiceImpl_test.cpp
@@ -82,7 +82,7 @@ class gRPCServiceImplTests : public testing::Test {
         oldCout_ = std::cout.rdbuf(MockConsole_.rdbuf());
         EXPECT_CALL(dm_, slot()).WillRepeatedly(testing::Return(0));
         // Creating the gRPC server.
-        builder_.AddListeningPort(serverAddr_, grpc::InsecureServerCredentials());
+        builder_.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials(), &selectedPort_);
         cq_ = builder_.AddCompletionQueue();
         ServiceConfig config = ServiceConfig()
             .set_EOPath(EOPath_)
@@ -97,6 +97,7 @@ class gRPCServiceImplTests : public testing::Test {
         ASSERT_EQ(service_->registrySize(), 14) << "ServiceImpl failed to register " << 14 - service_->registrySize() << " CallData objects";
         cqthread_ = std::make_unique<std::thread>([&]() { service_->processEvents(); });
         // Creating the gRPC client.
+        serverAddr_ = "127.0.0.1:" + std::to_string(selectedPort_);
         channel_ = grpc::CreateChannel(serverAddr_, grpc::InsecureChannelCredentials());
         client_ = st2138::CatenaService::NewStub(channel_);
     }
@@ -121,7 +122,8 @@ class gRPCServiceImplTests : public testing::Test {
     std::streambuf* oldCout_;
 
     // Address used for gRPC tests.
-    std::string serverAddr_ = "0.0.0.0:50051";
+    std::string serverAddr_ = "";
+    int selectedPort_ = 0;
     // Server and service variables.
     grpc::ServerBuilder builder_;
     std::unique_ptr<grpc::Server> server_ = nullptr;
@@ -191,7 +193,7 @@ TEST(gRPCServiceImplTests_NoFixture, ServiceImpl_CreateDuplicateSlot) {
     ServiceConfig config;
     // Adding completion queue
     grpc::ServerBuilder builder;
-    builder.AddListeningPort("0.0.0.0:50051", grpc::InsecureServerCredentials());
+    builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials());
     auto cq = builder.AddCompletionQueue();
     config.cq = cq.get();
     // Adding devices


### PR DESCRIPTION
Fixes the unit tests using hardcoded ports that may collide, especially in CI.