### PR TITLE
[Workflow] Copilot/fix GitHub actions release job

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -647,7 +647,7 @@ jobs:
           echo "PR numbers found: $(echo "$PR_NUMBERS" | tr '\n' ' ')"
 
           # Fetch PR titles and bucket them by [TAG]
-          declare -A GROUPS
+          declare -A PR_GROUPS
           while IFS= read -r PR_NUM; do
             [[ -z "$PR_NUM" ]] && continue
 
@@ -657,7 +657,7 @@ jobs:
             # Only include titles that start with "[" — extract the group tag
             if [[ "$TITLE" =~ ^\[([^]]+)\] ]]; then
               GROUP_KEY="${BASH_REMATCH[1]}"
-              GROUPS["$GROUP_KEY"]+="- $TITLE"$'\n'
+              PR_GROUPS["$GROUP_KEY"]+="- $TITLE"$'\n'
               echo "  ✅ [$GROUP_KEY] $TITLE"
             else
               echo "  ⏭  Skipped (no [tag]): $TITLE"
@@ -668,12 +668,12 @@ jobs:
           {
             echo "## What's Changed in $NEW_VERSION"
             echo ""
-            if [[ ${#GROUPS[@]} -eq 0 ]]; then
+            if [[ ${#PR_GROUPS[@]} -eq 0 ]]; then
               echo "_No tagged PR titles found since the last release._"
             else
-              for KEY in $(echo "${!GROUPS[@]}" | tr ' ' '\n' | sort); do
+              for KEY in $(echo "${!PR_GROUPS[@]}" | tr ' ' '\n' | sort); do
                 echo "### [$KEY]"
-                echo "${GROUPS[$KEY]}"
+                echo "${PR_GROUPS[$KEY]}"
               done
             fi
           } > /tmp/release_notes.md


### PR DESCRIPTION
## 📖 Description

The "4 - Create GitHub Release" workflow job was failing because `GROUPS` is a bash built-in read-only indexed array (holds user group memberships). Attempting `declare -A GROUPS` to create an associative array fails with `cannot convert indexed to associative array`.

---

## ✅ Definition of Done (DoD)

- [x] Bug is fixed and workflow can proceed past the release notes generation step
- [ ] Code is reviewed and approved

---

## 🛠️ Implementation Notes

- `.github/workflows/Release.yml`: renamed `GROUPS` → `PR_GROUPS` in all 5 occurrences within the release notes generation script

**Before:**
```bash
declare -A GROUPS
...
GROUPS["$GROUP_KEY"]+="- $TITLE"$'\n'
...
if [[ ${#GROUPS[@]} -eq 0 ]]; then
  for KEY in $(echo "${!GROUPS[@]}" | tr ' ' '\n' | sort); do
    echo "${GROUPS[$KEY]}"
```

**After:**
```bash
declare -A PR_GROUPS
...
PR_GROUPS["$GROUP_KEY"]+="- $TITLE"$'\n'
...
if [[ ${#PR_GROUPS[@]} -eq 0 ]]; then
  for KEY in $(echo "${!PR_GROUPS[@]}" | tr ' ' '\n' | sort); do
    echo "${PR_GROUPS[$KEY]}"
```

---

## 🔗 Related Issues / Links

- Failing job: https://github.com/rossvideo/Catena/actions/runs/30283209136/job/90035084444

---

## 📝 Additional Context

`GROUPS` is a bash special variable automatically populated as an indexed array with the current user's group IDs. It cannot be redeclared as an associative array — only the variable name needed to change.

---

## 🚧 Risks / Open Questions

None.

---

## ✨ Updates

- Renamed `GROUPS` → `PR_GROUPS` to resolve bash reserved variable conflict