### PR TITLE
[GO] Languages Endpoint

### DIFF
--- a/sdks/go/examples/oneOfEverything/languages_handler.go
+++ b/sdks/go/examples/oneOfEverything/languages_handler.go
@@ -9,7 +9,7 @@ import (
 // handler returns the language codes the device model supports; adopters would
 // derive this from their own language packs. Here a small static list is used.
 func registerLanguagesHandlers(srv catena.Server) {
-	supported := []string{"en", "fr", "es", "de"}
+	supported := []string{"en", "fr"}
 	for _, slot := range slotList {
 		srv.RegisterListLanguagesHandler(slot, func(slot uint16, ctx catena.HandlerContext) ([]string, catena.StatusResult) {
 			logger.Info("ListLanguages", "slot", slot)

--- a/sdks/go/examples/oneOfEverything/languages_handler.go
+++ b/sdks/go/examples/oneOfEverything/languages_handler.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
+)
+
+// registerLanguagesHandlers wires the Languages endpoint for each slot. The
+// handler returns the language codes the device model supports; adopters would
+// derive this from their own language packs. Here a small static list is used.
+func registerLanguagesHandlers(srv catena.Server) {
+	supported := []string{"en", "fr", "es", "de"}
+	for _, slot := range slotList {
+		srv.RegisterListLanguagesHandler(slot, func(slot uint16, ctx catena.HandlerContext) ([]string, catena.StatusResult) {
+			logger.Info("ListLanguages", "slot", slot)
+			return supported, catena.StatusWithCode(catena.StatusCodeOk, "")
+		})
+	}
+}

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -391,6 +391,7 @@ func main() {
 	registerCommandHandler(srv, counter, broadcastRunning, counterScope) // ExecuteCommand
 	registerAssetHandlers(srv, assets)                                   // ExternalObjectRequest
 	registerParamInfoHandlers(srv, counter, state)                       // ParamInfoRequest
+	registerLanguagesHandlers(srv)                                       // ListLanguages
 	registerHeartbeatHandlers(srv, state)                                // periodic BroadcastUpdate
 
 	srv.StartHeartbeat(5 * time.Second)

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -68,6 +68,7 @@ const (
 	EndpointExecuteCommand
 	EndpointParamInfo
 	EndpointConnect
+	EndpointListLanguages
 )
 
 type TransportContext struct {
@@ -139,6 +140,10 @@ type SetValueHandler func(slot uint16, entries []SetValueEntry, ctx HandlerConte
 type GetAssetHandler func(slot uint16, fqoid string, ctx HandlerContext) (Asset, StatusResult)
 type ExecuteCommandHandler func(slot uint16, commandFqoid string, payload any, ctx HandlerContext) (CommandResult, StatusResult)
 type ParamInfoHandler func(slot uint16, oidPrefix string, recursive bool, ctx HandlerContext) ([]ParamInfo, StatusResult)
+
+// ListLanguagesHandler returns the language codes supported by the device model
+// at a slot (e.g. ["en", "fr"]). An empty slice indicates no multi-lingual support.
+type ListLanguagesHandler func(slot uint16, ctx HandlerContext) ([]string, StatusResult)
 type HeartbeatHandler func(slot uint16)
 type AccessHandler func(endpointType EndpointType, ctx HandlerContext) bool
 
@@ -195,6 +200,7 @@ type Server interface {
 	RegisterGetAssetHandler(slot uint16, handler GetAssetHandler)
 	RegisterExecuteCommandHandler(slot uint16, handler ExecuteCommandHandler)
 	RegisterParamInfoHandler(slot uint16, handler ParamInfoHandler)
+	RegisterListLanguagesHandler(slot uint16, handler ListLanguagesHandler)
 	RegisterHeartbeatHandler(slot uint16, handler HeartbeatHandler)
 	RegisterAccessHandler(handler AccessHandler)
 
@@ -217,6 +223,7 @@ type ServerRuntime interface {
 	InvokeGetAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (Asset, StatusResult)
 	InvokeExecuteCommandHandler(slot uint16, commandFqoid string, payload any, transportContext TransportContext) (CommandResult, StatusResult)
 	InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive bool, transportContext TransportContext) ([]ParamInfo, StatusResult)
+	InvokeListLanguagesHandler(slot uint16, transportContext TransportContext) ([]string, StatusResult)
 	RegisterTransportConnection(transport Transport, transportContext TransportContext) (*Connection, StatusResult)
 	ShutdownTransportConnections(ctx context.Context, transport Transport)
 	DeregisterConnection(connID int)
@@ -243,6 +250,7 @@ type server struct {
 	getAssetHandlers       map[uint16]GetAssetHandler
 	executeCommandHandlers map[uint16]ExecuteCommandHandler
 	paramInfoHandlers      map[uint16]ParamInfoHandler
+	listLanguagesHandlers  map[uint16]ListLanguagesHandler
 	heartbeatHandlers      map[uint16]HeartbeatHandler
 	accessHandler          AccessHandler // optional fallback for slots without specific handlers
 	connectionQueue        connectionQueueInterface
@@ -280,6 +288,7 @@ func NewServer(opts config.ServerOptions) (Server, error) {
 		getAssetHandlers:       make(map[uint16]GetAssetHandler),
 		executeCommandHandlers: make(map[uint16]ExecuteCommandHandler),
 		paramInfoHandlers:      make(map[uint16]ParamInfoHandler),
+		listLanguagesHandlers:  make(map[uint16]ListLanguagesHandler),
 		heartbeatHandlers:      make(map[uint16]HeartbeatHandler),
 		accessHandler:          allowAllAccessHandler,
 		connectionQueue:        newConnectionQueue(opts.MaxConnections),
@@ -594,6 +603,17 @@ func (s *server) RegisterParamInfoHandler(slot uint16, handler ParamInfoHandler)
 	}
 }
 
+func (s *server) RegisterListLanguagesHandler(slot uint16, handler ListLanguagesHandler) {
+	s.mu.Lock()
+	s.listLanguagesHandlers[slot] = handler
+	newSlot := s.registerSlotLocked(slot)
+	s.mu.Unlock()
+
+	if newSlot {
+		s.notifySlotsAdded(slot)
+	}
+}
+
 func (s *server) RegisterHeartbeatHandler(slot uint16, handler HeartbeatHandler) {
 	s.mu.Lock()
 	s.heartbeatHandlers[slot] = handler
@@ -791,6 +811,31 @@ func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive
 	// TODO: lookup default handler for slot
 	logger.Warning("ParamInfoHandler called - no handler registered for this slot", "slot", slot, "oidPrefix", oidPrefix)
 	return nil, StatusWithCode(StatusCodeNotFound, "ParamInfo "+oidPrefix+" not found at slot "+strconv.Itoa(int(slot)))
+}
+
+func (s *server) InvokeListLanguagesHandler(slot uint16, transportContext TransportContext) ([]string, StatusResult) {
+	handlerContext, res := s.resolveHandlerContext(transportContext)
+	if res.Code != StatusCodeOk {
+		return nil, res
+	}
+
+	if !s.hasReadAccess(handlerContext) {
+		return nil, StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+	}
+	if !s.isAccessAllowed(EndpointListLanguages, handlerContext) {
+		return nil, StatusWithCode(StatusCodePermissionDenied, "Permission denied")
+	}
+
+	s.mu.Lock()
+	handler, ok := s.listLanguagesHandlers[slot]
+	s.mu.Unlock()
+
+	if ok {
+		return handler(slot, handlerContext)
+	}
+	// TODO: lookup default handler for slot
+	logger.Warning("ListLanguagesHandler called - no handler registered for this slot", "slot", slot)
+	return nil, StatusWithCode(StatusCodeNotFound, "no ListLanguages handler registered for slot "+strconv.Itoa(int(slot)))
 }
 
 func (s *server) RegisterTransportConnection(transport Transport, transportContext TransportContext) (*Connection, StatusResult) {

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -1508,6 +1508,51 @@ func TestServer_RegisterParamInfoHandler(t *testing.T) {
 	}
 }
 
+func TestServer_RegisterListLanguagesHandler(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	handlerCalled := false
+	srv.RegisterListLanguagesHandler(0, func(slot uint16, ctx HandlerContext) ([]string, StatusResult) {
+		handlerCalled = true
+		if slot != 0 {
+			t.Errorf("expected slot 0, got %d", slot)
+		}
+		return []string{"en", "fr"}, StatusResult{Code: StatusCodeOk}
+	})
+
+	languages, status := srv.InvokeListLanguagesHandler(0, validTestTransportContext(nil))
+
+	if !handlerCalled {
+		t.Error("registered handler was not called")
+	}
+	if status.Code != StatusCodeOk {
+		t.Errorf("expected OK status, got %v", status.Code)
+	}
+	if len(languages) != 2 || languages[0] != "en" || languages[1] != "fr" {
+		t.Errorf("expected [en fr], got %v", languages)
+	}
+
+	// check that the slot is registered
+	slots, status := srv.GetSlots(validTestTransportContext(nil))
+	if status.Code != StatusCodeOk {
+		t.Errorf("expected OK status from GetSlots, got %v", status.Code)
+	}
+	if !slices.Contains(slots, uint16(0)) {
+		t.Error("slot 0 should be registered in server slots")
+	}
+}
+
+func TestServer_InvokeListLanguagesHandler_NoHandler(t *testing.T) {
+	srv := newTestServer(t, true)
+
+	_, status := srv.InvokeListLanguagesHandler(0, validTestTransportContext(nil))
+
+	// no handler should return StatusCodeNotFound status
+	if status.Code != StatusCodeNotFound {
+		t.Errorf("expected StatusCodeNotFound status, got %v", status.Code)
+	}
+}
+
 func TestServer_RegisterHeartbeatHandler(t *testing.T) {
 	srv := newTestServer(t, true)
 

--- a/sdks/go/pkg/transports/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc_transport.go
@@ -593,9 +593,23 @@ func (s *catenaService) LanguagePackRequest(ctx context.Context, req *protos.Lan
 	return nil, status.Error(codes.Unimplemented, "LanguagePackRequest not implemented")
 }
 
-// ListLanguages returns the list of available languages
+// ListLanguages returns the language codes supported by the device model at a slot.
 func (s *catenaService) ListLanguages(ctx context.Context, req *protos.Slot) (*protos.LanguageList, error) {
-	return nil, status.Error(codes.Unimplemented, "ListLanguages not implemented")
+	slot, err := catena.ValidateSlot(req.GetSlot())
+	if err.Code != catena.StatusCodeOk {
+		return nil, status.Error(ToGRPCCode(err.Code), err.Error)
+	}
+
+	logger.Info("ListLanguages", "slot", slot)
+
+	transportContext := s.transport.retrieveMetadataFromContext(ctx)
+	languages, result := s.transport.runtime.InvokeListLanguagesHandler(slot, transportContext)
+	if result.IsError() {
+		logger.Error("ListLanguages handler error", "slot", slot, "error", result.Error)
+		return nil, status.Error(ToGRPCCode(result.Code), result.Error)
+	}
+
+	return &protos.LanguageList{Languages: languages}, nil
 }
 
 // RefreshToken refreshes an authentication token

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -597,6 +597,60 @@ func TestGrpcTransport_GetValue_HandlerError(t *testing.T) {
 }
 
 // =============================================================================
+// Test: ListLanguages
+// =============================================================================
+
+func TestGrpcTransport_ListLanguages_Success(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
+	defer cleanup()
+
+	handlerCalled := false
+	runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+		handlerCalled = true
+		if slot != 0 {
+			t.Errorf("expected slot 0, got %d", slot)
+		}
+		return []string{"en", "fr", "es", "de"}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	resp, err := client.ListLanguages(ctx, &protos.Slot{Slot: 0})
+	assertNoError(t, err)
+	if !handlerCalled {
+		t.Error("registered handler was not called")
+	}
+
+	expected := []string{"en", "fr", "es", "de"}
+	if len(resp.GetLanguages()) != len(expected) {
+		t.Fatalf("expected %d languages, got %d", len(expected), len(resp.GetLanguages()))
+	}
+	for i, lang := range expected {
+		if resp.GetLanguages()[i] != lang {
+			t.Errorf("language[%d]: expected %q, got %q", i, lang, resp.GetLanguages()[i])
+		}
+	}
+}
+
+func TestGrpcTransport_ListLanguages_HandlerError(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
+	defer cleanup()
+
+	runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "no languages handler registered")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	_, err := client.ListLanguages(ctx, &protos.Slot{Slot: 0})
+	assertGRPCCode(t, err, codes.NotFound, "handler error")
+}
+
+// =============================================================================
 // Test: GetParam
 // =============================================================================
 
@@ -1475,15 +1529,6 @@ func TestGrpcTransport_ErrorMessages_DevVsProd(t *testing.T) {
 			},
 		},
 		{
-			name:       "ListLanguages",
-			devMessage: "ListLanguages not implemented",
-			grpcCode:   codes.Unimplemented,
-			callEndpoint: func(client protos.CatenaServiceClient, ctx context.Context) error {
-				_, err := client.ListLanguages(ctx, &protos.Slot{Slot: 0})
-				return err
-			},
-		},
-		{
 			name:       "RefreshToken",
 			devMessage: "RefreshToken not implemented",
 			grpcCode:   codes.Unimplemented,
@@ -1745,15 +1790,6 @@ func TestGrpcTransport_UnimplementedEndpoints(t *testing.T) {
 			name: "LanguagePackRequest",
 			callFunc: func(client protos.CatenaServiceClient, ctx context.Context) error {
 				_, err := client.LanguagePackRequest(ctx, &protos.LanguagePackRequestPayload{
-					Slot: 0,
-				})
-				return err
-			},
-		},
-		{
-			name: "ListLanguages",
-			callFunc: func(client protos.CatenaServiceClient, ctx context.Context) error {
-				_, err := client.ListLanguages(ctx, &protos.Slot{
 					Slot: 0,
 				})
 				return err

--- a/sdks/go/pkg/transports/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc_transport_test.go
@@ -650,6 +650,27 @@ func TestGrpcTransport_ListLanguages_HandlerError(t *testing.T) {
 	assertGRPCCode(t, err, codes.NotFound, "handler error")
 }
 
+func TestGrpcTransport_ListLanguages_InvalidSlot(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestGrpcTransport(t, []uint16{0})
+	defer cleanup()
+
+	handlerCalled := false
+	runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+		handlerCalled = true
+		return nil, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	_, err := client.ListLanguages(ctx, &protos.Slot{Slot: 999999})
+	assertGRPCCode(t, err, codes.InvalidArgument, "invalid slot number")
+	if handlerCalled {
+		t.Error("handler should not be called when slot validation fails")
+	}
+}
+
 // =============================================================================
 // Test: GetParam
 // =============================================================================

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -517,8 +517,8 @@ func (t *RestTransport) handleGetPopulatedSlots(w http.ResponseWriter, r *http.R
 }
 
 // handleLanguagesEndpoint handles GET /st2138-api/v1/{slot}/languages (Languages).
-// It returns the language codes supported by the device model as a JSON array of
-// strings, e.g. ["en", "fr", "es", "de"]. An empty result serializes as [].
+// It returns the language codes supported by the device model as a LanguageList,
+// e.g. {"languages":["en","fr","es","de"]}. An empty result serializes as {"languages":[]}.
 func (t *RestTransport) handleLanguagesEndpoint(w http.ResponseWriter, r *http.Request, slot uint16) {
 	if r.Method != http.MethodGet {
 		t.writeHTTPMethodNotAllowed(w, "only GET allowed")
@@ -536,9 +536,11 @@ func (t *RestTransport) handleLanguagesEndpoint(w http.ResponseWriter, r *http.R
 		languages = []string{}
 	}
 
+	response := &protos.LanguageList{Languages: languages}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(languages); err != nil {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		logger.Error("failed to write languages response", "error", err)
 	}
 }

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -440,6 +440,8 @@ func (t *RestTransport) registerRoutes() {
 				t.handleParamEndpoint(w, r, slot, parts[4:])
 			case "param-info":
 				t.handleParamInfoEndpoint(w, r, slot, parts[4:])
+			case "languages":
+				t.handleLanguagesEndpoint(w, r, slot)
 			default:
 				val, res := catena.ReplyError[catena.Value](catena.StatusCodeNotFound, "unknown endpoint")
 				t.writeHTTPResult(w, res, val)
@@ -511,6 +513,33 @@ func (t *RestTransport) handleGetPopulatedSlots(w http.ResponseWriter, r *http.R
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		logger.Error("failed to write slots response", "error", err)
+	}
+}
+
+// handleLanguagesEndpoint handles GET /st2138-api/v1/{slot}/languages (Languages).
+// It returns the language codes supported by the device model as a JSON array of
+// strings, e.g. ["en", "fr", "es", "de"]. An empty result serializes as [].
+func (t *RestTransport) handleLanguagesEndpoint(w http.ResponseWriter, r *http.Request, slot uint16) {
+	if r.Method != http.MethodGet {
+		t.writeHTTPMethodNotAllowed(w, "only GET allowed")
+		return
+	}
+
+	transportContext := t.retrieveMetadataFromRequest(r)
+	languages, result := t.runtime.InvokeListLanguagesHandler(slot, transportContext)
+	if result.IsError() {
+		t.writeHTTPStatusResult(w, result)
+		return
+	}
+
+	if languages == nil {
+		languages = []string{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(languages); err != nil {
+		logger.Error("failed to write languages response", "error", err)
 	}
 }
 

--- a/sdks/go/pkg/transports/rest_transport.go
+++ b/sdks/go/pkg/transports/rest_transport.go
@@ -517,8 +517,8 @@ func (t *RestTransport) handleGetPopulatedSlots(w http.ResponseWriter, r *http.R
 }
 
 // handleLanguagesEndpoint handles GET /st2138-api/v1/{slot}/languages (Languages).
-// It returns the language codes supported by the device model as a LanguageList,
-// e.g. {"languages":["en","fr","es","de"]}. An empty result serializes as {"languages":[]}.
+// Per the OpenAPI contract (GET /{slot}/languages), the body is a bare JSON array
+// of language codes, e.g. ["en","fr","es","de"]. An empty result serializes as [].
 func (t *RestTransport) handleLanguagesEndpoint(w http.ResponseWriter, r *http.Request, slot uint16) {
 	if r.Method != http.MethodGet {
 		t.writeHTTPMethodNotAllowed(w, "only GET allowed")
@@ -536,11 +536,9 @@ func (t *RestTransport) handleLanguagesEndpoint(w http.ResponseWriter, r *http.R
 		languages = []string{}
 	}
 
-	response := &protos.LanguageList{Languages: languages}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
+	if err := json.NewEncoder(w).Encode(languages); err != nil {
 		logger.Error("failed to write languages response", "error", err)
 	}
 }

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -236,6 +236,19 @@ func TestRestTransport_PropagatesTransportContext(t *testing.T) {
 			},
 		},
 		{
+			name: "languages",
+			setup: func(t *testing.T, runtime *stubServerRuntime) {
+				runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+					assertContext(t, ctx)
+					return []string{"en", "fr"}, catena.StatusWithCode(catena.StatusCodeOk, "")
+				}
+			},
+			run: func(t *testing.T, transport *RestTransport) {
+				rec := makeRequestWithHeaders(t, transport, http.MethodGet, "/st2138-api/v1/0/languages", "", headers)
+				assertStatus(t, rec, http.StatusOK)
+			},
+		},
+		{
 			name: "connect",
 			setup: func(t *testing.T, runtime *stubServerRuntime) {
 				connection := makeTestConnection(1)
@@ -2082,4 +2095,75 @@ func TestRestTransport_ParamInfo_TopLevelStream_Empty(t *testing.T) {
 	if err := assertHasError(t, rec); !strings.Contains(err, "No top-level parameters found") {
 		t.Errorf("expected 'No top-level parameters found' error, got %q", err)
 	}
+}
+
+// =============================================================================
+// Test: Languages endpoint
+// =============================================================================
+
+func TestRestTransport_Languages_Route(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	handlerCalled := false
+	runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+		handlerCalled = true
+		if slot != 0 {
+			t.Errorf("expected slot 0, got %d", slot)
+		}
+		return []string{"en", "fr", "es", "de"}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/languages", "")
+	assertStatus(t, rec, http.StatusOK)
+	assertContentType(t, rec, "application/json")
+	if !handlerCalled {
+		t.Error("registered handler was not called")
+	}
+
+	var languages []string
+	if err := json.Unmarshal(rec.Body.Bytes(), &languages); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	expected := []string{"en", "fr", "es", "de"}
+	if len(languages) != len(expected) {
+		t.Fatalf("expected %d languages, got %d", len(expected), len(languages))
+	}
+	for i, lang := range expected {
+		if languages[i] != lang {
+			t.Errorf("language[%d]: expected %q, got %q", i, lang, languages[i])
+		}
+	}
+}
+
+func TestRestTransport_Languages_EmptyList(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/languages", "")
+	assertStatus(t, rec, http.StatusOK)
+	assertContentType(t, rec, "application/json")
+
+	if body := strings.TrimSpace(rec.Body.String()); body != "[]" {
+		t.Errorf("expected empty JSON array '[]', got %q", body)
+	}
+}
+
+func TestRestTransport_Languages_HandlerError(t *testing.T) {
+	transport, runtime := makeTestRestTransport(t)
+
+	runtime.listLanguagesFn = func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "no languages handler registered")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/languages", "")
+	assertStatus(t, rec, http.StatusNotFound)
+}
+
+func TestRestTransport_Languages_MethodNotAllowed(t *testing.T) {
+	transport, _ := makeTestRestTransport(t)
+	rec := makeRequest(t, transport, http.MethodPost, "/st2138-api/v1/0/languages", "")
+	assertStatus(t, rec, http.StatusMethodNotAllowed)
 }

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -2120,17 +2120,19 @@ func TestRestTransport_Languages_Route(t *testing.T) {
 		t.Error("registered handler was not called")
 	}
 
-	var languages []string
-	if err := json.Unmarshal(rec.Body.Bytes(), &languages); err != nil {
+	var response struct {
+		Languages []string `json:"languages"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("invalid JSON response: %v", err)
 	}
 	expected := []string{"en", "fr", "es", "de"}
-	if len(languages) != len(expected) {
-		t.Fatalf("expected %d languages, got %d", len(expected), len(languages))
+	if len(response.Languages) != len(expected) {
+		t.Fatalf("expected %d languages, got %d", len(expected), len(response.Languages))
 	}
 	for i, lang := range expected {
-		if languages[i] != lang {
-			t.Errorf("language[%d]: expected %q, got %q", i, lang, languages[i])
+		if response.Languages[i] != lang {
+			t.Errorf("language[%d]: expected %q, got %q", i, lang, response.Languages[i])
 		}
 	}
 }
@@ -2146,8 +2148,14 @@ func TestRestTransport_Languages_EmptyList(t *testing.T) {
 	assertStatus(t, rec, http.StatusOK)
 	assertContentType(t, rec, "application/json")
 
-	if body := strings.TrimSpace(rec.Body.String()); body != "[]" {
-		t.Errorf("expected empty JSON array '[]', got %q", body)
+	var response struct {
+		Languages []string `json:"languages"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if len(response.Languages) != 0 {
+		t.Errorf("expected empty languages list, got %v", response.Languages)
 	}
 }
 

--- a/sdks/go/pkg/transports/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest_transport_test.go
@@ -2120,19 +2120,17 @@ func TestRestTransport_Languages_Route(t *testing.T) {
 		t.Error("registered handler was not called")
 	}
 
-	var response struct {
-		Languages []string `json:"languages"`
-	}
+	var response []string
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("invalid JSON response: %v", err)
 	}
 	expected := []string{"en", "fr", "es", "de"}
-	if len(response.Languages) != len(expected) {
-		t.Fatalf("expected %d languages, got %d", len(expected), len(response.Languages))
+	if len(response) != len(expected) {
+		t.Fatalf("expected %d languages, got %d", len(expected), len(response))
 	}
 	for i, lang := range expected {
-		if response.Languages[i] != lang {
-			t.Errorf("language[%d]: expected %q, got %q", i, lang, response.Languages[i])
+		if response[i] != lang {
+			t.Errorf("language[%d]: expected %q, got %q", i, lang, response[i])
 		}
 	}
 }
@@ -2148,14 +2146,15 @@ func TestRestTransport_Languages_EmptyList(t *testing.T) {
 	assertStatus(t, rec, http.StatusOK)
 	assertContentType(t, rec, "application/json")
 
-	var response struct {
-		Languages []string `json:"languages"`
-	}
+	var response []string
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
 		t.Fatalf("invalid JSON response: %v", err)
 	}
-	if len(response.Languages) != 0 {
-		t.Errorf("expected empty languages list, got %v", response.Languages)
+	if len(response) != 0 {
+		t.Errorf("expected empty languages list, got %v", response)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(rec.Body.String()), "[") {
+		t.Errorf("expected bare JSON array, got %q", rec.Body.String())
 	}
 }
 

--- a/sdks/go/pkg/transports/stub_server_test.go
+++ b/sdks/go/pkg/transports/stub_server_test.go
@@ -60,6 +60,7 @@ type stubServerRuntime struct {
 	getAssetFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (catena.Asset, catena.StatusResult)
 	commandFn                func(slot uint16, commandFqoid string, payload any, ctx catena.TransportContext) (catena.CommandResult, catena.StatusResult)
 	paramInfoFn              func(slot uint16, oidPrefix string, recursive bool, ctx catena.TransportContext) ([]catena.ParamInfo, catena.StatusResult)
+	listLanguagesFn          func(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult)
 	registerTransportConnFn  func(transport catena.Transport, ctx catena.TransportContext) (*catena.Connection, catena.StatusResult)
 	deregisterConnFn         func(connID int)
 	shutdownTransportConnsFn func(ctx context.Context, transport catena.Transport)
@@ -149,6 +150,14 @@ func (s *stubServerRuntime) InvokeParamInfoHandler(slot uint16, oidPrefix string
 	}
 	s.panicf("ParamInfo handler not implemented in stubServerRuntime for slot %d, oidPrefix %s", slot, oidPrefix)
 	return nil, catena.StatusResult{Code: catena.StatusCodeInternal}
+}
+
+func (s *stubServerRuntime) InvokeListLanguagesHandler(slot uint16, ctx catena.TransportContext) ([]string, catena.StatusResult) {
+	if s.listLanguagesFn != nil {
+		return s.listLanguagesFn(slot, ctx)
+	}
+	s.panicf("ListLanguages handler not implemented in stubServerRuntime for slot %d", slot)
+	return nil, catena.StatusResult{Code: catena.StatusCodeInternal, Error: "ListLanguages handler not implemented"}
 }
 
 func (s *stubServerRuntime) RegisterTransportConnection(transport catena.Transport, ctx catena.TransportContext) (*catena.Connection, catena.StatusResult) {


### PR DESCRIPTION
## 📖 Description

Adds the **Languages** endpoint to the Go SDK, exposing the language codes a device model supports at a given slot. The work follows the SDK's established per-endpoint pattern (handler type → `Server` registration → `ServerRuntime` invoke with access checks → transport route → test stub) and implements it across both transports:

- **REST:** `GET /st2138-api/v1/{slot}/languages` returns a JSON array of language codes (e.g. `["en","fr","es","de"]`).
- **gRPC:** the previously `Unimplemented` `ListLanguages` RPC now returns a populated `protos.LanguageList`.

A shared `ListLanguagesHandler` (`func(slot uint16, ctx HandlerContext) ([]string, StatusResult)`) backs both transports, and the `oneOfEverything` example registers a sample handler.

---

## 🎯 Goal / Outcome

Clients can query the set of supported language codes for a device slot over REST or gRPC, matching the ST 2138 Languages endpoint specification, instead of receiving an `Unimplemented` error.

---

## ✅ Definition of Done (DoD)

- [x] `ListLanguagesHandler` type, `EndpointListLanguages`, and `Register/InvokeListLanguagesHandler` added to `server.go` (with read-scope access checks)
- [x] REST route `GET /{slot}/languages` implemented (`handleLanguagesEndpoint`), serializing results as a JSON array
- [x] gRPC `ListLanguages` implemented against the shared runtime handler
- [x] Sample handler registered in the `oneOfEverything` example
- [x] Edge cases handled: unregistered slot → `404 NotFound`; empty/nil result → `200 []` ("no multi-lingual support"); wrong HTTP method → `405`
- [x] Unit tests added for REST, gRPC, and the server runtime; obsolete `ListLanguages` "Unimplemented" test entries removed
- [x] `go build ./...` and `go test ./...` pass; no linter errors

---

## 🛠️ Implementation Notes

- The handler returns a plain `[]string`; REST encodes it directly via `json.NewEncoder`, while gRPC wraps it in `&protos.LanguageList{Languages: ...}` (reusing the existing proto type).
- Access control mirrors `GetDevice`/`GetValue`: read scope required, gated by a new `EndpointListLanguages` enum value.
- **Behavioral distinction:** an *unregistered* slot yields `404` (consistent with other endpoints), whereas a *registered* handler returning an empty slice yields `200 []`. In REST, nil is coerced to `[]string{}` so the body is always a valid JSON array.
- The test `stubServerRuntime` gained a `listLanguagesFn` + `InvokeListLanguagesHandler` method to keep the `ServerRuntime` interface assertion compiling.

---

## 🔗 Related Issues / Links

Closes issues:
- #1367 
- #1377 

