### PR TITLE
[GO] coverpkg was messing with coverage accounting

### DIFF
--- a/sdks/go/Makefile
+++ b/sdks/go/Makefile
@@ -60,9 +60,6 @@ clean-protos:
 PROTO_PKG := github.com/rossvideo/catena/sdks/go/pkg/protos
 TEST_PACKAGES := $(shell go list ./pkg/... | grep -vE '^$(PROTO_PKG)($$|/)')
 
-# coverpkg takes a comma-separated list
-COVER_PACKAGES := $(shell go list ./pkg/... | grep -vE '^$(PROTO_PKG)($$|/)' | paste -sd, -)
-
 COVERAGE_DIR ?= $(HOME)/Catena/coverage
 COVERAGE_OUT := $(COVERAGE_DIR)/go_coverage.out
 VERBOSE ?= 0
@@ -89,7 +86,6 @@ coverage: | $(COVERAGE_DIR) protos-all
 		-coverprofile=$(COVERAGE_OUT) \
 		-covermode=count \
 		$(if $(filter 1,$(VERBOSE)),-v) \
-		-coverpkg=$(COVER_PACKAGES) \
 		$(TEST_PACKAGES)
 	@echo ""
 	@echo "Coverage Summary:"

--- a/sdks/go/pkg/catena/command_test.go
+++ b/sdks/go/pkg/catena/command_test.go
@@ -191,3 +191,16 @@ func TestCommandResult_GetProtoResponse_Exception(t *testing.T) {
 		t.Errorf("expected fr='erreur', got %s", exc.GetErrorMessage().GetDisplayStrings()["fr"])
 	}
 }
+
+func TestCommandResult_Wire(t *testing.T) {
+	val, _ := ToValue(123)
+	result := CommandValue(val)
+
+	wire := result.Wire()
+	if wire == nil {
+		t.Fatal("Wire() returned nil")
+	}
+	if wire != result.Proto {
+		t.Errorf("expected Wire() to return the underlying proto, got %v", wire)
+	}
+}


### PR DESCRIPTION
quick little fix for the coverage profiling. `-coverpkg` is to count coverage across the whole system for each package, instead of just with each pkg. The biggest issue is that state cached coverage results from other pkgs were conflicting with each other, so this fixes that. But also I'd argue this is more correct, it will help ensure that the tests in a pkg accurately cover its entire pkg, no cheating from a random test in another pkg happening to lend some coverage over the borders.

**edit**
even found a cheater in command.go so added another test to cover that!