### PR TITLE
[GO] REST Server Startup

### DIFF
--- a/sdks/go/pkg/catena/connection_props.go
+++ b/sdks/go/pkg/catena/connection_props.go
@@ -111,8 +111,6 @@ func (c *ConnectionProps) Start() error {
 	// Bind synchronously so that errors (privileged port, address already in
 	// use, etc.) are returned to the caller instead of only being logged
 	// asynchronously after Start has already reported success.
-	// TODO: replicate this synchronous-listener startup routine in RestTransport
-	// (sdks/go/pkg/transports/rest_transport.go) so its errors surface to the caller too.
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		c.mu.Unlock()

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -45,6 +45,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -82,6 +83,16 @@ func NewRestTransport(cfg config.RestOptions) *RestTransport {
 // Start starts the HTTP server on the specified port using this server's mux
 func (t *RestTransport) Start(ctx context.Context, runtime catena.ServerRuntime) error {
 	addr := fmt.Sprintf(":%d", t.port)
+	// Bind synchronously so that startup errors (privileged port, address
+	// already in use, invalid address, etc.) are returned to the caller
+	// instead of only being logged asynchronously after Start has already
+	// reported success. This mirrors ConnectionProps.Start.
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		logger.Error("REST Transport failed to listen", "address", addr, "error", err)
+		return fmt.Errorf("REST transport failed to listen on %s: %w", addr, err)
+	}
+
 	t.server = &http.Server{
 		Addr:    addr,
 		Handler: t.mux,
@@ -89,10 +100,10 @@ func (t *RestTransport) Start(ctx context.Context, runtime catena.ServerRuntime)
 	t.runtime = runtime
 
 	// http server does not use context
-	// listen and serve blocks so do it in a goroutine
+	// serve blocks so do it in a goroutine
 	go func() {
 		logger.Info("REST Transport listening", "address", addr)
-		err := t.server.ListenAndServe()
+		err := t.server.Serve(listener)
 		if err != nil && err != http.ErrServerClosed {
 			logger.Error("HTTP server error", "error", err)
 		}

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -1246,6 +1246,28 @@ func TestRestTransport_Start(t *testing.T) {
 	transport.Shutdown(ctx)
 }
 
+func TestRestTransport_Start_BindError(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	// Occupy a port so the transport's synchronous bind fails with
+	// "address already in use".
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer listener.Close()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	transport.port = port
+	err = transport.Start(context.Background(), runtime)
+	if err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		transport.Shutdown(ctx)
+		t.Fatal("expected Start to return a bind error, got nil")
+	}
+}
+
 func TestRestTransport_Shutdown_NotStarted(t *testing.T) {
 	transport, runtime := makeTestRestTransport(t)
 	runtime.shutdownTransportConnsFn = func(ctx context.Context, gotTransport catena.Transport) {


### PR DESCRIPTION
## 📖 Description

Makes `RestTransport.Start` bind its TCP listener synchronously so that startup errors are returned to the caller instead of only being logged asynchronously from the serve goroutine after `Start` has already reported success. This brings `RestTransport` in line with the existing behavior in `ConnectionProps.Start`.

---

## 🎯 Goal / Outcome

Callers of `RestTransport.Start` receive an immediate, actionable error when the HTTP server cannot bind, rather than a false success followed by a background log message. This removes a long-standing inconsistency between the two
transports and resolves the TODO left in `connection_props.go`.

---

## ✅ Definition of Done (DoD)

- [x] `RestTransport.Start` binds via `net.Listen` before serving and returns bind errors to the caller
- [x] Server now uses `http.Server.Serve(listener)` instead of `ListenAndServe()`
- [x] Behavior mirrors `ConnectionProps.Start` (stale TODO removed from `connection_props.go`)
- [x] Test added covering the bind-failure path (`TestRestTransport_Start_BindError`)

---

## 🛠️ Implementation Notes (Optional)

- Switched from `t.server.ListenAndServe()` to creating the `net.Listener` up-front and passing it to `t.server.Serve(listener)`. The blocking `Serve`
  call stays in a goroutine; only the bind step is now synchronous.
- Errors are both logged (`"REST Transport failed to listen"`) and wrapped with `%w` so callers can inspect the underlying cause.
- Added `net` to the import list in `rest_transport.go`.

---

## 🔗 Related Issues / Links

Closes issue #1374 