### PR TITLE
Bump fast-uri from 3.1.2 to 3.1.4 in /tools/codegen

### DIFF
--- a/tools/codegen/package-lock.json
+++ b/tools/codegen/package-lock.json
@@ -2294,9 +2294,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/tools/codegen/package.json
+++ b/tools/codegen/package.json
@@ -33,7 +33,7 @@
     "yaml": "^2.9.0"
   },
   "overrides": {
-    "fast-uri": "3.1.2",
+    "fast-uri": "3.1.4",
     "js-yaml": "4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumping fast-uri to 3.1.4 to address 
- https://github.com/rossvideo/Catena/security/code-scanning/94
- https://github.com/rossvideo/Catena/security/code-scanning/93