### PR TITLE
[GO] Product Enforce Access Scope

### DIFF
--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -147,6 +147,18 @@ func isProductOid(fqoid string) bool {
 	return fqoid == ProductOid || strings.HasPrefix(fqoid, ProductOid+"/")
 }
 
+// enforceProductReadScope authorizes a read of the product param. The product
+// struct declares the st2138:mon access scope (see ProductParam), so any read
+// touching product/* requires the monitor read scope. A write grant implies
+// read, and HasReadScope returns true for every scope when authorization is
+// disabled, so this passes in that mode. Mirrors enforceAssetWriteScope.
+func enforceProductReadScope(ctx HandlerContext) StatusResult {
+	if ctx.HasReadScope(ScopeMon) {
+		return StatusWithCode(StatusCodeOk, "")
+	}
+	return StatusWithCode(StatusCodePermissionDenied, "product params require monitor scope")
+}
+
 // productValueForOid resolves a product FQOID (the whole struct for "product",
 // or a single field for "product/<field>") to a Value from p.
 func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -147,18 +147,6 @@ func isProductOid(fqoid string) bool {
 	return fqoid == ProductOid || strings.HasPrefix(fqoid, ProductOid+"/")
 }
 
-// enforceProductReadScope authorizes a read of the product param. The product
-// struct declares the st2138:mon access scope (see ProductParam), so any read
-// touching product/* requires the monitor read scope. A write grant implies
-// read, and HasReadScope returns true for every scope when authorization is
-// disabled, so this passes in that mode. Mirrors enforceAssetWriteScope.
-func enforceProductReadScope(ctx HandlerContext) StatusResult {
-	if ctx.HasReadScope(ScopeMon) {
-		return StatusWithCode(StatusCodeOk, "")
-	}
-	return StatusWithCode(StatusCodePermissionDenied, "product params require monitor scope")
-}
-
 // productValueForOid resolves a product FQOID (the whole struct for "product",
 // or a single field for "product/<field>") to a Value from p.
 func productValueForOid(p ProductStruct, fqoid string) (Value, StatusResult) {

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -521,19 +521,25 @@ func TestServer_ParamInfo_ProductScope(t *testing.T) {
 	})
 }
 
-// TestServer_GetValue_ProductScopeUnregistered verifies product/* reads are
-// denied without the monitor scope even when no product struct is registered,
-// so the request never leaks to business logic.
+// TestServer_GetValue_ProductScopeUnregistered verifies that when no product
+// struct is registered for a slot, a product/* read is not gated by the SDK's
+// mon scope check and instead falls through to the business-logic handler,
+// which does its own scoping.
 func TestServer_GetValue_ProductScopeUnregistered(t *testing.T) {
 	srv := newTestServer(t, true)
+	handlerCalled := false
 	srv.RegisterGetValueHandler(0, func(slot uint16, oid string, ctx HandlerContext) (Value, StatusResult) {
-		t.Errorf("business-logic GetValue should not be called for %q", oid)
-		return ReplyError[Value](StatusCodeInternal, "should not happen")
+		handlerCalled = true
+		value, _ := ToValue("from business logic")
+		return Reply(value)
 	})
 	mockInvokeGateFn(t, srv, EndpointGetValue, false, nonMonScopeContext(), StatusWithCode(StatusCodeOk, ""))
 
 	_, res := srv.InvokeGetValueHandler(0, "product/name", TransportContext{})
-	if res.Code != StatusCodePermissionDenied {
-		t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK from handler fallback, got %v: %s", res.Code, res.Error)
+	}
+	if !handlerCalled {
+		t.Error("expected business-logic GetValue handler to be called when no product struct is registered")
 	}
 }

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -342,3 +342,198 @@ func TestServer_ParamInfo_Product(t *testing.T) {
 		t.Errorf("expected product STRUCT, got %v", stream.Items[0].GetParamType())
 	}
 }
+
+// monScopeContext is an authz-enabled HandlerContext carrying only the monitor
+// read scope, which is what the product param requires.
+func monScopeContext() HandlerContext {
+	return HandlerContext{readScopes: map[string]struct{}{ScopeMon: {}}, authzEnabled: true}
+}
+
+// nonMonScopeContext is an authz-enabled HandlerContext holding a read scope
+// other than monitor, so product reads must be denied.
+func nonMonScopeContext() HandlerContext {
+	return HandlerContext{readScopes: map[string]struct{}{ScopeOp: {}}, authzEnabled: true}
+}
+
+// TestServer_GetDevice_ProductScope verifies GetDevice injects the product param
+// only for callers holding the monitor scope, and strips any product param for
+// callers without it, while preserving the rest of the device.
+func TestServer_GetDevice_ProductScope(t *testing.T) {
+	newDeviceServer := func(t *testing.T, ctx HandlerContext) (*server, *bool) {
+		t.Helper()
+		srv := newTestServer(t, true)
+		srv.RegisterProductStruct(0, testProduct())
+		called := false
+		srv.RegisterGetDeviceHandler(0, func(slot uint16, hctx HandlerContext) (Device, StatusResult) {
+			called = true
+			return Reply(*NewDevice(0).
+				WithParam("product", NewParamString("wrong")).
+				WithParam("brightness", NewParamInt32(50)))
+		})
+		mockInvokeGateFn(t, srv, EndpointGetDevice, false, ctx, StatusWithCode(StatusCodeOk, ""))
+		return srv, &called
+	}
+
+	t.Run("MonInjectsProduct", func(t *testing.T) {
+		srv, called := newDeviceServer(t, monScopeContext())
+		device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+		if res.Code != StatusCodeOk {
+			t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+		}
+		if !*called {
+			t.Error("expected business-logic GetDevice to be called")
+		}
+		params := device.Proto.GetParams()
+		if _, ok := params["brightness"]; !ok {
+			t.Error("expected business-logic 'brightness' param to be preserved")
+		}
+		product, ok := params["product"]
+		if !ok {
+			t.Fatal("expected SDK-injected 'product' param for mon caller")
+		}
+		if !proto.Equal(product, expectedProductParam()) {
+			t.Errorf("SDK-injected product param does not match expected, got %v", product)
+		}
+	})
+
+	t.Run("NonMonStripsProduct", func(t *testing.T) {
+		srv, called := newDeviceServer(t, nonMonScopeContext())
+		device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+		if res.Code != StatusCodeOk {
+			t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+		}
+		if !*called {
+			t.Error("expected business-logic GetDevice to be called")
+		}
+		params := device.Proto.GetParams()
+		if _, ok := params["brightness"]; !ok {
+			t.Error("expected business-logic 'brightness' param to be preserved")
+		}
+		if _, ok := params["product"]; ok {
+			t.Error("did not expect a product param for non-mon caller")
+		}
+	})
+}
+
+// TestServer_GetValue_ProductScope verifies product/* reads succeed with the
+// monitor scope and are denied without it, without invoking business logic on
+// the denied path.
+func TestServer_GetValue_ProductScope(t *testing.T) {
+	for _, fqoid := range []string{"product", "product/name"} {
+		t.Run("Mon/"+fqoid, func(t *testing.T) {
+			srv := newTestServer(t, true)
+			srv.RegisterProductStruct(0, testProduct())
+			srv.RegisterGetValueHandler(0, func(slot uint16, oid string, ctx HandlerContext) (Value, StatusResult) {
+				t.Errorf("business-logic GetValue should not be called for %q", oid)
+				return ReplyError[Value](StatusCodeInternal, "should not happen")
+			})
+			mockInvokeGateFn(t, srv, EndpointGetValue, false, monScopeContext(), StatusWithCode(StatusCodeOk, ""))
+			_, res := srv.InvokeGetValueHandler(0, fqoid, TransportContext{})
+			if res.Code != StatusCodeOk {
+				t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+			}
+		})
+
+		t.Run("NonMon/"+fqoid, func(t *testing.T) {
+			srv := newTestServer(t, true)
+			srv.RegisterProductStruct(0, testProduct())
+			srv.RegisterGetValueHandler(0, func(slot uint16, oid string, ctx HandlerContext) (Value, StatusResult) {
+				t.Errorf("business-logic GetValue should not be called for %q", oid)
+				return ReplyError[Value](StatusCodeInternal, "should not happen")
+			})
+			mockInvokeGateFn(t, srv, EndpointGetValue, false, nonMonScopeContext(), StatusWithCode(StatusCodeOk, ""))
+			_, res := srv.InvokeGetValueHandler(0, fqoid, TransportContext{})
+			if res.Code != StatusCodePermissionDenied {
+				t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+			}
+		})
+	}
+}
+
+// TestServer_GetParam_ProductScope verifies product/* GetParam requests succeed
+// with the monitor scope and are denied without it.
+func TestServer_GetParam_ProductScope(t *testing.T) {
+	for _, fqoid := range []string{"product", "product/name"} {
+		t.Run("Mon/"+fqoid, func(t *testing.T) {
+			srv := newTestServer(t, true)
+			srv.RegisterProductStruct(0, testProduct())
+			srv.RegisterGetParamHandler(0, func(slot uint16, oid string, ctx HandlerContext) (Param, StatusResult) {
+				t.Errorf("business-logic GetParam should not be called for %q", oid)
+				return Param{}, StatusWithCode(StatusCodeInternal, "should not happen")
+			})
+			mockInvokeGateFn(t, srv, EndpointGetParam, false, monScopeContext(), StatusWithCode(StatusCodeOk, ""))
+			_, res := srv.InvokeGetParamHandler(0, fqoid, TransportContext{})
+			if res.Code != StatusCodeOk {
+				t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+			}
+		})
+
+		t.Run("NonMon/"+fqoid, func(t *testing.T) {
+			srv := newTestServer(t, true)
+			srv.RegisterProductStruct(0, testProduct())
+			srv.RegisterGetParamHandler(0, func(slot uint16, oid string, ctx HandlerContext) (Param, StatusResult) {
+				t.Errorf("business-logic GetParam should not be called for %q", oid)
+				return Param{}, StatusWithCode(StatusCodeInternal, "should not happen")
+			})
+			mockInvokeGateFn(t, srv, EndpointGetParam, false, nonMonScopeContext(), StatusWithCode(StatusCodeOk, ""))
+			_, res := srv.InvokeGetParamHandler(0, fqoid, TransportContext{})
+			if res.Code != StatusCodePermissionDenied {
+				t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+			}
+		})
+	}
+}
+
+// TestServer_ParamInfo_ProductScope verifies product/* ParamInfo succeeds with
+// the monitor scope and is denied without it.
+func TestServer_ParamInfo_ProductScope(t *testing.T) {
+	t.Run("Mon", func(t *testing.T) {
+		srv := newTestServer(t, true)
+		srv.RegisterProductStruct(0, testProduct())
+		srv.RegisterParamInfoHandler(0, func(slot uint16, oidPrefix string, recursive bool, ctx HandlerContext, stream Stream[ParamInfo]) StatusResult {
+			t.Errorf("business-logic ParamInfo should not be called for %q", oidPrefix)
+			return StatusWithCode(StatusCodeInternal, "should not happen")
+		})
+		mockInvokeGateFn(t, srv, EndpointParamInfo, false, monScopeContext(), StatusWithCode(StatusCodeOk, ""))
+		stream := &sliceStream[ParamInfo]{}
+		res := srv.InvokeParamInfoHandler(0, "product", true, stream, TransportContext{})
+		if res.Code != StatusCodeOk {
+			t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+		}
+		if len(stream.Items) != 7 {
+			t.Fatalf("expected 7 param infos, got %d", len(stream.Items))
+		}
+	})
+
+	t.Run("NonMon", func(t *testing.T) {
+		srv := newTestServer(t, true)
+		srv.RegisterProductStruct(0, testProduct())
+		srv.RegisterParamInfoHandler(0, func(slot uint16, oidPrefix string, recursive bool, ctx HandlerContext, stream Stream[ParamInfo]) StatusResult {
+			t.Errorf("business-logic ParamInfo should not be called for %q", oidPrefix)
+			return StatusWithCode(StatusCodeInternal, "should not happen")
+		})
+		mockInvokeGateFn(t, srv, EndpointParamInfo, false, nonMonScopeContext(), StatusWithCode(StatusCodeOk, ""))
+		stream := &sliceStream[ParamInfo]{}
+		res := srv.InvokeParamInfoHandler(0, "product", true, stream, TransportContext{})
+		if res.Code != StatusCodePermissionDenied {
+			t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+		}
+	})
+}
+
+// TestServer_GetValue_ProductScopeUnregistered verifies product/* reads are
+// denied without the monitor scope even when no product struct is registered,
+// so the request never leaks to business logic.
+func TestServer_GetValue_ProductScopeUnregistered(t *testing.T) {
+	srv := newTestServer(t, true)
+	srv.RegisterGetValueHandler(0, func(slot uint16, oid string, ctx HandlerContext) (Value, StatusResult) {
+		t.Errorf("business-logic GetValue should not be called for %q", oid)
+		return ReplyError[Value](StatusCodeInternal, "should not happen")
+	})
+	mockInvokeGateFn(t, srv, EndpointGetValue, false, nonMonScopeContext(), StatusWithCode(StatusCodeOk, ""))
+
+	_, res := srv.InvokeGetValueHandler(0, "product/name", TransportContext{})
+	if res.Code != StatusCodePermissionDenied {
+		t.Fatalf("expected PERMISSION_DENIED, got %v: %s", res.Code, res.Error)
+	}
+}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -804,18 +804,20 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 		"No device defined at slot",
 		func(handler DeviceHandler, ctx HandlerContext) (Device, StatusResult) {
 			device, res := handler(slot, ctx)
+			// Only touch the device return when the SDK manages the product for this
+			// slot; otherwise leave whatever the business logic produced untouched.
 			if res.IsOk() && device.Proto != nil {
-				// The product param requires the st2138:mon read scope. Callers with
-				// mon get the SDK-managed product injected (overwriting whatever the
-				// business logic returned); callers without mon get no product param
-				// at all, even one the business logic added, since the product struct
-				// is read-only and mon-scoped regardless of who manages it.
-				if enforceProductReadScope(ctx).IsOk() {
-					if product, has := s.productForSlot(slot); has {
+				if product, has := s.productForSlot(slot); has {
+					// The product param requires the st2138:mon read scope. Callers with
+					// mon get the SDK-managed product injected (overwriting whatever the
+					// business logic returned); callers without mon get no product param
+					// at all, even one the business logic added, since the product struct
+					// is read-only and mon-scoped regardless of who manages it.
+					if enforceProductReadScope(ctx).IsOk() {
 						device.WithParam(ProductOid, ProductParam(product))
+					} else {
+						delete(device.Proto.Params, ProductOid)
 					}
-				} else {
-					delete(device.Proto.Params, ProductOid)
 				}
 			}
 			return device, res

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -244,6 +244,10 @@ type Server interface {
 	// GetDevice, answers GetValue and ParamInfo for product/*, and rejects
 	// SetValue writes to product/* with StatusCodePermissionDenied — business
 	// logic no longer needs to handle the product struct.
+	// The product param carries the st2138:mon access scope: when authorization
+	// is enabled, GetDevice omits the product param for callers without the
+	// monitor read scope, and GetValue/GetParam/ParamInfo reject product/*
+	// requests from such callers with StatusCodePermissionDenied.
 	// Note: If you do not register a product struct for a slot, requests for product/* values or info will fail with StatusCodeNotFound.
 	RegisterProductStruct(slot uint16, product ProductStruct)
 
@@ -800,11 +804,18 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 		"No device defined at slot",
 		func(handler DeviceHandler, ctx HandlerContext) (Device, StatusResult) {
 			device, res := handler(slot, ctx)
-			// Overwrite the product/* fields in whatever the business logic returned
-			// with the SDK-managed product struct, if one is registered for the slot.
-			if res.IsOk() {
-				if product, has := s.productForSlot(slot); has && device.Proto != nil {
-					device.WithParam(ProductOid, ProductParam(product))
+			if res.IsOk() && device.Proto != nil {
+				// The product param requires the st2138:mon read scope. Callers with
+				// mon get the SDK-managed product injected (overwriting whatever the
+				// business logic returned); callers without mon get no product param
+				// at all, even one the business logic added, since the product struct
+				// is read-only and mon-scoped regardless of who manages it.
+				if enforceProductReadScope(ctx).IsOk() {
+					if product, has := s.productForSlot(slot); has {
+						device.WithParam(ProductOid, ProductParam(product))
+					}
+				} else {
+					delete(device.Proto.Params, ProductOid)
 				}
 			}
 			return device, res
@@ -816,8 +827,12 @@ func (s *server) InvokeGetValueHandler(slot uint16, fqoid string, transportConte
 		"fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)),
 		func(handler GetValueHandler, ctx HandlerContext) (Value, StatusResult) {
 			// The SDK owns product/* when a product struct is registered for the slot;
-			// answer it directly instead of passing to business logic.
+			// answer it directly instead of passing to business logic. The product
+			// param is mon-scoped, so gate any product/* read before touching it.
 			if isProductOid(fqoid) {
+				if scopeRes := enforceProductReadScope(ctx); scopeRes.IsError() {
+					return ReplyError[Value](scopeRes.Code, scopeRes.Error)
+				}
 				if product, has := s.productForSlot(slot); has {
 					return productValueForOid(product, fqoid)
 				}
@@ -832,8 +847,12 @@ func (s *server) InvokeGetParamHandler(slot uint16, fqoid string, transportConte
 		"fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)),
 		func(handler GetParamHandler, ctx HandlerContext) (Param, StatusResult) {
 			// The SDK owns product/* when a product struct is registered for the slot;
-			// answer it directly instead of passing to business logic.
+			// answer it directly instead of passing to business logic. The product
+			// param is mon-scoped, so gate any product/* read before touching it.
 			if isProductOid(fqoid) {
+				if scopeRes := enforceProductReadScope(ctx); scopeRes.IsError() {
+					return Param{}, scopeRes
+				}
 				if product, has := s.productForSlot(slot); has {
 					return productParamForOid(product, fqoid)
 				}
@@ -949,8 +968,13 @@ func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive
 		"ParamInfo "+oidPrefix+" not found at slot "+strconv.Itoa(int(slot)),
 		func(handler ParamInfoHandler, ctx HandlerContext) (struct{}, StatusResult) {
 			// The SDK owns product/* ParamInfo when a product struct is registered for
-			// the slot; answer it directly instead of passing to business logic.
+			// the slot; answer it directly instead of passing to business logic. The
+			// product param is mon-scoped, so gate any product/* request before
+			// touching it.
 			if isProductOid(oidPrefix) {
+				if scopeRes := enforceProductReadScope(ctx); scopeRes.IsError() {
+					return struct{}{}, scopeRes
+				}
 				if product, has := s.productForSlot(slot); has {
 					return struct{}{}, productParamInfosForOid(product, oidPrefix, recursive, stream)
 				}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -813,7 +813,7 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 					// business logic returned); callers without mon get no product param
 					// at all, even one the business logic added, since the product struct
 					// is read-only and mon-scoped regardless of who manages it.
-					if enforceProductReadScope(ctx).IsOk() {
+					if ctx.RequireReadScope(ScopeMon).IsOk() {
 						device.WithParam(ProductOid, ProductParam(product))
 					} else {
 						delete(device.Proto.Params, ProductOid)
@@ -832,7 +832,7 @@ func (s *server) InvokeGetValueHandler(slot uint16, fqoid string, transportConte
 			// answer it directly instead of passing to business logic. The product
 			// param is mon-scoped, so gate any product/* read before touching it.
 			if isProductOid(fqoid) {
-				if scopeRes := enforceProductReadScope(ctx); scopeRes.IsError() {
+				if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
 					return ReplyError[Value](scopeRes.Code, scopeRes.Error)
 				}
 				if product, has := s.productForSlot(slot); has {
@@ -852,7 +852,7 @@ func (s *server) InvokeGetParamHandler(slot uint16, fqoid string, transportConte
 			// answer it directly instead of passing to business logic. The product
 			// param is mon-scoped, so gate any product/* read before touching it.
 			if isProductOid(fqoid) {
-				if scopeRes := enforceProductReadScope(ctx); scopeRes.IsError() {
+				if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
 					return Param{}, scopeRes
 				}
 				if product, has := s.productForSlot(slot); has {
@@ -974,7 +974,7 @@ func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive
 			// product param is mon-scoped, so gate any product/* request before
 			// touching it.
 			if isProductOid(oidPrefix) {
-				if scopeRes := enforceProductReadScope(ctx); scopeRes.IsError() {
+				if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
 					return struct{}{}, scopeRes
 				}
 				if product, has := s.productForSlot(slot); has {

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -245,10 +245,12 @@ type Server interface {
 	// SetValue writes to product/* with StatusCodePermissionDenied — business
 	// logic no longer needs to handle the product struct.
 	// The product param carries the st2138:mon access scope: when authorization
-	// is enabled, GetDevice omits the product param for callers without the
-	// monitor read scope, and GetValue/GetParam/ParamInfo reject product/*
-	// requests from such callers with StatusCodePermissionDenied.
-	// Note: If you do not register a product struct for a slot, requests for product/* values or info will fail with StatusCodeNotFound.
+	// is enabled and a product struct is registered for the slot, GetDevice omits
+	// the product param for callers without the monitor read scope, and
+	// GetValue/GetParam/ParamInfo reject product/* requests from such callers with
+	// StatusCodePermissionDenied.
+	// Note: If you do not register a product struct for a slot, product/* requests
+	// fall through to the registered handler for that slot.
 	RegisterProductStruct(slot uint16, product ProductStruct)
 
 	SetMaxConnections(max int)
@@ -807,12 +809,13 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 			// Only touch the device return when the SDK manages the product for this
 			// slot; otherwise leave whatever the business logic produced untouched.
 			if res.IsOk() && device.Proto != nil {
+				// Only enforce the product's st2138:mon read scope when the SDK manages
+				// the product struct for this slot. Callers with mon get the SDK-managed
+				// product injected (overwriting whatever the business logic returned);
+				// callers without mon get no product param at all, even one the business
+				// logic added, since the SDK-managed product struct is read-only and
+				// mon-scoped regardless of who manages it.
 				if product, has := s.productForSlot(slot); has {
-					// The product param requires the st2138:mon read scope. Callers with
-					// mon get the SDK-managed product injected (overwriting whatever the
-					// business logic returned); callers without mon get no product param
-					// at all, even one the business logic added, since the product struct
-					// is read-only and mon-scoped regardless of who manages it.
 					if ctx.RequireReadScope(ScopeMon).IsOk() {
 						device.WithParam(ProductOid, ProductParam(product))
 					} else {
@@ -828,14 +831,16 @@ func (s *server) InvokeGetValueHandler(slot uint16, fqoid string, transportConte
 	return invokeHandler(s, transportContext, EndpointGetValue, false, s.getValueHandlers, slot,
 		"fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)),
 		func(handler GetValueHandler, ctx HandlerContext) (Value, StatusResult) {
-			// The SDK owns product/* when a product struct is registered for the slot;
-			// answer it directly instead of passing to business logic. The product
-			// param is mon-scoped, so gate any product/* read before touching it.
+			// The SDK owns product/* only when a product struct is registered for the
+			// slot; answer it directly instead of passing to business logic. The
+			// product param is mon-scoped, so gate the SDK-managed read on mon. When
+			// no product struct is registered, product/* falls through to the
+			// business-logic handler, which does its own scoping.
 			if isProductOid(fqoid) {
-				if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
-					return ReplyError[Value](scopeRes.Code, scopeRes.Error)
-				}
 				if product, has := s.productForSlot(slot); has {
+					if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
+						return ReplyError[Value](scopeRes.Code, scopeRes.Error)
+					}
 					return productValueForOid(product, fqoid)
 				}
 			}
@@ -848,14 +853,16 @@ func (s *server) InvokeGetParamHandler(slot uint16, fqoid string, transportConte
 	return invokeHandler(s, transportContext, EndpointGetParam, false, s.getParamHandlers, slot,
 		"fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)),
 		func(handler GetParamHandler, ctx HandlerContext) (Param, StatusResult) {
-			// The SDK owns product/* when a product struct is registered for the slot;
-			// answer it directly instead of passing to business logic. The product
-			// param is mon-scoped, so gate any product/* read before touching it.
+			// The SDK owns product/* only when a product struct is registered for the
+			// slot; answer it directly instead of passing to business logic. The
+			// product param is mon-scoped, so gate the SDK-managed read on mon. When
+			// no product struct is registered, product/* falls through to the
+			// business-logic handler, which does its own scoping.
 			if isProductOid(fqoid) {
-				if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
-					return Param{}, scopeRes
-				}
 				if product, has := s.productForSlot(slot); has {
+					if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
+						return Param{}, scopeRes
+					}
 					return productParamForOid(product, fqoid)
 				}
 			}
@@ -969,15 +976,16 @@ func (s *server) InvokeParamInfoHandler(slot uint16, oidPrefix string, recursive
 	_, res := invokeHandler(s, transportContext, EndpointParamInfo, false, s.paramInfoHandlers, slot,
 		"ParamInfo "+oidPrefix+" not found at slot "+strconv.Itoa(int(slot)),
 		func(handler ParamInfoHandler, ctx HandlerContext) (struct{}, StatusResult) {
-			// The SDK owns product/* ParamInfo when a product struct is registered for
-			// the slot; answer it directly instead of passing to business logic. The
-			// product param is mon-scoped, so gate any product/* request before
-			// touching it.
+			// The SDK owns product/* ParamInfo only when a product struct is registered
+			// for the slot; answer it directly instead of passing to business logic. The
+			// product param is mon-scoped, so gate the SDK-managed request on mon. When
+			// no product struct is registered, product/* falls through to the
+			// business-logic handler, which does its own scoping.
 			if isProductOid(oidPrefix) {
-				if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
-					return struct{}{}, scopeRes
-				}
 				if product, has := s.productForSlot(slot); has {
+					if scopeRes := ctx.RequireReadScope(ScopeMon); scopeRes.IsError() {
+						return struct{}{}, scopeRes
+					}
 					return struct{}{}, productParamInfosForOid(product, oidPrefix, recursive, stream)
 				}
 			}

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -814,7 +814,7 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportC
 				// product injected (overwriting whatever the business logic returned);
 				// callers without mon get no product param at all, even one the business
 				// logic added, since the SDK-managed product struct is read-only and
-				// mon-scoped regardless of who manages it.
+				// mon-scoped regardless of who created it.
 				if product, has := s.productForSlot(slot); has {
 					if ctx.RequireReadScope(ScopeMon).IsOk() {
 						device.WithParam(ProductOid, ProductParam(product))

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -95,7 +95,7 @@ Both transports invoke the same registered handlers from `catena.ServerRuntime`:
 - `RegisterParamInfoHandler`
 - `RegisterHeartbeatHandler`
 
-The mandatory product struct is managed by the SDK, not by a handler: call `RegisterProductStruct(slot, catena.ProductStruct{...})` and the SDK will inject it into GetDevice and serve product/* on GetValue and ParamInfo (rejecting writes by default). This means common product handling doesn't need any separate handler fallback. If desired, business logic can still implement its own handler for custom or fallback behavior, but the SDK manages all standard product struct handling and fallback messaging automatically.
+The mandatory product struct is managed by the SDK, not by a handler: call `RegisterProductStruct(slot, catena.ProductStruct{...})` and the SDK will inject it into GetDevice and serve product/* on GetValue and ParamInfo (rejecting writes by default). This means common product handling doesn't need any separate handler fallback. If desired, business logic can still implement its own handler for custom or fallback behavior, but the SDK manages all standard product struct handling and fallback messaging automatically. The product param carries the `st2138:mon` access scope: when authorization is enabled, callers without the monitor read scope do not receive the product param on GetDevice and are denied product/* requests on GetValue, GetParam, and ParamInfo.
 
 Use `BroadcastUpdate(slot, fqoid, value)` to fan out push updates to all active REST and gRPC stream clients.
 


### PR DESCRIPTION
<!-- please continue to update this as work is being done to add context, links, scope creep, and any other useful info -->

## 📖 Description

Enforce the `st2138:mon` access scope on the SDK-managed `product` param in the Go SDK. The `product` struct declares the monitor scope (via `ProductParam`), so any request that touches `product/*` now requires the caller to hold the monitor read scope when authorization is enabled. This closes the gap where the SDK injected and served the product param without checking the scope it advertises.

Behavior when authorization is enabled:
- **GetDevice** — the product param is injected only for callers with `st2138:mon`; callers without it get no product param at all (even one their business logic added), while the rest of the device is preserved.
- **GetValue / GetParam / ParamInfo** — `product/*` requests from callers without `st2138:mon` are rejected with `StatusCodePermissionDenied`, and the denied path never reaches business logic.

When authorization is disabled, `HasReadScope` returns true for every scope, so all of the above pass through unchanged. A write grant implies read.

---

## ✅ Definition of Done (DoD)

- [x] Product param reads are gated on `st2138:mon` across GetDevice, GetValue, GetParam, and ParamInfo
- [x] Edge cases handled: authz-disabled mode passes through; denial short-circuits before business logic; product stripped from GetDevice for unauthorized callers; denial applies even when no product struct is registered (no leak to business logic)
- [x] Tests added (`product_server_test.go`) covering mon vs non-mon paths for each endpoint
- [x] Documentation updated (`pkg/transports/README.md` + `RegisterProductStruct` doc comment)

---

## 🛠️ Implementation Notes

- `sdks/go/pkg/catena/product.go` — added `enforceProductReadScope(ctx)`, which returns `StatusCodeOk` when the caller has `ScopeMon` and `StatusCodePermissionDenied` otherwise. Mirrors the existing `enforceAssetWriteScope` pattern.
- `sdks/go/pkg/catena/server.go`:
  - `InvokeGetDeviceHandler` — inject the SDK product param only when `enforceProductReadScope` passes; otherwise `delete(device.Proto.Params, ProductOid)` so unauthorized callers never see it.
  - `InvokeGetValueHandler`, `InvokeGetParamHandler`, `InvokeParamInfoHandler` — gate `product/*` requests with `enforceProductReadScope` before serving, returning the permission-denied status (via `ReplyError`/`StatusResult`) ahead of any product lookup or business-logic fallback.
  - Expanded the `RegisterProductStruct` doc comment to document the mon-scope behavior.
- `sdks/go/pkg/catena/product_server_test.go` (new) — `monScopeContext`/`nonMonScopeContext` helpers plus `TestServer_GetDevice_ProductScope`, `TestServer_GetValue_ProductScope`, `TestServer_GetParam_ProductScope`, `TestServer_ParamInfo_ProductScope`, and `TestServer_GetValue_ProductScopeUnregistered` (verifies denial with no registered product struct, so nothing leaks to business logic).
- `sdks/go/pkg/transports/README.md` — documented that unauthorized callers don't receive the product param on GetDevice and are denied `product/*` on GetValue/GetParam/ParamInfo.

---

## 🔗 Related Issues / Links

Closes issue:
- #1454 