### PR TITLE
[GO] Child Param read_only bug

### DIFF
--- a/sdks/go/pkg/catena/param.go
+++ b/sdks/go/pkg/catena/param.go
@@ -254,9 +254,29 @@ func (cp *Param) WithConstraint(c *Constraint) *Param {
 	return cp
 }
 
+// WithReadOnly sets the param's read_only flag. Read-only is inherited
+// downward: when set to true, every existing sub-param (recursively) is also
+// marked read-only, since a child of a read-only parent cannot be writable.
+// Setting it to false leaves sub-params untouched, so a child may still be
+// independently marked read-only under a writable parent.
 func (cp *Param) WithReadOnly(readOnly bool) *Param {
 	cp.Proto.ReadOnly = readOnly
+	if readOnly {
+		propagateReadOnly(cp.Proto.Params)
+	}
 	return cp
+}
+
+// propagateReadOnly recursively marks every param in the map (and their
+// sub-params) as read-only.
+func propagateReadOnly(params map[string]*protos.Param) {
+	for _, p := range params {
+		if p == nil {
+			continue
+		}
+		p.ReadOnly = true
+		propagateReadOnly(p.Params)
+	}
 }
 
 func (cp *Param) WithWidget(widget string) *Param {
@@ -320,6 +340,13 @@ func (cp *Param) WithParam(oid string, param *Param) *Param {
 	}
 	if cp.Proto.Params == nil {
 		cp.Proto.Params = map[string]*protos.Param{}
+	}
+	// A read-only parent forces its children read-only. When the parent is
+	// writable the child keeps its own read_only flag, so a child can still be
+	// independently marked read-only.
+	if cp.Proto.ReadOnly {
+		cloned.ReadOnly = true
+		propagateReadOnly(cloned.Params)
 	}
 	cp.Proto.Params[oid] = cloned
 	return cp

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -185,6 +185,78 @@ func TestWithReadOnly(t *testing.T) {
 	}
 }
 
+// A read-only parent propagates read_only to sub-params added afterward,
+// including nested descendants.
+func TestWithReadOnly_PropagatesToChildrenAddedAfter(t *testing.T) {
+	grandchild := NewParamString("deep")
+	child := NewParamStruct(nil).WithParam("grandchild", grandchild)
+	p := NewParamStruct(nil).
+		WithReadOnly(true).
+		WithParam("child", child).
+		Proto
+
+	sub := p.GetParams()["child"]
+	if sub == nil {
+		t.Fatal("expected sub-param 'child'")
+	}
+	if !sub.GetReadOnly() {
+		t.Error("expected child of read-only parent to be read_only")
+	}
+	if !sub.GetParams()["grandchild"].GetReadOnly() {
+		t.Error("expected grandchild of read-only parent to be read_only")
+	}
+}
+
+// Marking a parent read-only after its children were added propagates
+// read_only down to the existing children recursively.
+func TestWithReadOnly_PropagatesToExistingChildren(t *testing.T) {
+	grandchild := NewParamString("deep")
+	child := NewParamStruct(nil).WithParam("grandchild", grandchild)
+	p := NewParamStruct(nil).
+		WithParam("child", child).
+		WithReadOnly(true).
+		Proto
+
+	sub := p.GetParams()["child"]
+	if !sub.GetReadOnly() {
+		t.Error("expected existing child to become read_only when parent set read-only")
+	}
+	if !sub.GetParams()["grandchild"].GetReadOnly() {
+		t.Error("expected existing grandchild to become read_only when parent set read-only")
+	}
+}
+
+// A writable parent leaves children untouched, so a child may still be
+// independently marked read-only.
+func TestWithReadOnly_WritableParentKeepsChildReadOnly(t *testing.T) {
+	child := NewParamInt32(0).WithReadOnly(true)
+	p := NewParamStruct(nil).
+		WithReadOnly(false).
+		WithParam("child", child).
+		Proto
+
+	if p.GetReadOnly() {
+		t.Error("expected parent to remain writable")
+	}
+	if !p.GetParams()["child"].GetReadOnly() {
+		t.Error("expected child under writable parent to keep its own read_only=true")
+	}
+}
+
+// A writable parent must not force its children to writable: a read-only child
+// added before the parent is marked writable stays read-only.
+func TestWithReadOnly_WritableParentDoesNotClearChild(t *testing.T) {
+	child := NewParamInt32(0).WithReadOnly(true)
+	p := NewParamStruct(nil).
+		WithParam("child", child).
+		WithReadOnly(false).
+		Proto
+
+	if !p.GetParams()["child"].GetReadOnly() {
+		t.Error("expected read-only child to stay read_only under writable parent")
+	}
+}
+
 func TestWithWidget(t *testing.T) {
 	p := NewParamInt32(0).WithWidget("slider").Proto
 	if p.GetWidget() != "slider" {

--- a/sdks/go/pkg/catena/param_test.go
+++ b/sdks/go/pkg/catena/param_test.go
@@ -257,6 +257,27 @@ func TestWithReadOnly_WritableParentDoesNotClearChild(t *testing.T) {
 	}
 }
 
+// A nil entry in the sub-param map must be skipped by read-only propagation
+// without panicking, while non-nil siblings are still marked read-only.
+func TestWithReadOnly_SkipsNilSubParam(t *testing.T) {
+	cp := &Param{Proto: &protos.Param{
+		Type: protos.ParamType_STRUCT,
+		Params: map[string]*protos.Param{
+			"nilChild": nil,
+			"realChild": {Type: protos.ParamType_INT32},
+		},
+	}}
+
+	p := cp.WithReadOnly(true).Proto
+
+	if p.GetParams()["nilChild"] != nil {
+		t.Error("expected nil sub-param to remain nil")
+	}
+	if !p.GetParams()["realChild"].GetReadOnly() {
+		t.Error("expected non-nil sibling to be marked read_only")
+	}
+}
+
 func TestWithWidget(t *testing.T) {
 	p := NewParamInt32(0).WithWidget("slider").Proto
 	if p.GetWidget() != "slider" {

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -55,19 +55,20 @@ func testProduct() ProductStruct {
 
 // expectedProductParam is the golden proto for the SDK-managed product param
 // built from testProduct(): a read-only STRUCT with STRING field descriptors and
-// the field values carried in the struct's Value.
+// the field values carried in the struct's Value. Because the struct itself is
+// read-only, its field descriptors inherit read_only too.
 func expectedProductParam() *protos.Param {
 	return &protos.Param{
 		Type:        protos.ParamType_STRUCT,
 		ReadOnly:    true,
 		AccessScope: ScopeMon,
 		Params: map[string]*protos.Param{
-			ProductOidName:             {Type: protos.ParamType_STRING},
-			ProductOidVendor:           {Type: protos.ParamType_STRING},
-			ProductOidVersion:          {Type: protos.ParamType_STRING},
-			ProductOidSerialNumber:     {Type: protos.ParamType_STRING},
-			ProductOidCatenaSDKVersion: {Type: protos.ParamType_STRING},
-			ProductOidCatenaSDK:        {Type: protos.ParamType_STRING},
+			ProductOidName:             {Type: protos.ParamType_STRING, ReadOnly: true},
+			ProductOidVendor:           {Type: protos.ParamType_STRING, ReadOnly: true},
+			ProductOidVersion:          {Type: protos.ParamType_STRING, ReadOnly: true},
+			ProductOidSerialNumber:     {Type: protos.ParamType_STRING, ReadOnly: true},
+			ProductOidCatenaSDKVersion: {Type: protos.ParamType_STRING, ReadOnly: true},
+			ProductOidCatenaSDK:        {Type: protos.ParamType_STRING, ReadOnly: true},
 		},
 		Value: &protos.Value{
 			Kind: &protos.Value_StructValue{


### PR DESCRIPTION
## 📖 Description
Fixes read-only inheritance for sub-params in the Go SDK. Previously, marking a parent param `read_only` did not propagate to its children, so a child of a read-only struct could still be writable. `WithReadOnly` and `WithParam` now
enforce downward inheritance while still allowing a child to be independently read-only under a writable parent.

---

## 🎯 Goal / Outcome
When a parent param is read-only, all of its sub-params (recursively) are guaranteed to be read-only too — regardless of the order in which `WithReadOnly` and `WithParam` are chained. A writable parent (`read_only: false`) leaves children untouched, so a child can still be explicitly marked read-only.

---

## ✅ Definition of Done (DoD)
- [x] `WithReadOnly(true)` propagates `read_only` to all existing sub-params recursively
- [x] `WithParam` forces a newly added child (and its descendants) read-only when the parent is already read-only
- [x] A writable parent does not clear or override a child's own `read_only` flag
- [x] Behavior is order-independent across the fluent builder chain
- [x] Tests added covering both chaining orders and the writable-parent edge cases
- [x] SDK-managed `product` param golden test updated to reflect inherited read-only field descriptors

---

## 🛠️ Implementation Notes (Optional)
- Added an unexported recursive helper `propagateReadOnly(params map[string]*protos.Param)` that walks the sub-param tree and sets `ReadOnly = true` (nil-safe).
- `WithReadOnly(true)` now calls `propagateReadOnly` over existing children; `WithReadOnly(false)` intentionally leaves children as-is.
- `WithParam` applies `propagateReadOnly` to the cloned child subtree only when the parent is already read-only, preserving the "writable parent can hold a read-only child" semantic.
- Read-only is treated as a one-way (downward, true-only) propagation; it never forces a child back to writable.

---

## 🔗 Related Issues / Links

Closes issue:
- #1445 

---
