### PR TITLE
[GO] Device Creation Helper

### DIFF
--- a/sdks/go/examples/hello_world/main.go
+++ b/sdks/go/examples/hello_world/main.go
@@ -73,28 +73,15 @@ func (s *helloWorldState) Set(value string) {
 	s.value = value
 }
 
-func buildDevice() map[string]any {
-	return map[string]any{
-		"slot":              uint32(slot),
-		"detail_level":      catena.DetailLevelFull,
-		"multi_set_enabled": true,
-		"subscriptions":     true,
-		"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-		"default_scope":     "st2138:op",
-		"params": map[string]any{
-			helloWorldOID: map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Hello World",
-					},
-				},
-				"type": catena.ParamTypeString,
-				"value": map[string]any{
-					"string_value": helloWorld.Get(),
-				},
-			},
-		},
-	}
+func buildDevice() *catena.Device {
+	return catena.NewDevice(slot, "Hello World", "Ross Video", "1.0.0", "SN-HELLO-0001").
+		WithDetailLevel(catena.DetailLevelFull).
+		WithMultiSetEnabled(true).
+		WithSubscriptions(true).
+		WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+		WithDefaultScope("st2138:op").
+		WithParam(helloWorldOID, catena.NewParamString(helloWorld.Get()).
+			WithName(catena.NewPolyglotText("en", "Hello World")))
 }
 
 func main() {
@@ -109,12 +96,7 @@ func main() {
 
 	srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext) (catena.Device, catena.StatusResult) {
 		logger.Info("GetDevice", "slot", slot)
-		device, err := catena.ToDevice(buildDevice())
-		if err != nil {
-			logger.Error("Failed to convert device", "slot", slot, "error", err)
-			return catena.ReplyError[catena.Device](catena.StatusCodeInternal, "failed to convert device")
-		}
-		return catena.Reply(device)
+		return catena.Reply(*buildDevice())
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot uint16, fqoid string, ctx catena.HandlerContext) (catena.Value, catena.StatusResult) {

--- a/sdks/go/examples/hello_world/main.go
+++ b/sdks/go/examples/hello_world/main.go
@@ -74,7 +74,7 @@ func (s *helloWorldState) Set(value string) {
 }
 
 func buildDevice() *catena.Device {
-	return catena.NewDevice(slot, "Hello World", "Ross Video", "1.0.0", "SN-HELLO-0001").
+	return catena.NewDevice(slot).
 		WithDetailLevel(catena.DetailLevelFull).
 		WithMultiSetEnabled(true).
 		WithSubscriptions(true).
@@ -93,6 +93,15 @@ func main() {
 		logger.Error("Failed to create Catena server", "error", err)
 		os.Exit(1)
 	}
+
+	// The SDK owns the mandatory product struct: register it once and the SDK
+	// injects it into GetDevice and answers product/* on GetValue / ParamInfo.
+	srv.RegisterProductStruct(slot, catena.ProductStruct{
+		Name:         "Hello World",
+		Vendor:       "Ross Video",
+		Version:      "1.0.0",
+		SerialNumber: "SN-HELLO-0001",
+	})
 
 	srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext) (catena.Device, catena.StatusResult) {
 		logger.Info("GetDevice", "slot", slot)

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -174,7 +174,10 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 				WithName(catena.NewPolyglotText("en", "Muted"))).
 			WithParam("device_name", catena.NewParamString(deviceName).
 				WithName(catena.NewPolyglotText("en", "Device Name"))).
-			WithParam("struct_example", catena.NewParamStruct().
+			WithParam("struct_example", catena.NewParamStruct(map[string]any{
+				"number": structNumber,
+				"text":   structText,
+			}).
 				WithName(catena.NewPolyglotText("en", "Struct Example")).
 				WithParam("number", catena.NewParamInt32(structNumber)).
 				WithParam("text", catena.NewParamString(structText))).

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -36,9 +36,12 @@ func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *Exa
 // GetDevice time. device_handler.go calls this and returns the result directly.
 // Keep param OIDs in sync with value_handlers and param_info_handler.
 //
-// catena.NewDevice seeds the mandatory "product" struct param from the
-// identity fields passed to it; additional params, commands, constraints, and
-// menus are attached with the fluent With* builders.
+// catena.NewDevice(slot) creates an empty device for the slot; params, commands,
+// constraints, and menus are attached with the fluent With* builders. The
+// mandatory "product" struct param is managed by the SDK, not built here:
+// registerProductStructs registers one per slot via Server.RegisterProductStruct
+// and the SDK injects it on GetDevice (so menus may still reference the "product"
+// OID) and serves it on GetValue / ParamInfo.
 //
 // Slot roles:
 //   - 0: counter, commands, constraints, subscriptions, cfg-scope reads

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -21,14 +21,6 @@ func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *Exa
 	}
 }
 
-// productString safely extracts a string field from a product map.
-func productString(product map[string]any, key string) string {
-	if value, ok := product[key].(string); ok {
-		return value
-	}
-	return ""
-}
-
 // buildDeviceDefinition returns the descriptor for one slot. It is a function
 // (not a static YAML file) so every param's value field reflects live state at
 // GetDevice time. device_handler.go calls this and returns the result directly.
@@ -48,12 +40,9 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		// Slot 0: INT32, STRUCT, EMPTY commands, INT32_CHOICE constraint.
 		state.mu.RLock()
 		product := state.slotZeroProduct
-		name := productString(product, "name")
-		vendor := productString(product, "vendor")
-		version := productString(product, "version")
 		state.mu.RUnlock()
 
-		device := catena.NewDevice(0, name, vendor, version, "SN-SLOT0-0001").
+		device := catena.NewDevice(0, product.Name, product.Vendor, product.Version, product.SerialNumber).
 			WithDetailLevel(catena.DetailLevelFull).
 			WithMultiSetEnabled(true).
 			WithSubscriptions(true).
@@ -169,10 +158,10 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		structText, _ := structExample["text"].(string)
 
 		device := catena.NewDevice(2,
-			productString(product, "name"),
-			productString(product, "vendor"),
-			productString(product, "version"),
-			productString(product, "serial_number")).
+			product.Name,
+			product.Vendor,
+			product.Version,
+			product.SerialNumber).
 			WithDetailLevel(catena.DetailLevelFull).
 			WithMultiSetEnabled(true).
 			WithSubscriptions(false).

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -9,111 +9,79 @@ func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *Exa
 	// GetDeviceHandler returns the complete device descriptor for a slot.
 	// Build the descriptor from the same data model your app uses at runtime;
 	// this example rebuilds per request so "value" fields stay current.
-	// catena.ToDevice converts a plain map into the SDK Device wrapper.
 	for _, slot := range slotList {
 		srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext) (catena.Device, catena.StatusResult) {
 			logger.Info("GetDevice", "slot", slot)
-			deviceInfo, ok := buildDeviceDefinition(slot, counter, state)
+			device, ok := buildDeviceDefinition(slot, counter, state)
 			if !ok {
 				return catena.ReplyError[catena.Device](catena.StatusCodeNotFound, "device not found")
 			}
-			device, err := catena.ToDevice(deviceInfo)
-			if err != nil {
-				return catena.ReplyError[catena.Device](catena.StatusCodeInternal, err.Error())
-			}
-			return catena.Reply(device)
+			return catena.Reply(*device)
 		})
 	}
 }
 
+// productString safely extracts a string field from a product map.
+func productString(product map[string]any, key string) string {
+	if value, ok := product[key].(string); ok {
+		return value
+	}
+	return ""
+}
+
 // buildDeviceDefinition returns the descriptor for one slot. It is a function
 // (not a static YAML file) so every param's value field reflects live state at
-// GetDevice time. device_handler.go calls this and passes the result to
-// catena.ToDevice. Keep param OIDs in sync with value_handlers and param_info_handler.
+// GetDevice time. device_handler.go calls this and returns the result directly.
+// Keep param OIDs in sync with value_handlers and param_info_handler.
+//
+// catena.NewDevice seeds the mandatory "product" struct param from the
+// identity fields passed to it; additional params, commands, constraints, and
+// menus are attached with the fluent With* builders.
 //
 // Slot roles:
 //   - 0: counter, commands, constraints, subscriptions, cfg-scope reads
 //   - 1: sync.Map-backed picture controls; ParamInfo delegates here via ParamInfosForRequest
 //   - 2: prefix-dispatched params plus sample_* types (including INT32_ARRAY)
-func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleState) (map[string]any, bool) {
+func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleState) (*catena.Device, bool) {
 	switch slot {
 	case 0:
 		// Slot 0: INT32, STRUCT, EMPTY commands, INT32_CHOICE constraint.
 		state.mu.RLock()
-		productValue, _ := state.slotZeroProductValue("product")
+		product := state.slotZeroProduct
+		name := productString(product, "name")
+		vendor := productString(product, "vendor")
+		version := productString(product, "version")
 		state.mu.RUnlock()
-		productParam := catena.NewParamStruct(productValue.(map[string]any)).
-			WithReadOnly(true).
-			WithParam("name", catena.NewParamString("")).
-			WithParam("vendor", catena.NewParamString("")).
-			WithParam("version", catena.NewParamString("")).ToMap()
-		counterParam := makeCounterParam(counter).ToMap()
-		runningParam := makeRunningParam(counter).ToMap()
-		startCommand := catena.NewParamEmpty().
-			WithName(catena.NewPolyglotText("en", "Start Counter")).ToMap()
-		stopCommand := catena.NewParamEmpty().
-			WithName(catena.NewPolyglotText("en", "Stop Counter")).ToMap()
-		add10Command := catena.NewParamEmpty().
-			WithName(catena.NewPolyglotText("en", "Add 10 to Counter")).ToMap()
-		resetCommand := catena.NewParamEmpty().
-			WithName(catena.NewPolyglotText("en", "Reset Counter")).ToMap()
-		return map[string]any{
-			"slot":              uint32(0),
-			"detail_level":      catena.DetailLevelFull,
-			"multi_set_enabled": true,
-			"subscriptions":     true,
-			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-			"default_scope":     "st2138:cfg",
-			"params": map[string]any{
-				"product": productParam,
-				"counter": counterParam,
-				"running": runningParam,
-			},
-			"commands": map[string]any{
-				"start": startCommand,
-				"stop":  stopCommand,
-				"add10": add10Command,
-				"reset": resetCommand,
-			},
-			"menu_groups": map[string]any{
-				"status": map[string]any{
-					"name": map[string]any{
-						"display_strings": map[string]string{
-							"en": "Status",
-						},
-					},
-					"order": 0,
-					"menus": map[string]any{
-						"status": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Status",
-								},
-							},
-							"param_oids": []string{"product", "counter", "running"},
-						},
-					},
-				},
-				"config": map[string]any{
-					"name": map[string]any{
-						"display_strings": map[string]string{
-							"en": "Configuration",
-						},
-					},
-					"order": 1,
-					"menus": map[string]any{
-						"control": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Control",
-								},
-							},
-							"command_oids": []string{"start", "stop", "add10", "reset"},
-						},
-					},
-				},
-			},
-		}, true
+
+		device := catena.NewDevice(0, name, vendor, version, "SN-SLOT0-0001").
+			WithDetailLevel(catena.DetailLevelFull).
+			WithMultiSetEnabled(true).
+			WithSubscriptions(true).
+			WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+			WithDefaultScope("st2138:cfg").
+			WithParam("counter", makeCounterParam(counter)).
+			WithParam("running", makeRunningParam(counter)).
+			WithCommand("start", catena.NewParamEmpty().
+				WithName(catena.NewPolyglotText("en", "Start Counter"))).
+			WithCommand("stop", catena.NewParamEmpty().
+				WithName(catena.NewPolyglotText("en", "Stop Counter"))).
+			WithCommand("add10", catena.NewParamEmpty().
+				WithName(catena.NewPolyglotText("en", "Add 10 to Counter"))).
+			WithCommand("reset", catena.NewParamEmpty().
+				WithName(catena.NewPolyglotText("en", "Reset Counter"))).
+			WithMenuGroup("status", catena.NewMenuGroup().
+				WithName(catena.NewPolyglotText("en", "Status")).
+				WithOrder(0).
+				WithMenu("status", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Status")).
+					WithParamOids("product", "counter", "running"))).
+			WithMenuGroup("config", catena.NewMenuGroup().
+				WithName(catena.NewPolyglotText("en", "Configuration")).
+				WithOrder(1).
+				WithMenu("control", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Control")).
+					WithCommandOids("start", "stop", "add10", "reset")))
+		return device, true
 	case 1:
 		// Slot 1 intentionally stores its business data in a sync.Map to show
 		// adopters they can back handlers with any application data structure,
@@ -145,93 +113,45 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 			}
 		}
 		state.mu.RUnlock()
-		productParam := catena.NewParamStruct(map[string]any{
-			"name":               "Map-Backed Slot 1 Product",
-			"vendor":             "Ross Video",
-			"version":            "1.0.0",
-			"catena_sdk":         "github.com/rossvideo/catena/sdks/go",
-			"catena_sdk_version": "v0.1.0",
-			"serial_number":      "SN12345678",
-		}).
-			WithReadOnly(true).
-			WithParam("name", catena.NewParamString("")).
-			WithParam("vendor", catena.NewParamString("")).
-			WithParam("version", catena.NewParamString("")).
-			WithParam("catena_sdk", catena.NewParamString("")).
-			WithParam("catena_sdk_version", catena.NewParamString("")).
-			WithParam("serial_number", catena.NewParamString("")).ToMap()
-		resolutionParam := catena.NewParamString(resolution).
-			WithName(catena.NewPolyglotText("en", "Resolution")).ToMap()
-		brightnessParam := catena.NewParamInt32(brightness).
-			WithName(catena.NewPolyglotText("en", "Brightness")).ToMap()
-		contrastParam := catena.NewParamInt32(contrast).
-			WithName(catena.NewPolyglotText("en", "Contrast")).ToMap()
-		saturationParam := catena.NewParamInt32(saturation).
-			WithName(catena.NewPolyglotText("en", "Saturation")).ToMap()
-		return map[string]any{
-			"slot":              uint32(1),
-			"detail_level":      catena.DetailLevelFull,
-			"multi_set_enabled": false,
-			"subscriptions":     true,
-			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-			"default_scope":     "st2138:mon",
-			"params": map[string]any{
-				"product":    productParam,
-				"resolution": resolutionParam,
-				"brightness": brightnessParam,
-				"contrast":   contrastParam,
-				"saturation": saturationParam,
-			},
-			"menu_groups": map[string]any{
-				"status": map[string]any{
-					"name": map[string]any{
-						"display_strings": map[string]string{
-							"en": "Status",
-						},
-					},
-					"order": 0,
-					"menus": map[string]any{
-						"status": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Status",
-								},
-							},
-							"param_oids": []string{"resolution"},
-						},
-					},
-				},
-				"config": map[string]any{
-					"name": map[string]any{
-						"display_strings": map[string]string{
-							"en": "Configuration",
-						},
-					},
-					"order": 1,
-					"menus": map[string]any{
-						"picture": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Picture",
-								},
-							},
-							"param_oids": []string{"brightness", "contrast", "saturation"},
-						},
-					},
-				},
-			},
-		}, true
+
+		device := catena.NewDevice(1, "Map-Backed Slot 1 Product", "Ross Video", "1.0.0", "SN12345678").
+			WithDetailLevel(catena.DetailLevelFull).
+			WithMultiSetEnabled(false).
+			WithSubscriptions(true).
+			WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+			WithDefaultScope("st2138:mon").
+			WithParam("resolution", catena.NewParamString(resolution).
+				WithName(catena.NewPolyglotText("en", "Resolution"))).
+			WithParam("brightness", catena.NewParamInt32(brightness).
+				WithName(catena.NewPolyglotText("en", "Brightness"))).
+			WithParam("contrast", catena.NewParamInt32(contrast).
+				WithName(catena.NewPolyglotText("en", "Contrast"))).
+			WithParam("saturation", catena.NewParamInt32(saturation).
+				WithName(catena.NewPolyglotText("en", "Saturation"))).
+			WithMenuGroup("status", catena.NewMenuGroup().
+				WithName(catena.NewPolyglotText("en", "Status")).
+				WithOrder(0).
+				WithMenu("status", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Status")).
+					WithParamOids("resolution"))).
+			WithMenuGroup("config", catena.NewMenuGroup().
+				WithName(catena.NewPolyglotText("en", "Configuration")).
+				WithOrder(1).
+				WithMenu("picture", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Picture")).
+					WithParamOids("brightness", "contrast", "saturation")))
+		return device, true
 	case 2:
 		// Slot 2: prefix-dispatched identity/audio params plus FLOAT32, arrays,
 		// BINARY, STRUCT_VARIANT, STRUCT_ARRAY, STRUCT_VARIANT_ARRAY examples.
 		// Hold state.mu through param building: copied slices and maps alias
 		// ExampleState backing storage, and SetValue holds the write lock for
-		// the full handler. Release only after ToMap serializes values so
+		// the full handler. Release only after the builder clones each proto so
 		// GetDevice cannot observe torn array/map data (same pattern as slot 2
 		// GetValue, which keeps RLock through catena.ToValue).
 		state.mu.RLock()
 		defer state.mu.RUnlock()
-		productValue := state.slotTwoProduct
+		product := state.slotTwoProduct
 		volume := state.volume
 		muted := state.muted
 		deviceName := state.deviceName
@@ -244,124 +164,77 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		sampleStructVariant := state.sampleStructVariant
 		sampleStructArray := state.sampleStructArray
 		sampleStructVariantArray := state.sampleStructVariantArray
-		productParam := catena.NewParamStruct(productValue).
-			WithReadOnly(true).
-			WithParam("name", catena.NewParamString("")).
-			WithParam("vendor", catena.NewParamString("")).
-			WithParam("version", catena.NewParamString("")).
-			WithParam("catena_sdk", catena.NewParamString("")).
-			WithParam("catena_sdk_version", catena.NewParamString("")).
-			WithParam("serial_number", catena.NewParamString("")).ToMap()
-		volumeParam := catena.NewParamInt32(volume).
-			WithName(catena.NewPolyglotText("en", "Volume")).ToMap()
-		mutedParam := catena.NewParamInt32(muted).
-			WithName(catena.NewPolyglotText("en", "Muted")).ToMap()
-		deviceNameParam := catena.NewParamString(deviceName).
-			WithName(catena.NewPolyglotText("en", "Device Name")).ToMap()
-		structExampleParam := catena.NewParamStruct(structExample).
-			WithName(catena.NewPolyglotText("en", "Struct Example")).
-			WithParam("number", catena.NewParamInt32(0)).
-			WithParam("text", catena.NewParamString("")).ToMap()
-		sampleFloatParam := catena.NewParamFloat32(sampleFloat).
-			WithName(catena.NewPolyglotText("en", "Sample Float")).ToMap()
-		sampleIntArrayParam := catena.NewParamInt32Array(sampleIntArray).
-			WithName(catena.NewPolyglotText("en", "Sample Int Array")).ToMap()
-		sampleFloatArrayParam := catena.NewParamFloat32Array(sampleFloatArray).
-			WithName(catena.NewPolyglotText("en", "Sample Float Array")).ToMap()
-		sampleStringArrayParam := catena.NewParamStringArray(sampleStringArray).
-			WithName(catena.NewPolyglotText("en", "Sample String Array")).ToMap()
-		sampleBinaryParam := catena.NewParamBinary(sampleBinary).
-			WithName(catena.NewPolyglotText("en", "Sample Binary")).ToMap()
-		sampleStructVariantParam := catena.NewParamStructVariant(&sampleStructVariant).
-			WithName(catena.NewPolyglotText("en", "Sample Struct Variant")).
-			WithParam("int_kind", catena.NewParamInt32(0)).
-			WithParam("string_kind", catena.NewParamString("")).ToMap()
-		sampleStructArrayParam := catena.NewParamStructArray(sampleStructArray).
-			WithName(catena.NewPolyglotText("en", "Sample Struct Array")).
-			WithParam("label", catena.NewParamString("")).
-			WithParam("count", catena.NewParamInt32(0)).ToMap()
-		sampleStructVariantArrayParam := catena.NewParamStructVariantArray(sampleStructVariantArray).
-			WithName(catena.NewPolyglotText("en", "Sample Struct Variant Array")).
-			WithParam("int_kind", catena.NewParamInt32(0)).
-			WithParam("string_kind", catena.NewParamString("")).ToMap()
-		return map[string]any{
-			"slot":              uint32(2),
-			"detail_level":      catena.DetailLevelFull,
-			"multi_set_enabled": true,
-			"subscriptions":     false,
-			"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-			"default_scope":     "st2138:op",
-			"params": map[string]any{
-				"product":                     productParam,
-				"volume":                      volumeParam,
-				"muted":                       mutedParam,
-				"device_name":                 deviceNameParam,
-				"struct_example":              structExampleParam,
-				"sample_float":                sampleFloatParam,
-				"sample_int_array":            sampleIntArrayParam,
-				"sample_float_array":          sampleFloatArrayParam,
-				"sample_string_array":         sampleStringArrayParam,
-				"sample_binary":               sampleBinaryParam,
-				"sample_struct_variant":       sampleStructVariantParam,
-				"sample_struct_array":         sampleStructArrayParam,
-				"sample_struct_variant_array": sampleStructVariantArrayParam,
-			},
-			"menu_groups": map[string]any{
-				"status": map[string]any{
-					"name": map[string]any{
-						"display_strings": map[string]string{
-							"en": "Status",
-						},
-					},
-					"order": 0,
-					"menus": map[string]any{
-						"identity": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Identity",
-								},
-							},
-							"param_oids": []string{"product", "device_name", "struct_example"},
-						},
-						"types": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Catena Types",
-								},
-							},
-							"param_oids": []string{
-								"sample_float",
-								"sample_int_array",
-								"sample_float_array",
-								"sample_string_array",
-								"sample_binary",
-								"sample_struct_variant",
-								"sample_struct_array",
-								"sample_struct_variant_array",
-							},
-						},
-					},
-				},
-				"config": map[string]any{
-					"name": map[string]any{
-						"display_strings": map[string]string{
-							"en": "Configuration",
-						},
-					},
-					"order": 1,
-					"menus": map[string]any{
-						"audio": map[string]any{
-							"name": map[string]any{
-								"display_strings": map[string]string{
-									"en": "Audio",
-								},
-							},
-							"param_oids": []string{"volume", "muted"},
-						},
-					},
-				},
-			},
-		}, true
+
+		structNumber, _ := structExample["number"].(int32)
+		structText, _ := structExample["text"].(string)
+
+		device := catena.NewDevice(2,
+			productString(product, "name"),
+			productString(product, "vendor"),
+			productString(product, "version"),
+			productString(product, "serial_number")).
+			WithDetailLevel(catena.DetailLevelFull).
+			WithMultiSetEnabled(true).
+			WithSubscriptions(false).
+			WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+			WithDefaultScope("st2138:op").
+			WithParam("volume", catena.NewParamInt32(volume).
+				WithName(catena.NewPolyglotText("en", "Volume"))).
+			WithParam("muted", catena.NewParamInt32(muted).
+				WithName(catena.NewPolyglotText("en", "Muted"))).
+			WithParam("device_name", catena.NewParamString(deviceName).
+				WithName(catena.NewPolyglotText("en", "Device Name"))).
+			WithParam("struct_example", catena.NewParamStruct().
+				WithName(catena.NewPolyglotText("en", "Struct Example")).
+				WithParam("number", catena.NewParamInt32(structNumber)).
+				WithParam("text", catena.NewParamString(structText))).
+			WithParam("sample_float", catena.NewParamFloat32(sampleFloat).
+				WithName(catena.NewPolyglotText("en", "Sample Float"))).
+			WithParam("sample_int_array", catena.NewParamInt32Array(sampleIntArray).
+				WithName(catena.NewPolyglotText("en", "Sample Int Array"))).
+			WithParam("sample_float_array", catena.NewParamFloat32Array(sampleFloatArray).
+				WithName(catena.NewPolyglotText("en", "Sample Float Array"))).
+			WithParam("sample_string_array", catena.NewParamStringArray(sampleStringArray).
+				WithName(catena.NewPolyglotText("en", "Sample String Array"))).
+			WithParam("sample_binary", catena.NewParamBinary(sampleBinary).
+				WithName(catena.NewPolyglotText("en", "Sample Binary"))).
+			WithParam("sample_struct_variant", catena.NewParamStructVariant(&sampleStructVariant).
+				WithName(catena.NewPolyglotText("en", "Sample Struct Variant")).
+				WithParam("int_kind", catena.NewParamInt32(0)).
+				WithParam("string_kind", catena.NewParamString(""))).
+			WithParam("sample_struct_array", catena.NewParamStructArray(sampleStructArray).
+				WithName(catena.NewPolyglotText("en", "Sample Struct Array")).
+				WithParam("label", catena.NewParamString("")).
+				WithParam("count", catena.NewParamInt32(0))).
+			WithParam("sample_struct_variant_array", catena.NewParamStructVariantArray(sampleStructVariantArray).
+				WithName(catena.NewPolyglotText("en", "Sample Struct Variant Array")).
+				WithParam("int_kind", catena.NewParamInt32(0)).
+				WithParam("string_kind", catena.NewParamString(""))).
+			WithMenuGroup("status", catena.NewMenuGroup().
+				WithName(catena.NewPolyglotText("en", "Status")).
+				WithOrder(0).
+				WithMenu("identity", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Identity")).
+					WithParamOids("product", "device_name", "struct_example")).
+				WithMenu("types", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Catena Types")).
+					WithParamOids(
+						"sample_float",
+						"sample_int_array",
+						"sample_float_array",
+						"sample_string_array",
+						"sample_binary",
+						"sample_struct_variant",
+						"sample_struct_array",
+						"sample_struct_variant_array",
+					))).
+			WithMenuGroup("config", catena.NewMenuGroup().
+				WithName(catena.NewPolyglotText("en", "Configuration")).
+				WithOrder(1).
+				WithMenu("audio", catena.NewMenu().
+					WithName(catena.NewPolyglotText("en", "Audio")).
+					WithParamOids("volume", "muted")))
+		return device, true
 	default:
 		return nil, false
 	}

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -5,6 +5,16 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 )
 
+// registerProductStructs hands each slot's mandatory product struct to the SDK.
+// Once registered, the SDK injects the product param into the device on
+// GetDevice and answers GetValue/ParamInfo for product/* (and rejects writes),
+// so none of the value/param-info handlers below deal with product.
+func registerProductStructs(srv catena.Server, state *ExampleState) {
+	srv.RegisterProductStruct(0, state.slotZeroProduct)
+	srv.RegisterProductStruct(1, state.slotOneProduct)
+	srv.RegisterProductStruct(2, state.slotTwoProduct)
+}
+
 func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *ExampleState) {
 	// GetDeviceHandler returns the complete device descriptor for a slot.
 	// Build the descriptor from the same data model your app uses at runtime;
@@ -38,11 +48,7 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 	switch slot {
 	case 0:
 		// Slot 0: INT32, STRUCT, EMPTY commands, INT32_CHOICE constraint.
-		state.mu.RLock()
-		product := state.slotZeroProduct
-		state.mu.RUnlock()
-
-		device := catena.NewDevice(0, product.Name, product.Vendor, product.Version, product.SerialNumber).
+		device := catena.NewDevice(0).
 			WithDetailLevel(catena.DetailLevelFull).
 			WithMultiSetEnabled(true).
 			WithSubscriptions(true).
@@ -103,7 +109,7 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		}
 		state.mu.RUnlock()
 
-		device := catena.NewDevice(1, "Map-Backed Slot 1 Product", "Ross Video", "1.0.0", "SN12345678").
+		device := catena.NewDevice(1).
 			WithDetailLevel(catena.DetailLevelFull).
 			WithMultiSetEnabled(false).
 			WithSubscriptions(true).
@@ -140,7 +146,6 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		// GetValue, which keeps RLock through catena.ToValue).
 		state.mu.RLock()
 		defer state.mu.RUnlock()
-		product := state.slotTwoProduct
 		volume := state.volume
 		muted := state.muted
 		deviceName := state.deviceName
@@ -157,11 +162,7 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		structNumber, _ := structExample["number"].(int32)
 		structText, _ := structExample["text"].(string)
 
-		device := catena.NewDevice(2,
-			product.Name,
-			product.Vendor,
-			product.Version,
-			product.SerialNumber).
+		device := catena.NewDevice(2).
 			WithDetailLevel(catena.DetailLevelFull).
 			WithMultiSetEnabled(true).
 			WithSubscriptions(false).

--- a/sdks/go/examples/oneOfEverything/get_param_handler.go
+++ b/sdks/go/examples/oneOfEverything/get_param_handler.go
@@ -26,7 +26,7 @@ func registerGetParamHandlers(srv catena.Server, counter *CounterState, state *E
 				return catena.Param{}, catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 			}
 
-			param, found := lookupParam(device.ToProtoDevice(), fqoid)
+			param, found := lookupParam(device.Proto, fqoid)
 			if !found {
 				return catena.Param{}, catena.StatusWithCode(catena.StatusCodeNotFound, "param not found: "+fqoid)
 			}

--- a/sdks/go/examples/oneOfEverything/get_param_handler.go
+++ b/sdks/go/examples/oneOfEverything/get_param_handler.go
@@ -21,17 +21,12 @@ func registerGetParamHandlers(srv catena.Server, counter *CounterState, state *E
 		srv.RegisterGetParamHandler(slot, func(slot uint16, fqoid string, ctx catena.HandlerContext) (catena.Param, catena.StatusResult) {
 			logger.Info("GetParam", "slot", slot, "fqoid", fqoid)
 
-			deviceInfo, ok := buildDeviceDefinition(slot, counter, state)
+			device, ok := buildDeviceDefinition(slot, counter, state)
 			if !ok {
 				return catena.Param{}, catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 			}
 
-			device, err := catena.ToDevice(deviceInfo)
-			if err != nil {
-				return catena.Param{}, catena.StatusWithCode(catena.StatusCodeInternal, "failed to build device: "+err.Error())
-			}
-
-			param, found := lookupParam(device.GetProtoDevice(), fqoid)
+			param, found := lookupParam(device.ToProtoDevice(), fqoid)
 			if !found {
 				return catena.Param{}, catena.StatusWithCode(catena.StatusCodeNotFound, "param not found: "+fqoid)
 			}

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -64,6 +64,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -152,15 +153,19 @@ var slotList = []uint16{0, 1, 2} // every handler file iterates this to register
 // intentionally uses a different storage style so adopters can pick a pattern:
 //   - slot 0 fields + CounterState: explicit typed fields, manual switch handlers
 //   - slot 1 slotOneParams sync.Map: map-backed params, direct key lookup
-//   - slot 2 typed fields + product map: prefix-based dispatch in value_handlers
+//   - slot 2 typed fields + product: prefix-based dispatch in value_handlers
+//
+// Product identity is stored as a catena.Product so GetDevice (via NewDevice)
+// and GetValue (via catena.ProductValues) report identical product metadata,
+// including the SDK-managed catena_sdk / catena_sdk_version fields.
 //
 // Slot 2's sample_* fields demonstrate the remaining Catena param types (except DATA).
 type ExampleState struct {
 	mu                       sync.RWMutex
-	slotZeroProduct          map[string]any
+	slotZeroProduct          catena.Product
 	sampleIntArray           []int32
 	slotOneParams            *sync.Map
-	slotTwoProduct           map[string]any
+	slotTwoProduct           catena.Product
 	volume                   int32
 	muted                    int32
 	deviceName               string
@@ -178,20 +183,19 @@ func NewExampleState() *ExampleState {
 	// Defaults here are what GetValue returns on first request and what
 	// buildDeviceDefinition embeds into each param's initial "value" field.
 	state := &ExampleState{
-		slotZeroProduct: map[string]any{
-			"name":    "Counter Slot 0 Product",
-			"vendor":  "Ross Video",
-			"version": "1.0.0",
+		slotZeroProduct: catena.Product{
+			Name:         "Counter Slot 0 Product",
+			Vendor:       "Ross Video",
+			Version:      "1.0.0",
+			SerialNumber: "SN-SLOT0-0001",
 		},
 		sampleIntArray: []int32{1, 2, 3, 4},
 		slotOneParams:  &sync.Map{},
-		slotTwoProduct: map[string]any{
-			"name":               "Prefix Slot 2 Product",
-			"vendor":             "Ross Video",
-			"version":            "1.0.0",
-			"catena_sdk":         "github.com/rossvideo/catena/sdks/go",
-			"catena_sdk_version": "v0.1.0",
-			"serial_number":      "SN12345678",
+		slotTwoProduct: catena.Product{
+			Name:         "Prefix Slot 2 Product",
+			Vendor:       "Ross Video",
+			Version:      "1.0.0",
+			SerialNumber: "SN12345678",
 		},
 		volume:     75,
 		muted:      0,
@@ -230,53 +234,34 @@ func (s *ExampleState) sampleIntArrayValue() []int32 {
 	return s.sampleIntArray
 }
 
-func (s *ExampleState) slotZeroProductValue(fqoid string) (any, bool) {
-	// Slot 0 product subtree lookup; called from value_handlers case switch.
-	// Caller must hold s.mu.RLock for the duration of catena.ToValue on the result.
-	switch fqoid {
-	case "product":
-		return s.slotZeroProduct, true
-	case "product/name":
-		value, ok := s.slotZeroProduct["name"]
-		return value, ok
-	case "product/vendor":
-		value, ok := s.slotZeroProduct["vendor"]
-		return value, ok
-	case "product/version":
-		value, ok := s.slotZeroProduct["version"]
-		return value, ok
-	default:
+// productValue resolves a product/* FQOID against a catena.Product using
+// catena.ProductValues, so the values returned match exactly what NewDevice
+// advertised in the device descriptor (including the SDK-managed catena_sdk /
+// catena_sdk_version fields). Returns the whole product map for the bare
+// "product" oid.
+func productValue(product catena.Product, fqoid string) (any, bool) {
+	values := catena.ProductValues(product)
+	if fqoid == "product" {
+		return values, true
+	}
+	field, ok := strings.CutPrefix(fqoid, "product/")
+	if !ok {
 		return nil, false
 	}
+	value, found := values[field]
+	return value, found
+}
+
+func (s *ExampleState) slotZeroProductValue(fqoid string) (any, bool) {
+	// Slot 0 product subtree lookup; called from value_handlers.
+	// Caller must hold s.mu.RLock for the duration of catena.ToValue on the result.
+	return productValue(s.slotZeroProduct, fqoid)
 }
 
 func (s *ExampleState) slotTwoProductValue(fqoid string) (any, bool) {
 	// Slot 2 product subtree lookup; prefix-dispatched from value_handlers.
 	// Caller must hold s.mu.RLock for the duration of catena.ToValue on the result.
-	switch fqoid {
-	case "product":
-		return s.slotTwoProduct, true
-	case "product/name":
-		value, ok := s.slotTwoProduct["name"]
-		return value, ok
-	case "product/vendor":
-		value, ok := s.slotTwoProduct["vendor"]
-		return value, ok
-	case "product/version":
-		value, ok := s.slotTwoProduct["version"]
-		return value, ok
-	case "product/catena_sdk":
-		value, ok := s.slotTwoProduct["catena_sdk"]
-		return value, ok
-	case "product/catena_sdk_version":
-		value, ok := s.slotTwoProduct["catena_sdk_version"]
-		return value, ok
-	case "product/serial_number":
-		value, ok := s.slotTwoProduct["serial_number"]
-		return value, ok
-	default:
-		return nil, false
-	}
+	return productValue(s.slotTwoProduct, fqoid)
 }
 
 func (s *ExampleState) sampleFloatArrayValue() []float32 {

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -64,7 +64,6 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -153,19 +152,20 @@ var slotList = []uint16{0, 1, 2} // every handler file iterates this to register
 // intentionally uses a different storage style so adopters can pick a pattern:
 //   - slot 0 fields + CounterState: explicit typed fields, manual switch handlers
 //   - slot 1 slotOneParams sync.Map: map-backed params, direct key lookup
-//   - slot 2 typed fields + product: prefix-based dispatch in value_handlers
+//   - slot 2 typed fields: prefix-based dispatch in value_handlers
 //
-// Product identity is stored as a catena.Product so GetDevice (via NewDevice)
-// and GetValue (via catena.ProductValues) report identical product metadata,
-// including the SDK-managed catena_sdk / catena_sdk_version fields.
+// The mandatory product struct is not stored here as params: it is handed to the
+// SDK via Server.RegisterProductStruct (see registerProductStructs), which then
+// serves GetDevice/GetValue/ParamInfo and rejects product writes on its own.
 //
 // Slot 2's sample_* fields demonstrate the remaining Catena param types (except DATA).
 type ExampleState struct {
 	mu                       sync.RWMutex
-	slotZeroProduct          catena.Product
+	slotZeroProduct          catena.ProductStruct
+	slotOneProduct           catena.ProductStruct
+	slotTwoProduct           catena.ProductStruct
 	sampleIntArray           []int32
 	slotOneParams            *sync.Map
-	slotTwoProduct           catena.Product
 	volume                   int32
 	muted                    int32
 	deviceName               string
@@ -183,20 +183,26 @@ func NewExampleState() *ExampleState {
 	// Defaults here are what GetValue returns on first request and what
 	// buildDeviceDefinition embeds into each param's initial "value" field.
 	state := &ExampleState{
-		slotZeroProduct: catena.Product{
+		slotZeroProduct: catena.ProductStruct{
 			Name:         "Counter Slot 0 Product",
 			Vendor:       "Ross Video",
 			Version:      "1.0.0",
 			SerialNumber: "SN-SLOT0-0001",
 		},
-		sampleIntArray: []int32{1, 2, 3, 4},
-		slotOneParams:  &sync.Map{},
-		slotTwoProduct: catena.Product{
+		slotOneProduct: catena.ProductStruct{
+			Name:         "Map-Backed Slot 1 Product",
+			Vendor:       "Ross Video",
+			Version:      "1.0.0",
+			SerialNumber: "SN-SLOT1-0001",
+		},
+		slotTwoProduct: catena.ProductStruct{
 			Name:         "Prefix Slot 2 Product",
 			Vendor:       "Ross Video",
 			Version:      "1.0.0",
 			SerialNumber: "SN12345678",
 		},
+		sampleIntArray: []int32{1, 2, 3, 4},
+		slotOneParams:  &sync.Map{},
 		volume:     75,
 		muted:      0,
 		deviceName: "Demo Device",
@@ -232,36 +238,6 @@ func (s *ExampleState) sampleIntArrayValue() []int32 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.sampleIntArray
-}
-
-// productValue resolves a product/* FQOID against a catena.Product using
-// catena.ProductValues, so the values returned match exactly what NewDevice
-// advertised in the device descriptor (including the SDK-managed catena_sdk /
-// catena_sdk_version fields). Returns the whole product map for the bare
-// "product" oid.
-func productValue(product catena.Product, fqoid string) (any, bool) {
-	values := catena.ProductValues(product)
-	if fqoid == "product" {
-		return values, true
-	}
-	field, ok := strings.CutPrefix(fqoid, "product/")
-	if !ok {
-		return nil, false
-	}
-	value, found := values[field]
-	return value, found
-}
-
-func (s *ExampleState) slotZeroProductValue(fqoid string) (any, bool) {
-	// Slot 0 product subtree lookup; called from value_handlers.
-	// Caller must hold s.mu.RLock for the duration of catena.ToValue on the result.
-	return productValue(s.slotZeroProduct, fqoid)
-}
-
-func (s *ExampleState) slotTwoProductValue(fqoid string) (any, bool) {
-	// Slot 2 product subtree lookup; prefix-dispatched from value_handlers.
-	// Caller must hold s.mu.RLock for the duration of catena.ToValue on the result.
-	return productValue(s.slotTwoProduct, fqoid)
 }
 
 func (s *ExampleState) sampleFloatArrayValue() []float32 {
@@ -370,6 +346,7 @@ func main() {
 	// Each register* function wires one Catena endpoint family. Transports call
 	// these through the SDK runtime; you do not implement HTTP/gRPC routing here.
 	registerAccessHandler(srv)                                           // EndpointAccess gate
+	registerProductStructs(srv, state)                                   // SDK-managed product per slot
 	registerDeviceHandlers(srv, counter, state)                          // GetDevice → buildDeviceDefinition
 	registerValueHandlers(srv, counter, state)                           // GetValue / SetValue
 	registerGetParamHandlers(srv, counter, state)                        // GetParam

--- a/sdks/go/examples/oneOfEverything/param_info_handler.go
+++ b/sdks/go/examples/oneOfEverything/param_info_handler.go
@@ -53,6 +53,12 @@ func slotZeroParamInfos(fqoid string, recursive bool) ([]catena.ParamInfo, caten
 		return []catena.ParamInfo{catena.NewParamInfo("product/vendor", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	case "product/version":
 		return []catena.ParamInfo{catena.NewParamInfo("product/version", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	case "product/serial_number":
+		return []catena.ParamInfo{catena.NewParamInfo("product/serial_number", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	case "product/catena_sdk_version":
+		return []catena.ParamInfo{catena.NewParamInfo("product/catena_sdk_version", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	case "product/catena_sdk":
+		return []catena.ParamInfo{catena.NewParamInfo("product/catena_sdk", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	case "counter":
 		return []catena.ParamInfo{newCounterParamInfo()}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	case "running":
@@ -202,6 +208,9 @@ func slotZeroProductParamInfos(recursive bool) []catena.ParamInfo {
 			catena.NewParamInfo("product/name", nil, catena.ParamTypeString, "", 0),
 			catena.NewParamInfo("product/vendor", nil, catena.ParamTypeString, "", 0),
 			catena.NewParamInfo("product/version", nil, catena.ParamTypeString, "", 0),
+			catena.NewParamInfo("product/serial_number", nil, catena.ParamTypeString, "", 0),
+			catena.NewParamInfo("product/catena_sdk_version", nil, catena.ParamTypeString, "", 0),
+			catena.NewParamInfo("product/catena_sdk", nil, catena.ParamTypeString, "", 0),
 		)
 	}
 	return infos

--- a/sdks/go/examples/oneOfEverything/param_info_handler.go
+++ b/sdks/go/examples/oneOfEverything/param_info_handler.go
@@ -40,25 +40,11 @@ func registerParamInfoHandlers(srv catena.Server, counter *CounterState, state *
 }
 
 func slotZeroParamInfos(fqoid string, recursive bool) ([]catena.ParamInfo, catena.StatusResult) {
+	// product/* is served by the SDK (RegisterProductStruct); this handler only
+	// covers the business-logic params.
 	switch fqoid {
 	case "":
-		infos := slotZeroProductParamInfos(recursive)
-		infos = append(infos, newCounterParamInfo(), newRunningParamInfo())
-		return infos, catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product":
-		return slotZeroProductParamInfos(recursive), catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product/name":
-		return []catena.ParamInfo{catena.NewParamInfo("product/name", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product/vendor":
-		return []catena.ParamInfo{catena.NewParamInfo("product/vendor", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product/version":
-		return []catena.ParamInfo{catena.NewParamInfo("product/version", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product/serial_number":
-		return []catena.ParamInfo{catena.NewParamInfo("product/serial_number", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product/catena_sdk_version":
-		return []catena.ParamInfo{catena.NewParamInfo("product/catena_sdk_version", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-	case "product/catena_sdk":
-		return []catena.ParamInfo{catena.NewParamInfo("product/catena_sdk", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
+		return []catena.ParamInfo{newCounterParamInfo(), newRunningParamInfo()}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	case "counter":
 		return []catena.ParamInfo{newCounterParamInfo()}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	case "running":
@@ -70,8 +56,8 @@ func slotZeroParamInfos(fqoid string, recursive bool) ([]catena.ParamInfo, caten
 
 func slotTwoParamInfos(fqoid string, recursive bool, state *ExampleState) ([]catena.ParamInfo, catena.StatusResult) {
 	if fqoid == "" {
+		// product/* is served by the SDK (RegisterProductStruct); omit it here.
 		return []catena.ParamInfo{
-			catena.NewParamInfo("product", nil, catena.ParamTypeStruct, "", 0),
 			catena.NewParamInfo("volume", catena.NewPolyglotText("en", "Volume"), catena.ParamTypeInt32, "", 0),
 			catena.NewParamInfo("muted", catena.NewPolyglotText("en", "Muted"), catena.ParamTypeInt32, "", 0),
 			catena.NewParamInfo("device_name", catena.NewPolyglotText("en", "Device Name"), catena.ParamTypeString, "", 0),
@@ -85,38 +71,6 @@ func slotTwoParamInfos(fqoid string, recursive bool, state *ExampleState) ([]cat
 			catena.NewParamInfo("sample_struct_array", catena.NewPolyglotText("en", "Sample Struct Array"), catena.ParamTypeStructArray, "", uint32(len(state.sampleStructArrayValue()))),
 			catena.NewParamInfo("sample_struct_variant_array", catena.NewPolyglotText("en", "Sample Struct Variant Array"), catena.ParamTypeStructVariantArray, "", uint32(len(state.sampleStructVariantArrayValue()))),
 		}, catena.StatusWithCode(catena.StatusCodeOk, "")
-	}
-
-	if strings.HasPrefix(fqoid, "product") {
-		infos := []catena.ParamInfo{
-			catena.NewParamInfo("product", nil, catena.ParamTypeStruct, "", 0),
-		}
-		if recursive {
-			infos = append(infos,
-				catena.NewParamInfo("product/name", nil, catena.ParamTypeString, "", 0),
-				catena.NewParamInfo("product/vendor", nil, catena.ParamTypeString, "", 0),
-				catena.NewParamInfo("product/version", nil, catena.ParamTypeString, "", 0),
-				catena.NewParamInfo("product/catena_sdk", nil, catena.ParamTypeString, "", 0),
-				catena.NewParamInfo("product/catena_sdk_version", nil, catena.ParamTypeString, "", 0),
-				catena.NewParamInfo("product/serial_number", nil, catena.ParamTypeString, "", 0),
-			)
-		}
-		switch fqoid {
-		case "product":
-			return infos, catena.StatusWithCode(catena.StatusCodeOk, "")
-		case "product/name":
-			return []catena.ParamInfo{catena.NewParamInfo("product/name", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-		case "product/vendor":
-			return []catena.ParamInfo{catena.NewParamInfo("product/vendor", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-		case "product/version":
-			return []catena.ParamInfo{catena.NewParamInfo("product/version", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-		case "product/catena_sdk":
-			return []catena.ParamInfo{catena.NewParamInfo("product/catena_sdk", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-		case "product/catena_sdk_version":
-			return []catena.ParamInfo{catena.NewParamInfo("product/catena_sdk_version", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-		case "product/serial_number":
-			return []catena.ParamInfo{catena.NewParamInfo("product/serial_number", nil, catena.ParamTypeString, "", 0)}, catena.StatusWithCode(catena.StatusCodeOk, "")
-		}
 	}
 
 	if strings.HasPrefix(fqoid, "struct_example") {
@@ -195,25 +149,6 @@ func slotTwoParamInfos(fqoid string, recursive bool, state *ExampleState) ([]cat
 
 func newCounterParamInfo() catena.ParamInfo {
 	return catena.NewParamInfo("counter", catena.NewPolyglotText("en", "Counter"), catena.ParamTypeInt32, "", 0)
-}
-
-func newSlotZeroProductParamInfo() catena.ParamInfo {
-	return catena.NewParamInfo("product", nil, catena.ParamTypeStruct, "", 0)
-}
-
-func slotZeroProductParamInfos(recursive bool) []catena.ParamInfo {
-	infos := []catena.ParamInfo{newSlotZeroProductParamInfo()}
-	if recursive {
-		infos = append(infos,
-			catena.NewParamInfo("product/name", nil, catena.ParamTypeString, "", 0),
-			catena.NewParamInfo("product/vendor", nil, catena.ParamTypeString, "", 0),
-			catena.NewParamInfo("product/version", nil, catena.ParamTypeString, "", 0),
-			catena.NewParamInfo("product/serial_number", nil, catena.ParamTypeString, "", 0),
-			catena.NewParamInfo("product/catena_sdk_version", nil, catena.ParamTypeString, "", 0),
-			catena.NewParamInfo("product/catena_sdk", nil, catena.ParamTypeString, "", 0),
-		)
-	}
-	return infos
 }
 
 func newRunningParamInfo() catena.ParamInfo {

--- a/sdks/go/examples/oneOfEverything/param_makers.go
+++ b/sdks/go/examples/oneOfEverything/param_makers.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Shared param makers are the single source of truth for slot 0's params. The
-// device descriptor (device_handler.go) calls .ToMap() on each; GetParam
+// device descriptor (device_handler.go) passes each maker to WithParam; GetParam
 // (get_param_handler.go) rebuilds that same device definition and reads the
 // requested OID back out of it. Because both endpoints trace back to these
 // makers, a param can never drift between GetDevice and GetParam.

--- a/sdks/go/examples/oneOfEverything/value_handlers.go
+++ b/sdks/go/examples/oneOfEverything/value_handlers.go
@@ -20,12 +20,14 @@ func registerValueHandlers(srv catena.Server, counter *CounterState, state *Exam
 			return catena.ReplyError[catena.Value](catena.StatusCodePermissionDenied, "configuration scope required")
 		}
 
-		switch fqoid {
-		case "product", "product/name", "product/vendor", "product/version":
+		if strings.HasPrefix(fqoid, "product") {
 			state.mu.RLock()
 			defer state.mu.RUnlock()
 			v, ok := state.slotZeroProductValue(fqoid)
 			return replyValue(fqoid, v, ok)
+		}
+
+		switch fqoid {
 		case "counter":
 			return replyValue(fqoid, counter.GetValue(), true)
 		case "running":

--- a/sdks/go/examples/oneOfEverything/value_handlers.go
+++ b/sdks/go/examples/oneOfEverything/value_handlers.go
@@ -20,13 +20,6 @@ func registerValueHandlers(srv catena.Server, counter *CounterState, state *Exam
 			return catena.ReplyError[catena.Value](catena.StatusCodePermissionDenied, "configuration scope required")
 		}
 
-		if strings.HasPrefix(fqoid, "product") {
-			state.mu.RLock()
-			defer state.mu.RUnlock()
-			v, ok := state.slotZeroProductValue(fqoid)
-			return replyValue(fqoid, v, ok)
-		}
-
 		switch fqoid {
 		case "counter":
 			return replyValue(fqoid, counter.GetValue(), true)
@@ -65,9 +58,7 @@ func registerValueHandlers(srv catena.Server, counter *CounterState, state *Exam
 
 		var v any
 		var ok bool
-		if strings.HasPrefix(fqoid, "product") {
-			v, ok = state.slotTwoProductValue(fqoid)
-		} else if fqoid == "volume" {
+		if fqoid == "volume" {
 			v, ok = state.volume, true
 		} else if fqoid == "muted" {
 			v, ok = state.muted, true
@@ -116,9 +107,6 @@ func registerValueHandlers(srv catena.Server, counter *CounterState, state *Exam
 			if entry.Value == nil {
 				logger.Error("SetValue nil value", "slot", slot, "fqoid", entry.Fqoid)
 				return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "nil value for "+entry.Fqoid)
-			}
-			if strings.HasPrefix(entry.Fqoid, "product") {
-				return catena.StatusWithCode(catena.StatusCodePermissionDenied, "product params are read-only")
 			}
 
 			switch entry.Fqoid {
@@ -279,9 +267,6 @@ func slotTwoValidateSet(fqoid string, value any, state *ExampleState) catena.Sta
 	if value == nil {
 		logger.Error("SetValue nil value", "slot", uint16(2), "fqoid", fqoid)
 		return catena.StatusWithCode(catena.StatusCodeInvalidArgument, "nil value for "+fqoid)
-	}
-	if strings.HasPrefix(fqoid, "product") {
-		return catena.StatusWithCode(catena.StatusCodePermissionDenied, "product params are read-only")
 	}
 
 	switch {

--- a/sdks/go/examples/oneOfEverything/webui/index.htm
+++ b/sdks/go/examples/oneOfEverything/webui/index.htm
@@ -93,7 +93,7 @@
         </div>
 
         <footer>
-            Made by Nelson Daniels <span style="font-size:1rem;vertical-align:middle;">•</span>
+            Made by Nelson G Daniels <span style="font-size:1rem;vertical-align:middle;">•</span>
             <a href="https://github.com/rossvideo/Catena">Catena</a>
         </footer>
     </div>

--- a/sdks/go/examples/oneOfEverything/webui/index.htm
+++ b/sdks/go/examples/oneOfEverything/webui/index.htm
@@ -93,7 +93,7 @@
         </div>
 
         <footer>
-            Made by Nelson G Daniels <span style="font-size:1rem;vertical-align:middle;">•</span>
+            Made by Nelson Daniels <span style="font-size:1rem;vertical-align:middle;">•</span>
             <a href="https://github.com/rossvideo/Catena">Catena</a>
         </footer>
     </div>

--- a/sdks/go/pkg/catena/asset.go
+++ b/sdks/go/pkg/catena/asset.go
@@ -82,9 +82,10 @@ func (e Encoding) String() string {
 	}
 }
 
-// Asset wraps protos.ExternalObjectPayload for asset handling
+// Asset wraps protos.ExternalObjectPayload for asset handling.
+// Proto is the underlying proto message; it may be read or replaced directly.
 type Asset struct {
-	asset *protos.ExternalObjectPayload
+	Proto *protos.ExternalObjectPayload
 }
 
 // DataPayload is a helper type for business logic to create assets
@@ -221,20 +222,13 @@ func dataPayloadFromProto(pdp *protos.DataPayload) (DataPayload, StatusResult) {
 func ToAsset(dp DataPayload, cachable bool) (Asset, StatusResult) {
 	protoPayload, res := dataPayloadToProto(dp)
 	if res.Code != StatusCodeOk {
-		return Asset{asset: nil}, res
+		return Asset{}, res
 	}
 
-	asset := &protos.ExternalObjectPayload{
+	return Asset{Proto: &protos.ExternalObjectPayload{
 		Cachable: cachable,
 		Payload:  protoPayload,
-	}
-
-	return Asset{asset: asset}, StatusResult{Code: StatusCodeOk}
-}
-
-// GetProtoAsset returns the underlying protos.ExternalObjectPayload
-func (ca Asset) GetProtoAsset() *protos.ExternalObjectPayload {
-	return ca.asset
+	}}, StatusResult{Code: StatusCodeOk}
 }
 
 func compressGzipTo(w io.Writer, data []byte) error {
@@ -357,12 +351,11 @@ func PayloadEncodingFromExt(filename string) Encoding {
 // re-encodes it to targetEncoding, modifying the asset in place.
 // If the asset is already in the target encoding, this is a no-op.
 func TranscodeAssetPayload(asset *Asset, targetEncoding Encoding) StatusResult {
-	original := asset.GetProtoAsset()
-	if original == nil || original.GetPayload() == nil {
+	if asset.Proto == nil || asset.Proto.GetPayload() == nil {
 		return StatusResult{Code: StatusCodeInvalidArgument, Error: "asset has no payload"}
 	}
 
-	dp := original.GetPayload()
+	dp := asset.Proto.GetPayload()
 	currentEncoding := Encoding(dp.GetPayloadEncoding())
 
 	if currentEncoding == targetEncoding {
@@ -379,12 +372,12 @@ func TranscodeAssetPayload(asset *Asset, targetEncoding Encoding) StatusResult {
 		return StatusResult{Code: StatusCodeInternal, Error: fmt.Sprintf("encode: %v", err)}
 	}
 
-	cloned := proto.Clone(original).(*protos.ExternalObjectPayload)
+	cloned := proto.Clone(asset.Proto).(*protos.ExternalObjectPayload)
 	cloned.Payload.Kind = &protos.DataPayload_Payload{Payload: encodedData}
 	cloned.Payload.PayloadEncoding = protos.DataPayload_PayloadEncoding(targetEncoding)
 	newDigest := sha256.Sum256(encodedData)
 	cloned.Payload.Digest = newDigest[:]
-	asset.asset = cloned
+	asset.Proto = cloned
 
 	return StatusResult{Code: StatusCodeOk}
 }

--- a/sdks/go/pkg/catena/asset_test.go
+++ b/sdks/go/pkg/catena/asset_test.go
@@ -71,7 +71,7 @@ func TestToAsset_WithPayload(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
-	proto := asset.GetProtoAsset()
+	proto := asset.Proto
 	if proto == nil {
 		t.Fatal("expected non-nil proto asset")
 	}
@@ -104,7 +104,7 @@ func TestToAsset_WithUrl(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
-	proto := asset.GetProtoAsset()
+	proto := asset.Proto
 	if proto == nil {
 		t.Fatal("expected non-nil proto asset")
 	}
@@ -157,7 +157,7 @@ func TestToAsset_WithGzipEncoding(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
-	proto := asset.GetProtoAsset()
+	proto := asset.Proto
 	if proto == nil {
 		t.Fatal("expected non-nil proto asset")
 	}
@@ -182,7 +182,7 @@ func TestToAsset_WithDeflateEncoding(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
-	proto := asset.GetProtoAsset()
+	proto := asset.Proto
 	payload := proto.GetPayload()
 	if Encoding(payload.GetPayloadEncoding()) != EncodingDeflate {
 		t.Errorf("expected DEFLATE encoding, got %v", payload.GetPayloadEncoding())
@@ -190,8 +190,8 @@ func TestToAsset_WithDeflateEncoding(t *testing.T) {
 }
 
 func TestAsset_GetProtoAsset_Nil(t *testing.T) {
-	asset := Asset{asset: nil}
-	if asset.GetProtoAsset() != nil {
+	asset := Asset{Proto: nil}
+	if asset.Proto != nil {
 		t.Error("expected nil proto asset")
 	}
 }
@@ -208,7 +208,7 @@ func TestToAsset_WithDigest(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
-	proto := asset.GetProtoAsset()
+	proto := asset.Proto
 	payload := proto.GetPayload()
 
 	if payload.GetDigest() == nil {
@@ -236,7 +236,7 @@ func TestToAsset_EmptyPayload_WithUrl(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", err.Error)
 	}
 
-	proto := asset.GetProtoAsset()
+	proto := asset.Proto
 	payload := proto.GetPayload()
 	if payload.GetUrl() != "https://example.com/data" {
 		t.Errorf("expected URL, got %v", payload.GetUrl())
@@ -645,7 +645,7 @@ func TestTranscodeAssetPayload(t *testing.T) {
 	if res := TranscodeAssetPayload(&asset, EncodingGzip); res.Code != StatusCodeOk {
 		t.Fatalf("TranscodeAssetPayload to GZIP: %v", res.Error)
 	}
-	proto := asset.GetProtoAsset().GetPayload()
+	proto := asset.Proto.GetPayload()
 	if Encoding(proto.GetPayloadEncoding()) != EncodingGzip {
 		t.Errorf("expected GZIP encoding, got %v", proto.GetPayloadEncoding())
 	}
@@ -663,7 +663,7 @@ func TestTranscodeAssetPayload(t *testing.T) {
 	if res := TranscodeAssetPayload(&asset, EncodingDeflate); res.Code != StatusCodeOk {
 		t.Fatalf("TranscodeAssetPayload GZIP→DEFLATE: %v", res.Error)
 	}
-	proto = asset.GetProtoAsset().GetPayload()
+	proto = asset.Proto.GetPayload()
 	if Encoding(proto.GetPayloadEncoding()) != EncodingDeflate {
 		t.Errorf("expected DEFLATE encoding, got %v", proto.GetPayloadEncoding())
 	}
@@ -679,7 +679,7 @@ func TestTranscodeAssetPayload(t *testing.T) {
 	if res := TranscodeAssetPayload(&asset, EncodingUncompressed); res.Code != StatusCodeOk {
 		t.Fatalf("TranscodeAssetPayload DEFLATE→UNCOMPRESSED: %v", res.Error)
 	}
-	proto = asset.GetProtoAsset().GetPayload()
+	proto = asset.Proto.GetPayload()
 	if Encoding(proto.GetPayloadEncoding()) != EncodingUncompressed {
 		t.Errorf("expected UNCOMPRESSED encoding, got %v", proto.GetPayloadEncoding())
 	}
@@ -697,8 +697,8 @@ func TestTranscodeAssetPayload_RecomputesDigest(t *testing.T) {
 		t.Fatalf("ToAsset: %v", err.Error)
 	}
 
-	originalDigest := make([]byte, len(asset.GetProtoAsset().GetPayload().GetDigest()))
-	copy(originalDigest, asset.GetProtoAsset().GetPayload().GetDigest())
+	originalDigest := make([]byte, len(asset.Proto.GetPayload().GetDigest()))
+	copy(originalDigest, asset.Proto.GetPayload().GetDigest())
 	expectedOriginal := sha256.Sum256(original)
 	if len(originalDigest) != len(expectedOriginal) {
 		t.Fatalf("original digest length %d, want %d", len(originalDigest), len(expectedOriginal[:]))
@@ -713,9 +713,9 @@ func TestTranscodeAssetPayload_RecomputesDigest(t *testing.T) {
 		t.Fatalf("TranscodeAssetPayload to GZIP: %v", res.Error)
 	}
 
-	newPayloadBytes := asset.GetProtoAsset().GetPayload().GetPayload()
+	newPayloadBytes := asset.Proto.GetPayload().GetPayload()
 	expectedDigest := sha256.Sum256(newPayloadBytes)
-	actualDigest := asset.GetProtoAsset().GetPayload().GetDigest()
+	actualDigest := asset.Proto.GetPayload().GetDigest()
 
 	if len(actualDigest) != sha256.Size {
 		t.Fatalf("digest length after transcode = %d, want %d", len(actualDigest), sha256.Size)
@@ -739,12 +739,12 @@ func TestTranscodeAssetPayload_SameEncoding_Noop(t *testing.T) {
 		Payload: []byte("data"),
 	}
 	asset, _ := ToAsset(dp, true)
-	originalBytes := asset.GetProtoAsset().GetPayload().GetPayload()
+	originalBytes := asset.Proto.GetPayload().GetPayload()
 
 	if res := TranscodeAssetPayload(&asset, EncodingUncompressed); res.Code != StatusCodeOk {
 		t.Fatalf("TranscodeAssetPayload same encoding: %v", res.Error)
 	}
-	if string(asset.GetProtoAsset().GetPayload().GetPayload()) != string(originalBytes) {
+	if string(asset.Proto.GetPayload().GetPayload()) != string(originalBytes) {
 		t.Error("expected no-op when transcoding to same encoding")
 	}
 }
@@ -760,7 +760,7 @@ func TestTranscodeAssetPayload_DoesNotMutateOriginalProto(t *testing.T) {
 		t.Fatalf("ToAsset: %v", err.Error)
 	}
 
-	originalProto := asset.GetProtoAsset()
+	originalProto := asset.Proto
 
 	copy := asset // shallow copy — shares the pointer
 	if res := TranscodeAssetPayload(&copy, EncodingGzip); res.Code != StatusCodeOk {
@@ -776,7 +776,7 @@ func TestTranscodeAssetPayload_DoesNotMutateOriginalProto(t *testing.T) {
 			originalProto.GetPayload().GetPayload(), original)
 	}
 
-	if copy.GetProtoAsset() == originalProto {
+	if copy.Proto == originalProto {
 		t.Error("transcoded asset should point to a different proto, not the original")
 	}
 }
@@ -790,7 +790,7 @@ func TestTranscodeAssetPayload_NilAsset(t *testing.T) {
 }
 
 func TestTranscodeAssetPayload_NilPayload(t *testing.T) {
-	asset := Asset{asset: &protos.ExternalObjectPayload{Payload: nil}}
+	asset := Asset{Proto: &protos.ExternalObjectPayload{Payload: nil}}
 	err := TranscodeAssetPayload(&asset, EncodingGzip)
 	if err.Code == StatusCodeOk {
 		t.Error("expected error for nil payload on non-nil asset")

--- a/sdks/go/pkg/catena/command.go
+++ b/sdks/go/pkg/catena/command.go
@@ -44,39 +44,32 @@ import (
 
 // CommandResult wraps protos.CommandResponse, representing the three possible
 // outcomes of ExecuteCommand: no_response, response, or exception.
+// Proto is the underlying proto message; it may be read or replaced directly.
 type CommandResult struct {
-	response *protos.CommandResponse
+	Proto *protos.CommandResponse
 }
 
 // IsEmpty returns true if this is a no_response result.
 func (r CommandResult) IsEmpty() bool {
-	return r.response == nil || r.response.GetNoResponse() != nil
+	return r.Proto == nil || r.Proto.GetNoResponse() != nil
 }
 
 // IsException returns true if this is an exception result.
 func (r CommandResult) IsException() bool {
-	return r.response != nil && r.response.GetException() != nil
+	return r.Proto != nil && r.Proto.GetException() != nil
 }
 
 // GetException returns the underlying proto Exception.
 // Only valid when IsException() is true.
 func (r CommandResult) GetException() *protos.Exception {
-	if r.response != nil {
-		return r.response.GetException()
-	}
-	return nil
-}
-
-// GetProtoResponse returns the underlying protos.CommandResponse.
-func (r CommandResult) GetProtoResponse() *protos.CommandResponse {
-	return r.response
+	return r.Proto.GetException()
 }
 
 // CommandReply returns a successful command response wrapping a value.
 func CommandReply(value Value) (CommandResult, StatusResult) {
 	return CommandResult{
-		response: &protos.CommandResponse{
-			Kind: &protos.CommandResponse_Response{Response: value.Value},
+		Proto: &protos.CommandResponse{
+			Kind: &protos.CommandResponse_Response{Response: value.Proto},
 		},
 	}, StatusResult{Code: StatusCodeOk}
 }
@@ -84,7 +77,7 @@ func CommandReply(value Value) (CommandResult, StatusResult) {
 // CommandNoResponse returns an empty command response (no_response).
 func CommandNoResponse() (CommandResult, StatusResult) {
 	return CommandResult{
-		response: &protos.CommandResponse{
+		Proto: &protos.CommandResponse{
 			Kind: &protos.CommandResponse_NoResponse{NoResponse: &protos.Empty{}},
 		},
 	}, StatusResult{Code: StatusCodeOk}
@@ -102,7 +95,7 @@ func CommandExceptionResult(exType, details string, errorMessage PolyglotText) (
 		exc.ErrorMessage = &protos.PolyglotText{DisplayStrings: errorMessage}
 	}
 	return CommandResult{
-		response: &protos.CommandResponse{
+		Proto: &protos.CommandResponse{
 			Kind: &protos.CommandResponse_Exception{Exception: exc},
 		},
 	}, StatusResult{Code: StatusCodeOk}

--- a/sdks/go/pkg/catena/command_test.go
+++ b/sdks/go/pkg/catena/command_test.go
@@ -58,7 +58,7 @@ func TestCommandReply(t *testing.T) {
 		t.Error("expected non-exception result")
 	}
 
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 	resp := proto.GetResponse()
 	if resp == nil {
 		t.Fatal("expected response in proto")
@@ -81,7 +81,7 @@ func TestCommandNoResponse(t *testing.T) {
 		t.Error("expected non-exception result")
 	}
 
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 	if proto.GetNoResponse() == nil {
 		t.Error("expected no_response in proto")
 	}
@@ -119,7 +119,7 @@ func TestCommandExceptionResult(t *testing.T) {
 			exc.GetErrorMessage().GetDisplayStrings()["en"])
 	}
 
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 	protoExc := proto.GetException()
 	if protoExc == nil {
 		t.Fatal("expected exception in proto")
@@ -153,7 +153,7 @@ func TestCommandExceptionResult_MultipleLanguages(t *testing.T) {
 func TestCommandExceptionResult_NilErrorMessage(t *testing.T) {
 	result, _ := CommandExceptionResult("Error", "details", nil)
 
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 	protoExc := proto.GetException()
 	if protoExc == nil {
 		t.Fatal("expected exception in proto")
@@ -179,7 +179,7 @@ func TestCommandError(t *testing.T) {
 
 func TestCommandError_NilResponse(t *testing.T) {
 	result, _ := CommandError(StatusCodeInternal, "error")
-	if result.GetProtoResponse() != nil {
+	if result.Proto != nil {
 		t.Error("expected nil proto response for CommandError")
 	}
 	if result.GetException() != nil {
@@ -190,7 +190,7 @@ func TestCommandError_NilResponse(t *testing.T) {
 func TestCommandResult_GetProtoResponse_Response(t *testing.T) {
 	val, _ := ToValue("hello")
 	result, _ := CommandReply(val)
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 
 	if _, ok := proto.Kind.(*protos.CommandResponse_Response); !ok {
 		t.Errorf("expected CommandResponse_Response, got %T", proto.Kind)
@@ -202,7 +202,7 @@ func TestCommandResult_GetProtoResponse_Response(t *testing.T) {
 
 func TestCommandResult_GetProtoResponse_NoResponse(t *testing.T) {
 	result, _ := CommandNoResponse()
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 
 	if _, ok := proto.Kind.(*protos.CommandResponse_NoResponse); !ok {
 		t.Errorf("expected CommandResponse_NoResponse, got %T", proto.Kind)
@@ -211,7 +211,7 @@ func TestCommandResult_GetProtoResponse_NoResponse(t *testing.T) {
 
 func TestCommandResult_GetProtoResponse_Exception(t *testing.T) {
 	result, _ := CommandExceptionResult("E", "d", NewPolyglotText("fr", "erreur"))
-	proto := result.GetProtoResponse()
+	proto := result.Proto
 
 	if _, ok := proto.Kind.(*protos.CommandResponse_Exception); !ok {
 		t.Errorf("expected CommandResponse_Exception, got %T", proto.Kind)

--- a/sdks/go/pkg/catena/constraint.go
+++ b/sdks/go/pkg/catena/constraint.go
@@ -39,7 +39,6 @@
 package catena
 
 import (
-	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
@@ -47,27 +46,6 @@ import (
 // every constraint kind defined in the protocol.
 type Constraint struct {
 	Proto *protos.Constraint
-}
-
-// ToMap converts a Constraint into the map shape accepted by ToDevice. This is
-// useful when constructing device["constraints"] with the SDK's Constraint builders.
-func (c *Constraint) ToMap() map[string]any {
-	if c == nil || c.Proto == nil {
-		logger.Error("Constraint.ToMap: nil Constraint")
-		return map[string]any{}
-	}
-
-	definition, err := protoMessageToMap("Constraint.ToMap", c.Proto)
-	if err != nil {
-		logger.Error("Constraint.ToMap: failed to convert constraint", "error", err)
-		return map[string]any{}
-	}
-	normalizeConstraintMap(definition, c.Proto)
-	return definition
-}
-
-func normalizeConstraintMap(definition map[string]any, constraint *protos.Constraint) {
-	definition["type"] = constraint.GetType()
 }
 
 // --- Input types for constraint builders ---

--- a/sdks/go/pkg/catena/constraint_test.go
+++ b/sdks/go/pkg/catena/constraint_test.go
@@ -257,29 +257,13 @@ func TestAlarmSeverityConstants(t *testing.T) {
 	}
 }
 
-func TestConstraintToMap_ForDeviceDefinition(t *testing.T) {
+func TestDevice_WithSharedConstraint(t *testing.T) {
 	constraint := NewConstraintStringChoice(true, "SDI", "HDMI", "IP")
 
-	definition := constraint.ToMap()
-	if got, want := definition["type"], protos.Constraint_STRING_CHOICE; got != want {
-		t.Fatalf("expected type %v, got %v", want, got)
-	}
-	if _, ok := definition["string_choice"].(map[string]any); !ok {
-		t.Fatalf("expected string_choice definition, got %#v", definition["string_choice"])
-	}
+	device := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithConstraint("input_source", constraint)
 
-	device, err := ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"constraints": map[string]any{
-			"input_source": definition,
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice with Constraint.ToMap output error: %v", err)
-	}
-
-	stringChoice := device.GetProtoDevice().GetConstraints()["input_source"].GetStringChoice()
+	stringChoice := device.ToProtoDevice().GetConstraints()["input_source"].GetStringChoice()
 	if stringChoice == nil {
 		t.Fatal("expected string_choice constraint")
 	}
@@ -288,19 +272,5 @@ func TestConstraintToMap_ForDeviceDefinition(t *testing.T) {
 	}
 	if got := len(stringChoice.GetChoices()); got != 3 {
 		t.Fatalf("expected 3 choices, got %d", got)
-	}
-}
-
-func TestConstraintToMap_NilConstraint(t *testing.T) {
-	var constraint *Constraint
-	if definition := constraint.ToMap(); len(definition) != 0 {
-		t.Fatalf("expected empty map for nil Constraint, got %#v", definition)
-	}
-}
-
-func TestConstraintToMap_NilProto(t *testing.T) {
-	constraint := &Constraint{}
-	if definition := constraint.ToMap(); len(definition) != 0 {
-		t.Fatalf("expected empty map for Constraint with nil Proto, got %#v", definition)
 	}
 }

--- a/sdks/go/pkg/catena/constraint_test.go
+++ b/sdks/go/pkg/catena/constraint_test.go
@@ -256,21 +256,3 @@ func TestAlarmSeverityConstants(t *testing.T) {
 		}
 	}
 }
-
-func TestDevice_WithSharedConstraint(t *testing.T) {
-	constraint := NewConstraintStringChoice(true, "SDI", "HDMI", "IP")
-
-	device := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
-		WithConstraint("input_source", constraint)
-
-	stringChoice := device.ToProtoDevice().GetConstraints()["input_source"].GetStringChoice()
-	if stringChoice == nil {
-		t.Fatal("expected string_choice constraint")
-	}
-	if !stringChoice.GetStrict() {
-		t.Fatal("expected strict string choice")
-	}
-	if got := len(stringChoice.GetChoices()); got != 3 {
-		t.Fatalf("expected 3 choices, got %d", got)
-	}
-}

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -40,12 +40,10 @@
 package catena
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
@@ -63,52 +61,154 @@ const (
 	DetailLevelUnset         DetailLevel = protos.Device_UNSET
 )
 
-// Device wraps protos.Device for device model handling
+// SDKVersion is the Catena Go SDK version reported in the device's mandatory
+// product struct (the "catena_sdk_version" field).
+const SDKVersion = "1.0.0"
+
+// CatenaSDKURL identifies the Catena SDK in the device's mandatory product
+// struct (the "catena_sdk" field).
+const CatenaSDKURL = "https://github.com/rossvideo/Catena"
+
+// Device wraps protos.Device and exposes a fluent builder API.
 type Device struct {
 	device *protos.Device
 }
 
-// ToDevice converts a Go map/struct to Device
-// This allows developers to work with native Go types and convert to the protobuf format
-func ToDevice(m map[string]any) (Device, error) {
-	device, err := toProtoDevice(m)
-	if err != nil {
-		return Device{}, fmt.Errorf("ToDevice: %w", err)
-	}
-	return Device{device: device}, nil
+// NewDevice creates a Device for the given slot and seeds the mandatory
+// "product" struct param with the supplied identity fields. The product param
+// is read-only and scoped to st2138:mon. Additional fields are populated with
+// the chainable With* methods.
+func NewDevice(slot uint16, name, vendor, version, serialNumber string) *Device {
+	cd := &Device{device: &protos.Device{}}
+	cd.device.Slot = uint32(slot)
+	cd.WithParam("product",
+		NewParamStruct().
+			WithReadOnly(true).
+			WithAccessScope(ScopeMon).
+			WithParam("name", NewParamString(name)).
+			WithParam("vendor", NewParamString(vendor)).
+			WithParam("version", NewParamString(version)).
+			WithParam("serial_number", NewParamString(serialNumber)).
+			WithParam("catena_sdk_version", NewParamString(SDKVersion)).
+			WithParam("catena_sdk", NewParamString(CatenaSDKURL)))
+	return cd
 }
 
-// toProtoDevice converts native Go types to protos.Device
-// For complex nested types (params, constraints, etc.), uses JSON marshaling
-// to leverage protojson's automatic conversion and validation
-func toProtoDevice(m map[string]any) (*protos.Device, error) {
-	jsonData, err := json.Marshal(m)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal map to JSON: %w", err)
+// WithParam inserts param into the device's params map, keyed by oid. The
+// param's proto is deep-copied so later builder mutations on the caller's Param
+// do not affect entries already added. A nil param is ignored.
+func (cd *Device) WithParam(oid string, param *Param) *Device {
+	if param == nil || param.Proto == nil {
+		logger.Warning("Device.WithParam called with nil param; ignoring", "oid", oid)
+		return cd
 	}
-
-	device := &protos.Device{}
-	if err := protojson.Unmarshal(jsonData, device); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON to Device proto: %w", err)
+	if cd.device.Params == nil {
+		cd.device.Params = map[string]*protos.Param{}
 	}
-
-	return device, nil
+	cd.device.Params[oid] = proto.Clone(param.Proto).(*protos.Param)
+	return cd
 }
 
-func protoMessageToMap(context string, msg proto.Message) (map[string]any, error) {
-	jsonData, err := protojson.MarshalOptions{UseProtoNames: true}.Marshal(msg)
-	if err != nil {
-		return nil, fmt.Errorf("%s: marshal proto: %w", context, err)
+// WithCommand inserts command into the device's commands map, keyed by oid. The
+// command's proto is deep-copied. A nil command is ignored.
+func (cd *Device) WithCommand(oid string, command *Param) *Device {
+	if command == nil || command.Proto == nil {
+		logger.Warning("Device.WithCommand called with nil command; ignoring", "oid", oid)
+		return cd
 	}
-
-	var definition map[string]any
-	if err := json.Unmarshal(jsonData, &definition); err != nil {
-		return nil, fmt.Errorf("%s: unmarshal map: %w", context, err)
+	if cd.device.Commands == nil {
+		cd.device.Commands = map[string]*protos.Param{}
 	}
-	return definition, nil
+	cd.device.Commands[oid] = proto.Clone(command.Proto).(*protos.Param)
+	return cd
 }
 
-// GetProtoDevice returns the underlying protos.Device
-func (cd Device) GetProtoDevice() *protos.Device {
+// WithConstraint inserts a shared constraint into the device's constraints map,
+// keyed by oid. The constraint's proto is deep-copied. A nil constraint is
+// ignored. Params can reference shared constraints via NewConstraintRefOid.
+func (cd *Device) WithConstraint(oid string, constraint *Constraint) *Device {
+	if constraint == nil || constraint.Proto == nil {
+		logger.Warning("Device.WithConstraint called with nil constraint; ignoring", "oid", oid)
+		return cd
+	}
+	if cd.device.Constraints == nil {
+		cd.device.Constraints = map[string]*protos.Constraint{}
+	}
+	cd.device.Constraints[oid] = proto.Clone(constraint.Proto).(*protos.Constraint)
+	return cd
+}
+
+// WithMenuGroup inserts a menu group into the device's menu_groups map, keyed
+// by oid. The group's proto is deep-copied. A nil group is ignored.
+func (cd *Device) WithMenuGroup(oid string, group *MenuGroup) *Device {
+	if group == nil || group.Proto == nil {
+		logger.Warning("Device.WithMenuGroup called with nil menu group; ignoring", "oid", oid)
+		return cd
+	}
+	if cd.device.MenuGroups == nil {
+		cd.device.MenuGroups = map[string]*protos.MenuGroup{}
+	}
+	cd.device.MenuGroups[oid] = proto.Clone(group.Proto).(*protos.MenuGroup)
+	return cd
+}
+
+// WithLanguagePack inserts a language pack into the device's language_packs map,
+// keyed by language code (e.g. "en"). Replaces any existing pack at that code.
+func (cd *Device) WithLanguagePack(code, name string, words map[string]string) *Device {
+	if cd.device.LanguagePacks == nil {
+		cd.device.LanguagePacks = &protos.LanguagePacks{}
+	}
+	if cd.device.LanguagePacks.Packs == nil {
+		cd.device.LanguagePacks.Packs = map[string]*protos.LanguagePack{}
+	}
+	copied := make(map[string]string, len(words))
+	for k, v := range words {
+		copied[k] = v
+	}
+	cd.device.LanguagePacks.Packs[code] = &protos.LanguagePack{
+		Name:  name,
+		Words: copied,
+	}
+	return cd
+}
+
+// WithDetailLevel sets how much of the device model to deliver.
+func (cd *Device) WithDetailLevel(level DetailLevel) *Device {
+	cd.device.DetailLevel = level
+	return cd
+}
+
+// WithMultiSetEnabled sets whether the device supports multi-set requests.
+func (cd *Device) WithMultiSetEnabled(enabled bool) *Device {
+	cd.device.MultiSetEnabled = enabled
+	return cd
+}
+
+// WithSubscriptions sets whether the device supports subscriptions.
+func (cd *Device) WithSubscriptions(subscriptions bool) *Device {
+	cd.device.Subscriptions = subscriptions
+	return cd
+}
+
+// WithAccessScopes sets the device's access scopes, replacing any existing ones.
+func (cd *Device) WithAccessScopes(scopes ...string) *Device {
+	cd.device.AccessScopes = scopes
+	return cd
+}
+
+// WithDefaultScope sets the device's default access scope.
+func (cd *Device) WithDefaultScope(scope string) *Device {
+	cd.device.DefaultScope = scope
+	return cd
+}
+
+// ToProtoDevice returns the underlying protos.Device for gRPC responses.
+func (cd Device) ToProtoDevice() *protos.Device {
 	return cd.device
+}
+
+// ToJSON serializes the device to its REST JSON representation using proto
+// field names.
+func (cd Device) ToJSON() ([]byte, error) {
+	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(cd.device)
 }

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -40,6 +40,8 @@
 package catena
 
 import (
+	"runtime/debug"
+
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -61,9 +63,38 @@ const (
 	DetailLevelUnset         DetailLevel = protos.Device_UNSET
 )
 
+// sdkModulePath is the SDK's Go module path, used to locate the SDK's resolved
+// version in the running binary's build info.
+const sdkModulePath = "github.com/rossvideo/catena/sdks/go"
+
 // SDKVersion is the Catena Go SDK version reported in the SDK-managed product
-// struct (the "catena_sdk_version" field).
-const SDKVersion = "1.0.0"
+// struct (the "catena_sdk_version" field). It is resolved at startup from the
+// binary's build info (the git tag or pseudo-version Go recorded for the SDK
+// module), so it stays accurate without a hand-maintained constant.
+var SDKVersion = sdkVersion()
+
+// sdkVersion resolves the SDK's version from the running binary's build info.
+// It returns the version Go recorded for the SDK module, falling back to
+// "(devel)" for unversioned local builds and "(unknown)" when build info is
+// unavailable.
+func sdkVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "(unknown)"
+	}
+	// When the SDK is imported as a dependency, its resolved version lives in
+	// Deps. When the SDK module is itself the main module (e.g. running its own
+	// tests or examples), the version lives on Main instead.
+	if bi.Main.Path == sdkModulePath && bi.Main.Version != "" {
+		return bi.Main.Version
+	}
+	for _, d := range bi.Deps {
+		if d.Path == sdkModulePath {
+			return d.Version // resolved from the git tag / pseudo-version
+		}
+	}
+	return "(devel)"
+}
 
 // CatenaSDKURL identifies the Catena SDK in the SDK-managed product struct (the
 // "catena_sdk" field).

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -40,8 +40,6 @@
 package catena
 
 import (
-	"runtime/debug"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
@@ -61,43 +59,6 @@ const (
 	DetailLevelNone          DetailLevel = protos.Device_NONE
 	DetailLevelUnset         DetailLevel = protos.Device_UNSET
 )
-
-// sdkModulePath is the SDK's Go module path, used to locate the SDK's resolved
-// version in the running binary's build info.
-const sdkModulePath = "github.com/rossvideo/catena/sdks/go"
-
-// SDKVersion is the Catena Go SDK version reported in the SDK-managed product
-// struct (the "catena_sdk_version" field). It is resolved at startup from the
-// binary's build info (the git tag or pseudo-version Go recorded for the SDK
-// module), so it stays accurate without a hand-maintained constant.
-var SDKVersion = sdkVersion()
-
-// sdkVersion resolves the SDK's version from the running binary's build info.
-// It returns the version Go recorded for the SDK module, falling back to
-// "(devel)" for unversioned local builds and "(unknown)" when build info is
-// unavailable.
-func sdkVersion() string {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "(unknown)"
-	}
-	// When the SDK is imported as a dependency, its resolved version lives in
-	// Deps. When the SDK module is itself the main module (e.g. running its own
-	// tests or examples), the version lives on Main instead.
-	if bi.Main.Path == sdkModulePath && bi.Main.Version != "" {
-		return bi.Main.Version
-	}
-	for _, d := range bi.Deps {
-		if d.Path == sdkModulePath {
-			return d.Version // resolved from the git tag / pseudo-version
-		}
-	}
-	return "(devel)"
-}
-
-// CatenaSDKURL identifies the Catena SDK in the SDK-managed product struct (the
-// "catena_sdk" field).
-const CatenaSDKURL = "https://github.com/rossvideo/Catena"
 
 // Device wraps protos.Device and exposes a fluent builder API.
 // Proto is the underlying proto message; it may be read or replaced directly.

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -81,16 +81,12 @@ type Device struct {
 func NewDevice(slot uint16, name, vendor, version, serialNumber string) *Device {
 	cd := &Device{device: &protos.Device{}}
 	cd.device.Slot = uint32(slot)
-	cd.WithParam("product",
-		NewParamStruct().
-			WithReadOnly(true).
-			WithAccessScope(ScopeMon).
-			WithParam("name", NewParamString(name)).
-			WithParam("vendor", NewParamString(vendor)).
-			WithParam("version", NewParamString(version)).
-			WithParam("serial_number", NewParamString(serialNumber)).
-			WithParam("catena_sdk_version", NewParamString(SDKVersion)).
-			WithParam("catena_sdk", NewParamString(CatenaSDKURL)))
+	cd.WithParam("product", ProductParam(Product{
+		Name:         name,
+		Vendor:       vendor,
+		Version:      version,
+		SerialNumber: serialNumber,
+	}))
 	return cd
 }
 

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -70,8 +70,9 @@ const SDKVersion = "1.0.0"
 const CatenaSDKURL = "https://github.com/rossvideo/Catena"
 
 // Device wraps protos.Device and exposes a fluent builder API.
+// Proto is the underlying proto message; it may be read or replaced directly.
 type Device struct {
-	device *protos.Device
+	Proto *protos.Device
 }
 
 // NewDevice creates an empty Device for the given slot. Params, commands,
@@ -82,7 +83,7 @@ type Device struct {
 // GetDevice and serves it on GetValue / ParamInfo. NewDevice does not deal with
 // the product struct.
 func NewDevice(slot uint16) *Device {
-	return &Device{device: &protos.Device{Slot: uint32(slot)}}
+	return &Device{Proto: &protos.Device{Slot: uint32(slot)}}
 }
 
 // WithParam inserts param into the device's params map, keyed by oid. The
@@ -93,10 +94,10 @@ func (cd *Device) WithParam(oid string, param *Param) *Device {
 		logger.Warning("Device.WithParam called with nil param; ignoring", "oid", oid)
 		return cd
 	}
-	if cd.device.Params == nil {
-		cd.device.Params = map[string]*protos.Param{}
+	if cd.Proto.Params == nil {
+		cd.Proto.Params = map[string]*protos.Param{}
 	}
-	cd.device.Params[oid] = proto.Clone(param.Proto).(*protos.Param)
+	cd.Proto.Params[oid] = proto.Clone(param.Proto).(*protos.Param)
 	return cd
 }
 
@@ -107,10 +108,10 @@ func (cd *Device) WithCommand(oid string, command *Param) *Device {
 		logger.Warning("Device.WithCommand called with nil command; ignoring", "oid", oid)
 		return cd
 	}
-	if cd.device.Commands == nil {
-		cd.device.Commands = map[string]*protos.Param{}
+	if cd.Proto.Commands == nil {
+		cd.Proto.Commands = map[string]*protos.Param{}
 	}
-	cd.device.Commands[oid] = proto.Clone(command.Proto).(*protos.Param)
+	cd.Proto.Commands[oid] = proto.Clone(command.Proto).(*protos.Param)
 	return cd
 }
 
@@ -122,10 +123,10 @@ func (cd *Device) WithConstraint(oid string, constraint *Constraint) *Device {
 		logger.Warning("Device.WithConstraint called with nil constraint; ignoring", "oid", oid)
 		return cd
 	}
-	if cd.device.Constraints == nil {
-		cd.device.Constraints = map[string]*protos.Constraint{}
+	if cd.Proto.Constraints == nil {
+		cd.Proto.Constraints = map[string]*protos.Constraint{}
 	}
-	cd.device.Constraints[oid] = proto.Clone(constraint.Proto).(*protos.Constraint)
+	cd.Proto.Constraints[oid] = proto.Clone(constraint.Proto).(*protos.Constraint)
 	return cd
 }
 
@@ -136,27 +137,27 @@ func (cd *Device) WithMenuGroup(oid string, group *MenuGroup) *Device {
 		logger.Warning("Device.WithMenuGroup called with nil menu group; ignoring", "oid", oid)
 		return cd
 	}
-	if cd.device.MenuGroups == nil {
-		cd.device.MenuGroups = map[string]*protos.MenuGroup{}
+	if cd.Proto.MenuGroups == nil {
+		cd.Proto.MenuGroups = map[string]*protos.MenuGroup{}
 	}
-	cd.device.MenuGroups[oid] = proto.Clone(group.Proto).(*protos.MenuGroup)
+	cd.Proto.MenuGroups[oid] = proto.Clone(group.Proto).(*protos.MenuGroup)
 	return cd
 }
 
 // WithLanguagePack inserts a language pack into the device's language_packs map,
 // keyed by language code (e.g. "en"). Replaces any existing pack at that code.
 func (cd *Device) WithLanguagePack(code, name string, words map[string]string) *Device {
-	if cd.device.LanguagePacks == nil {
-		cd.device.LanguagePacks = &protos.LanguagePacks{}
+	if cd.Proto.LanguagePacks == nil {
+		cd.Proto.LanguagePacks = &protos.LanguagePacks{}
 	}
-	if cd.device.LanguagePacks.Packs == nil {
-		cd.device.LanguagePacks.Packs = map[string]*protos.LanguagePack{}
+	if cd.Proto.LanguagePacks.Packs == nil {
+		cd.Proto.LanguagePacks.Packs = map[string]*protos.LanguagePack{}
 	}
 	copied := make(map[string]string, len(words))
 	for k, v := range words {
 		copied[k] = v
 	}
-	cd.device.LanguagePacks.Packs[code] = &protos.LanguagePack{
+	cd.Proto.LanguagePacks.Packs[code] = &protos.LanguagePack{
 		Name:  name,
 		Words: copied,
 	}
@@ -165,41 +166,36 @@ func (cd *Device) WithLanguagePack(code, name string, words map[string]string) *
 
 // WithDetailLevel sets how much of the device model to deliver.
 func (cd *Device) WithDetailLevel(level DetailLevel) *Device {
-	cd.device.DetailLevel = level
+	cd.Proto.DetailLevel = level
 	return cd
 }
 
 // WithMultiSetEnabled sets whether the device supports multi-set requests.
 func (cd *Device) WithMultiSetEnabled(enabled bool) *Device {
-	cd.device.MultiSetEnabled = enabled
+	cd.Proto.MultiSetEnabled = enabled
 	return cd
 }
 
 // WithSubscriptions sets whether the device supports subscriptions.
 func (cd *Device) WithSubscriptions(subscriptions bool) *Device {
-	cd.device.Subscriptions = subscriptions
+	cd.Proto.Subscriptions = subscriptions
 	return cd
 }
 
 // WithAccessScopes sets the device's access scopes, replacing any existing ones.
 func (cd *Device) WithAccessScopes(scopes ...string) *Device {
-	cd.device.AccessScopes = scopes
+	cd.Proto.AccessScopes = scopes
 	return cd
 }
 
 // WithDefaultScope sets the device's default access scope.
 func (cd *Device) WithDefaultScope(scope string) *Device {
-	cd.device.DefaultScope = scope
+	cd.Proto.DefaultScope = scope
 	return cd
-}
-
-// ToProtoDevice returns the underlying protos.Device for gRPC responses.
-func (cd Device) ToProtoDevice() *protos.Device {
-	return cd.device
 }
 
 // ToJSON serializes the device to its REST JSON representation using proto
 // field names.
 func (cd Device) ToJSON() ([]byte, error) {
-	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(cd.device)
+	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(cd.Proto)
 }

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -42,7 +42,6 @@ package catena
 import (
 	"runtime/debug"
 
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
@@ -223,10 +222,4 @@ func (cd *Device) WithAccessScopes(scopes ...string) *Device {
 func (cd *Device) WithDefaultScope(scope string) *Device {
 	cd.Proto.DefaultScope = scope
 	return cd
-}
-
-// ToJSON serializes the device to its REST JSON representation using proto
-// field names.
-func (cd Device) ToJSON() ([]byte, error) {
-	return protojson.MarshalOptions{UseProtoNames: true}.Marshal(cd.Proto)
 }

--- a/sdks/go/pkg/catena/device.go
+++ b/sdks/go/pkg/catena/device.go
@@ -61,12 +61,12 @@ const (
 	DetailLevelUnset         DetailLevel = protos.Device_UNSET
 )
 
-// SDKVersion is the Catena Go SDK version reported in the device's mandatory
-// product struct (the "catena_sdk_version" field).
+// SDKVersion is the Catena Go SDK version reported in the SDK-managed product
+// struct (the "catena_sdk_version" field).
 const SDKVersion = "1.0.0"
 
-// CatenaSDKURL identifies the Catena SDK in the device's mandatory product
-// struct (the "catena_sdk" field).
+// CatenaSDKURL identifies the Catena SDK in the SDK-managed product struct (the
+// "catena_sdk" field).
 const CatenaSDKURL = "https://github.com/rossvideo/Catena"
 
 // Device wraps protos.Device and exposes a fluent builder API.
@@ -74,20 +74,15 @@ type Device struct {
 	device *protos.Device
 }
 
-// NewDevice creates a Device for the given slot and seeds the mandatory
-// "product" struct param with the supplied identity fields. The product param
-// is read-only and scoped to st2138:mon. Additional fields are populated with
-// the chainable With* methods.
-func NewDevice(slot uint16, name, vendor, version, serialNumber string) *Device {
-	cd := &Device{device: &protos.Device{}}
-	cd.device.Slot = uint32(slot)
-	cd.WithParam("product", ProductParam(Product{
-		Name:         name,
-		Vendor:       vendor,
-		Version:      version,
-		SerialNumber: serialNumber,
-	}))
-	return cd
+// NewDevice creates an empty Device for the given slot. Params, commands,
+// constraints, and menus are attached with the chainable With* methods.
+//
+// The mandatory "product" struct is managed by the SDK: register it once with
+// Server.RegisterProductStruct and the SDK injects it into the device on
+// GetDevice and serves it on GetValue / ParamInfo. NewDevice does not deal with
+// the product struct.
+func NewDevice(slot uint16) *Device {
+	return &Device{device: &protos.Device{Slot: uint32(slot)}}
 }
 
 // WithParam inserts param into the device's params map, keyed by oid. The

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -40,98 +40,106 @@ package catena
 
 import (
 	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-func TestToDevice_Basic(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-	}
-
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	if cd.GetProtoDevice() == nil {
-		t.Error("expected non-nil proto device")
-	}
-}
-
-func TestToDevice_WithParams(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"params": map[string]any{
-			"brightness": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Brightness",
-					},
-				},
-				"type":      ParamTypeInt32,
-				"read_only": false,
-				"widget":    "SLIDER",
-			},
-		},
-	}
-
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	proto := cd.GetProtoDevice()
+func TestNewDevice_Basic(t *testing.T) {
+	cd := NewDevice(3, "Camera", "Ross Video", "1.0", "SN-12345")
+	proto := cd.ToProtoDevice()
 	if proto == nil {
 		t.Fatal("expected non-nil proto device")
 	}
-
-	// Check that params were converted
-	params := proto.GetParams()
-	if params == nil {
-		t.Fatal("expected params to be set")
+	if proto.GetSlot() != 3 {
+		t.Errorf("expected slot 3, got %v", proto.GetSlot())
 	}
-	brightness, ok := params["brightness"]
+
+	product, ok := proto.GetParams()["product"]
+	if !ok {
+		t.Fatal("expected mandatory 'product' param")
+	}
+	if product.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected product to be a STRUCT param, got %v", product.GetType())
+	}
+	if !product.GetReadOnly() {
+		t.Error("expected product param to be read-only")
+	}
+	if product.GetAccessScope() != ScopeMon {
+		t.Errorf("expected product access scope %q, got %q", ScopeMon, product.GetAccessScope())
+	}
+
+	subParams := product.GetParams()
+	expected := map[string]string{
+		"name":               "Camera",
+		"vendor":             "Ross Video",
+		"version":            "1.0",
+		"serial_number":      "SN-12345",
+		"catena_sdk_version": SDKVersion,
+		"catena_sdk":         CatenaSDKURL,
+	}
+	for oid, want := range expected {
+		child, ok := subParams[oid]
+		if !ok {
+			t.Fatalf("expected product sub-param %q", oid)
+		}
+		if got := child.GetValue().GetStringValue(); got != want {
+			t.Errorf("product/%s = %q, want %q", oid, got, want)
+		}
+	}
+}
+
+func TestNewDevice_WithParams(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithParam("brightness", NewParamInt32(50).
+			WithName(NewPolyglotText("en", "Brightness")).
+			WithWidget("SLIDER"))
+
+	brightness, ok := cd.ToProtoDevice().GetParams()["brightness"]
 	if !ok {
 		t.Fatal("expected 'brightness' param")
 	}
 	if brightness.GetWidget() != "SLIDER" {
 		t.Errorf("expected widget 'SLIDER', got %v", brightness.GetWidget())
 	}
+	if brightness.GetValue().GetInt32Value() != 50 {
+		t.Errorf("expected value 50, got %v", brightness.GetValue().GetInt32Value())
+	}
 }
 
-func TestToDevice_WithConstraints(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"constraints": map[string]any{
-			"brightness_range": map[string]any{
-				"int32_range": map[string]any{
-					"min_value": int32(0),
-					"max_value": int32(100),
-				},
-			},
-			"input_source_choice": map[string]any{
-				"string_choice": map[string]any{
-					"choices": []string{"SDI", "HDMI", "IP"},
-				},
-			},
-		},
-	}
+func TestDevice_WithParam_DeepCopies(t *testing.T) {
+	param := NewParamInt32(1)
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithParam("counter", param)
 
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	proto := cd.GetProtoDevice()
-	if proto == nil {
-		t.Fatal("expected non-nil proto device")
-	}
+	// Mutating the original param after WithParam must not affect the device.
+	param.WithValue(Value{Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}})
 
-	constraints := proto.GetConstraints()
+	stored := cd.ToProtoDevice().GetParams()["counter"]
+	if stored.GetValue().GetInt32Value() != 1 {
+		t.Errorf("expected stored value to remain 1, got %v", stored.GetValue().GetInt32Value())
+	}
+}
+
+func TestDevice_WithParam_Nil(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithParam("nothing", nil)
+	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
+		t.Error("expected nil param to be ignored")
+	}
+}
+
+func TestDevice_WithConstraints(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithConstraint("brightness_range", NewConstraintInt32Range(0, 100, 1)).
+		WithConstraint("input_source_choice", NewConstraintStringChoice(false, "SDI", "HDMI", "IP"))
+
+	constraints := cd.ToProtoDevice().GetConstraints()
 	if constraints == nil {
 		t.Fatal("expected constraints to be set")
 	}
 
-	// Check int32_range constraint
 	brightnessRange, ok := constraints["brightness_range"]
 	if !ok {
 		t.Fatal("expected 'brightness_range' constraint")
@@ -140,73 +148,28 @@ func TestToDevice_WithConstraints(t *testing.T) {
 	if int32Range == nil {
 		t.Fatal("expected int32_range to be set")
 	}
-	if int32Range.GetMinValue() != 0 {
-		t.Errorf("expected min_value 0, got %v", int32Range.GetMinValue())
-	}
 	if int32Range.GetMaxValue() != 100 {
 		t.Errorf("expected max_value 100, got %v", int32Range.GetMaxValue())
 	}
 
-	// Check string_choice constraint
 	inputChoice, ok := constraints["input_source_choice"]
 	if !ok {
 		t.Fatal("expected 'input_source_choice' constraint")
 	}
-	stringChoice := inputChoice.GetStringChoice()
-	if stringChoice == nil {
-		t.Fatal("expected string_choice to be set")
-	}
-	choices := stringChoice.GetChoices()
-	if len(choices) != 3 {
-		t.Errorf("expected 3 choices, got %d", len(choices))
+	if got := len(inputChoice.GetStringChoice().GetChoices()); got != 3 {
+		t.Errorf("expected 3 choices, got %d", got)
 	}
 }
 
-func TestToDevice_WithLanguagePacks(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"language_packs": map[string]any{
-			"packs": map[string]any{
-				"en": map[string]any{
-					"name": "English",
-					"words": map[string]string{
-						"brightness": "Brightness",
-						"contrast":   "Contrast",
-					},
-				},
-				"fr": map[string]any{
-					"name": "Français",
-					"words": map[string]string{
-						"brightness": "Luminosité",
-						"contrast":   "Contraste",
-					},
-				},
-			},
-		},
-	}
+func TestDevice_WithLanguagePacks(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithLanguagePack("en", "English", map[string]string{"brightness": "Brightness"}).
+		WithLanguagePack("fr", "Français", map[string]string{"brightness": "Luminosité"})
 
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	proto := cd.GetProtoDevice()
-	if proto == nil {
-		t.Fatal("expected non-nil proto device")
-	}
-
-	langPacks := proto.GetLanguagePacks()
-	if langPacks == nil {
-		t.Fatal("expected language_packs to be set")
-	}
-	packs := langPacks.GetPacks()
-	if packs == nil {
-		t.Fatal("expected packs to be set")
-	}
+	packs := cd.ToProtoDevice().GetLanguagePacks().GetPacks()
 	if len(packs) != 2 {
 		t.Errorf("expected 2 language packs, got %d", len(packs))
 	}
-
 	enPack, ok := packs["en"]
 	if !ok {
 		t.Fatal("expected 'en' language pack")
@@ -214,99 +177,38 @@ func TestToDevice_WithLanguagePacks(t *testing.T) {
 	if enPack.GetName() != "English" {
 		t.Errorf("expected name 'English', got %v", enPack.GetName())
 	}
+	if enPack.GetWords()["brightness"] != "Brightness" {
+		t.Errorf("expected word 'Brightness', got %v", enPack.GetWords()["brightness"])
+	}
 }
 
-func TestToDevice_WithMenuGroups(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"menu_groups": map[string]any{
-			"video": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Video Settings",
-					},
-				},
-				"menus": map[string]any{
-					"basic": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Basic",
-							},
-						},
-						"param_oids": []string{"brightness", "contrast"},
-					},
-				},
-			},
-		},
-	}
+func TestDevice_WithMenuGroups(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithMenuGroup("video", NewMenuGroup().
+			WithName(NewPolyglotText("en", "Video Settings")).
+			WithMenu("basic", NewMenu().
+				WithName(NewPolyglotText("en", "Basic")).
+				WithParamOids("brightness", "contrast")))
 
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	proto := cd.GetProtoDevice()
-	if proto == nil {
-		t.Fatal("expected non-nil proto device")
-	}
-
-	menuGroups := proto.GetMenuGroups()
-	if menuGroups == nil {
-		t.Fatal("expected menu_groups to be set")
-	}
-
-	videoGroup, ok := menuGroups["video"]
+	videoGroup, ok := cd.ToProtoDevice().GetMenuGroups()["video"]
 	if !ok {
 		t.Fatal("expected 'video' menu group")
 	}
-
-	menus := videoGroup.GetMenus()
-	if menus == nil {
-		t.Fatal("expected menus to be set")
-	}
-
-	basicMenu, ok := menus["basic"]
+	basicMenu, ok := videoGroup.GetMenus()["basic"]
 	if !ok {
 		t.Fatal("expected 'basic' menu")
 	}
-
-	paramOids := basicMenu.GetParamOids()
-	if len(paramOids) != 2 {
-		t.Errorf("expected 2 param_oids, got %d", len(paramOids))
+	if len(basicMenu.GetParamOids()) != 2 {
+		t.Errorf("expected 2 param_oids, got %d", len(basicMenu.GetParamOids()))
 	}
 }
 
-func TestToDevice_WithCommands(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"commands": map[string]any{
-			"reboot": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Reboot Device",
-					},
-				},
-				"type": ParamTypeEmpty,
-			},
-		},
-	}
+func TestDevice_WithCommands(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithCommand("reboot", NewParamEmpty().
+			WithName(NewPolyglotText("en", "Reboot Device")))
 
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	proto := cd.GetProtoDevice()
-	if proto == nil {
-		t.Fatal("expected non-nil proto device")
-	}
-
-	commands := proto.GetCommands()
-	if commands == nil {
-		t.Fatal("expected commands to be set")
-	}
-
-	reboot, ok := commands["reboot"]
+	reboot, ok := cd.ToProtoDevice().GetCommands()["reboot"]
 	if !ok {
 		t.Fatal("expected 'reboot' command")
 	}
@@ -315,9 +217,51 @@ func TestToDevice_WithCommands(t *testing.T) {
 	}
 }
 
-func TestDevice_GetProtoDevice_Nil(t *testing.T) {
+func TestDevice_ScalarFields(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithDetailLevel(DetailLevelFull).
+		WithMultiSetEnabled(true).
+		WithSubscriptions(true).
+		WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+		WithDefaultScope("st2138:op")
+
+	proto := cd.ToProtoDevice()
+	if !proto.GetMultiSetEnabled() {
+		t.Error("expected multi_set_enabled to be true")
+	}
+	if !proto.GetSubscriptions() {
+		t.Error("expected subscriptions to be true")
+	}
+	if proto.GetDefaultScope() != "st2138:op" {
+		t.Errorf("expected default_scope 'st2138:op', got %v", proto.GetDefaultScope())
+	}
+	if len(proto.GetAccessScopes()) != 4 {
+		t.Errorf("expected 4 access_scopes, got %d", len(proto.GetAccessScopes()))
+	}
+}
+
+func TestDevice_ToJSON(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345")
+	data, err := cd.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty JSON")
+	}
+
+	roundTrip := &protos.Device{}
+	if err := protojson.Unmarshal(data, roundTrip); err != nil {
+		t.Fatalf("failed to unmarshal ToJSON output: %v", err)
+	}
+	if _, ok := roundTrip.GetParams()["product"]; !ok {
+		t.Error("expected 'product' param in ToJSON output")
+	}
+}
+
+func TestDevice_ToProtoDevice_Nil(t *testing.T) {
 	cd := Device{device: nil}
-	if cd.GetProtoDevice() != nil {
+	if cd.ToProtoDevice() != nil {
 		t.Error("expected nil proto device")
 	}
 }
@@ -345,90 +289,32 @@ func TestDetailLevelConstants(t *testing.T) {
 	}
 }
 
-func TestToDevice_CompleteDevice(t *testing.T) {
-	// This test verifies a complete device configuration like the example
-	deviceMap := map[string]any{
-		"slot":              uint32(0),
-		"detail_level":      DetailLevelFull,
-		"multi_set_enabled": true,
-		"subscriptions":     true,
-		"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-		"default_scope":     "st2138:op",
-		"params": map[string]any{
-			"brightness": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Brightness",
-					},
-				},
-				"type": ParamTypeInt32,
-				"constraint": map[string]any{
-					"ref_oid": "brightness_range",
-				},
-				"read_only": false,
-				"widget":    "SLIDER",
-			},
-		},
-		"constraints": map[string]any{
-			"brightness_range": map[string]any{
-				"int32_range": map[string]any{
-					"min_value": int32(0),
-					"max_value": int32(100),
-				},
-			},
-		},
-		"menu_groups": map[string]any{
-			"video": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Video Settings",
-					},
-				},
-				"menus": map[string]any{
-					"basic": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{
-								"en": "Basic",
-							},
-						},
-						"param_oids": []string{"brightness"},
-					},
-				},
-			},
-		},
-		"commands": map[string]any{
-			"reboot": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Reboot Device",
-					},
-				},
-				"type": ParamTypeEmpty,
-			},
-		},
-		"language_packs": map[string]any{
-			"packs": map[string]any{
-				"en": map[string]any{
-					"name": "English",
-					"words": map[string]string{
-						"brightness": "Brightness",
-					},
-				},
-			},
-		},
-	}
+func TestNewDevice_CompleteDevice(t *testing.T) {
+	// This test verifies a complete device configuration like the example.
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithDetailLevel(DetailLevelFull).
+		WithMultiSetEnabled(true).
+		WithSubscriptions(true).
+		WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+		WithDefaultScope("st2138:op").
+		WithParam("brightness", NewParamInt32(50).
+			WithName(NewPolyglotText("en", "Brightness")).
+			WithConstraint(NewConstraintRefOid("brightness_range")).
+			WithWidget("SLIDER")).
+		WithConstraint("brightness_range", NewConstraintInt32Range(0, 100, 1)).
+		WithMenuGroup("video", NewMenuGroup().
+			WithName(NewPolyglotText("en", "Video Settings")).
+			WithMenu("basic", NewMenu().
+				WithName(NewPolyglotText("en", "Basic")).
+				WithParamOids("brightness"))).
+		WithCommand("reboot", NewParamEmpty().
+			WithName(NewPolyglotText("en", "Reboot Device"))).
+		WithLanguagePack("en", "English", map[string]string{"brightness": "Brightness"})
 
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-
-	proto := cd.GetProtoDevice()
+	proto := cd.ToProtoDevice()
 	if proto == nil {
 		t.Fatal("expected non-nil proto device")
 	}
-
-	// Verify key fields
 	if proto.GetSlot() != 0 {
 		t.Errorf("expected slot 0, got %v", proto.GetSlot())
 	}
@@ -441,43 +327,25 @@ func TestToDevice_CompleteDevice(t *testing.T) {
 	if proto.GetDefaultScope() != "st2138:op" {
 		t.Errorf("expected default_scope 'st2138:op', got %v", proto.GetDefaultScope())
 	}
-
-	// Verify access scopes
-	scopes := proto.GetAccessScopes()
-	if len(scopes) != 4 {
-		t.Errorf("expected 4 access_scopes, got %d", len(scopes))
+	if len(proto.GetAccessScopes()) != 4 {
+		t.Errorf("expected 4 access_scopes, got %d", len(proto.GetAccessScopes()))
+	}
+	if proto.GetParams()["brightness"].GetConstraint().GetRefOid() != "brightness_range" {
+		t.Error("expected brightness to reference shared constraint 'brightness_range'")
+	}
+	if proto.GetConstraints()["brightness_range"].GetInt32Range().GetMaxValue() != 100 {
+		t.Error("expected shared brightness_range constraint max 100")
+	}
+	if _, ok := proto.GetCommands()["reboot"]; !ok {
+		t.Error("expected 'reboot' command")
 	}
 }
 
-func TestToDevice_FloatRangeConstraint(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"constraints": map[string]any{
-			"gain_range": map[string]any{
-				"float_range": map[string]any{
-					"min_value": float32(-60.0),
-					"max_value": float32(12.0),
-				},
-			},
-		},
-	}
+func TestDevice_WithFloatRangeConstraint(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithConstraint("gain_range", NewConstraintFloatRange(-60.0, 12.0, 0.5))
 
-	cd, err := ToDevice(deviceMap)
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
-	proto := cd.GetProtoDevice()
-	if proto == nil {
-		t.Fatal("expected non-nil proto device")
-	}
-
-	constraints := proto.GetConstraints()
-	if constraints == nil {
-		t.Fatal("expected constraints to be set")
-	}
-
-	gainRange, ok := constraints["gain_range"]
+	gainRange, ok := cd.ToProtoDevice().GetConstraints()["gain_range"]
 	if !ok {
 		t.Fatal("expected 'gain_range' constraint")
 	}
@@ -490,21 +358,6 @@ func TestToDevice_FloatRangeConstraint(t *testing.T) {
 	}
 	if floatRange.GetMaxValue() != 12.0 {
 		t.Errorf("expected max_value 12.0, got %v", floatRange.GetMaxValue())
-	}
-}
-
-func TestProtoMessageToMap_Param(t *testing.T) {
-	param := NewParamInt32(42).WithName(NewPolyglotText("en", "Brightness")).Proto
-
-	definition, err := protoMessageToMap("test", param)
-	if err != nil {
-		t.Fatalf("protoMessageToMap error: %v", err)
-	}
-	if definition["name"] == nil {
-		t.Fatal("expected param name in map definition")
-	}
-	if definition["value"] == nil {
-		t.Fatal("expected param value in map definition")
 	}
 }
 

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -48,7 +48,7 @@ import (
 
 func TestNewDevice_Basic(t *testing.T) {
 	cd := NewDevice(3)
-	proto := cd.ToProtoDevice()
+	proto := cd.Proto
 	if proto == nil {
 		t.Fatal("expected non-nil proto device")
 	}
@@ -69,7 +69,7 @@ func TestNewDevice_WithParams(t *testing.T) {
 			WithName(NewPolyglotText("en", "Brightness")).
 			WithWidget("SLIDER"))
 
-	brightness, ok := cd.ToProtoDevice().GetParams()["brightness"]
+	brightness, ok := cd.Proto.GetParams()["brightness"]
 	if !ok {
 		t.Fatal("expected 'brightness' param")
 	}
@@ -87,9 +87,9 @@ func TestDevice_WithParam_DeepCopies(t *testing.T) {
 		WithParam("counter", param)
 
 	// Mutating the original param after WithParam must not affect the device.
-	param.WithValue(Value{Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}})
+	param.WithValue(Value{Proto: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 999}}})
 
-	stored := cd.ToProtoDevice().GetParams()["counter"]
+	stored := cd.Proto.GetParams()["counter"]
 	if stored.GetValue().GetInt32Value() != 1 {
 		t.Errorf("expected stored value to remain 1, got %v", stored.GetValue().GetInt32Value())
 	}
@@ -98,13 +98,13 @@ func TestDevice_WithParam_DeepCopies(t *testing.T) {
 func TestDevice_WithParam_Nil(t *testing.T) {
 	cd := NewDevice(0).
 		WithParam("nothing", nil)
-	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
+	if _, ok := cd.Proto.GetParams()["nothing"]; ok {
 		t.Error("expected nil param to be ignored")
 	}
 
 	cd = NewDevice(0).
 		WithParam("nothing", &Param{})
-	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
+	if _, ok := cd.Proto.GetParams()["nothing"]; ok {
 		t.Error("expected param with nil Proto to be ignored")
 	}
 }
@@ -112,13 +112,13 @@ func TestDevice_WithParam_Nil(t *testing.T) {
 func TestDevice_WithCommand_Nil(t *testing.T) {
 	cd := NewDevice(0).
 		WithCommand("nothing", nil)
-	if _, ok := cd.ToProtoDevice().GetCommands()["nothing"]; ok {
+	if _, ok := cd.Proto.GetCommands()["nothing"]; ok {
 		t.Error("expected nil command to be ignored")
 	}
 
 	cd = NewDevice(0).
 		WithCommand("nothing", &Param{})
-	if _, ok := cd.ToProtoDevice().GetCommands()["nothing"]; ok {
+	if _, ok := cd.Proto.GetCommands()["nothing"]; ok {
 		t.Error("expected command with nil Proto to be ignored")
 	}
 }
@@ -126,13 +126,13 @@ func TestDevice_WithCommand_Nil(t *testing.T) {
 func TestDevice_WithConstraint_Nil(t *testing.T) {
 	cd := NewDevice(0).
 		WithConstraint("nothing", nil)
-	if _, ok := cd.ToProtoDevice().GetConstraints()["nothing"]; ok {
+	if _, ok := cd.Proto.GetConstraints()["nothing"]; ok {
 		t.Error("expected nil constraint to be ignored")
 	}
 
 	cd = NewDevice(0).
 		WithConstraint("nothing", &Constraint{})
-	if _, ok := cd.ToProtoDevice().GetConstraints()["nothing"]; ok {
+	if _, ok := cd.Proto.GetConstraints()["nothing"]; ok {
 		t.Error("expected constraint with nil Proto to be ignored")
 	}
 }
@@ -140,13 +140,13 @@ func TestDevice_WithConstraint_Nil(t *testing.T) {
 func TestDevice_WithMenuGroup_Nil(t *testing.T) {
 	cd := NewDevice(0).
 		WithMenuGroup("nothing", nil)
-	if _, ok := cd.ToProtoDevice().GetMenuGroups()["nothing"]; ok {
+	if _, ok := cd.Proto.GetMenuGroups()["nothing"]; ok {
 		t.Error("expected nil menu group to be ignored")
 	}
 
 	cd = NewDevice(0).
 		WithMenuGroup("nothing", &MenuGroup{})
-	if _, ok := cd.ToProtoDevice().GetMenuGroups()["nothing"]; ok {
+	if _, ok := cd.Proto.GetMenuGroups()["nothing"]; ok {
 		t.Error("expected menu group with nil Proto to be ignored")
 	}
 }
@@ -156,7 +156,7 @@ func TestDevice_WithConstraints(t *testing.T) {
 		WithConstraint("brightness_range", NewConstraintInt32Range(0, 100, 1)).
 		WithConstraint("input_source_choice", NewConstraintStringChoice(false, "SDI", "HDMI", "IP"))
 
-	constraints := cd.ToProtoDevice().GetConstraints()
+	constraints := cd.Proto.GetConstraints()
 	if constraints == nil {
 		t.Fatal("expected constraints to be set")
 	}
@@ -187,7 +187,7 @@ func TestDevice_WithLanguagePacks(t *testing.T) {
 		WithLanguagePack("en", "English", map[string]string{"brightness": "Brightness"}).
 		WithLanguagePack("fr", "Français", map[string]string{"brightness": "Luminosité"})
 
-	packs := cd.ToProtoDevice().GetLanguagePacks().GetPacks()
+	packs := cd.Proto.GetLanguagePacks().GetPacks()
 	if len(packs) != 2 {
 		t.Errorf("expected 2 language packs, got %d", len(packs))
 	}
@@ -211,7 +211,7 @@ func TestDevice_WithMenuGroups(t *testing.T) {
 				WithName(NewPolyglotText("en", "Basic")).
 				WithParamOids("brightness", "contrast")))
 
-	videoGroup, ok := cd.ToProtoDevice().GetMenuGroups()["video"]
+	videoGroup, ok := cd.Proto.GetMenuGroups()["video"]
 	if !ok {
 		t.Fatal("expected 'video' menu group")
 	}
@@ -229,7 +229,7 @@ func TestDevice_WithCommands(t *testing.T) {
 		WithCommand("reboot", NewParamEmpty().
 			WithName(NewPolyglotText("en", "Reboot Device")))
 
-	reboot, ok := cd.ToProtoDevice().GetCommands()["reboot"]
+	reboot, ok := cd.Proto.GetCommands()["reboot"]
 	if !ok {
 		t.Fatal("expected 'reboot' command")
 	}
@@ -246,7 +246,7 @@ func TestDevice_ScalarFields(t *testing.T) {
 		WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
 		WithDefaultScope("st2138:op")
 
-	proto := cd.ToProtoDevice()
+	proto := cd.Proto
 	if !proto.GetMultiSetEnabled() {
 		t.Error("expected multi_set_enabled to be true")
 	}
@@ -282,8 +282,8 @@ func TestDevice_ToJSON(t *testing.T) {
 }
 
 func TestDevice_ToProtoDevice_Nil(t *testing.T) {
-	cd := Device{device: nil}
-	if cd.ToProtoDevice() != nil {
+	cd := Device{Proto: nil}
+	if cd.Proto != nil {
 		t.Error("expected nil proto device")
 	}
 }
@@ -333,7 +333,7 @@ func TestNewDevice_CompleteDevice(t *testing.T) {
 			WithName(NewPolyglotText("en", "Reboot Device"))).
 		WithLanguagePack("en", "English", map[string]string{"brightness": "Brightness"})
 
-	proto := cd.ToProtoDevice()
+	proto := cd.Proto
 	if proto == nil {
 		t.Fatal("expected non-nil proto device")
 	}
@@ -367,7 +367,7 @@ func TestDevice_WithFloatRangeConstraint(t *testing.T) {
 	cd := NewDevice(0).
 		WithConstraint("gain_range", NewConstraintFloatRange(-60.0, 12.0, 0.5))
 
-	gainRange, ok := cd.ToProtoDevice().GetConstraints()["gain_range"]
+	gainRange, ok := cd.Proto.GetConstraints()["gain_range"]
 	if !ok {
 		t.Fatal("expected 'gain_range' constraint")
 	}
@@ -389,7 +389,7 @@ func TestDevice_WithSharedConstraint(t *testing.T) {
 	device := NewDevice(0).
 		WithConstraint("input_source", constraint)
 
-	stringChoice := device.ToProtoDevice().GetConstraints()["input_source"].GetStringChoice()
+	stringChoice := device.Proto.GetConstraints()["input_source"].GetStringChoice()
 	if stringChoice == nil {
 		t.Fatal("expected string_choice constraint")
 	}

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -41,8 +41,6 @@ package catena
 import (
 	"testing"
 
-	"google.golang.org/protobuf/encoding/protojson"
-
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
@@ -258,26 +256,6 @@ func TestDevice_ScalarFields(t *testing.T) {
 	}
 	if len(proto.GetAccessScopes()) != 4 {
 		t.Errorf("expected 4 access_scopes, got %d", len(proto.GetAccessScopes()))
-	}
-}
-
-func TestDevice_ToJSON(t *testing.T) {
-	cd := NewDevice(0).
-		WithParam("brightness", NewParamInt32(50))
-	data, err := cd.ToJSON()
-	if err != nil {
-		t.Fatalf("ToJSON error: %v", err)
-	}
-	if len(data) == 0 {
-		t.Fatal("expected non-empty JSON")
-	}
-
-	roundTrip := &protos.Device{}
-	if err := protojson.Unmarshal(data, roundTrip); err != nil {
-		t.Fatalf("failed to unmarshal ToJSON output: %v", err)
-	}
-	if _, ok := roundTrip.GetParams()["brightness"]; !ok {
-		t.Error("expected 'brightness' param in ToJSON output")
 	}
 }
 

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -128,6 +128,54 @@ func TestDevice_WithParam_Nil(t *testing.T) {
 	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
 		t.Error("expected nil param to be ignored")
 	}
+
+	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithParam("nothing", &Param{})
+	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
+		t.Error("expected param with nil Proto to be ignored")
+	}
+}
+
+func TestDevice_WithCommand_Nil(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithCommand("nothing", nil)
+	if _, ok := cd.ToProtoDevice().GetCommands()["nothing"]; ok {
+		t.Error("expected nil command to be ignored")
+	}
+
+	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithCommand("nothing", &Param{})
+	if _, ok := cd.ToProtoDevice().GetCommands()["nothing"]; ok {
+		t.Error("expected command with nil Proto to be ignored")
+	}
+}
+
+func TestDevice_WithConstraint_Nil(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithConstraint("nothing", nil)
+	if _, ok := cd.ToProtoDevice().GetConstraints()["nothing"]; ok {
+		t.Error("expected nil constraint to be ignored")
+	}
+
+	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithConstraint("nothing", &Constraint{})
+	if _, ok := cd.ToProtoDevice().GetConstraints()["nothing"]; ok {
+		t.Error("expected constraint with nil Proto to be ignored")
+	}
+}
+
+func TestDevice_WithMenuGroup_Nil(t *testing.T) {
+	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithMenuGroup("nothing", nil)
+	if _, ok := cd.ToProtoDevice().GetMenuGroups()["nothing"]; ok {
+		t.Error("expected nil menu group to be ignored")
+	}
+
+	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithMenuGroup("nothing", &MenuGroup{})
+	if _, ok := cd.ToProtoDevice().GetMenuGroups()["nothing"]; ok {
+		t.Error("expected menu group with nil Proto to be ignored")
+	}
 }
 
 func TestDevice_WithConstraints(t *testing.T) {
@@ -358,6 +406,24 @@ func TestDevice_WithFloatRangeConstraint(t *testing.T) {
 	}
 	if floatRange.GetMaxValue() != 12.0 {
 		t.Errorf("expected max_value 12.0, got %v", floatRange.GetMaxValue())
+	}
+}
+
+func TestDevice_WithSharedConstraint(t *testing.T) {
+	constraint := NewConstraintStringChoice(true, "SDI", "HDMI", "IP")
+
+	device := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithConstraint("input_source", constraint)
+
+	stringChoice := device.ToProtoDevice().GetConstraints()["input_source"].GetStringChoice()
+	if stringChoice == nil {
+		t.Fatal("expected string_choice constraint")
+	}
+	if !stringChoice.GetStrict() {
+		t.Fatal("expected strict string choice")
+	}
+	if got := len(stringChoice.GetChoices()); got != 3 {
+		t.Fatalf("expected 3 choices, got %d", got)
 	}
 }
 

--- a/sdks/go/pkg/catena/device_test.go
+++ b/sdks/go/pkg/catena/device_test.go
@@ -47,7 +47,7 @@ import (
 )
 
 func TestNewDevice_Basic(t *testing.T) {
-	cd := NewDevice(3, "Camera", "Ross Video", "1.0", "SN-12345")
+	cd := NewDevice(3)
 	proto := cd.ToProtoDevice()
 	if proto == nil {
 		t.Fatal("expected non-nil proto device")
@@ -56,42 +56,15 @@ func TestNewDevice_Basic(t *testing.T) {
 		t.Errorf("expected slot 3, got %v", proto.GetSlot())
 	}
 
-	product, ok := proto.GetParams()["product"]
-	if !ok {
-		t.Fatal("expected mandatory 'product' param")
-	}
-	if product.GetType() != protos.ParamType_STRUCT {
-		t.Errorf("expected product to be a STRUCT param, got %v", product.GetType())
-	}
-	if !product.GetReadOnly() {
-		t.Error("expected product param to be read-only")
-	}
-	if product.GetAccessScope() != ScopeMon {
-		t.Errorf("expected product access scope %q, got %q", ScopeMon, product.GetAccessScope())
-	}
-
-	subParams := product.GetParams()
-	expected := map[string]string{
-		"name":               "Camera",
-		"vendor":             "Ross Video",
-		"version":            "1.0",
-		"serial_number":      "SN-12345",
-		"catena_sdk_version": SDKVersion,
-		"catena_sdk":         CatenaSDKURL,
-	}
-	for oid, want := range expected {
-		child, ok := subParams[oid]
-		if !ok {
-			t.Fatalf("expected product sub-param %q", oid)
-		}
-		if got := child.GetValue().GetStringValue(); got != want {
-			t.Errorf("product/%s = %q, want %q", oid, got, want)
-		}
+	// The product struct is managed by the SDK (RegisterProductStruct), not by
+	// NewDevice, so a freshly built device has no product param.
+	if _, ok := proto.GetParams()["product"]; ok {
+		t.Error("did not expect NewDevice to create a 'product' param")
 	}
 }
 
 func TestNewDevice_WithParams(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithParam("brightness", NewParamInt32(50).
 			WithName(NewPolyglotText("en", "Brightness")).
 			WithWidget("SLIDER"))
@@ -110,7 +83,7 @@ func TestNewDevice_WithParams(t *testing.T) {
 
 func TestDevice_WithParam_DeepCopies(t *testing.T) {
 	param := NewParamInt32(1)
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithParam("counter", param)
 
 	// Mutating the original param after WithParam must not affect the device.
@@ -123,13 +96,13 @@ func TestDevice_WithParam_DeepCopies(t *testing.T) {
 }
 
 func TestDevice_WithParam_Nil(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithParam("nothing", nil)
 	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
 		t.Error("expected nil param to be ignored")
 	}
 
-	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd = NewDevice(0).
 		WithParam("nothing", &Param{})
 	if _, ok := cd.ToProtoDevice().GetParams()["nothing"]; ok {
 		t.Error("expected param with nil Proto to be ignored")
@@ -137,13 +110,13 @@ func TestDevice_WithParam_Nil(t *testing.T) {
 }
 
 func TestDevice_WithCommand_Nil(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithCommand("nothing", nil)
 	if _, ok := cd.ToProtoDevice().GetCommands()["nothing"]; ok {
 		t.Error("expected nil command to be ignored")
 	}
 
-	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd = NewDevice(0).
 		WithCommand("nothing", &Param{})
 	if _, ok := cd.ToProtoDevice().GetCommands()["nothing"]; ok {
 		t.Error("expected command with nil Proto to be ignored")
@@ -151,13 +124,13 @@ func TestDevice_WithCommand_Nil(t *testing.T) {
 }
 
 func TestDevice_WithConstraint_Nil(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithConstraint("nothing", nil)
 	if _, ok := cd.ToProtoDevice().GetConstraints()["nothing"]; ok {
 		t.Error("expected nil constraint to be ignored")
 	}
 
-	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd = NewDevice(0).
 		WithConstraint("nothing", &Constraint{})
 	if _, ok := cd.ToProtoDevice().GetConstraints()["nothing"]; ok {
 		t.Error("expected constraint with nil Proto to be ignored")
@@ -165,13 +138,13 @@ func TestDevice_WithConstraint_Nil(t *testing.T) {
 }
 
 func TestDevice_WithMenuGroup_Nil(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithMenuGroup("nothing", nil)
 	if _, ok := cd.ToProtoDevice().GetMenuGroups()["nothing"]; ok {
 		t.Error("expected nil menu group to be ignored")
 	}
 
-	cd = NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd = NewDevice(0).
 		WithMenuGroup("nothing", &MenuGroup{})
 	if _, ok := cd.ToProtoDevice().GetMenuGroups()["nothing"]; ok {
 		t.Error("expected menu group with nil Proto to be ignored")
@@ -179,7 +152,7 @@ func TestDevice_WithMenuGroup_Nil(t *testing.T) {
 }
 
 func TestDevice_WithConstraints(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithConstraint("brightness_range", NewConstraintInt32Range(0, 100, 1)).
 		WithConstraint("input_source_choice", NewConstraintStringChoice(false, "SDI", "HDMI", "IP"))
 
@@ -210,7 +183,7 @@ func TestDevice_WithConstraints(t *testing.T) {
 }
 
 func TestDevice_WithLanguagePacks(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithLanguagePack("en", "English", map[string]string{"brightness": "Brightness"}).
 		WithLanguagePack("fr", "Français", map[string]string{"brightness": "Luminosité"})
 
@@ -231,7 +204,7 @@ func TestDevice_WithLanguagePacks(t *testing.T) {
 }
 
 func TestDevice_WithMenuGroups(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithMenuGroup("video", NewMenuGroup().
 			WithName(NewPolyglotText("en", "Video Settings")).
 			WithMenu("basic", NewMenu().
@@ -252,7 +225,7 @@ func TestDevice_WithMenuGroups(t *testing.T) {
 }
 
 func TestDevice_WithCommands(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithCommand("reboot", NewParamEmpty().
 			WithName(NewPolyglotText("en", "Reboot Device")))
 
@@ -266,7 +239,7 @@ func TestDevice_WithCommands(t *testing.T) {
 }
 
 func TestDevice_ScalarFields(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithDetailLevel(DetailLevelFull).
 		WithMultiSetEnabled(true).
 		WithSubscriptions(true).
@@ -289,7 +262,8 @@ func TestDevice_ScalarFields(t *testing.T) {
 }
 
 func TestDevice_ToJSON(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345")
+	cd := NewDevice(0).
+		WithParam("brightness", NewParamInt32(50))
 	data, err := cd.ToJSON()
 	if err != nil {
 		t.Fatalf("ToJSON error: %v", err)
@@ -302,8 +276,8 @@ func TestDevice_ToJSON(t *testing.T) {
 	if err := protojson.Unmarshal(data, roundTrip); err != nil {
 		t.Fatalf("failed to unmarshal ToJSON output: %v", err)
 	}
-	if _, ok := roundTrip.GetParams()["product"]; !ok {
-		t.Error("expected 'product' param in ToJSON output")
+	if _, ok := roundTrip.GetParams()["brightness"]; !ok {
+		t.Error("expected 'brightness' param in ToJSON output")
 	}
 }
 
@@ -339,7 +313,7 @@ func TestDetailLevelConstants(t *testing.T) {
 
 func TestNewDevice_CompleteDevice(t *testing.T) {
 	// This test verifies a complete device configuration like the example.
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithDetailLevel(DetailLevelFull).
 		WithMultiSetEnabled(true).
 		WithSubscriptions(true).
@@ -390,7 +364,7 @@ func TestNewDevice_CompleteDevice(t *testing.T) {
 }
 
 func TestDevice_WithFloatRangeConstraint(t *testing.T) {
-	cd := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := NewDevice(0).
 		WithConstraint("gain_range", NewConstraintFloatRange(-60.0, 12.0, 0.5))
 
 	gainRange, ok := cd.ToProtoDevice().GetConstraints()["gain_range"]
@@ -412,7 +386,7 @@ func TestDevice_WithFloatRangeConstraint(t *testing.T) {
 func TestDevice_WithSharedConstraint(t *testing.T) {
 	constraint := NewConstraintStringChoice(true, "SDI", "HDMI", "IP")
 
-	device := NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	device := NewDevice(0).
 		WithConstraint("input_source", constraint)
 
 	stringChoice := device.ToProtoDevice().GetConstraints()["input_source"].GetStringChoice()

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -50,43 +50,6 @@ type Param struct {
 	Proto *protos.Param
 }
 
-// ToMap converts a Param into the map shape accepted by ToDevice. This is
-// useful when constructing a device definition map with the SDK's Param builders.
-func (cp *Param) ToMap() map[string]any {
-	if cp == nil || cp.Proto == nil {
-		logger.Error("Param.ToMap: nil Param")
-		return map[string]any{}
-	}
-
-	definition, err := protoMessageToMap("Param.ToMap", cp.Proto)
-	if err != nil {
-		logger.Error("Param.ToMap: failed to convert param", "error", err)
-		return map[string]any{}
-	}
-	normalizeParamMap(definition, cp.Proto)
-	return definition
-}
-
-func normalizeParamMap(definition map[string]any, param *protos.Param) {
-	definition["type"] = param.GetType()
-
-	if constraintDefinition, ok := definition["constraint"].(map[string]any); ok && param.GetConstraint() != nil {
-		normalizeConstraintMap(constraintDefinition, param.GetConstraint())
-	}
-
-	childDefinitions, ok := definition["params"].(map[string]any)
-	if !ok {
-		return
-	}
-	for oid, childParam := range param.GetParams() {
-		childDefinition, ok := childDefinitions[oid].(map[string]any)
-		if !ok {
-			continue
-		}
-		normalizeParamMap(childDefinition, childParam)
-	}
-}
-
 // --- Factory functions (one per ParamType) ---
 
 func NewParamInt32(value int32) *Param {
@@ -116,20 +79,14 @@ func NewParamString(value string) *Param {
 	}
 }
 
-func NewParamStruct(value map[string]any) *Param {
-	cp := &Param{
+// NewParamStruct creates a STRUCT param. Its fields are defined by attaching
+// sub-params with WithParam; each sub-param carries its own value.
+func NewParamStruct() *Param {
+	return &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
 	}
-	pv, res := ToProto(value)
-	if res.Code != StatusCodeOk {
-		logger.Warning("NewParamStruct: failed to convert value; value left nil",
-			"error", res.Error)
-		return cp
-	}
-	cp.Proto.Value = pv
-	return cp
 }
 
 func NewParamStructVariant(value *StructVariantValue) *Param {

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -205,14 +205,14 @@ func NewParamData(payload DataPayload) *Param {
 // DataPayload values are mapped to ParamType_DATA since the two
 // cannot be distinguished from the value alone.
 func NewParamFromValue(v Value) *Param {
-	pt := paramTypeFromValueKind(v.Value)
+	pt := paramTypeFromValueKind(v.Proto)
 	if pt == protos.ParamType_UNDEFINED {
 		logger.Warning("NewParamFromValue: could not infer param type from value; using UNDEFINED")
 	}
 	return &Param{
 		Proto: &protos.Param{
 			Type:  pt,
-			Value: v.Value,
+			Value: v.Proto,
 		},
 	}
 }
@@ -225,12 +225,12 @@ func (cp *Param) WithName(name PolyglotText) *Param {
 }
 
 func (cp *Param) WithValue(v Value) *Param {
-	if !isValueValidForParamType(v.Value, cp.Proto.Type) {
+	if !isValueValidForParamType(v.Proto, cp.Proto.Type) {
 		logger.Warning("WithValue: value kind incompatible with param type; ignoring",
 			"param_type", cp.Proto.Type.String())
 		return cp
 	}
-	cp.Proto.Value = v.Value
+	cp.Proto.Value = v.Proto
 	return cp
 }
 

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -79,17 +79,11 @@ func NewParamString(value string) *Param {
 	}
 }
 
-// NewParamStruct creates a STRUCT param whose value is built from the given
-// field map. Field descriptors may additionally be attached with WithParam.
-// A nil or empty map yields a descriptor-only struct with no value set.
 func NewParamStruct(value map[string]any) *Param {
 	cp := &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
-	}
-	if len(value) == 0 {
-		return cp
 	}
 	pv, res := ToProto(value)
 	if res.Code != StatusCodeOk {

--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -79,14 +79,26 @@ func NewParamString(value string) *Param {
 	}
 }
 
-// NewParamStruct creates a STRUCT param. Its fields are defined by attaching
-// sub-params with WithParam; each sub-param carries its own value.
-func NewParamStruct() *Param {
-	return &Param{
+// NewParamStruct creates a STRUCT param whose value is built from the given
+// field map. Field descriptors may additionally be attached with WithParam.
+// A nil or empty map yields a descriptor-only struct with no value set.
+func NewParamStruct(value map[string]any) *Param {
+	cp := &Param{
 		Proto: &protos.Param{
 			Type: protos.ParamType_STRUCT,
 		},
 	}
+	if len(value) == 0 {
+		return cp
+	}
+	pv, res := ToProto(value)
+	if res.Code != StatusCodeOk {
+		logger.Warning("NewParamStruct: failed to convert value; value left nil",
+			"error", res.Error)
+		return cp
+	}
+	cp.Proto.Value = pv
+	return cp
 }
 
 func NewParamStructVariant(value *StructVariantValue) *Param {

--- a/sdks/go/pkg/catena/param_info.go
+++ b/sdks/go/pkg/catena/param_info.go
@@ -41,7 +41,6 @@ package catena
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -93,115 +92,47 @@ func ToParamInfo(m map[string]any) (ParamInfo, error) {
 }
 
 // ParamInfosForRequest builds ParamInfo responses for the requested FQOID from
-// a device definition map containing a "params" subtree.
-func ParamInfosForRequest(fqoid string, deviceDefinition map[string]any, recursive bool) ([]ParamInfo, StatusResult) {
-	params, ok := deviceDefinition["params"].(map[string]any)
-	if !ok {
-		return []ParamInfo{}, StatusWithCode(StatusCodeInternal, "invalid device params structure")
+// a Device's params subtree.
+func ParamInfosForRequest(fqoid string, device *Device, recursive bool) ([]ParamInfo, StatusResult) {
+	if device == nil || device.device == nil {
+		return []ParamInfo{}, StatusWithCode(StatusCodeInternal, "invalid device")
 	}
 
 	oid := strings.TrimPrefix(fqoid, "/")
-	return paramInfosForRequest(params, oid, recursive)
+	return paramInfosForRequest(device.device.GetParams(), oid, recursive)
 }
 
-func paramDisplayName(paramInfo map[string]any) PolyglotText {
-	nameInfo, ok := paramInfo["name"].(map[string]any)
-	if !ok {
+func paramDisplayName(param *protos.Param) PolyglotText {
+	displayStrings := param.GetName().GetDisplayStrings()
+	if len(displayStrings) == 0 {
 		return nil
 	}
-
-	if displayStrings, ok := nameInfo["display_strings"].(map[string]string); ok {
-		return PolyglotText(displayStrings)
-	}
-
-	displayStrings, ok := nameInfo["display_strings"].(map[string]any)
-	if !ok {
-		return nil
-	}
-
-	name := PolyglotText{}
-	for lang, text := range displayStrings {
-		if s, ok := text.(string); ok {
-			name.With(lang, s)
-		}
-	}
-	if len(name) == 0 {
-		return nil
-	}
-	return name
+	return PolyglotText(displayStrings)
 }
 
-func paramArrayLength(paramInfo map[string]any) uint32 {
-	paramType, ok := paramInfo["type"].(ParamType)
-	if !ok || !isArrayParamType(paramType) {
+func paramArrayLength(param *protos.Param) uint32 {
+	value := param.GetValue()
+	switch param.GetType() {
+	case ParamTypeInt32Array:
+		return uint32(len(value.GetInt32ArrayValues().GetInts()))
+	case ParamTypeFloat32Array:
+		return uint32(len(value.GetFloat32ArrayValues().GetFloats()))
+	case ParamTypeStringArray:
+		return uint32(len(value.GetStringArrayValues().GetStrings()))
+	case ParamTypeStructArray:
+		return uint32(len(value.GetStructArrayValues().GetStructValues()))
+	case ParamTypeStructVariantArray:
+		return uint32(len(value.GetStructVariantArrayValues().GetStructVariants()))
+	default:
 		return 0
 	}
-
-	value, ok := paramInfo["value"].(map[string]any)
-	if !ok {
-		return 0
-	}
-
-	for _, field := range []struct {
-		valueKey string
-		listKey  string
-	}{
-		{valueKey: "int32_array_values", listKey: "ints"},
-		{valueKey: "float32_array_values", listKey: "floats"},
-		{valueKey: "string_array_values", listKey: "strings"},
-		{valueKey: "struct_array_values", listKey: "struct_values"},
-		{valueKey: "struct_variant_array_values", listKey: "struct_variants"},
-	} {
-		list, ok := value[field.valueKey].(map[string]any)
-		if !ok {
-			continue
-		}
-		if length, ok := repeatedFieldLength(list[field.listKey]); ok {
-			return length
-		}
-	}
-
-	return 0
 }
 
-func isArrayParamType(paramType ParamType) bool {
-	switch paramType {
-	case ParamTypeInt32Array, ParamTypeFloat32Array, ParamTypeStringArray, ParamTypeStructArray, ParamTypeStructVariantArray:
-		return true
-	default:
-		return false
-	}
+func newParamInfoFromDescriptor(oid string, param *protos.Param) ParamInfo {
+	return NewParamInfo(oid, paramDisplayName(param), param.GetType(), param.GetTemplateOid(), paramArrayLength(param))
 }
 
-func repeatedFieldLength(value any) (uint32, bool) {
-	rv := reflect.ValueOf(value)
-	if !rv.IsValid() {
-		return 0, false
-	}
-	switch rv.Kind() {
-	case reflect.Array, reflect.Slice:
-		return uint32(rv.Len()), true
-	default:
-		return 0, false
-	}
-}
-
-func newParamInfoFromDescriptor(oid string, paramInfo map[string]any) ParamInfo {
-	paramType, ok := paramInfo["type"].(ParamType)
-	if !ok {
-		paramType = ParamTypeUndefined
-	}
-
-	templateOID, _ := paramInfo["template_oid"].(string)
-	return NewParamInfo(oid, paramDisplayName(paramInfo), paramType, templateOID, paramArrayLength(paramInfo))
-}
-
-func childParamMap(paramInfo map[string]any) map[string]any {
-	children, _ := paramInfo["params"].(map[string]any)
-	return children
-}
-
-func flattenParamInfos(params map[string]any, prefix string, recursive bool) []ParamInfo {
+func flattenParamInfos(params map[string]*protos.Param, prefix string, recursive bool) []ParamInfo {
 	keys := make([]string, 0, len(params))
 	for key := range params {
 		keys = append(keys, key)
@@ -210,8 +141,8 @@ func flattenParamInfos(params map[string]any, prefix string, recursive bool) []P
 
 	infos := make([]ParamInfo, 0, len(keys))
 	for _, key := range keys {
-		paramInfo, ok := params[key].(map[string]any)
-		if !ok {
+		param := params[key]
+		if param == nil {
 			continue
 		}
 
@@ -219,10 +150,10 @@ func flattenParamInfos(params map[string]any, prefix string, recursive bool) []P
 		if prefix != "" {
 			oid = prefix + "/" + key
 		}
-		infos = append(infos, newParamInfoFromDescriptor(oid, paramInfo))
+		infos = append(infos, newParamInfoFromDescriptor(oid, param))
 
 		if recursive {
-			if children := childParamMap(paramInfo); children != nil {
+			if children := param.GetParams(); len(children) > 0 {
 				infos = append(infos, flattenParamInfos(children, oid, true)...)
 			}
 		}
@@ -230,43 +161,38 @@ func flattenParamInfos(params map[string]any, prefix string, recursive bool) []P
 	return infos
 }
 
-func findParamDescriptor(params map[string]any, oid string) (map[string]any, bool) {
+func findParamDescriptor(params map[string]*protos.Param, oid string) (*protos.Param, bool) {
 	if oid == "" {
 		return nil, false
 	}
 
 	pathParts := strings.Split(oid, "/")
-	var paramInfo map[string]any
+	var param *protos.Param
 	for _, part := range pathParts {
-		nextParam, exists := params[part]
-		if !exists {
+		next, exists := params[part]
+		if !exists || next == nil {
 			return nil, false
 		}
-
-		var ok bool
-		paramInfo, ok = nextParam.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		params = childParamMap(paramInfo)
+		param = next
+		params = param.GetParams()
 	}
 
-	return paramInfo, true
+	return param, true
 }
 
-func paramInfosForRequest(params map[string]any, oid string, recursive bool) ([]ParamInfo, StatusResult) {
+func paramInfosForRequest(params map[string]*protos.Param, oid string, recursive bool) ([]ParamInfo, StatusResult) {
 	if oid == "" {
 		return flattenParamInfos(params, "", recursive), StatusWithCode(StatusCodeOk, "")
 	}
 
-	paramInfo, ok := findParamDescriptor(params, oid)
+	param, ok := findParamDescriptor(params, oid)
 	if !ok {
 		return []ParamInfo{}, StatusWithCode(StatusCodeNotFound, "param not found: "+oid)
 	}
 
-	result := []ParamInfo{newParamInfoFromDescriptor(oid, paramInfo)}
+	result := []ParamInfo{newParamInfoFromDescriptor(oid, param)}
 	if recursive {
-		if children := childParamMap(paramInfo); children != nil {
+		if children := param.GetParams(); len(children) > 0 {
 			result = append(result, flattenParamInfos(children, oid, true)...)
 		}
 	}

--- a/sdks/go/pkg/catena/param_info.go
+++ b/sdks/go/pkg/catena/param_info.go
@@ -39,12 +39,8 @@
 package catena
 
 import (
-	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
-
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
@@ -77,21 +73,6 @@ func NewParamInfo(oid string, name PolyglotText, paramType ParamType, templateOi
 	}
 }
 
-// ToParamInfo converts a Go map to a ParamInfo by marshalling
-// through protojson. The map keys mirror the protos.ParamInfoResponse schema
-func ToParamInfo(m map[string]any) (ParamInfo, error) {
-	jsonData, err := json.Marshal(m)
-	if err != nil {
-		return ParamInfo{}, fmt.Errorf("ToParamInfo: marshal map: %w", err)
-	}
-
-	resp := &protos.ParamInfoResponse{}
-	if err := protojson.Unmarshal(jsonData, resp); err != nil {
-		return ParamInfo{}, fmt.Errorf("ToParamInfo: unmarshal to proto: %w", err)
-	}
-	return ParamInfo{Proto: resp}, nil
-}
-
 // ParamInfosForRequest builds ParamInfo responses for the requested FQOID from
 // a Device's params subtree.
 func ParamInfosForRequest(fqoid string, device *Device, recursive bool) ([]ParamInfo, StatusResult) {
@@ -99,8 +80,7 @@ func ParamInfosForRequest(fqoid string, device *Device, recursive bool) ([]Param
 		return []ParamInfo{}, StatusWithCode(StatusCodeInternal, "invalid device")
 	}
 
-	oid := strings.TrimPrefix(fqoid, "/")
-	return paramInfosForRequest(device.Proto.GetParams(), oid, recursive)
+	return paramInfosForRequest(device.Proto.GetParams(), fqoid, recursive)
 }
 
 func paramDisplayName(param *protos.Param) PolyglotText {

--- a/sdks/go/pkg/catena/param_info.go
+++ b/sdks/go/pkg/catena/param_info.go
@@ -51,9 +51,10 @@ import (
 
 // ParamInfo wraps protos.ParamInfoResponse for parameter info handling.
 // It carries both a ParamInfo descriptor and, for array parameters, the
-// current array length.
+// current array length. Proto is the underlying proto message; it may be read
+// or replaced directly.
 type ParamInfo struct {
-	response *protos.ParamInfoResponse
+	Proto *protos.ParamInfoResponse
 }
 
 // NewParamInfo creates a ParamInfo with the specified fields.
@@ -69,7 +70,7 @@ func NewParamInfo(oid string, name PolyglotText, paramType ParamType, templateOi
 		info.Name = &protos.PolyglotText{DisplayStrings: name}
 	}
 	return ParamInfo{
-		response: &protos.ParamInfoResponse{
+		Proto: &protos.ParamInfoResponse{
 			Info:        info,
 			ArrayLength: arrayLength,
 		},
@@ -88,18 +89,18 @@ func ToParamInfo(m map[string]any) (ParamInfo, error) {
 	if err := protojson.Unmarshal(jsonData, resp); err != nil {
 		return ParamInfo{}, fmt.Errorf("ToParamInfo: unmarshal to proto: %w", err)
 	}
-	return ParamInfo{response: resp}, nil
+	return ParamInfo{Proto: resp}, nil
 }
 
 // ParamInfosForRequest builds ParamInfo responses for the requested FQOID from
 // a Device's params subtree.
 func ParamInfosForRequest(fqoid string, device *Device, recursive bool) ([]ParamInfo, StatusResult) {
-	if device == nil || device.device == nil {
+	if device == nil || device.Proto == nil {
 		return []ParamInfo{}, StatusWithCode(StatusCodeInternal, "invalid device")
 	}
 
 	oid := strings.TrimPrefix(fqoid, "/")
-	return paramInfosForRequest(device.device.GetParams(), oid, recursive)
+	return paramInfosForRequest(device.Proto.GetParams(), oid, recursive)
 }
 
 func paramDisplayName(param *protos.Param) PolyglotText {
@@ -200,38 +201,22 @@ func paramInfosForRequest(params map[string]*protos.Param, oid string, recursive
 	return result, StatusWithCode(StatusCodeOk, "")
 }
 
-// GetProtoResponse returns the underlying protos.ParamInfoResponse.
-func (p ParamInfo) GetProtoResponse() *protos.ParamInfoResponse {
-	return p.response
-}
-
-// GetProtoInfo returns the underlying protos.ParamInfo, or nil if unset.
-func (p ParamInfo) GetProtoInfo() *protos.ParamInfo {
-	if p.response == nil {
-		return nil
-	}
-	return p.response.GetInfo()
-}
-
 // GetOid returns the parameter's OID, or "" if unset.
 func (p ParamInfo) GetOid() string {
-	return p.GetProtoInfo().GetOid()
+	return p.Proto.GetInfo().GetOid()
 }
 
 // GetParamType returns the parameter's type, or UNDEFINED if unset.
 func (p ParamInfo) GetParamType() ParamType {
-	return p.GetProtoInfo().GetType()
+	return p.Proto.GetInfo().GetType()
 }
 
 // GetTemplateOid returns the template OID, or "" if unset.
 func (p ParamInfo) GetTemplateOid() string {
-	return p.GetProtoInfo().GetTemplateOid()
+	return p.Proto.GetInfo().GetTemplateOid()
 }
 
 // GetArrayLength returns the array length for array parameters, or 0 otherwise.
 func (p ParamInfo) GetArrayLength() uint32 {
-	if p.response == nil {
-		return 0
-	}
-	return p.response.GetArrayLength()
+	return p.Proto.GetArrayLength()
 }

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -146,7 +146,7 @@ func TestParamInfosForRequest_RootNonRecursive(t *testing.T) {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
 
-	assertParamInfoOids(t, infos, []string{"alpha", "numbers", "parent"})
+	assertParamInfoOids(t, infos, []string{"alpha", "numbers", "parent", "product"})
 }
 
 func TestParamInfosForRequest_NestedRecursive(t *testing.T) {
@@ -174,20 +174,6 @@ func TestParamInfosForRequest_ArrayLengthFromValue(t *testing.T) {
 	}
 }
 
-func TestParamInfosForRequest_IgnoresDescriptorArrayLengthField(t *testing.T) {
-	device := testDeviceDefinition()
-	numbers := device["params"].(map[string]any)["numbers"].(map[string]any)
-	numbers["array_length"] = 99
-
-	infos, res := ParamInfosForRequest("/numbers", device, false)
-	if res.Code != StatusCodeOk {
-		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
-	}
-	if infos[0].GetArrayLength() != 3 {
-		t.Errorf("expected descriptor array_length to be ignored, got %d", infos[0].GetArrayLength())
-	}
-}
-
 func TestParamInfosForRequest_MissingParam(t *testing.T) {
 	infos, res := ParamInfosForRequest("missing", testDeviceDefinition(), false)
 	if res.Code != StatusCodeNotFound {
@@ -198,43 +184,21 @@ func TestParamInfosForRequest_MissingParam(t *testing.T) {
 	}
 }
 
-func TestParamInfosForRequest_InvalidDeviceParams(t *testing.T) {
-	_, res := ParamInfosForRequest("", map[string]any{}, false)
+func TestParamInfosForRequest_NilDevice(t *testing.T) {
+	_, res := ParamInfosForRequest("", nil, false)
 	if res.Code != StatusCodeInternal {
 		t.Fatalf("expected INTERNAL, got %v: %s", res.Code, res.Error)
 	}
 }
 
-func testDeviceDefinition() map[string]any {
-	return map[string]any{
-		"params": map[string]any{
-			"parent": map[string]any{
-				"type": ParamTypeStruct,
-				"name": map[string]any{
-					"display_strings": map[string]any{"en": "Parent"},
-				},
-				"params": map[string]any{
-					"child": map[string]any{
-						"type": ParamTypeString,
-					},
-				},
-			},
-			"alpha": map[string]any{
-				"type": ParamTypeInt32,
-				"name": map[string]any{
-					"display_strings": map[string]string{"en": "Alpha"},
-				},
-			},
-			"numbers": map[string]any{
-				"type": ParamTypeInt32Array,
-				"value": map[string]any{
-					"int32_array_values": map[string]any{
-						"ints": []int32{1, 2, 3},
-					},
-				},
-			},
-		},
-	}
+func testDeviceDefinition() *Device {
+	return NewDevice(0, "Test", "Ross Video", "1.0", "SN-0001").
+		WithParam("parent", NewParamStruct().
+			WithName(NewPolyglotText("en", "Parent")).
+			WithParam("child", NewParamString(""))).
+		WithParam("alpha", NewParamInt32(0).
+			WithName(NewPolyglotText("en", "Alpha"))).
+		WithParam("numbers", NewParamInt32Array([]int32{1, 2, 3}))
 }
 
 func assertParamInfoOids(t *testing.T, infos []ParamInfo, expected []string) {

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -193,7 +193,7 @@ func TestParamInfosForRequest_NilDevice(t *testing.T) {
 
 func testDeviceDefinition() *Device {
 	return NewDevice(0).
-		WithParam("parent", NewParamStruct().
+		WithParam("parent", NewParamStruct(nil).
 			WithName(NewPolyglotText("en", "Parent")).
 			WithParam("child", NewParamString(""))).
 		WithParam("alpha", NewParamInt32(0).

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -146,7 +146,7 @@ func TestParamInfosForRequest_RootNonRecursive(t *testing.T) {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
 
-	assertParamInfoOids(t, infos, []string{"alpha", "numbers", "parent", "product"})
+	assertParamInfoOids(t, infos, []string{"alpha", "numbers", "parent"})
 }
 
 func TestParamInfosForRequest_NestedRecursive(t *testing.T) {
@@ -192,7 +192,7 @@ func TestParamInfosForRequest_NilDevice(t *testing.T) {
 }
 
 func testDeviceDefinition() *Device {
-	return NewDevice(0, "Test", "Ross Video", "1.0", "SN-0001").
+	return NewDevice(0).
 		WithParam("parent", NewParamStruct().
 			WithName(NewPolyglotText("en", "Parent")).
 			WithParam("child", NewParamString(""))).

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -57,13 +57,13 @@ func TestNewParamInfo_Basic(t *testing.T) {
 	if pi.GetArrayLength() != 0 {
 		t.Errorf("expected array_length 0, got %d", pi.GetArrayLength())
 	}
-	if pi.GetProtoResponse() == nil {
+	if pi.Proto == nil {
 		t.Fatal("expected non-nil proto response")
 	}
-	if pi.GetProtoInfo() == nil {
+	if pi.Proto.GetInfo() == nil {
 		t.Fatal("expected non-nil proto info")
 	}
-	name := pi.GetProtoInfo().GetName()
+	name := pi.Proto.GetInfo().GetName()
 	if name == nil || name.GetDisplayStrings()["en"] != "Text Box" {
 		t.Errorf("expected display name 'Text Box' for en, got %v", name)
 	}
@@ -71,7 +71,7 @@ func TestNewParamInfo_Basic(t *testing.T) {
 
 func TestNewParamInfo_NilName(t *testing.T) {
 	pi := NewParamInfo("foo", nil, ParamTypeInt32, "", 0)
-	if pi.GetProtoInfo().GetName() != nil {
+	if pi.Proto.GetInfo().GetName() != nil {
 		t.Error("expected nil name when none was provided")
 	}
 }
@@ -126,10 +126,10 @@ func TestToParamInfo_InvalidProto(t *testing.T) {
 
 func TestParamInfo_ZeroValue(t *testing.T) {
 	var pi ParamInfo
-	if pi.GetProtoResponse() != nil {
+	if pi.Proto != nil {
 		t.Error("expected nil proto response for zero value")
 	}
-	if pi.GetProtoInfo() != nil {
+	if pi.Proto.GetInfo() != nil {
 		t.Error("expected nil proto info for zero value")
 	}
 	if pi.GetOid() != "" {

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -83,47 +83,6 @@ func TestNewParamInfo_ArrayLength(t *testing.T) {
 	}
 }
 
-func TestToParamInfo_FromMap(t *testing.T) {
-	m := map[string]any{
-		"info": map[string]any{
-			"oid":          "brightness",
-			"type":         "INT32",
-			"template_oid": "tpl-2",
-			"name": map[string]any{
-				"display_strings": map[string]string{
-					"en": "Brightness",
-				},
-			},
-		},
-		"array_length": 0,
-	}
-
-	pi, err := ToParamInfo(m)
-	if err != nil {
-		t.Fatalf("ToParamInfo error: %v", err)
-	}
-	if pi.GetOid() != "brightness" {
-		t.Errorf("expected oid 'brightness', got %s", pi.GetOid())
-	}
-	if pi.GetParamType() != ParamTypeInt32 {
-		t.Errorf("expected type INT32, got %v", pi.GetParamType())
-	}
-	if pi.GetTemplateOid() != "tpl-2" {
-		t.Errorf("expected template_oid 'tpl-2', got %s", pi.GetTemplateOid())
-	}
-}
-
-func TestToParamInfo_InvalidProto(t *testing.T) {
-	m := map[string]any{
-		"info": map[string]any{
-			"type": "NOT_A_TYPE",
-		},
-	}
-	if _, err := ToParamInfo(m); err == nil {
-		t.Error("expected error for invalid ParamType, got nil")
-	}
-}
-
 func TestParamInfo_ZeroValue(t *testing.T) {
 	var pi ParamInfo
 	if pi.Proto != nil {
@@ -150,7 +109,7 @@ func TestParamInfosForRequest_RootNonRecursive(t *testing.T) {
 }
 
 func TestParamInfosForRequest_NestedRecursive(t *testing.T) {
-	infos, res := ParamInfosForRequest("/parent", testDeviceDefinition(), true)
+	infos, res := ParamInfosForRequest("parent", testDeviceDefinition(), true)
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
@@ -165,7 +124,7 @@ func TestParamInfosForRequest_NestedRecursive(t *testing.T) {
 }
 
 func TestParamInfosForRequest_ArrayLengthFromValue(t *testing.T) {
-	infos, res := ParamInfosForRequest("/numbers", testDeviceDefinition(), false)
+	infos, res := ParamInfosForRequest("numbers", testDeviceDefinition(), false)
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -77,7 +77,7 @@ func TestNewParamString(t *testing.T) {
 }
 
 func TestNewParamStruct(t *testing.T) {
-	p := NewParamStruct(nil).Proto
+	p := NewParamStruct().Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
@@ -262,7 +262,7 @@ func TestWithClientHint(t *testing.T) {
 
 func TestWithParam_Struct(t *testing.T) {
 	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
-	p := NewParamStruct(nil).WithParam("brightness", child).Proto
+	p := NewParamStruct().WithParam("brightness", child).Proto
 
 	sub := p.GetParams()["brightness"]
 	if sub == nil {
@@ -275,7 +275,7 @@ func TestWithParam_Struct(t *testing.T) {
 
 func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
-	parent := NewParamStruct(nil).WithParam("x", child).Proto
+	parent := NewParamStruct().WithParam("x", child).Proto
 
 	child.SetValue(int32(999))
 	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
@@ -295,7 +295,7 @@ func TestWithParam_Nil(t *testing.T) {
 	// Passing a nil sub-param must not panic and must not add an entry,
 	// preserving the contract that method chaining is never interrupted
 	// by error handling.
-	cp := NewParamStruct(nil).WithParam("x", nil)
+	cp := NewParamStruct().WithParam("x", nil)
 	p := cp.Proto
 	if len(p.GetParams()) != 0 {
 		t.Error("expected nil sub-param to be a no-op")
@@ -416,7 +416,7 @@ func TestWithConstraint_RefOid_AnyType(t *testing.T) {
 		func() *Param { return NewParamInt32(0) },
 		func() *Param { return NewParamFloat32(0) },
 		func() *Param { return NewParamString("") },
-		func() *Param { return NewParamStruct(nil) },
+		func() *Param { return NewParamStruct() },
 	} {
 		p := factory().WithConstraint(c).Proto
 		if p.GetConstraint() == nil {
@@ -590,7 +590,7 @@ func TestWithValue_Struct(t *testing.T) {
 	if res.Code != StatusCodeOk {
 		t.Fatal(res.Error)
 	}
-	p := NewParamStruct(nil).WithValue(v).Proto
+	p := NewParamStruct().WithValue(v).Proto
 	fields := p.GetValue().GetStructValue().GetFields()
 	if fields["name"].GetStringValue() != "test" {
 		t.Errorf("expected struct field 'name'='test', got %q", fields["name"].GetStringValue())
@@ -667,7 +667,7 @@ func TestGetValue_OK(t *testing.T) {
 }
 
 func TestGetValue_Nil(t *testing.T) {
-	cp := NewParamStruct(nil)
+	cp := NewParamStruct()
 	v, res := cp.GetValue()
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK for nil value, got %v: %s", res.Code, res.Error)
@@ -678,7 +678,7 @@ func TestGetValue_Nil(t *testing.T) {
 }
 
 func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
-	cp := NewParamStruct(nil)
+	cp := NewParamStruct()
 	input := map[string]any{"x": int32(1), "y": int32(2)}
 	res := cp.SetValue(input)
 	if res.Code != StatusCodeOk {
@@ -699,21 +699,13 @@ func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
 
 // --- Typed factory value tests ---
 
-func TestNewParamStruct_WithValue(t *testing.T) {
-	p := NewParamStruct(map[string]any{"a": int32(1)}).Proto
-	fields := p.GetValue().GetStructValue().GetFields()
-	if fields["a"].GetInt32Value() != 1 {
-		t.Errorf("expected struct field 'a'=1, got %d", fields["a"].GetInt32Value())
-	}
-}
-
 func TestNewParamStruct_NoValue(t *testing.T) {
-	p := NewParamStruct(nil).Proto
+	p := NewParamStruct().Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 	if p.GetValue() != nil {
-		t.Error("expected nil value when no arg provided")
+		t.Error("expected nil value; struct values come from sub-params")
 	}
 }
 
@@ -873,7 +865,7 @@ func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
 }
 
 func TestWithParam_SelfReference(t *testing.T) {
-	cp := NewParamStruct(nil)
+	cp := NewParamStruct()
 	cp.WithParam("self", cp)
 	sub := cp.Proto.GetParams()["self"]
 	if sub == nil {
@@ -882,16 +874,6 @@ func TestWithParam_SelfReference(t *testing.T) {
 }
 
 // --- Error path tests ---
-
-func TestNewParamStruct_InvalidValue(t *testing.T) {
-	p := NewParamStruct(map[string]any{"bad": struct{}{}}).Proto
-	if p.GetType() != protos.ParamType_STRUCT {
-		t.Errorf("expected STRUCT, got %v", p.GetType())
-	}
-	if p.GetValue() != nil {
-		t.Error("expected nil value when conversion fails")
-	}
-}
 
 func TestNewParamStructVariant_InvalidValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "t", Value: struct{}{}}
@@ -1040,91 +1022,23 @@ func TestSetValue_InvalidThenValid(t *testing.T) {
 	}
 }
 
-func TestParamToMap_ForDeviceDefinition(t *testing.T) {
-	param := NewParamStruct(map[string]any{
-		"number": int32(7),
-		"text":   "hello",
-	}).
+func TestWithParam_StructValuesFromSubParams(t *testing.T) {
+	param := NewParamStruct().
 		WithName(NewPolyglotText("en", "Struct Example")).
-		WithParam("number", NewParamInt32(0).WithConstraint(NewConstraintInt32Range(0, 10, 1))).
-		WithParam("text", NewParamString(""))
+		WithParam("number", NewParamInt32(7).WithConstraint(NewConstraintInt32Range(0, 10, 1))).
+		WithParam("text", NewParamString("hello"))
 
-	definition := param.ToMap()
-	if got, want := definition["type"], protos.ParamType_STRUCT; got != want {
-		t.Fatalf("expected top-level type %v, got %v", want, got)
+	if param.Proto.GetType() != protos.ParamType_STRUCT {
+		t.Fatalf("expected STRUCT, got %v", param.Proto.GetType())
 	}
-
-	childDefinitions, ok := definition["params"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected child params map, got %#v", definition["params"])
+	number := param.Proto.GetParams()["number"]
+	if number.GetValue().GetInt32Value() != 7 {
+		t.Errorf("expected number sub-param value 7, got %d", number.GetValue().GetInt32Value())
 	}
-	numberDefinition, ok := childDefinitions["number"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected number child definition, got %#v", childDefinitions["number"])
+	if number.GetConstraint().GetInt32Range().GetMaxValue() != 10 {
+		t.Fatal("expected nested int32 range constraint max 10")
 	}
-	if got, want := numberDefinition["type"], protos.ParamType_INT32; got != want {
-		t.Fatalf("expected number type %v, got %v", want, got)
-	}
-
-	constraintDefinition, ok := numberDefinition["constraint"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected inline constraint map, got %#v", numberDefinition["constraint"])
-	}
-	if got, want := constraintDefinition["type"], protos.Constraint_INT_RANGE; got != want {
-		t.Fatalf("expected constraint type %v, got %v", want, got)
-	}
-
-	device, err := ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-		"params": map[string]any{
-			"struct_example": definition,
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice with Param.ToMap output error: %v", err)
-	}
-
-	structParam := device.GetProtoDevice().GetParams()["struct_example"]
-	if structParam.GetType() != protos.ParamType_STRUCT {
-		t.Fatalf("expected STRUCT param, got %v", structParam.GetType())
-	}
-	if structParam.GetParams()["number"].GetConstraint().GetInt32Range().GetMaxValue() != 10 {
-		t.Fatalf("expected nested int32 range constraint max 10")
-	}
-}
-
-func TestParamToMap_NilParam(t *testing.T) {
-	var param *Param
-	if definition := param.ToMap(); len(definition) != 0 {
-		t.Fatalf("expected empty map for nil Param, got %#v", definition)
-	}
-}
-
-func TestParamToMap_NilProto(t *testing.T) {
-	param := &Param{}
-	if definition := param.ToMap(); len(definition) != 0 {
-		t.Fatalf("expected empty map for Param with nil Proto, got %#v", definition)
-	}
-}
-
-func TestNormalizeParamMap_SkipsInvalidChildDefinition(t *testing.T) {
-	param := NewParamStruct(map[string]any{
-		"number": int32(1),
-	}).WithParam("number", NewParamInt32(1)).Proto
-
-	definition := map[string]any{
-		"params": map[string]any{
-			"number": "not-a-map",
-		},
-	}
-
-	normalizeParamMap(definition, param)
-
-	if got, want := definition["type"], protos.ParamType_STRUCT; got != want {
-		t.Fatalf("expected parent type %v, got %v", want, got)
-	}
-	if definition["params"].(map[string]any)["number"] != "not-a-map" {
-		t.Fatal("expected invalid child definition to be left unchanged")
+	if param.Proto.GetParams()["text"].GetValue().GetStringValue() != "hello" {
+		t.Errorf("expected text sub-param value 'hello', got %q", param.Proto.GetParams()["text"].GetValue().GetStringValue())
 	}
 }

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -77,9 +77,23 @@ func TestNewParamString(t *testing.T) {
 }
 
 func TestNewParamStruct(t *testing.T) {
-	p := NewParamStruct().Proto
+	p := NewParamStruct(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
+	}
+}
+
+func TestNewParamStruct_WithValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"x": int32(1), "y": int32(2)}).Proto
+	if p.GetType() != protos.ParamType_STRUCT {
+		t.Fatalf("expected STRUCT, got %v", p.GetType())
+	}
+	fields := p.GetValue().GetStructValue().GetFields()
+	if fields["x"].GetInt32Value() != 1 {
+		t.Errorf("expected field x=1, got %d", fields["x"].GetInt32Value())
+	}
+	if fields["y"].GetInt32Value() != 2 {
+		t.Errorf("expected field y=2, got %d", fields["y"].GetInt32Value())
 	}
 }
 
@@ -262,7 +276,7 @@ func TestWithClientHint(t *testing.T) {
 
 func TestWithParam_Struct(t *testing.T) {
 	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
-	p := NewParamStruct().WithParam("brightness", child).Proto
+	p := NewParamStruct(nil).WithParam("brightness", child).Proto
 
 	sub := p.GetParams()["brightness"]
 	if sub == nil {
@@ -275,7 +289,7 @@ func TestWithParam_Struct(t *testing.T) {
 
 func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
-	parent := NewParamStruct().WithParam("x", child).Proto
+	parent := NewParamStruct(nil).WithParam("x", child).Proto
 
 	child.SetValue(int32(999))
 	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
@@ -295,7 +309,7 @@ func TestWithParam_Nil(t *testing.T) {
 	// Passing a nil sub-param must not panic and must not add an entry,
 	// preserving the contract that method chaining is never interrupted
 	// by error handling.
-	cp := NewParamStruct().WithParam("x", nil)
+	cp := NewParamStruct(nil).WithParam("x", nil)
 	p := cp.Proto
 	if len(p.GetParams()) != 0 {
 		t.Error("expected nil sub-param to be a no-op")
@@ -416,7 +430,7 @@ func TestWithConstraint_RefOid_AnyType(t *testing.T) {
 		func() *Param { return NewParamInt32(0) },
 		func() *Param { return NewParamFloat32(0) },
 		func() *Param { return NewParamString("") },
-		func() *Param { return NewParamStruct() },
+		func() *Param { return NewParamStruct(nil) },
 	} {
 		p := factory().WithConstraint(c).Proto
 		if p.GetConstraint() == nil {
@@ -590,7 +604,7 @@ func TestWithValue_Struct(t *testing.T) {
 	if res.Code != StatusCodeOk {
 		t.Fatal(res.Error)
 	}
-	p := NewParamStruct().WithValue(v).Proto
+	p := NewParamStruct(nil).WithValue(v).Proto
 	fields := p.GetValue().GetStructValue().GetFields()
 	if fields["name"].GetStringValue() != "test" {
 		t.Errorf("expected struct field 'name'='test', got %q", fields["name"].GetStringValue())
@@ -667,7 +681,7 @@ func TestGetValue_OK(t *testing.T) {
 }
 
 func TestGetValue_Nil(t *testing.T) {
-	cp := NewParamStruct()
+	cp := NewParamStruct(nil)
 	v, res := cp.GetValue()
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK for nil value, got %v: %s", res.Code, res.Error)
@@ -678,7 +692,7 @@ func TestGetValue_Nil(t *testing.T) {
 }
 
 func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
-	cp := NewParamStruct()
+	cp := NewParamStruct(nil)
 	input := map[string]any{"x": int32(1), "y": int32(2)}
 	res := cp.SetValue(input)
 	if res.Code != StatusCodeOk {
@@ -700,12 +714,12 @@ func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
 // --- Typed factory value tests ---
 
 func TestNewParamStruct_NoValue(t *testing.T) {
-	p := NewParamStruct().Proto
+	p := NewParamStruct(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 	if p.GetValue() != nil {
-		t.Error("expected nil value; struct values come from sub-params")
+		t.Error("expected nil value for a descriptor-only struct (nil map)")
 	}
 }
 
@@ -865,7 +879,7 @@ func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
 }
 
 func TestWithParam_SelfReference(t *testing.T) {
-	cp := NewParamStruct()
+	cp := NewParamStruct(nil)
 	cp.WithParam("self", cp)
 	sub := cp.Proto.GetParams()["self"]
 	if sub == nil {
@@ -1023,7 +1037,7 @@ func TestSetValue_InvalidThenValid(t *testing.T) {
 }
 
 func TestWithParam_StructValuesFromSubParams(t *testing.T) {
-	param := NewParamStruct().
+	param := NewParamStruct(nil).
 		WithName(NewPolyglotText("en", "Struct Example")).
 		WithParam("number", NewParamInt32(7).WithConstraint(NewConstraintInt32Range(0, 10, 1))).
 		WithParam("text", NewParamString("hello"))

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -83,20 +83,6 @@ func TestNewParamStruct(t *testing.T) {
 	}
 }
 
-func TestNewParamStruct_WithValue(t *testing.T) {
-	p := NewParamStruct(map[string]any{"x": int32(1), "y": int32(2)}).Proto
-	if p.GetType() != protos.ParamType_STRUCT {
-		t.Fatalf("expected STRUCT, got %v", p.GetType())
-	}
-	fields := p.GetValue().GetStructValue().GetFields()
-	if fields["x"].GetInt32Value() != 1 {
-		t.Errorf("expected field x=1, got %d", fields["x"].GetInt32Value())
-	}
-	if fields["y"].GetInt32Value() != 2 {
-		t.Errorf("expected field y=2, got %d", fields["y"].GetInt32Value())
-	}
-}
-
 func TestNewParamStructVariant(t *testing.T) {
 	p := NewParamStructVariant(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
@@ -713,13 +699,21 @@ func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
 
 // --- Typed factory value tests ---
 
+func TestNewParamStruct_WithValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"a": int32(1)}).Proto
+	fields := p.GetValue().GetStructValue().GetFields()
+	if fields["a"].GetInt32Value() != 1 {
+		t.Errorf("expected struct field 'a'=1, got %d", fields["a"].GetInt32Value())
+	}
+}
+
 func TestNewParamStruct_NoValue(t *testing.T) {
 	p := NewParamStruct(nil).Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 	if p.GetValue() != nil {
-		t.Error("expected nil value for a descriptor-only struct (nil map)")
+		t.Error("expected nil value when no arg provided")
 	}
 }
 
@@ -888,6 +882,16 @@ func TestWithParam_SelfReference(t *testing.T) {
 }
 
 // --- Error path tests ---
+
+func TestNewParamStruct_InvalidValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"bad": struct{}{}}).Proto
+	if p.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("expected STRUCT, got %v", p.GetType())
+	}
+	if p.GetValue() != nil {
+		t.Error("expected nil value when conversion fails")
+	}
+}
 
 func TestNewParamStructVariant_InvalidValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "t", Value: struct{}{}}

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -100,14 +100,12 @@ func ProductValues(p ProductStruct) map[string]any {
 // isProductOid reports whether fqoid targets the product struct or one of its
 // sub-fields (e.g. "product" or "product/name").
 func isProductOid(fqoid string) bool {
-	fqoid = strings.TrimPrefix(fqoid, "/")
 	return fqoid == productOid || strings.HasPrefix(fqoid, productOid+"/")
 }
 
 // productValueForOid resolves a product FQOID (the whole struct for "product",
 // or a single field for "product/<field>") to a Value from p.
 func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {
-	fqoid = strings.TrimPrefix(fqoid, "/")
 	values := ProductValues(p)
 
 	var native any

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -106,18 +106,25 @@ const (
 )
 
 // ProductParam builds the mandatory read-only "product" STRUCT param from p,
-// including the SDK-managed catena_sdk and catena_sdk_version sub-params. The
-// SDK uses this to seed the product param into the device on GetDevice.
+// including the SDK-managed catena_sdk and catena_sdk_version fields. The field
+// values live in the struct's Value; the sub-params carry only the field
+// descriptors (their STRING type). The SDK uses this to seed the product param
+// into the device on GetDevice.
 func ProductParam(p ProductStruct) *Param {
-	return NewParamStruct(nil).
+	values := ProductValues(p)
+	param := NewParamStruct(values).
 		WithReadOnly(true).
-		WithAccessScope(ScopeMon).
-		WithParam(ProductOidName, NewParamString(p.Name)).
-		WithParam(ProductOidVendor, NewParamString(p.Vendor)).
-		WithParam(ProductOidVersion, NewParamString(p.Version)).
-		WithParam(ProductOidSerialNumber, NewParamString(p.SerialNumber)).
-		WithParam(ProductOidCatenaSDKVersion, NewParamString(SDKVersion)).
-		WithParam(ProductOidCatenaSDK, NewParamString(CatenaSDKURL))
+		WithAccessScope(ScopeMon)
+	for oid := range values {
+		param.WithParam(oid, productFieldDescriptor())
+	}
+	return param
+}
+
+// productFieldDescriptor is a valueless STRING sub-param used to describe a
+// product field. The field's value lives in the parent struct's Value.
+func productFieldDescriptor() *Param {
+	return &Param{Proto: &protos.Param{Type: protos.ParamType_STRING}}
 }
 
 // ProductValues returns the product field values keyed by their sub-OID,
@@ -162,6 +169,27 @@ func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {
 		return ReplyError[Value](StatusCodeInternal, "failed to convert product value")
 	}
 	return Reply(value)
+}
+
+// productParamForOid resolves a product FQOID to a Param: the whole struct for
+// "product", or a single STRING field descriptor (with its value) for
+// "product/<field>".
+func productParamForOid(p ProductStruct, fqoid string) (Param, StatusResult) {
+	if fqoid == ProductOid {
+		return *ProductParam(p), StatusWithCode(StatusCodeOk, "")
+	}
+
+	field := strings.TrimPrefix(fqoid, ProductOid+"/")
+	value, ok := ProductValues(p)[field]
+	if !ok {
+		return Param{}, StatusWithCode(StatusCodeNotFound, "parameter not found: "+fqoid)
+	}
+
+	pv, res := ToProto(value)
+	if res.Code != StatusCodeOk {
+		return Param{}, StatusWithCode(StatusCodeInternal, "failed to convert product value")
+	}
+	return Param{Proto: &protos.Param{Type: protos.ParamType_STRING, Value: pv}}, StatusWithCode(StatusCodeOk, "")
 }
 
 // productParamInfosForOid builds ParamInfo responses for a product FQOID by

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -38,6 +38,7 @@
 package catena
 
 import (
+	"runtime/debug"
 	"strings"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
@@ -45,6 +46,43 @@ import (
 
 // productOid is the OID of the mandatory product struct param.
 const productOid = "product"
+
+// sdkModulePath is the SDK's Go module path, used to locate the SDK's resolved
+// version in the running binary's build info.
+const sdkModulePath = "github.com/rossvideo/catena/sdks/go"
+
+// SDKVersion is the Catena Go SDK version reported in the SDK-managed product
+// struct (the "catena_sdk_version" field). It is resolved at startup from the
+// binary's build info (the git tag or pseudo-version Go recorded for the SDK
+// module), so it stays accurate without a hand-maintained constant.
+var SDKVersion = sdkVersion()
+
+// sdkVersion resolves the SDK's version from the running binary's build info.
+// It returns the version Go recorded for the SDK module, falling back to
+// "(devel)" for unversioned local builds and "(unknown)" when build info is
+// unavailable.
+func sdkVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "(unknown)"
+	}
+	// When the SDK is imported as a dependency, its resolved version lives in
+	// Deps. When the SDK module is itself the main module (e.g. running its own
+	// tests or examples), the version lives on Main instead.
+	if bi.Main.Path == sdkModulePath && bi.Main.Version != "" {
+		return bi.Main.Version
+	}
+	for _, d := range bi.Deps {
+		if d.Path == sdkModulePath {
+			return d.Version // resolved from the git tag / pseudo-version
+		}
+	}
+	return "(devel)"
+}
+
+// CatenaSDKURL identifies the Catena SDK in the SDK-managed product struct (the
+// "catena_sdk" field).
+const CatenaSDKURL = "https://github.com/rossvideo/Catena"
 
 // ProductStruct carries the mandatory device product identity fields. The
 // catena_sdk and catena_sdk_version fields are managed by the SDK

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -72,7 +72,7 @@ const (
 // including the SDK-managed catena_sdk and catena_sdk_version sub-params. The
 // SDK uses this to seed the product param into the device on GetDevice.
 func ProductParam(p ProductStruct) *Param {
-	return NewParamStruct().
+	return NewParamStruct(nil).
 		WithReadOnly(true).
 		WithAccessScope(ScopeMon).
 		WithParam(ProductOidName, NewParamString(p.Name)).

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -132,7 +132,7 @@ func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {
 // productParamInfosForOid builds ParamInfo responses for a product FQOID by
 // reusing the standard params-subtree walker over the SDK-built product param.
 func productParamInfosForOid(p ProductStruct, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult) {
-	device := &Device{device: &protos.Device{
+	device := &Device{Proto: &protos.Device{
 		Params: map[string]*protos.Param{productOid: ProductParam(p).Proto},
 	}}
 	return ParamInfosForRequest(oidPrefix, device, recursive)

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Product struct helpers for the Catena SDK.
+ * @file product.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ */
+
+package catena
+
+// Product carries the mandatory device product identity fields. The
+// catena_sdk and catena_sdk_version fields are managed by the SDK
+// (SDKVersion / CatenaSDKURL), so callers do not supply them.
+type Product struct {
+	Name         string
+	Vendor       string
+	Version      string
+	SerialNumber string
+}
+
+// Sub-OIDs of the mandatory product struct param.
+const (
+	ProductOidName             = "name"
+	ProductOidVendor           = "vendor"
+	ProductOidVersion          = "version"
+	ProductOidSerialNumber     = "serial_number"
+	ProductOidCatenaSDKVersion = "catena_sdk_version"
+	ProductOidCatenaSDK        = "catena_sdk"
+)
+
+// ProductParam builds the mandatory read-only "product" STRUCT param from p,
+// including the SDK-managed catena_sdk and catena_sdk_version sub-params.
+// NewDevice uses this to seed every device; call it directly only if you need
+// the param on its own.
+func ProductParam(p Product) *Param {
+	return NewParamStruct().
+		WithReadOnly(true).
+		WithAccessScope(ScopeMon).
+		WithParam(ProductOidName, NewParamString(p.Name)).
+		WithParam(ProductOidVendor, NewParamString(p.Vendor)).
+		WithParam(ProductOidVersion, NewParamString(p.Version)).
+		WithParam(ProductOidSerialNumber, NewParamString(p.SerialNumber)).
+		WithParam(ProductOidCatenaSDKVersion, NewParamString(SDKVersion)).
+		WithParam(ProductOidCatenaSDK, NewParamString(CatenaSDKURL))
+}
+
+// ProductValues returns the product field values keyed by their sub-OID,
+// matching the sub-params built by ProductParam (including the SDK-managed
+// catena_sdk and catena_sdk_version fields). Use it in GetValue handlers so the
+// values reported for product/* stay in sync with the device descriptor.
+func ProductValues(p Product) map[string]any {
+	return map[string]any{
+		ProductOidName:             p.Name,
+		ProductOidVendor:           p.Vendor,
+		ProductOidVersion:          p.Version,
+		ProductOidSerialNumber:     p.SerialNumber,
+		ProductOidCatenaSDKVersion: SDKVersion,
+		ProductOidCatenaSDK:        CatenaSDKURL,
+	}
+}

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -29,7 +29,7 @@
  */
 
 /**
- * @brief Product struct helpers for the Catena SDK.
+ * @brief SDK-managed product struct for the Catena SDK.
  * @file product.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @author Nelson Daniels (nelson.daniels@rossvideo.com)
@@ -37,10 +37,21 @@
 
 package catena
 
-// Product carries the mandatory device product identity fields. The
+import (
+	"strings"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// productOid is the OID of the mandatory product struct param.
+const productOid = "product"
+
+// ProductStruct carries the mandatory device product identity fields. The
 // catena_sdk and catena_sdk_version fields are managed by the SDK
-// (SDKVersion / CatenaSDKURL), so callers do not supply them.
-type Product struct {
+// (SDKVersion / CatenaSDKURL), so callers do not supply them. Register one per
+// slot with Server.RegisterProductStruct and the SDK serves it on GetDevice,
+// GetValue, and ParamInfo, and rejects writes to it on SetValue.
+type ProductStruct struct {
 	Name         string
 	Vendor       string
 	Version      string
@@ -58,10 +69,9 @@ const (
 )
 
 // ProductParam builds the mandatory read-only "product" STRUCT param from p,
-// including the SDK-managed catena_sdk and catena_sdk_version sub-params.
-// NewDevice uses this to seed every device; call it directly only if you need
-// the param on its own.
-func ProductParam(p Product) *Param {
+// including the SDK-managed catena_sdk and catena_sdk_version sub-params. The
+// SDK uses this to seed the product param into the device on GetDevice.
+func ProductParam(p ProductStruct) *Param {
 	return NewParamStruct().
 		WithReadOnly(true).
 		WithAccessScope(ScopeMon).
@@ -75,9 +85,8 @@ func ProductParam(p Product) *Param {
 
 // ProductValues returns the product field values keyed by their sub-OID,
 // matching the sub-params built by ProductParam (including the SDK-managed
-// catena_sdk and catena_sdk_version fields). Use it in GetValue handlers so the
-// values reported for product/* stay in sync with the device descriptor.
-func ProductValues(p Product) map[string]any {
+// catena_sdk and catena_sdk_version fields).
+func ProductValues(p ProductStruct) map[string]any {
 	return map[string]any{
 		ProductOidName:             p.Name,
 		ProductOidVendor:           p.Vendor,
@@ -86,4 +95,45 @@ func ProductValues(p Product) map[string]any {
 		ProductOidCatenaSDKVersion: SDKVersion,
 		ProductOidCatenaSDK:        CatenaSDKURL,
 	}
+}
+
+// isProductOid reports whether fqoid targets the product struct or one of its
+// sub-fields (e.g. "product" or "product/name").
+func isProductOid(fqoid string) bool {
+	fqoid = strings.TrimPrefix(fqoid, "/")
+	return fqoid == productOid || strings.HasPrefix(fqoid, productOid+"/")
+}
+
+// productValueForOid resolves a product FQOID (the whole struct for "product",
+// or a single field for "product/<field>") to a Value from p.
+func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {
+	fqoid = strings.TrimPrefix(fqoid, "/")
+	values := ProductValues(p)
+
+	var native any
+	if fqoid == productOid {
+		native = values
+	} else {
+		field := strings.TrimPrefix(fqoid, productOid+"/")
+		value, ok := values[field]
+		if !ok {
+			return ReplyError[Value](StatusCodeNotFound, "parameter not found: "+fqoid)
+		}
+		native = value
+	}
+
+	value, res := ToValue(native)
+	if res.Code != StatusCodeOk {
+		return ReplyError[Value](StatusCodeInternal, "failed to convert product value")
+	}
+	return Reply(value)
+}
+
+// productParamInfosForOid builds ParamInfo responses for a product FQOID by
+// reusing the standard params-subtree walker over the SDK-built product param.
+func productParamInfosForOid(p ProductStruct, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult) {
+	device := &Device{device: &protos.Device{
+		Params: map[string]*protos.Param{productOid: ProductParam(p).Proto},
+	}}
+	return ParamInfosForRequest(oidPrefix, device, recursive)
 }

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -44,9 +44,6 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
-// productOid is the OID of the mandatory product struct param.
-const productOid = "product"
-
 // sdkModulePath is the SDK's Go module path, used to locate the SDK's resolved
 // version in the running binary's build info.
 const sdkModulePath = "github.com/rossvideo/catena/sdks/go"
@@ -96,8 +93,10 @@ type ProductStruct struct {
 	SerialNumber string
 }
 
-// Sub-OIDs of the mandatory product struct param.
+// ProductOid is the OID of the mandatory product struct param, and the
+// following are the sub-OIDs of its fields.
 const (
+	ProductOid                 = "product"
 	ProductOidName             = "name"
 	ProductOidVendor           = "vendor"
 	ProductOidVersion          = "version"
@@ -138,7 +137,7 @@ func ProductValues(p ProductStruct) map[string]any {
 // isProductOid reports whether fqoid targets the product struct or one of its
 // sub-fields (e.g. "product" or "product/name").
 func isProductOid(fqoid string) bool {
-	return fqoid == productOid || strings.HasPrefix(fqoid, productOid+"/")
+	return fqoid == ProductOid || strings.HasPrefix(fqoid, ProductOid+"/")
 }
 
 // productValueForOid resolves a product FQOID (the whole struct for "product",
@@ -147,10 +146,10 @@ func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {
 	values := ProductValues(p)
 
 	var native any
-	if fqoid == productOid {
+	if fqoid == ProductOid {
 		native = values
 	} else {
-		field := strings.TrimPrefix(fqoid, productOid+"/")
+		field := strings.TrimPrefix(fqoid, ProductOid+"/")
 		value, ok := values[field]
 		if !ok {
 			return ReplyError[Value](StatusCodeNotFound, "parameter not found: "+fqoid)
@@ -169,7 +168,7 @@ func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {
 // reusing the standard params-subtree walker over the SDK-built product param.
 func productParamInfosForOid(p ProductStruct, oidPrefix string, recursive bool) ([]ParamInfo, StatusResult) {
 	device := &Device{Proto: &protos.Device{
-		Params: map[string]*protos.Param{productOid: ProductParam(p).Proto},
+		Params: map[string]*protos.Param{ProductOid: ProductParam(p).Proto},
 	}}
 	return ParamInfosForRequest(oidPrefix, device, recursive)
 }

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -189,6 +189,22 @@ func TestServer_SetValue_ProductRejected(t *testing.T) {
 	}
 }
 
+// TestServer_SetValue_ProductRejectedWithoutRegistration verifies writes to
+// product/* are rejected even when no product is registered, since the product
+// struct is always read-only regardless of who manages it.
+func TestServer_SetValue_ProductRejectedWithoutRegistration(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
+		t.Error("business-logic SetValue should not be called for product writes")
+		return StatusWithCode(StatusCodeInternal, "should not happen")
+	})
+
+	res := srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "product/name", Value: "hacked"}}, TransportContext{})
+	if res.Code != StatusCodePermissionDenied {
+		t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+	}
+}
+
 // TestServer_SetValue_NonProductAllowed verifies non-product writes reach the
 // business-logic handler even when a product is registered.
 func TestServer_SetValue_NonProductAllowed(t *testing.T) {

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -65,7 +65,7 @@ func TestServer_GetDevice_InjectsProduct(t *testing.T) {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
 
-	params := device.ToProtoDevice().GetParams()
+	params := device.Proto.GetParams()
 	if _, ok := params["brightness"]; !ok {
 		t.Error("expected business-logic 'brightness' param to be preserved")
 	}
@@ -96,7 +96,7 @@ func TestServer_GetDevice_NoProductRegistered(t *testing.T) {
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
-	if _, ok := device.ToProtoDevice().GetParams()["product"]; ok {
+	if _, ok := device.Proto.GetParams()["product"]; ok {
 		t.Error("did not expect a product param when none is registered")
 	}
 }
@@ -122,7 +122,7 @@ func TestServer_GetValue_Product(t *testing.T) {
 		if res.Code != StatusCodeOk {
 			t.Fatalf("%s: expected OK, got %v: %s", fqoid, res.Code, res.Error)
 		}
-		if got := value.Value.GetStringValue(); got != want {
+		if got := value.Proto.GetStringValue(); got != want {
 			t.Errorf("%s = %q, want %q", fqoid, got, want)
 		}
 	}
@@ -132,7 +132,7 @@ func TestServer_GetValue_Product(t *testing.T) {
 	if res.Code != StatusCodeOk {
 		t.Fatalf("product: expected OK, got %v: %s", res.Code, res.Error)
 	}
-	if value.Value.GetStructValue() == nil {
+	if value.Proto.GetStructValue() == nil {
 		t.Error("expected struct value for bare 'product' oid")
 	}
 }
@@ -168,8 +168,8 @@ func TestServer_GetValue_NonProductCallsHandler(t *testing.T) {
 	if !called {
 		t.Error("expected business-logic handler to be called for non-product oid")
 	}
-	if value.Value.GetInt32Value() != 7 {
-		t.Errorf("brightness = %d, want 7", value.Value.GetInt32Value())
+	if value.Proto.GetInt32Value() != 7 {
+		t.Errorf("brightness = %d, want 7", value.Proto.GetInt32Value())
 	}
 }
 

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -36,7 +36,13 @@
 
 package catena
 
-import "testing"
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
 
 func testProduct() ProductStruct {
 	return ProductStruct{
@@ -44,6 +50,39 @@ func testProduct() ProductStruct {
 		Vendor:       "Ross Video",
 		Version:      "1.0",
 		SerialNumber: "SN-12345",
+	}
+}
+
+// expectedProductParam is the golden proto for the SDK-managed product param
+// built from testProduct(): a read-only STRUCT with STRING field descriptors and
+// the field values carried in the struct's Value.
+func expectedProductParam() *protos.Param {
+	return &protos.Param{
+		Type:        protos.ParamType_STRUCT,
+		ReadOnly:    true,
+		AccessScope: ScopeMon,
+		Params: map[string]*protos.Param{
+			ProductOidName:             {Type: protos.ParamType_STRING},
+			ProductOidVendor:           {Type: protos.ParamType_STRING},
+			ProductOidVersion:          {Type: protos.ParamType_STRING},
+			ProductOidSerialNumber:     {Type: protos.ParamType_STRING},
+			ProductOidCatenaSDKVersion: {Type: protos.ParamType_STRING},
+			ProductOidCatenaSDK:        {Type: protos.ParamType_STRING},
+		},
+		Value: &protos.Value{
+			Kind: &protos.Value_StructValue{
+				StructValue: &protos.StructValue{
+					Fields: map[string]*protos.Value{
+						ProductOidName:             {Kind: &protos.Value_StringValue{StringValue: "Camera"}},
+						ProductOidVendor:           {Kind: &protos.Value_StringValue{StringValue: "Ross Video"}},
+						ProductOidVersion:          {Kind: &protos.Value_StringValue{StringValue: "1.0"}},
+						ProductOidSerialNumber:     {Kind: &protos.Value_StringValue{StringValue: "SN-12345"}},
+						ProductOidCatenaSDKVersion: {Kind: &protos.Value_StringValue{StringValue: SDKVersion}},
+						ProductOidCatenaSDK:        {Kind: &protos.Value_StringValue{StringValue: CatenaSDKURL}},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -73,14 +112,8 @@ func TestServer_GetDevice_InjectsProduct(t *testing.T) {
 	if !ok {
 		t.Fatal("expected SDK-injected 'product' param")
 	}
-	if product.GetType() != ParamTypeStruct {
-		t.Errorf("expected product STRUCT, got %v", product.GetType())
-	}
-	if got := product.GetParams()["name"].GetValue().GetStringValue(); got != "Camera" {
-		t.Errorf("product/name = %q, want %q", got, "Camera")
-	}
-	if got := product.GetParams()["catena_sdk"].GetValue().GetStringValue(); got != CatenaSDKURL {
-		t.Errorf("product/catena_sdk = %q, want %q", got, CatenaSDKURL)
+	if !proto.Equal(product, expectedProductParam()) {
+		t.Errorf("SDK-injected product param does not match expected, got %v", product)
 	}
 }
 
@@ -132,8 +165,8 @@ func TestServer_GetValue_Product(t *testing.T) {
 	if res.Code != StatusCodeOk {
 		t.Fatalf("product: expected OK, got %v: %s", res.Code, res.Error)
 	}
-	if value.Proto.GetStructValue() == nil {
-		t.Error("expected struct value for bare 'product' oid")
+	if !proto.Equal(value.Proto, expectedProductParam().GetValue()) {
+		t.Errorf("bare 'product' value does not match expected, got %v", value.Proto)
 	}
 }
 
@@ -170,6 +203,63 @@ func TestServer_GetValue_NonProductCallsHandler(t *testing.T) {
 	}
 	if value.Proto.GetInt32Value() != 7 {
 		t.Errorf("brightness = %d, want 7", value.Proto.GetInt32Value())
+	}
+}
+
+// TestServer_GetParam_Product verifies product/* GetParam requests are answered
+// by the SDK without invoking the business-logic GetParam handler.
+func TestServer_GetParam_Product(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	srv.RegisterGetParamHandler(0, func(slot uint16, fqoid string, ctx HandlerContext) (Param, StatusResult) {
+		t.Errorf("business-logic GetParam should not be called for %q", fqoid)
+		return Param{}, StatusWithCode(StatusCodeInternal, "should not happen")
+	})
+
+	// Bare "product" returns the full golden proto.
+	param, res := srv.InvokeGetParamHandler(0, "product", TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("product: expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if !proto.Equal(param.Proto, expectedProductParam()) {
+		t.Errorf("bare 'product' param does not match expected, got %v", param.Proto)
+	}
+
+	// A single field returns a STRING param carrying that field's value.
+	param, res = srv.InvokeGetParamHandler(0, "product/name", TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("product/name: expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if param.Proto.GetType() != ParamTypeString {
+		t.Errorf("product/name type = %v, want STRING", param.Proto.GetType())
+	}
+	if got := param.Proto.GetValue().GetStringValue(); got != "Camera" {
+		t.Errorf("product/name = %q, want %q", got, "Camera")
+	}
+
+	// An unknown field is NotFound.
+	_, res = srv.InvokeGetParamHandler(0, "product/nope", TransportContext{})
+	if res.Code != StatusCodeNotFound {
+		t.Fatalf("product/nope: expected NOT_FOUND, got %v: %s", res.Code, res.Error)
+	}
+}
+
+// TestServer_GetParam_NoProductRegistered verifies product/* GetParam falls
+// through to the business-logic handler when no product is registered.
+func TestServer_GetParam_NoProductRegistered(t *testing.T) {
+	srv := newTestServer(t, false)
+	called := false
+	srv.RegisterGetParamHandler(0, func(slot uint16, fqoid string, ctx HandlerContext) (Param, StatusResult) {
+		called = true
+		return *NewParamString("bl"), StatusWithCode(StatusCodeOk, "")
+	})
+
+	_, res := srv.InvokeGetParamHandler(0, "product", TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if !called {
+		t.Error("expected business-logic GetParam to be called when no product registered")
 	}
 }
 

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for SDK-managed product struct dispatch in the server.
+ * @file product_server_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package catena
+
+import "testing"
+
+func testProduct() ProductStruct {
+	return ProductStruct{
+		Name:         "Camera",
+		Vendor:       "Ross Video",
+		Version:      "1.0",
+		SerialNumber: "SN-12345",
+	}
+}
+
+// TestServer_GetDevice_InjectsProduct verifies GetDevice overwrites the product
+// param in whatever the business logic returned with the SDK-managed product.
+func TestServer_GetDevice_InjectsProduct(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext) (Device, StatusResult) {
+		// Business logic returns a device with a bogus product that must be
+		// overwritten, plus its own param that must be preserved.
+		return Reply(*NewDevice(0).
+			WithParam("product", NewParamString("wrong")).
+			WithParam("brightness", NewParamInt32(50)))
+	})
+
+	device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+
+	params := device.ToProtoDevice().GetParams()
+	if _, ok := params["brightness"]; !ok {
+		t.Error("expected business-logic 'brightness' param to be preserved")
+	}
+	product, ok := params["product"]
+	if !ok {
+		t.Fatal("expected SDK-injected 'product' param")
+	}
+	if product.GetType() != ParamTypeStruct {
+		t.Errorf("expected product STRUCT, got %v", product.GetType())
+	}
+	if got := product.GetParams()["name"].GetValue().GetStringValue(); got != "Camera" {
+		t.Errorf("product/name = %q, want %q", got, "Camera")
+	}
+	if got := product.GetParams()["catena_sdk"].GetValue().GetStringValue(); got != CatenaSDKURL {
+		t.Errorf("product/catena_sdk = %q, want %q", got, CatenaSDKURL)
+	}
+}
+
+// TestServer_GetDevice_NoProductRegistered verifies the device is passed through
+// untouched when no product is registered for the slot.
+func TestServer_GetDevice_NoProductRegistered(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext) (Device, StatusResult) {
+		return Reply(*NewDevice(0).WithParam("brightness", NewParamInt32(50)))
+	})
+
+	device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if _, ok := device.ToProtoDevice().GetParams()["product"]; ok {
+		t.Error("did not expect a product param when none is registered")
+	}
+}
+
+// TestServer_GetValue_Product verifies product/* reads are answered by the SDK
+// without invoking the business-logic GetValue handler.
+func TestServer_GetValue_Product(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string, ctx HandlerContext) (Value, StatusResult) {
+		t.Errorf("business-logic GetValue should not be called for %q", fqoid)
+		return ReplyError[Value](StatusCodeInternal, "should not happen")
+	})
+
+	cases := map[string]string{
+		"product/name":               "Camera",
+		"product/serial_number":      "SN-12345",
+		"product/catena_sdk":         CatenaSDKURL,
+		"product/catena_sdk_version": SDKVersion,
+	}
+	for fqoid, want := range cases {
+		value, res := srv.InvokeGetValueHandler(0, fqoid, TransportContext{})
+		if res.Code != StatusCodeOk {
+			t.Fatalf("%s: expected OK, got %v: %s", fqoid, res.Code, res.Error)
+		}
+		if got := value.Value.GetStringValue(); got != want {
+			t.Errorf("%s = %q, want %q", fqoid, got, want)
+		}
+	}
+
+	// The whole struct is returned for the bare "product" oid.
+	value, res := srv.InvokeGetValueHandler(0, "product", TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("product: expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if value.Value.GetStructValue() == nil {
+		t.Error("expected struct value for bare 'product' oid")
+	}
+}
+
+// TestServer_GetValue_ProductUnknownField verifies an unknown product sub-field
+// is NotFound.
+func TestServer_GetValue_ProductUnknownField(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+
+	_, res := srv.InvokeGetValueHandler(0, "product/nope", TransportContext{})
+	if res.Code != StatusCodeNotFound {
+		t.Fatalf("expected NOT_FOUND, got %v: %s", res.Code, res.Error)
+	}
+}
+
+// TestServer_GetValue_NonProductCallsHandler verifies non-product reads still go
+// to the business-logic handler.
+func TestServer_GetValue_NonProductCallsHandler(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	called := false
+	srv.RegisterGetValueHandler(0, func(slot uint16, fqoid string, ctx HandlerContext) (Value, StatusResult) {
+		called = true
+		v, _ := ToValue(int32(7))
+		return Reply(v)
+	})
+
+	value, res := srv.InvokeGetValueHandler(0, "brightness", TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if !called {
+		t.Error("expected business-logic handler to be called for non-product oid")
+	}
+	if value.Value.GetInt32Value() != 7 {
+		t.Errorf("brightness = %d, want 7", value.Value.GetInt32Value())
+	}
+}
+
+// TestServer_SetValue_ProductRejected verifies writes to product/* are rejected
+// with PermissionDenied when a product is registered.
+func TestServer_SetValue_ProductRejected(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
+		t.Error("business-logic SetValue should not be called for product writes")
+		return StatusWithCode(StatusCodeInternal, "should not happen")
+	})
+
+	res := srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "product/name", Value: "hacked"}}, TransportContext{})
+	if res.Code != StatusCodePermissionDenied {
+		t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+	}
+}
+
+// TestServer_SetValue_NonProductAllowed verifies non-product writes reach the
+// business-logic handler even when a product is registered.
+func TestServer_SetValue_NonProductAllowed(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	called := false
+	srv.RegisterSetValueHandler(0, func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult {
+		called = true
+		return StatusWithCode(StatusCodeOk, "")
+	})
+
+	res := srv.InvokeSetValueHandler(0, []SetValueEntry{{Fqoid: "brightness", Value: int32(1)}}, TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	if !called {
+		t.Error("expected business-logic SetValue to be called for non-product write")
+	}
+}
+
+// TestServer_ParamInfo_Product verifies product/* ParamInfo is answered by the
+// SDK with the full product subtree.
+func TestServer_ParamInfo_Product(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	srv.RegisterParamInfoHandler(0, func(slot uint16, oidPrefix string, recursive bool, ctx HandlerContext) ([]ParamInfo, StatusResult) {
+		t.Errorf("business-logic ParamInfo should not be called for %q", oidPrefix)
+		return nil, StatusWithCode(StatusCodeInternal, "should not happen")
+	})
+
+	infos, res := srv.InvokeParamInfoHandler(0, "product", true, TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+	// product + its 6 sub-params.
+	if len(infos) != 7 {
+		t.Fatalf("expected 7 param infos, got %d", len(infos))
+	}
+	if infos[0].GetOid() != "product" {
+		t.Errorf("expected first oid 'product', got %q", infos[0].GetOid())
+	}
+	if infos[0].GetParamType() != ParamTypeStruct {
+		t.Errorf("expected product STRUCT, got %v", infos[0].GetParamType())
+	}
+}

--- a/sdks/go/pkg/catena/product_test.go
+++ b/sdks/go/pkg/catena/product_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Product struct helper tests for the Catena SDK.
+ * @file product_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package catena
+
+import "testing"
+
+// TestProductParamValuesParity guards the invariant behind the "Product SDK
+// fields diverge" bug: the sub-params ProductParam advertises in the device
+// descriptor must exactly match what ProductValues reports to GetValue handlers,
+// including the SDK-managed catena_sdk / catena_sdk_version fields.
+func TestProductParamValuesParity(t *testing.T) {
+	p := Product{
+		Name:         "Camera",
+		Vendor:       "Ross Video",
+		Version:      "1.0",
+		SerialNumber: "SN-12345",
+	}
+
+	param := ProductParam(p)
+	values := ProductValues(p)
+
+	subParams := param.Proto.GetParams()
+	if len(subParams) != len(values) {
+		t.Fatalf("sub-param count %d != value count %d", len(subParams), len(values))
+	}
+
+	for oid, child := range subParams {
+		want, ok := values[oid]
+		if !ok {
+			t.Errorf("descriptor advertises %q but ProductValues has no such field", oid)
+			continue
+		}
+		wantStr, ok := want.(string)
+		if !ok {
+			t.Errorf("ProductValues[%q] is not a string: %T", oid, want)
+			continue
+		}
+		if got := child.GetValue().GetStringValue(); got != wantStr {
+			t.Errorf("product/%s: descriptor=%q, value=%q", oid, got, wantStr)
+		}
+	}
+
+	if values[ProductOidCatenaSDK] != CatenaSDKURL {
+		t.Errorf("catena_sdk = %v, want %q", values[ProductOidCatenaSDK], CatenaSDKURL)
+	}
+	if values[ProductOidCatenaSDKVersion] != SDKVersion {
+		t.Errorf("catena_sdk_version = %v, want %q", values[ProductOidCatenaSDKVersion], SDKVersion)
+	}
+}

--- a/sdks/go/pkg/catena/product_test.go
+++ b/sdks/go/pkg/catena/product_test.go
@@ -36,48 +36,20 @@
 
 package catena
 
-import "testing"
+import (
+	"testing"
 
-// TestProductParamValuesParity guards the invariant behind the "Product SDK
-// fields diverge" bug: the sub-params ProductParam advertises in the device
-// descriptor must exactly match what ProductValues reports to GetValue handlers,
-// including the SDK-managed catena_sdk / catena_sdk_version fields.
-func TestProductParamValuesParity(t *testing.T) {
-	p := ProductStruct{
-		Name:         "Camera",
-		Vendor:       "Ross Video",
-		Version:      "1.0",
-		SerialNumber: "SN-12345",
-	}
+	"google.golang.org/protobuf/proto"
+)
 
-	param := ProductParam(p)
-	values := ProductValues(p)
-
-	subParams := param.Proto.GetParams()
-	if len(subParams) != len(values) {
-		t.Fatalf("sub-param count %d != value count %d", len(subParams), len(values))
-	}
-
-	for oid, child := range subParams {
-		want, ok := values[oid]
-		if !ok {
-			t.Errorf("descriptor advertises %q but ProductValues has no such field", oid)
-			continue
-		}
-		wantStr, ok := want.(string)
-		if !ok {
-			t.Errorf("ProductValues[%q] is not a string: %T", oid, want)
-			continue
-		}
-		if got := child.GetValue().GetStringValue(); got != wantStr {
-			t.Errorf("product/%s: descriptor=%q, value=%q", oid, got, wantStr)
-		}
-	}
-
-	if values[ProductOidCatenaSDK] != CatenaSDKURL {
-		t.Errorf("catena_sdk = %v, want %q", values[ProductOidCatenaSDK], CatenaSDKURL)
-	}
-	if values[ProductOidCatenaSDKVersion] != SDKVersion {
-		t.Errorf("catena_sdk_version = %v, want %q", values[ProductOidCatenaSDKVersion], SDKVersion)
+// TestProductParam_Golden verifies ProductParam builds exactly the expected
+// proto: a read-only STRUCT with STRING field descriptors and all field values
+// (including the SDK-managed catena_sdk / catena_sdk_version fields) carried in
+// the struct's Value. This guards the invariant behind the "Product SDK fields
+// diverge" bug by pinning the full descriptor + value shape.
+func TestProductParam_Golden(t *testing.T) {
+	got := ProductParam(testProduct()).Proto
+	if !proto.Equal(got, expectedProductParam()) {
+		t.Errorf("ProductParam does not match expected golden proto, got %v", got)
 	}
 }

--- a/sdks/go/pkg/catena/product_test.go
+++ b/sdks/go/pkg/catena/product_test.go
@@ -43,7 +43,7 @@ import "testing"
 // descriptor must exactly match what ProductValues reports to GetValue handlers,
 // including the SDK-managed catena_sdk / catena_sdk_version fields.
 func TestProductParamValuesParity(t *testing.T) {
-	p := Product{
+	p := ProductStruct{
 		Name:         "Camera",
 		Vendor:       "Ross Video",
 		Version:      "1.0",

--- a/sdks/go/pkg/catena/roundtrip_test.go
+++ b/sdks/go/pkg/catena/roundtrip_test.go
@@ -39,13 +39,14 @@ package catena
 import (
 	"testing"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
 // TestDevice_ProtoRoundtrip builds a Device directly via the exported Proto
-// field and verifies it feeds ToJSON and ParamInfosForRequest correctly.
+// field and verifies it feeds serialization and ParamInfosForRequest correctly.
 func TestDevice_ProtoRoundtrip(t *testing.T) {
 	inner := &protos.Device{
 		Slot: 3,
@@ -62,13 +63,13 @@ func TestDevice_ProtoRoundtrip(t *testing.T) {
 		t.Fatal("Device.Proto is not the assigned pointer")
 	}
 
-	// ToJSON must succeed and round-trip the slot.
-	data, err := d.ToJSON()
+	// The proto must serialize via protojson.
+	data, err := protojson.Marshal(d.Proto)
 	if err != nil {
-		t.Fatalf("ToJSON: %v", err)
+		t.Fatalf("marshal: %v", err)
 	}
 	if len(data) == 0 {
-		t.Error("ToJSON returned empty JSON")
+		t.Error("marshal returned empty JSON")
 	}
 
 	// ParamInfosForRequest must find the "gain" param.

--- a/sdks/go/pkg/catena/roundtrip_test.go
+++ b/sdks/go/pkg/catena/roundtrip_test.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Round-trip tests for wrapper structs with exported Proto fields.
+ * @file roundtrip_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package catena
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// TestDevice_ProtoRoundtrip builds a Device directly via the exported Proto
+// field and verifies it feeds ToJSON and ParamInfosForRequest correctly.
+func TestDevice_ProtoRoundtrip(t *testing.T) {
+	inner := &protos.Device{
+		Slot: 3,
+		Params: map[string]*protos.Param{
+			"gain": {
+				Type:  protos.ParamType_INT32,
+				Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 50}},
+			},
+		},
+	}
+	d := Device{Proto: inner}
+
+	if d.Proto != inner {
+		t.Fatal("Device.Proto is not the assigned pointer")
+	}
+
+	// ToJSON must succeed and round-trip the slot.
+	data, err := d.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("ToJSON returned empty JSON")
+	}
+
+	// ParamInfosForRequest must find the "gain" param.
+	infos, status := ParamInfosForRequest("gain", &d, false)
+	if status.Code != StatusCodeOk {
+		t.Fatalf("ParamInfosForRequest status: %v", status)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 ParamInfo, got %d", len(infos))
+	}
+	if infos[0].GetOid() != "gain" {
+		t.Errorf("expected oid 'gain', got %q", infos[0].GetOid())
+	}
+}
+
+// TestAsset_ProtoRoundtrip builds an Asset directly via the exported Proto
+// field and verifies the struct is accessible and usable.
+func TestAsset_ProtoRoundtrip(t *testing.T) {
+	inner := &protos.ExternalObjectPayload{
+		Cachable: true,
+		Payload: &protos.DataPayload{
+			Kind:            &protos.DataPayload_Payload{Payload: []byte("hello")},
+			PayloadEncoding: protos.DataPayload_UNCOMPRESSED,
+		},
+	}
+	a := Asset{Proto: inner}
+
+	if a.Proto != inner {
+		t.Fatal("Asset.Proto is not the assigned pointer")
+	}
+	if !a.Proto.GetCachable() {
+		t.Error("expected Cachable=true")
+	}
+
+	// TranscodeAssetPayload should operate on a.Proto in-place.
+	res := TranscodeAssetPayload(&a, EncodingGzip)
+	if res.Code != StatusCodeOk {
+		t.Fatalf("TranscodeAssetPayload: %v", res)
+	}
+	if Encoding(a.Proto.GetPayload().GetPayloadEncoding()) != EncodingGzip {
+		t.Errorf("expected GZIP encoding after transcode, got %v", a.Proto.GetPayload().GetPayloadEncoding())
+	}
+}
+
+// TestParamInfo_ProtoRoundtrip builds a ParamInfo directly via the exported
+// Proto field and verifies the convenience accessors delegate to it.
+func TestParamInfo_ProtoRoundtrip(t *testing.T) {
+	inner := &protos.ParamInfoResponse{
+		Info: &protos.ParamInfo{
+			Oid:  "brightness",
+			Type: protos.ParamType_INT32,
+		},
+		ArrayLength: 0,
+	}
+	pi := ParamInfo{Proto: inner}
+
+	if pi.Proto != inner {
+		t.Fatal("ParamInfo.Proto is not the assigned pointer")
+	}
+	if pi.GetOid() != "brightness" {
+		t.Errorf("GetOid = %q, want 'brightness'", pi.GetOid())
+	}
+	if pi.GetParamType() != ParamTypeInt32 {
+		t.Errorf("GetParamType = %v, want INT32", pi.GetParamType())
+	}
+	if pi.GetArrayLength() != 0 {
+		t.Errorf("GetArrayLength = %d, want 0", pi.GetArrayLength())
+	}
+}
+
+// TestCommandResult_ProtoRoundtrip builds a CommandResult directly via the
+// exported Proto field and verifies the behavioral helpers read through it.
+func TestCommandResult_ProtoRoundtrip(t *testing.T) {
+	inner := &protos.CommandResponse{
+		Kind: &protos.CommandResponse_Response{
+			Response: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: 7}},
+		},
+	}
+	cr := CommandResult{Proto: inner}
+
+	if cr.Proto != inner {
+		t.Fatal("CommandResult.Proto is not the assigned pointer")
+	}
+	if cr.IsEmpty() {
+		t.Error("IsEmpty should be false for a response result")
+	}
+	if cr.IsException() {
+		t.Error("IsException should be false for a response result")
+	}
+	if !proto.Equal(cr.Proto.GetResponse(), inner.GetResponse()) {
+		t.Error("Proto.GetResponse() mismatch")
+	}
+}
+
+// TestValue_ProtoRoundtrip builds a Value directly via the exported Proto
+// field and verifies it is preserved through FromProto.
+func TestValue_ProtoRoundtrip(t *testing.T) {
+	inner := &protos.Value{Kind: &protos.Value_StringValue{StringValue: "catena"}}
+	v := Value{Proto: inner}
+
+	if v.Proto != inner {
+		t.Fatal("Value.Proto is not the assigned pointer")
+	}
+
+	native, status := FromProto(v.Proto)
+	if status.Code != StatusCodeOk {
+		t.Fatalf("FromProto: %v", status)
+	}
+	if s, ok := native.(string); !ok || s != "catena" {
+		t.Errorf("FromProto = %v (%T), want string 'catena'", native, native)
+	}
+}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -743,6 +743,14 @@ func (s *server) InvokeGetParamHandler(slot uint16, fqoid string, transportConte
 		return Param{}, StatusWithCode(StatusCodePermissionDenied, "Permission denied")
 	}
 
+	// The SDK owns product/* when a product struct is registered for the slot;
+	// answer it directly instead of passing to business logic.
+	if isProductOid(fqoid) {
+		if product, has := s.productForSlot(slot); has {
+			return productParamForOid(product, fqoid)
+		}
+	}
+
 	s.mu.Lock()
 	handler, ok := s.getParamHandlers[slot]
 	s.mu.Unlock()

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -686,7 +686,7 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 		// with the SDK-managed product struct, if one is registered for the slot.
 		if res.Code == StatusCodeOk {
 			if product, has := s.productForSlot(slot); has && device.Proto != nil {
-				device.WithParam(productOid, ProductParam(product))
+				device.WithParam(ProductOid, ProductParam(product))
 			}
 		}
 		return device, res

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -204,6 +204,13 @@ type Server interface {
 	RegisterHeartbeatHandler(slot uint16, handler HeartbeatHandler)
 	RegisterAccessHandler(handler AccessHandler)
 
+	// RegisterProductStruct hands the mandatory product struct for a slot to the
+	// SDK. Once registered, the SDK injects the product param into the device on
+	// GetDevice, answers GetValue and ParamInfo for product/*, and rejects
+	// SetValue writes to product/* with StatusCodePermissionDenied — business
+	// logic no longer needs to handle the product struct.
+	RegisterProductStruct(slot uint16, product ProductStruct)
+
 	SetMaxConnections(max int)
 	ConnectionCount() int
 	BroadcastUpdate(slot uint16, oid string, value any, scope string)
@@ -252,7 +259,8 @@ type server struct {
 	paramInfoHandlers      map[uint16]ParamInfoHandler
 	listLanguagesHandlers  map[uint16]ListLanguagesHandler
 	heartbeatHandlers      map[uint16]HeartbeatHandler
-	accessHandler          AccessHandler // optional fallback for slots without specific handlers
+	productStructs         map[uint16]ProductStruct // SDK-managed product per slot
+	accessHandler          AccessHandler            // optional fallback for slots without specific handlers
 	connectionQueue        connectionQueueInterface
 	heartbeat              *Heartbeat
 	transports             []Transport
@@ -290,6 +298,7 @@ func NewServer(opts config.ServerOptions) (Server, error) {
 		paramInfoHandlers:      make(map[uint16]ParamInfoHandler),
 		listLanguagesHandlers:  make(map[uint16]ListLanguagesHandler),
 		heartbeatHandlers:      make(map[uint16]HeartbeatHandler),
+		productStructs:         make(map[uint16]ProductStruct),
 		accessHandler:          allowAllAccessHandler,
 		connectionQueue:        newConnectionQueue(opts.MaxConnections),
 		transports:             []Transport{},
@@ -634,6 +643,26 @@ func (s *server) RegisterAccessHandler(handler AccessHandler) {
 	s.mu.Unlock()
 }
 
+func (s *server) RegisterProductStruct(slot uint16, product ProductStruct) {
+	s.mu.Lock()
+	s.productStructs[slot] = product
+	newSlot := s.registerSlotLocked(slot)
+	s.mu.Unlock()
+
+	if newSlot {
+		s.notifySlotsAdded(slot)
+	}
+}
+
+// productForSlot returns the SDK-managed product struct registered for a slot,
+// if any.
+func (s *server) productForSlot(slot uint16) (ProductStruct, bool) {
+	s.mu.Lock()
+	product, ok := s.productStructs[slot]
+	s.mu.Unlock()
+	return product, ok
+}
+
 func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportContext) (Device, StatusResult) {
 	handlerContext, res := s.resolveHandlerContext(transportContext)
 	if res.Code != StatusCodeOk {
@@ -652,7 +681,15 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 	s.mu.Unlock()
 
 	if ok {
-		return handler(slot, handlerContext)
+		device, res := handler(slot, handlerContext)
+		// Overwrite the product/* fields in whatever the business logic returned
+		// with the SDK-managed product struct, if one is registered for the slot.
+		if res.Code == StatusCodeOk {
+			if product, has := s.productForSlot(slot); has && device.device != nil {
+				device.WithParam(productOid, ProductParam(product))
+			}
+		}
+		return device, res
 	}
 	// TODO: lookup default handler for slot
 	logger.Warning("GetDeviceHandler called - no handler registered for this slot")
@@ -670,6 +707,14 @@ func (s *server) InvokeGetValueHandler(slot uint16, fqoid string, transportConte
 	}
 	if !s.isAccessAllowed(EndpointGetValue, handlerContext) {
 		return ReplyError[Value](StatusCodePermissionDenied, "Permission denied")
+	}
+
+	// The SDK owns product/* when a product struct is registered for the slot;
+	// answer it directly instead of passing to business logic.
+	if isProductOid(fqoid) {
+		if product, has := s.productForSlot(slot); has {
+			return productValueForOid(product, fqoid)
+		}
 	}
 
 	s.mu.Lock()
@@ -724,6 +769,16 @@ func (s *server) InvokeSetValueHandler(slot uint16, entries []SetValueEntry, tra
 	}
 	if !s.isAccessAllowed(EndpointSetValue, handlerContext) {
 		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+	}
+
+	// The SDK-managed product struct is read-only; reject any write targeting
+	// product/* when a product is registered for the slot.
+	if _, has := s.productForSlot(slot); has {
+		for _, entry := range entries {
+			if isProductOid(entry.Fqoid) {
+				return StatusWithCode(StatusCodePermissionDenied, "product params are read-only")
+			}
+		}
 	}
 
 	s.mu.Lock()
@@ -799,6 +854,14 @@ func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive
 	}
 	if !s.isAccessAllowed(EndpointParamInfo, handlerContext) {
 		return nil, StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+	}
+
+	// The SDK owns product/* ParamInfo when a product struct is registered for
+	// the slot; answer it directly instead of passing to business logic.
+	if isProductOid(oidPrefix) {
+		if product, has := s.productForSlot(slot); has {
+			return productParamInfosForOid(product, oidPrefix, recursive)
+		}
 	}
 
 	s.mu.Lock()

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -685,7 +685,7 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 		// Overwrite the product/* fields in whatever the business logic returned
 		// with the SDK-managed product struct, if one is registered for the slot.
 		if res.Code == StatusCodeOk {
-			if product, has := s.productForSlot(slot); has && device.device != nil {
+			if product, has := s.productForSlot(slot); has && device.Proto != nil {
 				device.WithParam(productOid, ProductParam(product))
 			}
 		}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -209,6 +209,7 @@ type Server interface {
 	// GetDevice, answers GetValue and ParamInfo for product/*, and rejects
 	// SetValue writes to product/* with StatusCodePermissionDenied — business
 	// logic no longer needs to handle the product struct.
+	// Note: If you do not register a product struct for a slot, requests for product/* values or info will fail with StatusCodeNotFound.
 	RegisterProductStruct(slot uint16, product ProductStruct)
 
 	SetMaxConnections(max int)
@@ -658,8 +659,8 @@ func (s *server) RegisterProductStruct(slot uint16, product ProductStruct) {
 // if any.
 func (s *server) productForSlot(slot uint16) (ProductStruct, bool) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	product, ok := s.productStructs[slot]
-	s.mu.Unlock()
 	return product, ok
 }
 
@@ -684,7 +685,7 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 		device, res := handler(slot, handlerContext)
 		// Overwrite the product/* fields in whatever the business logic returned
 		// with the SDK-managed product struct, if one is registered for the slot.
-		if res.Code == StatusCodeOk {
+		if res.IsOk() {
 			if product, has := s.productForSlot(slot); has && device.Proto != nil {
 				device.WithParam(ProductOid, ProductParam(product))
 			}
@@ -771,13 +772,11 @@ func (s *server) InvokeSetValueHandler(slot uint16, entries []SetValueEntry, tra
 		return StatusWithCode(StatusCodePermissionDenied, "Permission denied")
 	}
 
-	// The SDK-managed product struct is read-only; reject any write targeting
-	// product/* when a product is registered for the slot.
-	if _, has := s.productForSlot(slot); has {
-		for _, entry := range entries {
-			if isProductOid(entry.Fqoid) {
-				return StatusWithCode(StatusCodePermissionDenied, "product params are read-only")
-			}
+	// The product struct is always read-only; reject any write targeting
+	// product/* regardless of whether the SDK or business logic manages it.
+	for _, entry := range entries {
+		if isProductOid(entry.Fqoid) {
+			return StatusWithCode(StatusCodePermissionDenied, "product params are read-only")
 		}
 	}
 

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -642,7 +642,7 @@ func TestServer_RegisterGetDeviceHandler(t *testing.T) {
 	if status.Code != StatusCodeOk {
 		t.Errorf("expected OK status, got %v", status.Code)
 	}
-	if !proto.Equal(actual.GetProtoDevice(), expected.GetProtoDevice()) {
+	if !proto.Equal(actual.ToProtoDevice(), expected.ToProtoDevice()) {
 		t.Errorf("expected device %v, got %v", expected, actual)
 	}
 

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -612,7 +612,7 @@ func TestServer_RegisterGetDeviceHandler(t *testing.T) {
 	transportContext := validTestTransportContext(map[string][]string{"tenant": {"test"}})
 
 	expected := Device{
-		device: &protos.Device{},
+		Proto: &protos.Device{},
 	}
 
 	handlerCalled := false
@@ -642,7 +642,7 @@ func TestServer_RegisterGetDeviceHandler(t *testing.T) {
 	if status.Code != StatusCodeOk {
 		t.Errorf("expected OK status, got %v", status.Code)
 	}
-	if !proto.Equal(actual.ToProtoDevice(), expected.ToProtoDevice()) {
+	if !proto.Equal(actual.Proto, expected.Proto) {
 		t.Errorf("expected device %v, got %v", expected, actual)
 	}
 
@@ -717,7 +717,7 @@ func TestServer_RegisterGetValueHandler(t *testing.T) {
 	if status.Code != StatusCodeOk {
 		t.Errorf("expected OK status, got %v", status.Code)
 	}
-	if !proto.Equal(actual.Value, expected.Value) {
+	if !proto.Equal(actual.Proto, expected.Proto) {
 		t.Errorf("expected value %v, got %v", expected, actual)
 	}
 
@@ -968,7 +968,7 @@ func TestServer_RegisterGetAssetHandler(t *testing.T) {
 	if status.Code != StatusCodeOk {
 		t.Errorf("expected OK status, got %v", status.Code)
 	}
-	if !proto.Equal(actual.GetProtoAsset(), expected.GetProtoAsset()) {
+	if !proto.Equal(actual.Proto, expected.Proto) {
 		t.Errorf("expected asset %v, got %v", expected, actual)
 	}
 

--- a/sdks/go/pkg/catena/status_code_test.go
+++ b/sdks/go/pkg/catena/status_code_test.go
@@ -59,17 +59,14 @@ func TestReply_Value(t *testing.T) {
 }
 
 func TestReply_Device(t *testing.T) {
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": DetailLevelFull,
-	}
-	device, _ := ToDevice(deviceMap)
+	device := *NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithDetailLevel(DetailLevelFull)
 	result, status := Reply(device)
 
 	if status.Code != StatusCodeOk {
 		t.Errorf("Reply status code = %d, want %d", status.Code, StatusCodeOk)
 	}
-	if result.GetProtoDevice() == nil {
+	if result.ToProtoDevice() == nil {
 		t.Error("Reply result device should not be nil")
 	}
 }
@@ -127,7 +124,7 @@ func TestReplyError_Device(t *testing.T) {
 	if status.Error != "internal error" {
 		t.Errorf("ReplyError status error = %q, want 'internal error'", status.Error)
 	}
-	if result.GetProtoDevice() != nil {
+	if result.ToProtoDevice() != nil {
 		t.Error("ReplyError result device should be nil (zero value)")
 	}
 }

--- a/sdks/go/pkg/catena/status_code_test.go
+++ b/sdks/go/pkg/catena/status_code_test.go
@@ -59,7 +59,7 @@ func TestReply_Value(t *testing.T) {
 }
 
 func TestReply_Device(t *testing.T) {
-	device := *NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	device := *NewDevice(0).
 		WithDetailLevel(DetailLevelFull)
 	result, status := Reply(device)
 

--- a/sdks/go/pkg/catena/status_code_test.go
+++ b/sdks/go/pkg/catena/status_code_test.go
@@ -53,7 +53,7 @@ func TestReply_Value(t *testing.T) {
 	if status.Error != "" {
 		t.Errorf("Reply status error = %q, want empty", status.Error)
 	}
-	if result.Value == nil {
+	if result.Proto == nil {
 		t.Error("Reply result value should not be nil")
 	}
 }
@@ -66,7 +66,7 @@ func TestReply_Device(t *testing.T) {
 	if status.Code != StatusCodeOk {
 		t.Errorf("Reply status code = %d, want %d", status.Code, StatusCodeOk)
 	}
-	if result.ToProtoDevice() == nil {
+	if result.Proto == nil {
 		t.Error("Reply result device should not be nil")
 	}
 }
@@ -81,7 +81,7 @@ func TestReply_Asset(t *testing.T) {
 	if status.Code != StatusCodeOk {
 		t.Errorf("Reply status code = %d, want %d", status.Code, StatusCodeOk)
 	}
-	if result.GetProtoAsset() == nil {
+	if result.Proto == nil {
 		t.Error("Reply result asset should not be nil")
 	}
 }
@@ -96,7 +96,7 @@ func TestReplyWithCode(t *testing.T) {
 	if status.Error != "" {
 		t.Errorf("ReplyWithCode status error = %q, want empty", status.Error)
 	}
-	if result.Value == nil {
+	if result.Proto == nil {
 		t.Error("ReplyWithCode result value should not be nil")
 	}
 }
@@ -110,7 +110,7 @@ func TestReplyError_Value(t *testing.T) {
 	if status.Error != "resource not found" {
 		t.Errorf("ReplyError status error = %q, want 'resource not found'", status.Error)
 	}
-	if result.Value != nil {
+	if result.Proto != nil {
 		t.Error("ReplyError result value should be nil (zero value)")
 	}
 }
@@ -124,7 +124,7 @@ func TestReplyError_Device(t *testing.T) {
 	if status.Error != "internal error" {
 		t.Errorf("ReplyError status error = %q, want 'internal error'", status.Error)
 	}
-	if result.ToProtoDevice() != nil {
+	if result.Proto != nil {
 		t.Error("ReplyError result device should be nil (zero value)")
 	}
 }
@@ -138,7 +138,7 @@ func TestReplyError_Asset(t *testing.T) {
 	if status.Error != "service unavailable" {
 		t.Errorf("ReplyError status error = %q, want 'service unavailable'", status.Error)
 	}
-	if result.GetProtoAsset() != nil {
+	if result.Proto != nil {
 		t.Error("ReplyError result asset should be nil (zero value)")
 	}
 }
@@ -220,7 +220,7 @@ func TestReplyError_AllStatusCodes(t *testing.T) {
 			if status.Code != code {
 				t.Errorf("test %d: ReplyError code = %d, want %d", i, status.Code, code)
 			}
-			if result.Value != nil {
+			if result.Proto != nil {
 				t.Error("ReplyError should return zero value")
 			}
 		})

--- a/sdks/go/pkg/catena/value.go
+++ b/sdks/go/pkg/catena/value.go
@@ -46,8 +46,10 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
+// Value wraps protos.Value for use in handler return types.
+// Proto is the underlying proto message; it may be read or replaced directly.
 type Value struct {
-	Value *protos.Value
+	Proto *protos.Value
 }
 
 type StructVariantValue struct {
@@ -109,7 +111,7 @@ func ToValue(v any) (Value, StatusResult) {
 	if res.Code != StatusCodeOk {
 		return Value{}, StatusResult{Code: res.Code, Error: "ToValue: " + res.Error}
 	}
-	return Value{Value: val}, StatusResult{Code: StatusCodeOk}
+	return Value{Proto: val}, StatusResult{Code: StatusCodeOk}
 }
 
 // ToProto converts native Go types to protos.Value

--- a/sdks/go/pkg/catena/value_test.go
+++ b/sdks/go/pkg/catena/value_test.go
@@ -79,7 +79,7 @@ func TestToValue(t *testing.T) {
 				t.Errorf("ToValue(%v) unexpected error: %v", tt.input, err.Error)
 				return
 			}
-			if cv.Value == nil {
+			if cv.Proto == nil {
 				t.Errorf("ToValue(%v) returned nil Value", tt.input)
 			}
 		})

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -35,8 +35,9 @@ func main() {
     srv := catena.NewServer(100) // max concurrent push connections
 
     // Register handlers once. All registered transports share this runtime.
-    srv.RegisterGetDeviceHandler(0, func() (catena.CatenaDevice, catena.StatusResult) {
-        return catena.ReplyError[catena.CatenaDevice](catena.StatusCodeUnimplemented, "implement me")
+    srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext) (catena.Device, catena.StatusResult) {
+        device := catena.NewDevice(slot, "My Device", "Ross Video", "1.0.0", "SN-0001")
+        return catena.Reply(*device)
     })
 
     if err := srv.RegisterTransport(transports.NewGrpcTransport(config.DefaultGrpcOptions())); err != nil {
@@ -49,8 +50,8 @@ func main() {
     }
 
     // Optional custom fallback endpoints on REST.
-    rest.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.CatenaValue, catena.StatusResult) {
-        return catena.ReplyError[catena.CatenaValue](catena.StatusCodeNotFound, "endpoint not found")
+    rest.RegisterFallbackHandler(func(w http.ResponseWriter, r *http.Request) (catena.Value, catena.StatusResult) {
+        return catena.ReplyError[catena.Value](catena.StatusCodeNotFound, "endpoint not found")
     })
 
     ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -34,9 +34,17 @@ import (
 func main() {
     srv := catena.NewServer(100) // max concurrent push connections
 
+    // The SDK manages the mandatory product struct; register it once per slot.
+    srv.RegisterProductStruct(0, catena.ProductStruct{
+        Name:         "My Device",
+        Vendor:       "Ross Video",
+        Version:      "1.0.0",
+        SerialNumber: "SN-0001",
+    })
+
     // Register handlers once. All registered transports share this runtime.
     srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext) (catena.Device, catena.StatusResult) {
-        device := catena.NewDevice(slot, "My Device", "Ross Video", "1.0.0", "SN-0001")
+        device := catena.NewDevice(slot)
         return catena.Reply(*device)
     })
 
@@ -83,6 +91,8 @@ Both transports invoke the same registered handlers from `catena.ServerRuntime`:
 - `RegisterExecuteCommandHandler`
 - `RegisterParamInfoHandler`
 - `RegisterHeartbeatHandler`
+
+The mandatory product struct is managed by the SDK, not by a handler: call `RegisterProductStruct(slot, catena.ProductStruct{...})` and the SDK injects it into GetDevice and serves product/* on GetValue and ParamInfo (rejecting writes).
 
 Use `BroadcastUpdate(slot, fqoid, value)` to fan out push updates to all active REST and gRPC stream clients.
 

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -92,7 +92,7 @@ Both transports invoke the same registered handlers from `catena.ServerRuntime`:
 - `RegisterParamInfoHandler`
 - `RegisterHeartbeatHandler`
 
-The mandatory product struct is managed by the SDK, not by a handler: call `RegisterProductStruct(slot, catena.ProductStruct{...})` and the SDK injects it into GetDevice and serves product/* on GetValue and ParamInfo (rejecting writes).
+The mandatory product struct is managed by the SDK, not by a handler: call `RegisterProductStruct(slot, catena.ProductStruct{...})` and the SDK will inject it into GetDevice and serve product/* on GetValue and ParamInfo (rejecting writes by default). This means common product handling doesn't need any separate handler fallback. If desired, business logic can still implement its own handler for custom or fallback behavior, but the SDK manages all standard product struct handling and fallback messaging automatically.
 
 Use `BroadcastUpdate(slot, fqoid, value)` to fan out push updates to all active REST and gRPC stream clients.
 

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -271,7 +271,7 @@ func (s *catenaService) DeviceRequest(req *protos.DeviceRequestPayload, stream g
 		return status.Error(ToGRPCCode(res.Code), res.Error)
 	}
 
-	protoDevice := device.GetProtoDevice()
+	protoDevice := device.ToProtoDevice()
 	if protoDevice == nil {
 		logger.Error("DeviceRequest device returned nil", "slot", slot)
 		return status.Error(codes.Internal, "device returned nil")

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -271,7 +271,7 @@ func (s *catenaService) DeviceRequest(req *protos.DeviceRequestPayload, stream g
 		return status.Error(ToGRPCCode(res.Code), res.Error)
 	}
 
-	protoDevice := device.ToProtoDevice()
+	protoDevice := device.Proto
 	if protoDevice == nil {
 		logger.Error("DeviceRequest device returned nil", "slot", slot)
 		return status.Error(codes.Internal, "device returned nil")
@@ -304,7 +304,7 @@ func (s *catenaService) GetValue(ctx context.Context, req *protos.GetValuePayloa
 		return nil, status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
-	return value.Value, nil
+	return value.Proto, nil
 }
 
 // SetValue sets the value of a parameter
@@ -390,7 +390,7 @@ func (s *catenaService) ExternalObjectRequest(req *protos.ExternalObjectRequestP
 		return status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
-	protoAsset := asset.GetProtoAsset()
+	protoAsset := asset.Proto
 	if protoAsset == nil {
 		logger.Error("ExternalObjectRequest asset returned nil", "slot", slot, "fqoid", fqoid)
 		return status.Error(codes.Internal, "asset returned nil")
@@ -427,7 +427,7 @@ func (s *catenaService) ExecuteCommand(req *protos.ExecuteCommandPayload, stream
 		return status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
-	return stream.Send(cmdResult.GetProtoResponse())
+	return stream.Send(cmdResult.Proto)
 }
 
 // GetParam returns a single parameter (metadata + value)
@@ -485,7 +485,7 @@ func (s *catenaService) ParamInfoRequest(req *protos.ParamInfoRequestPayload, st
 	}
 
 	for _, info := range infos {
-		protoResp := info.GetProtoResponse()
+		protoResp := info.Proto
 		if protoResp == nil {
 			logger.Error("ParamInfoRequest handler returned nil response entry", "slot", slot, "oid_prefix", oidPrefix)
 			return status.Error(codes.Internal, "param info entry is nil")

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -274,7 +274,7 @@ func TestGrpcTransport_PropagatesTransportContext(t *testing.T) {
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
 				runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 					assertContext(t, ctx)
-					device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001")
+					device := *catena.NewDevice(slot)
 					return catena.Reply(device)
 				}
 			},
@@ -402,7 +402,7 @@ func TestGrpcTransport_DeviceRequest_Success(t *testing.T) {
 	handlerCalled := false
 	runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
-		device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001").
+		device := *catena.NewDevice(slot).
 			WithDetailLevel(catena.DetailLevelFull)
 		return catena.Reply(device)
 	}
@@ -2038,7 +2038,7 @@ func TestGrpcTransport_Start_EndpointsReachable(t *testing.T) {
 	}
 
 	runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
-		device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001").
+		device := *catena.NewDevice(slot).
 			WithDetailLevel(catena.DetailLevelFull)
 		return catena.Reply(device)
 	}

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -274,7 +274,7 @@ func TestGrpcTransport_PropagatesTransportContext(t *testing.T) {
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
 				runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 					assertContext(t, ctx)
-					device, _ := catena.ToDevice(map[string]any{"slot": uint32(slot)})
+					device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001")
 					return catena.Reply(device)
 				}
 			},
@@ -402,14 +402,8 @@ func TestGrpcTransport_DeviceRequest_Success(t *testing.T) {
 	handlerCalled := false
 	runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
-		deviceMap := map[string]any{
-			"slot":         uint32(slot),
-			"detail_level": catena.DetailLevelFull,
-		}
-		device, err := catena.ToDevice(deviceMap)
-		if err != nil {
-			t.Fatalf("ToDevice failed: %v", err)
-		}
+		device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001").
+			WithDetailLevel(catena.DetailLevelFull)
 		return catena.Reply(device)
 	}
 
@@ -2044,11 +2038,8 @@ func TestGrpcTransport_Start_EndpointsReachable(t *testing.T) {
 	}
 
 	runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
-		deviceMap := map[string]any{
-			"slot":         uint32(slot),
-			"detail_level": catena.DetailLevelFull,
-		}
-		device, _ := catena.ToDevice(deviceMap)
+		device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001").
+			WithDetailLevel(catena.DetailLevelFull)
 		return catena.Reply(device)
 	}
 

--- a/sdks/go/pkg/transports/json_utils.go
+++ b/sdks/go/pkg/transports/json_utils.go
@@ -118,6 +118,16 @@ func MarshalAssetJSON(asset *protos.ExternalObjectPayload) ([]byte, error) {
 	return protoMarshalOpts.Marshal(asset)
 }
 
+// DeviceToJSON serializes a device to its REST JSON representation using proto
+// field names, without the SMPTE-compliant cleanup that MarshalDeviceJSON
+// applies.
+func DeviceToJSON(device *catena.Device) ([]byte, error) {
+	if device == nil {
+		return nil, nil
+	}
+	return protoMarshalOpts.Marshal(device.Proto)
+}
+
 type jsonPrimitive interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |

--- a/sdks/go/pkg/transports/json_utils.go
+++ b/sdks/go/pkg/transports/json_utils.go
@@ -118,16 +118,6 @@ func MarshalAssetJSON(asset *protos.ExternalObjectPayload) ([]byte, error) {
 	return protoMarshalOpts.Marshal(asset)
 }
 
-// DeviceToJSON serializes a device to its REST JSON representation using proto
-// field names, without the SMPTE-compliant cleanup that MarshalDeviceJSON
-// applies.
-func DeviceToJSON(device *catena.Device) ([]byte, error) {
-	if device == nil {
-		return nil, nil
-	}
-	return protoMarshalOpts.Marshal(device.Proto)
-}
-
 type jsonPrimitive interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -667,7 +667,7 @@ func TestMarshalDeviceJSON(t *testing.T) {
 		WithParam("brightness", catena.NewParamInt32(0).
 			WithName(catena.NewPolyglotText("en", "Brightness")))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -689,7 +689,7 @@ func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
 		WithDetailLevel(catena.DetailLevelFull).
 		WithParam("volume", catena.NewParamInt32(0))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -734,7 +734,7 @@ func TestMarshalDeviceJSON_Nil(t *testing.T) {
 
 func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
 	cd := catena.NewDevice(5)
-	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	b, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -747,7 +747,7 @@ func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
 func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
 	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull)
-	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	b, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -767,7 +767,7 @@ func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
 	cd := catena.NewDevice(0).
 		WithParam("brightness", catena.NewParamInt32(0)).
 		WithCommand("reboot", catena.NewParamEmpty())
-	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	b, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -940,7 +940,7 @@ func TestMarshalDeviceJSON_CompleteDevice(t *testing.T) {
 		WithCommand("reboot", catena.NewParamEmpty().
 			WithName(catena.NewPolyglotText("en", "Reboot Device")))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -1093,7 +1093,7 @@ func TestMarshalAssetJSON(t *testing.T) {
 		t.Fatalf("ToAsset error: %v", res.Error)
 	}
 
-	jsonData, err := MarshalAssetJSON(asset.GetProtoAsset())
+	jsonData, err := MarshalAssetJSON(asset.Proto)
 	if err != nil {
 		t.Fatalf("MarshalAssetJSON error: %v", err)
 	}

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // errReader is an io.Reader that always fails, used to exercise body-read
@@ -681,6 +682,37 @@ func TestMarshalDeviceJSON(t *testing.T) {
 	}
 	if _, ok := result["params"]; !ok {
 		t.Error("expected 'params' in JSON output")
+	}
+}
+
+func TestDeviceToJSON(t *testing.T) {
+	cd := catena.NewDevice(0).
+		WithParam("brightness", catena.NewParamInt32(50))
+
+	data, err := DeviceToJSON(cd)
+	if err != nil {
+		t.Fatalf("DeviceToJSON error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty JSON")
+	}
+
+	roundTrip := &protos.Device{}
+	if err := protojson.Unmarshal(data, roundTrip); err != nil {
+		t.Fatalf("failed to unmarshal DeviceToJSON output: %v", err)
+	}
+	if _, ok := roundTrip.GetParams()["brightness"]; !ok {
+		t.Error("expected 'brightness' param in DeviceToJSON output")
+	}
+}
+
+func TestDeviceToJSON_Nil(t *testing.T) {
+	data, err := DeviceToJSON(nil)
+	if err != nil {
+		t.Fatalf("DeviceToJSON(nil) error: %v", err)
+	}
+	if data != nil {
+		t.Errorf("expected nil data for nil device, got %s", data)
 	}
 }
 

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -662,25 +662,12 @@ func TestInjectJSONField_PushUpdatesSlotZero(t *testing.T) {
 // --- MarshalDeviceJSON tests (migrated from catena/device_test.go) ---
 
 func TestMarshalDeviceJSON(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": catena.DetailLevelFull,
-		"params": map[string]any{
-			"brightness": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Brightness",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
+	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithDetailLevel(catena.DetailLevelFull).
+		WithParam("brightness", catena.NewParamInt32(0).
+			WithName(catena.NewPolyglotText("en", "Brightness")))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -698,23 +685,11 @@ func TestMarshalDeviceJSON(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": catena.DetailLevelFull,
-		"params": map[string]any{
-			"volume": map[string]any{
-				"type": catena.ParamTypeInt32,
-				"value": map[string]any{
-					"int32_value": 0,
-				},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
+	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithDetailLevel(catena.DetailLevelFull).
+		WithParam("volume", catena.NewParamInt32(0))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -732,23 +707,11 @@ func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyStringValuePreserved(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": catena.DetailLevelFull,
-		"params": map[string]any{
-			"label": map[string]any{
-				"type": catena.ParamTypeString,
-				"value": map[string]any{
-					"string_value": "",
-				},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
+	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithDetailLevel(catena.DetailLevelFull).
+		WithParam("label", catena.NewParamString(""))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -770,13 +733,8 @@ func TestMarshalDeviceJSON_Nil(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot": uint32(5),
-	})
-	if err != nil {
-		t.Fatalf("ToDevice: %v", err)
-	}
-	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	cd := catena.NewDevice(5, "Test Device", "Ross Video", "1.0", "SN-0001")
+	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -787,14 +745,9 @@ func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": catena.DetailLevelFull,
-	})
-	if err != nil {
-		t.Fatalf("ToDevice: %v", err)
-	}
-	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithDetailLevel(catena.DetailLevelFull)
+	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -803,7 +756,7 @@ func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
 	if !strings.Contains(body, `"slot":0`) {
 		t.Errorf("expected slot:0; got %s", body)
 	}
-	for _, field := range []string{"params", "constraints", "commands", "menu_groups", "language_packs"} {
+	for _, field := range []string{"constraints", "commands", "menu_groups", "language_packs"} {
 		if strings.Contains(body, `"`+field+`":{}`) {
 			t.Errorf("empty %s should be stripped; got %s", field, body)
 		}
@@ -811,23 +764,10 @@ func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot": uint32(0),
-		"params": map[string]any{
-			"brightness": map[string]any{
-				"type": catena.ParamTypeInt32,
-			},
-		},
-		"commands": map[string]any{
-			"reboot": map[string]any{
-				"type": catena.ParamTypeEmpty,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice: %v", err)
-	}
-	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithParam("brightness", catena.NewParamInt32(0)).
+		WithCommand("reboot", catena.NewParamEmpty())
+	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -842,33 +782,17 @@ func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyMenuMetadataStringsStripped(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot":         uint32(0),
-		"detail_level": catena.DetailLevelFull,
-		"menu_groups": map[string]any{
-			"config": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{"en": "Config", "fr": ""},
-				},
-				"menus": map[string]any{
-					"main": map[string]any{
-						"name": map[string]any{
-							"display_strings": map[string]string{"en": "Main"},
-						},
-						"param_oids":   []string{"/brightness"},
-						"client_hints": map[string]string{"ui-url": ""},
-					},
-				},
-			},
-		},
-		"params": map[string]any{
-			"brightness": map[string]any{"type": catena.ParamTypeInt32},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice: %v", err)
-	}
-	b, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithDetailLevel(catena.DetailLevelFull).
+		WithParam("brightness", catena.NewParamInt32(0)).
+		WithMenuGroup("config", catena.NewMenuGroup().
+			WithName(catena.NewPolyglotText("en", "Config").With("fr", "")).
+			WithMenu("main", catena.NewMenu().
+				WithName(catena.NewPolyglotText("en", "Main")).
+				WithParamOids("/brightness").
+				WithClientHint("ui-url", "")))
+
+	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}
@@ -1002,52 +926,21 @@ func TestCleanDeviceJSON(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_CompleteDevice(t *testing.T) {
-	cd, err := catena.ToDevice(map[string]any{
-		"slot":              uint32(0),
-		"detail_level":      catena.DetailLevelFull,
-		"multi_set_enabled": true,
-		"subscriptions":     true,
-		"access_scopes":     []string{"st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm"},
-		"default_scope":     "st2138:op",
-		"params": map[string]any{
-			"brightness": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Brightness",
-					},
-				},
-				"type": catena.ParamTypeInt32,
-				"constraint": map[string]any{
-					"ref_oid": "brightness_range",
-				},
-				"read_only": false,
-				"widget":    "SLIDER",
-			},
-		},
-		"constraints": map[string]any{
-			"brightness_range": map[string]any{
-				"int32_range": map[string]any{
-					"min_value": int32(0),
-					"max_value": int32(100),
-				},
-			},
-		},
-		"commands": map[string]any{
-			"reboot": map[string]any{
-				"name": map[string]any{
-					"display_strings": map[string]string{
-						"en": "Reboot Device",
-					},
-				},
-				"type": catena.ParamTypeEmpty,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ToDevice error: %v", err)
-	}
+	cd := catena.NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+		WithDetailLevel(catena.DetailLevelFull).
+		WithMultiSetEnabled(true).
+		WithSubscriptions(true).
+		WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+		WithDefaultScope("st2138:op").
+		WithParam("brightness", catena.NewParamInt32(0).
+			WithName(catena.NewPolyglotText("en", "Brightness")).
+			WithConstraint(catena.NewConstraintRefOid("brightness_range")).
+			WithWidget("SLIDER")).
+		WithConstraint("brightness_range", catena.NewConstraintInt32Range(0, 100, 1)).
+		WithCommand("reboot", catena.NewParamEmpty().
+			WithName(catena.NewPolyglotText("en", "Reboot Device")))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.GetProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -52,7 +52,6 @@ import (
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // errReader is an io.Reader that always fails, used to exercise body-read
@@ -682,37 +681,6 @@ func TestMarshalDeviceJSON(t *testing.T) {
 	}
 	if _, ok := result["params"]; !ok {
 		t.Error("expected 'params' in JSON output")
-	}
-}
-
-func TestDeviceToJSON(t *testing.T) {
-	cd := catena.NewDevice(0).
-		WithParam("brightness", catena.NewParamInt32(50))
-
-	data, err := DeviceToJSON(cd)
-	if err != nil {
-		t.Fatalf("DeviceToJSON error: %v", err)
-	}
-	if len(data) == 0 {
-		t.Fatal("expected non-empty JSON")
-	}
-
-	roundTrip := &protos.Device{}
-	if err := protojson.Unmarshal(data, roundTrip); err != nil {
-		t.Fatalf("failed to unmarshal DeviceToJSON output: %v", err)
-	}
-	if _, ok := roundTrip.GetParams()["brightness"]; !ok {
-		t.Error("expected 'brightness' param in DeviceToJSON output")
-	}
-}
-
-func TestDeviceToJSON_Nil(t *testing.T) {
-	data, err := DeviceToJSON(nil)
-	if err != nil {
-		t.Fatalf("DeviceToJSON(nil) error: %v", err)
-	}
-	if data != nil {
-		t.Errorf("expected nil data for nil device, got %s", data)
 	}
 }
 

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -662,7 +662,7 @@ func TestInjectJSONField_PushUpdatesSlotZero(t *testing.T) {
 // --- MarshalDeviceJSON tests (migrated from catena/device_test.go) ---
 
 func TestMarshalDeviceJSON(t *testing.T) {
-	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull).
 		WithParam("brightness", catena.NewParamInt32(0).
 			WithName(catena.NewPolyglotText("en", "Brightness")))
@@ -685,7 +685,7 @@ func TestMarshalDeviceJSON(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
-	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull).
 		WithParam("volume", catena.NewParamInt32(0))
 
@@ -733,7 +733,7 @@ func TestMarshalDeviceJSON_Nil(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
-	cd := catena.NewDevice(5, "Test Device", "Ross Video", "1.0", "SN-0001")
+	cd := catena.NewDevice(5)
 	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
@@ -745,7 +745,7 @@ func TestMarshalDeviceJSON_SlotNonZero(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
-	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull)
 	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
 	if err2 != nil {
@@ -764,7 +764,7 @@ func TestMarshalDeviceJSON_EmptyMapsStripped(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
-	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	cd := catena.NewDevice(0).
 		WithParam("brightness", catena.NewParamInt32(0)).
 		WithCommand("reboot", catena.NewParamEmpty())
 	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
@@ -926,7 +926,7 @@ func TestCleanDeviceJSON(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_CompleteDevice(t *testing.T) {
-	cd := catena.NewDevice(0, "Camera", "Ross Video", "1.0", "SN-12345").
+	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull).
 		WithMultiSetEnabled(true).
 		WithSubscriptions(true).

--- a/sdks/go/pkg/transports/json_utils_test.go
+++ b/sdks/go/pkg/transports/json_utils_test.go
@@ -707,11 +707,11 @@ func TestMarshalDeviceJSON_SlotZeroPresent(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyStringValuePreserved(t *testing.T) {
-	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull).
 		WithParam("label", catena.NewParamString(""))
 
-	jsonData, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	jsonData, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON error: %v", err2)
 	}
@@ -782,7 +782,7 @@ func TestMarshalDeviceJSON_PopulatedMapsKept(t *testing.T) {
 }
 
 func TestMarshalDeviceJSON_EmptyMenuMetadataStringsStripped(t *testing.T) {
-	cd := catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	cd := catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull).
 		WithParam("brightness", catena.NewParamInt32(0)).
 		WithMenuGroup("config", catena.NewMenuGroup().
@@ -792,7 +792,7 @@ func TestMarshalDeviceJSON_EmptyMenuMetadataStringsStripped(t *testing.T) {
 				WithParamOids("/brightness").
 				WithClientHint("ui-url", "")))
 
-	b, err2 := MarshalDeviceJSON(cd.ToProtoDevice())
+	b, err2 := MarshalDeviceJSON(cd.Proto)
 	if err2 != nil {
 		t.Fatalf("MarshalDeviceJSON: %v", err2)
 	}

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -264,12 +264,12 @@ func writeValueResult(w http.ResponseWriter, value catena.Value, httpStatus int)
 
 // writeDeviceResult writes a Device as JSON
 func writeDeviceResult(w http.ResponseWriter, device catena.Device, httpStatus int) {
-	if device.GetProtoDevice() == nil {
+	if device.ToProtoDevice() == nil {
 		w.WriteHeader(httpStatus)
 		return
 	}
 
-	b, err := MarshalDeviceJSON(device.GetProtoDevice())
+	b, err := MarshalDeviceJSON(device.ToProtoDevice())
 	if err != nil {
 		logger.Error("failed to marshal device response", "error", err)
 		w.Header().Set("Content-Type", "application/json")

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -250,7 +250,7 @@ func (t *RestTransport) writeHTTPStatusResult(w http.ResponseWriter, result cate
 
 // writeValueResult writes a Value as JSON
 func writeValueResult(w http.ResponseWriter, value catena.Value, httpStatus int) {
-	protoValue := value.Value
+	protoValue := value.Proto
 	if protoValue == nil {
 		w.WriteHeader(httpStatus)
 		return
@@ -264,12 +264,12 @@ func writeValueResult(w http.ResponseWriter, value catena.Value, httpStatus int)
 
 // writeDeviceResult writes a Device as JSON
 func writeDeviceResult(w http.ResponseWriter, device catena.Device, httpStatus int) {
-	if device.ToProtoDevice() == nil {
+	if device.Proto == nil {
 		w.WriteHeader(httpStatus)
 		return
 	}
 
-	b, err := MarshalDeviceJSON(device.ToProtoDevice())
+	b, err := MarshalDeviceJSON(device.Proto)
 	if err != nil {
 		logger.Error("failed to marshal device response", "error", err)
 		w.Header().Set("Content-Type", "application/json")
@@ -287,7 +287,7 @@ func writeDeviceResult(w http.ResponseWriter, device catena.Device, httpStatus i
 
 // writeAssetResult writes an Asset as JSON-encoded ExternalObjectPayload
 func writeAssetResult(w http.ResponseWriter, asset catena.Asset, httpStatus int) {
-	protoAsset := asset.GetProtoAsset()
+	protoAsset := asset.Proto
 	if protoAsset == nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -730,7 +730,7 @@ func (t *RestTransport) handleParamInfoEndpoint(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := WriteProtoJSON(w, infos[0].GetProtoResponse(), http.StatusOK); err != nil {
+	if err := WriteProtoJSON(w, infos[0].Proto, http.StatusOK); err != nil {
 		logger.Error("failed to write param info response", "error", err)
 	}
 }
@@ -758,7 +758,7 @@ func (t *RestTransport) writeParamInfoStream(w http.ResponseWriter, r *http.Requ
 			return
 		default:
 		}
-		protoResp := info.GetProtoResponse()
+		protoResp := info.Proto
 		if protoResp == nil {
 			continue
 		}
@@ -819,7 +819,7 @@ func (t *RestTransport) handleCommandEndpoint(w http.ResponseWriter, r *http.Req
 		cmdResult, _ = catena.CommandNoResponse()
 	}
 
-	_ = WriteProtoJSON(w, cmdResult.GetProtoResponse(), http.StatusOK)
+	_ = WriteProtoJSON(w, cmdResult.Proto, http.StatusOK)
 }
 
 // ToHTTPStatus converts a transport-neutral StatusCode to an HTTP status code.

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -130,7 +130,7 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
 				runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 					assertContext(t, ctx)
-					device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001")
+					device := *catena.NewDevice(slot)
 					return catena.Reply(device)
 				}
 			},
@@ -288,7 +288,7 @@ func TestRestTransport_GetDevice_Route(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	device := *catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+	device := *catena.NewDevice(0).
 		WithDetailLevel(catena.DetailLevelFull)
 
 	runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
@@ -1116,7 +1116,7 @@ func TestRestTransport_Connect_TooManyConnections(t *testing.T) {
 }
 
 func TestWriteResults_ValidData(t *testing.T) {
-	device := *catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001")
+	device := *catena.NewDevice(0)
 	rec := httptest.NewRecorder()
 	writeDeviceResult(rec, device, http.StatusOK)
 	assertStatus(t, rec, http.StatusOK)
@@ -1634,7 +1634,7 @@ func TestWriteValueResult_WriteError(t *testing.T) {
 }
 
 func TestWriteDeviceResult_WriteError(t *testing.T) {
-	device := *catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001")
+	device := *catena.NewDevice(0)
 	rec := httptest.NewRecorder()
 	w := &failWriter{ResponseWriter: rec, failOnWrite: true}
 

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -130,7 +130,7 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
 				runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 					assertContext(t, ctx)
-					device, _ := catena.ToDevice(map[string]any{"slot": uint32(slot)})
+					device := *catena.NewDevice(slot, "Test Device", "Ross Video", "1.0", "SN-0001")
 					return catena.Reply(device)
 				}
 			},
@@ -288,11 +288,8 @@ func TestRestTransport_GetDevice_Route(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 
 	handlerCalled := false
-	deviceMap := map[string]any{
-		"slot":         uint32(0),
-		"detail_level": catena.DetailLevelFull,
-	}
-	device, _ := catena.ToDevice(deviceMap)
+	device := *catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001").
+		WithDetailLevel(catena.DetailLevelFull)
 
 	runtime.getDeviceFn = func(slot uint16, ctx catena.TransportContext) (catena.Device, catena.StatusResult) {
 		handlerCalled = true
@@ -1119,7 +1116,7 @@ func TestRestTransport_Connect_TooManyConnections(t *testing.T) {
 }
 
 func TestWriteResults_ValidData(t *testing.T) {
-	device, _ := catena.ToDevice(map[string]any{"slot": int32(0)})
+	device := *catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001")
 	rec := httptest.NewRecorder()
 	writeDeviceResult(rec, device, http.StatusOK)
 	assertStatus(t, rec, http.StatusOK)
@@ -1637,7 +1634,7 @@ func TestWriteValueResult_WriteError(t *testing.T) {
 }
 
 func TestWriteDeviceResult_WriteError(t *testing.T) {
-	device, _ := catena.ToDevice(map[string]any{"slot": int32(0)})
+	device := *catena.NewDevice(0, "Test Device", "Ross Video", "1.0", "SN-0001")
 	rec := httptest.NewRecorder()
 	w := &failWriter{ResponseWriter: rec, failOnWrite: true}
 


### PR DESCRIPTION
## 📖 Description
Refactors the Go SDK device model around a fluent `catena.Device` builder and moves mandatory **product** struct handling into the SDK. Applications register product identity once per slot via `Server.RegisterProductStruct`; the server then injects the product param on `GetDevice`, serves `product/*` on `GetValue` and `ParamInfo`, and rejects writes to product fields on `SetValue`.

This removes the map-based device construction path (`ToDevice`, `Param.ToMap`, `Constraint.ToMap`) and updates examples (`hello_world`, `oneOfEverything`) and transports to use the new typed API. `GetParam` continues to stay in sync with `GetDevice` by rebuilding the device definition and resolving params via `lookupParam(device.Proto, fqoid)`.

---

## 🎯 Goal / Outcome
- Adopters build devices with `catena.NewDevice(slot)` and `With*` builders instead of `map[string]any` + `ToDevice`.
- The mandatory SMPTE product struct is SDK-managed and spec-compliant (`catena_sdk`, `catena_sdk_version` set by the SDK).
- Business logic no longer duplicates product handling across GetDevice, GetValue, ParamInfo, and SetValue handlers.
- `Asset` and `CommandResult` expose their underlying protos via exported `Proto` fields for consistency with `Device` and `Param`.

---

## ✅ Definition of Done (DoD)
- [x] `RegisterProductStruct` injects product on GetDevice and serves product/* on GetValue / ParamInfo
- [x] SetValue to product/* returns `StatusCodePermissionDenied`
- [x] `NewDevice(slot)` simplified; product identity removed from device constructor
- [x] Map-based conversion APIs removed (`ToDevice`, `ToMap`)
- [x] `hello_world` and `oneOfEverything` examples migrated to fluent Device API
- [x] GetParam handler updated to use `device.Proto` with `lookupParam`
- [x] `Asset` / `CommandResult` refactored to exported `Proto` fields
- [x] Unit tests added/updated (`product_test.go`, `product_server_test.go`, `roundtrip_test.go`, transport tests)

---

## 🛠️ Implementation Notes (Optional)
- New types/helpers in `product.go`: `ProductStruct`, `ProductParam`, `ProductValues`, `productValueForOid`, `productParamInfosForOid`.
- `Device` now exposes `Proto *protos.Device` directly (replaces private `device` field and `ToProtoDevice()`).
- `ParamInfosForRequest` now accepts `*Device` instead of `map[string]any`.
- `oneOfEverything` adds `registerProductStructs()` and removes product branches from value/param-info handlers; slot 0 param makers (`makeCounterParam`, `makeRunningParam`) remain the shared source of truth for GetDevice and GetParam.
- Transports (`grpc_transport.go`, `rest_transport.go`) updated to read `device.Proto` when marshaling responses.

---

## 🔗 Related Issues / Links

Closes issues
- #1436 
- #1323
- #1304 

---
