### PR TITLE
[Go] Param Helper Improvements

### DIFF
--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -178,13 +178,13 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 				WithName(st2138.NewPolyglotText("en", "Muted"))).
 			WithParam("device_name", st2138.NewParamString(deviceName).
 				WithName(st2138.NewPolyglotText("en", "Device Name"))).
+			// NewParamStruct auto-creates the valueless "number" and "text"
+			// field descriptors from the values map.
 			WithParam("struct_example", st2138.NewParamStruct(map[string]any{
 				"number": structNumber,
 				"text":   structText,
 			}).
-				WithName(st2138.NewPolyglotText("en", "Struct Example")).
-				WithParam("number", st2138.NewParamInt32(structNumber)).
-				WithParam("text", st2138.NewParamString(structText))).
+				WithName(st2138.NewPolyglotText("en", "Struct Example"))).
 			WithParam("sample_float", st2138.NewParamFloat32(sampleFloat).
 				WithName(st2138.NewPolyglotText("en", "Sample Float"))).
 			WithParam("sample_int_array", st2138.NewParamInt32Array(sampleIntArray).
@@ -195,18 +195,20 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 				WithName(st2138.NewPolyglotText("en", "Sample String Array"))).
 			WithParam("sample_binary", st2138.NewParamBinary(sampleBinary).
 				WithName(st2138.NewPolyglotText("en", "Sample Binary"))).
-			WithParam("sample_struct_variant", st2138.NewParamStructVariant(&sampleStructVariant).
+			// Valueless NewParamX() calls build sub-param descriptors without
+			// dummy values; the actual values live in the parent param's value.
+			WithParam("sample_struct_variant", st2138.NewParamStructVariant(sampleStructVariant).
 				WithName(st2138.NewPolyglotText("en", "Sample Struct Variant")).
-				WithParam("int_kind", st2138.NewParamInt32(0)).
-				WithParam("string_kind", st2138.NewParamString(""))).
+				WithParam("int_kind", st2138.NewParamInt32()).
+				WithParam("string_kind", st2138.NewParamString())).
 			WithParam("sample_struct_array", st2138.NewParamStructArray(sampleStructArray).
 				WithName(st2138.NewPolyglotText("en", "Sample Struct Array")).
-				WithParam("label", st2138.NewParamString("")).
-				WithParam("count", st2138.NewParamInt32(0))).
+				WithParam("label", st2138.NewParamString()).
+				WithParam("count", st2138.NewParamInt32())).
 			WithParam("sample_struct_variant_array", st2138.NewParamStructVariantArray(sampleStructVariantArray).
 				WithName(st2138.NewPolyglotText("en", "Sample Struct Variant Array")).
-				WithParam("int_kind", st2138.NewParamInt32(0)).
-				WithParam("string_kind", st2138.NewParamString(""))).
+				WithParam("int_kind", st2138.NewParamInt32()).
+				WithParam("string_kind", st2138.NewParamString())).
 			WithMenuGroup("status", st2138.NewMenuGroup().
 				WithName(st2138.NewPolyglotText("en", "Status")).
 				WithOrder(0).

--- a/sdks/go/pkg/catena/param_info_test.go
+++ b/sdks/go/pkg/catena/param_info_test.go
@@ -196,7 +196,7 @@ func TestFindParamDescriptor_EmptyOid(t *testing.T) {
 
 func testDeviceDefinition() *st2138.Device {
 	return st2138.NewDevice(0).
-		WithParam("parent", st2138.NewParamStruct(nil).
+		WithParam("parent", st2138.NewParamStruct().
 			WithName(st2138.NewPolyglotText("en", "Parent")).
 			WithParam("child", st2138.NewParamString(""))).
 		WithParam("alpha", st2138.NewParamInt32(0).

--- a/sdks/go/pkg/catena/product.go
+++ b/sdks/go/pkg/catena/product.go
@@ -108,24 +108,13 @@ const (
 
 // ProductParam builds the mandatory read-only "product" STRUCT param from p,
 // including the SDK-managed catena_sdk and catena_sdk_version fields. The field
-// values live in the struct's Value; the sub-params carry only the field
-// descriptors (their STRING type). The SDK uses this to seed the product param
-// into the device on GetDevice.
+// values live in the struct's Value; NewParamStruct auto-creates the valueless
+// STRING field descriptors from the values map. The SDK uses this to seed the
+// product param into the device on GetDevice.
 func ProductParam(p ProductStruct) *st2138.Param {
-	values := ProductValues(p)
-	param := st2138.NewParamStruct(values).
+	return st2138.NewParamStruct(ProductValues(p)).
 		WithReadOnly(true).
 		WithAccessScope(st2138.ScopeMon)
-	for oid := range values {
-		param.WithParam(oid, productFieldDescriptor())
-	}
-	return param
-}
-
-// productFieldDescriptor is a valueless STRING sub-param used to describe a
-// product field. The field's value lives in the parent struct's Value.
-func productFieldDescriptor() *st2138.Param {
-	return &st2138.Param{Proto: &protos.Param{Type: protos.ParamType_STRING}}
 }
 
 // ProductValues returns the product field values keyed by their sub-OID,

--- a/sdks/go/pkg/st2138/param.go
+++ b/sdks/go/pkg/st2138/param.go
@@ -48,20 +48,8 @@ import (
 )
 
 // Param wraps a protos.Param and exposes a fluent builder API.
-//
-// hasValue records whether the param was intentionally given a value (via a
-// factory argument, WithValue, or SetValue), which distinguishes an
-// intentional default value from a param that was simply created without one.
-// WithParam uses this to decide whether a sub-param contributes its value to
-// a parent STRUCT's Value.
 type Param struct {
-	Proto    *protos.Param
-	hasValue bool
-}
-
-// HasValue reports whether the param was intentionally given a value.
-func (cp *Param) HasValue() bool {
-	return cp.hasValue
+	Proto *protos.Param
 }
 
 // --- Factory functions (one per ParamType) ---
@@ -85,7 +73,6 @@ func NewParamInt32(value ...int32) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_INT32}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: pickValue("NewParamInt32", value)}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -94,7 +81,6 @@ func NewParamFloat32(value ...float32) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_FLOAT32}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: pickValue("NewParamFloat32", value)}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -103,7 +89,6 @@ func NewParamString(value ...string) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRING}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_StringValue{StringValue: pickValue("NewParamString", value)}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -124,7 +109,6 @@ func NewParamStruct(value ...map[string]any) *Param {
 		return cp
 	}
 	cp.Proto.Value = pv
-	cp.hasValue = true
 	cp.Proto.Params = structFieldDescriptors(pv.GetStructValue())
 	return cp
 }
@@ -161,7 +145,6 @@ func NewParamStructVariant(value ...StructVariantValue) *Param {
 		return cp
 	}
 	cp.Proto.Value = pv
-	cp.hasValue = true
 	return cp
 }
 
@@ -169,7 +152,6 @@ func NewParamInt32Array(value ...[]int32) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_INT32_ARRAY}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: pickValue("NewParamInt32Array", value)}}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -178,7 +160,6 @@ func NewParamFloat32Array(value ...[]float32) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_FLOAT32_ARRAY}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: pickValue("NewParamFloat32Array", value)}}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -187,7 +168,6 @@ func NewParamStringArray(value ...[]string) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRING_ARRAY}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: pickValue("NewParamStringArray", value)}}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -196,7 +176,6 @@ func NewParamBinary(value ...[]byte) *Param {
 	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_BINARY}}
 	if len(value) > 0 {
 		cp.Proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: pickValue("NewParamBinary", value)}}}}
-		cp.hasValue = true
 	}
 	return cp
 }
@@ -213,7 +192,6 @@ func NewParamStructArray(value ...[]map[string]any) *Param {
 		return cp
 	}
 	cp.Proto.Value = pv
-	cp.hasValue = true
 	return cp
 }
 
@@ -229,7 +207,6 @@ func NewParamStructVariantArray(value ...[]StructVariantValue) *Param {
 		return cp
 	}
 	cp.Proto.Value = pv
-	cp.hasValue = true
 	return cp
 }
 
@@ -239,7 +216,6 @@ func NewParamEmpty() *Param {
 			Type:  protos.ParamType_EMPTY,
 			Value: &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}},
 		},
-		hasValue: true,
 	}
 }
 
@@ -255,7 +231,6 @@ func NewParamData(payload ...DataPayload) *Param {
 		return cp
 	}
 	cp.Proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
-	cp.hasValue = true
 	return cp
 }
 
@@ -273,7 +248,6 @@ func NewParamFromValue(v Value) *Param {
 			Type:  pt,
 			Value: v.Proto,
 		},
-		hasValue: v.Proto != nil,
 	}
 }
 
@@ -291,7 +265,6 @@ func (cp *Param) WithValue(v Value) *Param {
 		return cp
 	}
 	cp.Proto.Value = v.Proto
-	cp.hasValue = true
 	return cp
 }
 
@@ -380,12 +353,12 @@ var paramTypesWithSubParams = map[protos.ParamType]struct{}{
 }
 
 // WithParam attaches a sub-param descriptor under oid. On a STRUCT parent, a
-// sub-param that was intentionally given a value (see Param.hasValue)
-// contributes that value to the struct's own Value.Fields[oid]; the stored
-// descriptor is kept valueless, since field values live in the struct's Value
-// and sub-params are descriptors only. A valueless sub-param never touches
-// the parent's Value, so it can refine a descriptor (name, constraint, ...)
-// without overriding a value that came from the NewParamStruct map.
+// sub-param with a value contributes that value to the struct's own
+// Value.Fields[oid]; the stored descriptor is kept valueless, since field
+// values live in the struct's Value and sub-params are descriptors only. A
+// valueless sub-param never touches the parent's Value, so it can refine a
+// descriptor (name, constraint, ...) without overriding a value that came
+// from the NewParamStruct map.
 func (cp *Param) WithParam(oid string, param *Param) *Param {
 	if param == nil {
 		logger.Warning("WithParam called with nil sub-param; ignoring",
@@ -401,7 +374,7 @@ func (cp *Param) WithParam(oid string, param *Param) *Param {
 
 	cloned := proto.Clone(param.Proto).(*protos.Param)
 
-	if cp.Proto.Type == protos.ParamType_STRUCT && param.hasValue && cloned.Value != nil {
+	if cp.Proto.Type == protos.ParamType_STRUCT && cloned.Value != nil {
 		sv := cp.Proto.Value.GetStructValue()
 		if sv == nil {
 			sv = &protos.StructValue{}
@@ -412,7 +385,6 @@ func (cp *Param) WithParam(oid string, param *Param) *Param {
 		}
 		sv.Fields[oid] = cloned.Value
 		cloned.Value = nil
-		cp.hasValue = true
 	}
 
 	if cp.Proto.Params == nil {
@@ -478,7 +450,6 @@ func (cp *Param) SetValue(v any) error {
 		return fmt.Errorf("value kind incompatible with param type %s: %w", cp.Proto.Type.String(), ErrInvalid)
 	}
 	cp.Proto.Value = pv
-	cp.hasValue = true
 	return nil
 }
 

--- a/sdks/go/pkg/st2138/param.go
+++ b/sdks/go/pkg/st2138/param.go
@@ -48,138 +48,188 @@ import (
 )
 
 // Param wraps a protos.Param and exposes a fluent builder API.
+//
+// hasValue records whether the param was intentionally given a value (via a
+// factory argument, WithValue, or SetValue), which distinguishes an
+// intentional default value from a param that was simply created without one.
+// WithParam uses this to decide whether a sub-param contributes its value to
+// a parent STRUCT's Value.
 type Param struct {
-	Proto *protos.Param
+	Proto    *protos.Param
+	hasValue bool
+}
+
+// HasValue reports whether the param was intentionally given a value.
+func (cp *Param) HasValue() bool {
+	return cp.hasValue
 }
 
 // --- Factory functions (one per ParamType) ---
+//
+// Each factory accepts an optional value. With no arguments the param is
+// created without a value, which is useful for valueless sub-param
+// descriptors. If more than one value is passed, the first is used and the
+// rest are ignored with a warning.
 
-func NewParamInt32(value int32) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_INT32,
-			Value: &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: value}},
-		},
+// pickValue returns the first element of values, warning when extras beyond
+// the first were supplied. values must be non-empty.
+func pickValue[T any](fn string, values []T) T {
+	if len(values) > 1 {
+		logger.Warning(fn+": more than one value provided; using the first and ignoring the rest",
+			"ignored", len(values)-1)
 	}
+	return values[0]
 }
 
-func NewParamFloat32(value float32) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_FLOAT32,
-			Value: &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: value}},
-		},
+func NewParamInt32(value ...int32) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_INT32}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Int32Value{Int32Value: pickValue("NewParamInt32", value)}}
+		cp.hasValue = true
 	}
+	return cp
 }
 
-func NewParamString(value string) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_STRING,
-			Value: &protos.Value{Kind: &protos.Value_StringValue{StringValue: value}},
-		},
+func NewParamFloat32(value ...float32) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_FLOAT32}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Float32Value{Float32Value: pickValue("NewParamFloat32", value)}}
+		cp.hasValue = true
 	}
+	return cp
 }
 
-func NewParamStruct(value map[string]any) *Param {
-	cp := &Param{
-		Proto: &protos.Param{
-			Type: protos.ParamType_STRUCT,
-		},
+func NewParamString(value ...string) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRING}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_StringValue{StringValue: pickValue("NewParamString", value)}}
+		cp.hasValue = true
 	}
-	pv, err := ToProto(value)
+	return cp
+}
+
+// NewParamStruct creates a STRUCT param. When a map of field values is given,
+// it becomes the struct's Value and a valueless sub-param descriptor is
+// auto-created for every field (recursively for nested maps), so trivial
+// fields need no explicit WithParam calls.
+func NewParamStruct(value ...map[string]any) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRUCT}}
+	if len(value) == 0 {
+		return cp
+	}
+	pv, err := ToProto(pickValue("NewParamStruct", value))
 	if err != nil {
 		logger.Warning("NewParamStruct: failed to convert value; value left nil",
 			"error", err)
 		return cp
 	}
 	cp.Proto.Value = pv
+	cp.hasValue = true
+	cp.Proto.Params = structFieldDescriptors(pv.GetStructValue())
 	return cp
 }
 
-func NewParamStructVariant(value *StructVariantValue) *Param {
-	cp := &Param{
-		Proto: &protos.Param{
-			Type: protos.ParamType_STRUCT_VARIANT,
-		},
+// structFieldDescriptors builds a valueless sub-param descriptor for each
+// field of a struct value, inferring each descriptor's type from the field's
+// value kind. Nested struct fields recurse so their fields get descriptors
+// too.
+func structFieldDescriptors(sv *protos.StructValue) map[string]*protos.Param {
+	fields := sv.GetFields()
+	if len(fields) == 0 {
+		return nil
 	}
-	if value != nil {
-		pv, err := ToProto(*value)
-		if err != nil {
-			logger.Warning("NewParamStructVariant: failed to convert value; value left nil",
-				"error", err)
-			return cp
+	params := make(map[string]*protos.Param, len(fields))
+	for oid, fv := range fields {
+		p := &protos.Param{Type: paramTypeFromValueKind(fv)}
+		if nested := fv.GetStructValue(); nested != nil {
+			p.Params = structFieldDescriptors(nested)
 		}
-		cp.Proto.Value = pv
+		params[oid] = p
+	}
+	return params
+}
+
+func NewParamStructVariant(value ...StructVariantValue) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRUCT_VARIANT}}
+	if len(value) == 0 {
+		return cp
+	}
+	pv, err := ToProto(pickValue("NewParamStructVariant", value))
+	if err != nil {
+		logger.Warning("NewParamStructVariant: failed to convert value; value left nil",
+			"error", err)
+		return cp
+	}
+	cp.Proto.Value = pv
+	cp.hasValue = true
+	return cp
+}
+
+func NewParamInt32Array(value ...[]int32) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_INT32_ARRAY}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: pickValue("NewParamInt32Array", value)}}}
+		cp.hasValue = true
 	}
 	return cp
 }
 
-func NewParamInt32Array(value []int32) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_INT32_ARRAY,
-			Value: &protos.Value{Kind: &protos.Value_Int32ArrayValues{Int32ArrayValues: &protos.Int32List{Ints: value}}},
-		},
+func NewParamFloat32Array(value ...[]float32) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_FLOAT32_ARRAY}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: pickValue("NewParamFloat32Array", value)}}}
+		cp.hasValue = true
 	}
+	return cp
 }
 
-func NewParamFloat32Array(value []float32) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_FLOAT32_ARRAY,
-			Value: &protos.Value{Kind: &protos.Value_Float32ArrayValues{Float32ArrayValues: &protos.Float32List{Floats: value}}},
-		},
+func NewParamStringArray(value ...[]string) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRING_ARRAY}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: pickValue("NewParamStringArray", value)}}}
+		cp.hasValue = true
 	}
+	return cp
 }
 
-func NewParamStringArray(value []string) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_STRING_ARRAY,
-			Value: &protos.Value{Kind: &protos.Value_StringArrayValues{StringArrayValues: &protos.StringList{Strings: value}}},
-		},
+func NewParamBinary(value ...[]byte) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_BINARY}}
+	if len(value) > 0 {
+		cp.Proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: pickValue("NewParamBinary", value)}}}}
+		cp.hasValue = true
 	}
+	return cp
 }
 
-func NewParamBinary(value []byte) *Param {
-	return &Param{
-		Proto: &protos.Param{
-			Type:  protos.ParamType_BINARY,
-			Value: &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: &protos.DataPayload{Kind: &protos.DataPayload_Payload{Payload: value}}}},
-		},
+func NewParamStructArray(value ...[]map[string]any) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRUCT_ARRAY}}
+	if len(value) == 0 {
+		return cp
 	}
-}
-
-func NewParamStructArray(value []map[string]any) *Param {
-	cp := &Param{
-		Proto: &protos.Param{
-			Type: protos.ParamType_STRUCT_ARRAY,
-		},
-	}
-	pv, err := ToProto(value)
+	pv, err := ToProto(pickValue("NewParamStructArray", value))
 	if err != nil {
 		logger.Warning("NewParamStructArray: failed to convert value; value left nil",
 			"error", err)
 		return cp
 	}
 	cp.Proto.Value = pv
+	cp.hasValue = true
 	return cp
 }
 
-func NewParamStructVariantArray(value []StructVariantValue) *Param {
-	cp := &Param{
-		Proto: &protos.Param{
-			Type: protos.ParamType_STRUCT_VARIANT_ARRAY,
-		},
+func NewParamStructVariantArray(value ...[]StructVariantValue) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_STRUCT_VARIANT_ARRAY}}
+	if len(value) == 0 {
+		return cp
 	}
-	pv, err := ToProto(value)
+	pv, err := ToProto(pickValue("NewParamStructVariantArray", value))
 	if err != nil {
 		logger.Warning("NewParamStructVariantArray: failed to convert value; value left nil",
 			"error", err)
 		return cp
 	}
 	cp.Proto.Value = pv
+	cp.hasValue = true
 	return cp
 }
 
@@ -189,22 +239,23 @@ func NewParamEmpty() *Param {
 			Type:  protos.ParamType_EMPTY,
 			Value: &protos.Value{Kind: &protos.Value_EmptyValue{EmptyValue: &protos.Empty{}}},
 		},
+		hasValue: true,
 	}
 }
 
-func NewParamData(payload DataPayload) *Param {
-	cp := &Param{
-		Proto: &protos.Param{
-			Type: protos.ParamType_DATA,
-		},
+func NewParamData(payload ...DataPayload) *Param {
+	cp := &Param{Proto: &protos.Param{Type: protos.ParamType_DATA}}
+	if len(payload) == 0 {
+		return cp
 	}
-	pdp, err := dataPayloadToProto(payload)
+	pdp, err := dataPayloadToProto(pickValue("NewParamData", payload))
 	if err != nil {
 		logger.Warning("NewParamData: failed to convert DataPayload; value left nil",
 			"error", err)
 		return cp
 	}
 	cp.Proto.Value = &protos.Value{Kind: &protos.Value_DataPayload{DataPayload: pdp}}
+	cp.hasValue = true
 	return cp
 }
 
@@ -222,6 +273,7 @@ func NewParamFromValue(v Value) *Param {
 			Type:  pt,
 			Value: v.Proto,
 		},
+		hasValue: v.Proto != nil,
 	}
 }
 
@@ -239,6 +291,7 @@ func (cp *Param) WithValue(v Value) *Param {
 		return cp
 	}
 	cp.Proto.Value = v.Proto
+	cp.hasValue = true
 	return cp
 }
 
@@ -326,6 +379,13 @@ var paramTypesWithSubParams = map[protos.ParamType]struct{}{
 	protos.ParamType_STRUCT_VARIANT_ARRAY: {},
 }
 
+// WithParam attaches a sub-param descriptor under oid. On a STRUCT parent, a
+// sub-param that was intentionally given a value (see Param.hasValue)
+// contributes that value to the struct's own Value.Fields[oid]; the stored
+// descriptor is kept valueless, since field values live in the struct's Value
+// and sub-params are descriptors only. A valueless sub-param never touches
+// the parent's Value, so it can refine a descriptor (name, constraint, ...)
+// without overriding a value that came from the NewParamStruct map.
 func (cp *Param) WithParam(oid string, param *Param) *Param {
 	if param == nil {
 		logger.Warning("WithParam called with nil sub-param; ignoring",
@@ -333,13 +393,28 @@ func (cp *Param) WithParam(oid string, param *Param) *Param {
 		return cp
 	}
 
-	cloned := proto.Clone(param.Proto).(*protos.Param)
-
 	if _, ok := paramTypesWithSubParams[cp.Proto.Type]; !ok {
 		logger.Warning("WithParam called on param type that does not support sub-params; ignoring",
 			"param_type", cp.Proto.Type.String())
 		return cp
 	}
+
+	cloned := proto.Clone(param.Proto).(*protos.Param)
+
+	if cp.Proto.Type == protos.ParamType_STRUCT && param.hasValue && cloned.Value != nil {
+		sv := cp.Proto.Value.GetStructValue()
+		if sv == nil {
+			sv = &protos.StructValue{}
+			cp.Proto.Value = &protos.Value{Kind: &protos.Value_StructValue{StructValue: sv}}
+		}
+		if sv.Fields == nil {
+			sv.Fields = map[string]*protos.Value{}
+		}
+		sv.Fields[oid] = cloned.Value
+		cloned.Value = nil
+		cp.hasValue = true
+	}
+
 	if cp.Proto.Params == nil {
 		cp.Proto.Params = map[string]*protos.Param{}
 	}
@@ -403,6 +478,7 @@ func (cp *Param) SetValue(v any) error {
 		return fmt.Errorf("value kind incompatible with param type %s: %w", cp.Proto.Type.String(), ErrInvalid)
 	}
 	cp.Proto.Value = pv
+	cp.hasValue = true
 	return nil
 }
 

--- a/sdks/go/pkg/st2138/param_test.go
+++ b/sdks/go/pkg/st2138/param_test.go
@@ -1176,7 +1176,7 @@ func TestWithParam_StructValuesFromSubParams(t *testing.T) {
 	}
 }
 
-// --- Variadic factory / hasValue tests ---
+// --- Variadic factory value tests ---
 
 func TestNewParamX_NoValue(t *testing.T) {
 	tests := []struct {
@@ -1205,22 +1205,21 @@ func TestNewParamX_NoValue(t *testing.T) {
 			if tt.param.Proto.GetValue() != nil {
 				t.Error("expected nil value when no value given")
 			}
-			if tt.param.HasValue() {
-				t.Error("expected HasValue()=false when no value given")
-			}
 		})
 	}
 }
 
-func TestNewParamX_HasValue(t *testing.T) {
-	if !NewParamInt32(0).HasValue() {
-		t.Error("expected HasValue()=true for intentionally default value")
+// Intentionally default values (zero int, empty string, EMPTY) still produce
+// a non-nil value, which is what distinguishes them from no-arg factories.
+func TestNewParamX_DefaultValueIsSet(t *testing.T) {
+	if NewParamInt32(0).Proto.GetValue() == nil {
+		t.Error("expected non-nil value for intentionally default int32")
 	}
-	if !NewParamString("").HasValue() {
-		t.Error("expected HasValue()=true for intentionally empty string")
+	if NewParamString("").Proto.GetValue() == nil {
+		t.Error("expected non-nil value for intentionally empty string")
 	}
-	if !NewParamEmpty().HasValue() {
-		t.Error("expected HasValue()=true for EMPTY param")
+	if NewParamEmpty().Proto.GetValue() == nil {
+		t.Error("expected non-nil value for EMPTY param")
 	}
 }
 
@@ -1229,36 +1228,15 @@ func TestNewParamX_ExtraValuesIgnored(t *testing.T) {
 	if p.Proto.GetValue().GetInt32Value() != 1 {
 		t.Errorf("expected first value 1 to win, got %d", p.Proto.GetValue().GetInt32Value())
 	}
-	if !p.HasValue() {
-		t.Error("expected HasValue()=true when values were given")
-	}
 }
 
-func TestWithValue_SetsHasValue(t *testing.T) {
-	v, _ := ToValue(int32(42))
-	cp := NewParamInt32().WithValue(v)
-	if !cp.HasValue() {
-		t.Error("expected HasValue()=true after WithValue")
-	}
-}
-
-func TestSetValue_SetsHasValue(t *testing.T) {
-	cp := NewParamInt32()
-	if err := cp.SetValue(int32(5)); err != nil {
-		t.Fatalf("SetValue failed: %v", err)
-	}
-	if !cp.HasValue() {
-		t.Error("expected HasValue()=true after SetValue")
-	}
-}
-
-func TestSetValue_FailureDoesNotSetHasValue(t *testing.T) {
+func TestSetValue_FailureLeavesValueNil(t *testing.T) {
 	cp := NewParamInt32()
 	if err := cp.SetValue("wrong type"); err == nil {
 		t.Fatal("expected SetValue to fail")
 	}
-	if cp.HasValue() {
-		t.Error("expected HasValue()=false after failed SetValue")
+	if cp.Proto.GetValue() != nil {
+		t.Error("expected value to remain nil after failed SetValue")
 	}
 }
 
@@ -1365,8 +1343,8 @@ func TestWithParam_CleanBuilderEquivalence(t *testing.T) {
 		t.Errorf("expected clean builder proto to equal up-front map proto:\nclean:   %v\nupfront: %v",
 			clean.Proto, upfront.Proto)
 	}
-	if !clean.HasValue() {
-		t.Error("expected struct built via valued WithParam calls to report HasValue()=true")
+	if clean.Proto.GetValue() == nil {
+		t.Error("expected struct built via valued WithParam calls to have a non-nil value")
 	}
 
 	outer := NewParamStruct().WithParam("inner", clean)

--- a/sdks/go/pkg/st2138/param_test.go
+++ b/sdks/go/pkg/st2138/param_test.go
@@ -1301,6 +1301,21 @@ func TestNewParamStruct_AutoDescriptors(t *testing.T) {
 	}
 }
 
+// structFieldDescriptors is unreachable with empty fields via NewParamStruct
+// (ToProto rejects nil/empty maps), so exercise the guard directly: a nil or
+// field-less struct value must yield no descriptors rather than an empty map.
+func TestStructFieldDescriptors_NoFields(t *testing.T) {
+	if got := structFieldDescriptors(nil); got != nil {
+		t.Errorf("expected nil descriptors for nil struct value, got %v", got)
+	}
+	if got := structFieldDescriptors(&protos.StructValue{}); got != nil {
+		t.Errorf("expected nil descriptors for struct value without fields, got %v", got)
+	}
+	if got := structFieldDescriptors(&protos.StructValue{Fields: map[string]*protos.Value{}}); got != nil {
+		t.Errorf("expected nil descriptors for struct value with empty fields map, got %v", got)
+	}
+}
+
 // A valueless sub-param can refine an auto-created descriptor (name,
 // constraint, ...) without overriding the value that came from the map.
 func TestWithParam_ValuelessDoesNotOverrideMapValue(t *testing.T) {

--- a/sdks/go/pkg/st2138/param_test.go
+++ b/sdks/go/pkg/st2138/param_test.go
@@ -42,6 +42,8 @@ import (
 	"errors"
 	"testing"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 )
 
@@ -78,14 +80,14 @@ func TestNewParamString(t *testing.T) {
 }
 
 func TestNewParamStruct(t *testing.T) {
-	p := NewParamStruct(nil).Proto
+	p := NewParamStruct().Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariant(t *testing.T) {
-	p := NewParamStructVariant(nil).Proto
+	p := NewParamStructVariant().Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
 		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
 	}
@@ -136,14 +138,14 @@ func TestNewParamBinary(t *testing.T) {
 }
 
 func TestNewParamStructArray(t *testing.T) {
-	p := NewParamStructArray(nil).Proto
+	p := NewParamStructArray().Proto
 	if p.GetType() != protos.ParamType_STRUCT_ARRAY {
 		t.Errorf("expected STRUCT_ARRAY, got %v", p.GetType())
 	}
 }
 
 func TestNewParamStructVariantArray(t *testing.T) {
-	p := NewParamStructVariantArray(nil).Proto
+	p := NewParamStructVariantArray().Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT_ARRAY {
 		t.Errorf("expected STRUCT_VARIANT_ARRAY, got %v", p.GetType())
 	}
@@ -190,8 +192,8 @@ func TestWithReadOnly(t *testing.T) {
 // including nested descendants.
 func TestWithReadOnly_PropagatesToChildrenAddedAfter(t *testing.T) {
 	grandchild := NewParamString("deep")
-	child := NewParamStruct(nil).WithParam("grandchild", grandchild)
-	p := NewParamStruct(nil).
+	child := NewParamStruct().WithParam("grandchild", grandchild)
+	p := NewParamStruct().
 		WithReadOnly(true).
 		WithParam("child", child).
 		Proto
@@ -212,8 +214,8 @@ func TestWithReadOnly_PropagatesToChildrenAddedAfter(t *testing.T) {
 // read_only down to the existing children recursively.
 func TestWithReadOnly_PropagatesToExistingChildren(t *testing.T) {
 	grandchild := NewParamString("deep")
-	child := NewParamStruct(nil).WithParam("grandchild", grandchild)
-	p := NewParamStruct(nil).
+	child := NewParamStruct().WithParam("grandchild", grandchild)
+	p := NewParamStruct().
 		WithParam("child", child).
 		WithReadOnly(true).
 		Proto
@@ -231,7 +233,7 @@ func TestWithReadOnly_PropagatesToExistingChildren(t *testing.T) {
 // independently marked read-only.
 func TestWithReadOnly_WritableParentKeepsChildReadOnly(t *testing.T) {
 	child := NewParamInt32(0).WithReadOnly(true)
-	p := NewParamStruct(nil).
+	p := NewParamStruct().
 		WithReadOnly(false).
 		WithParam("child", child).
 		Proto
@@ -248,7 +250,7 @@ func TestWithReadOnly_WritableParentKeepsChildReadOnly(t *testing.T) {
 // added before the parent is marked writable stays read-only.
 func TestWithReadOnly_WritableParentDoesNotClearChild(t *testing.T) {
 	child := NewParamInt32(0).WithReadOnly(true)
-	p := NewParamStruct(nil).
+	p := NewParamStruct().
 		WithParam("child", child).
 		WithReadOnly(false).
 		Proto
@@ -356,24 +358,33 @@ func TestWithClientHint(t *testing.T) {
 
 func TestWithParam_Struct(t *testing.T) {
 	child := NewParamInt32(10).WithName(NewPolyglotText("en", "child"))
-	p := NewParamStruct(nil).WithParam("brightness", child).Proto
+	p := NewParamStruct().WithParam("brightness", child).Proto
 
 	sub := p.GetParams()["brightness"]
 	if sub == nil {
 		t.Fatal("expected sub-param 'brightness'")
 	}
-	if sub.GetValue().GetInt32Value() != 10 {
-		t.Errorf("expected sub-param value 10, got %d", sub.GetValue().GetInt32Value())
+	if sub.GetName().GetDisplayStrings()["en"] != "child" {
+		t.Errorf("expected sub-param name 'child', got %q", sub.GetName().GetDisplayStrings()["en"])
+	}
+	// The child's value is moved into the parent struct's Value; the stored
+	// descriptor stays valueless.
+	if sub.GetValue() != nil {
+		t.Error("expected stored sub-param descriptor to be valueless")
+	}
+	if p.GetValue().GetStructValue().GetFields()["brightness"].GetInt32Value() != 10 {
+		t.Errorf("expected parent struct value field 'brightness'=10, got %d",
+			p.GetValue().GetStructValue().GetFields()["brightness"].GetInt32Value())
 	}
 }
 
 func TestWithParam_DeepClone(t *testing.T) {
 	child := NewParamInt32(1)
-	parent := NewParamStruct(nil).WithParam("x", child).Proto
+	parent := NewParamStruct().WithParam("x", child).Proto
 
 	child.SetValue(int32(999))
-	if parent.GetParams()["x"].GetValue().GetInt32Value() != 1 {
-		t.Error("expected sub-param to be a deep clone, not affected by later mutation")
+	if parent.GetValue().GetStructValue().GetFields()["x"].GetInt32Value() != 1 {
+		t.Error("expected sub-param value to be a deep clone, not affected by later mutation")
 	}
 }
 
@@ -389,7 +400,7 @@ func TestWithParam_Nil(t *testing.T) {
 	// Passing a nil sub-param must not panic and must not add an entry,
 	// preserving the contract that method chaining is never interrupted
 	// by error handling.
-	cp := NewParamStruct(nil).WithParam("x", nil)
+	cp := NewParamStruct().WithParam("x", nil)
 	p := cp.Proto
 	if len(p.GetParams()) != 0 {
 		t.Error("expected nil sub-param to be a no-op")
@@ -397,8 +408,11 @@ func TestWithParam_Nil(t *testing.T) {
 	// Chaining must continue to work after the no-op.
 	child := NewParamInt32(7)
 	p = cp.WithParam("y", child).Proto
-	if p.GetParams()["y"].GetValue().GetInt32Value() != 7 {
-		t.Error("expected chaining to continue working after nil sub-param")
+	if p.GetParams()["y"] == nil {
+		t.Fatal("expected chaining to continue working after nil sub-param")
+	}
+	if p.GetValue().GetStructValue().GetFields()["y"].GetInt32Value() != 7 {
+		t.Error("expected sub-param value to land in parent struct value after nil no-op")
 	}
 }
 
@@ -510,7 +524,7 @@ func TestWithConstraint_RefOid_AnyType(t *testing.T) {
 		func() *Param { return NewParamInt32(0) },
 		func() *Param { return NewParamFloat32(0) },
 		func() *Param { return NewParamString("") },
-		func() *Param { return NewParamStruct(nil) },
+		func() *Param { return NewParamStruct() },
 	} {
 		p := factory().WithConstraint(c).Proto
 		if p.GetConstraint() == nil {
@@ -684,7 +698,7 @@ func TestWithValue_Struct(t *testing.T) {
 	if res != nil {
 		t.Fatal(res)
 	}
-	p := NewParamStruct(nil).WithValue(v).Proto
+	p := NewParamStruct().WithValue(v).Proto
 	fields := p.GetValue().GetStructValue().GetFields()
 	if fields["name"].GetStringValue() != "test" {
 		t.Errorf("expected struct field 'name'='test', got %q", fields["name"].GetStringValue())
@@ -697,7 +711,7 @@ func TestWithValue_StructVariant(t *testing.T) {
 	if res != nil {
 		t.Fatal(res)
 	}
-	p := NewParamStructVariant(nil).WithValue(v).Proto
+	p := NewParamStructVariant().WithValue(v).Proto
 	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "type_a" {
 		t.Errorf("expected struct_variant_type 'type_a', got %q",
 			p.GetValue().GetStructVariantValue().GetStructVariantType())
@@ -761,7 +775,7 @@ func TestGetValue_OK(t *testing.T) {
 }
 
 func TestGetValue_Nil(t *testing.T) {
-	cp := NewParamStruct(nil)
+	cp := NewParamStruct()
 	v, res := cp.GetValue()
 	if res != nil {
 		t.Fatalf("expected OK for nil value, got %v", res)
@@ -772,7 +786,7 @@ func TestGetValue_Nil(t *testing.T) {
 }
 
 func TestSetGetValue_Roundtrip_Struct(t *testing.T) {
-	cp := NewParamStruct(nil)
+	cp := NewParamStruct()
 	input := map[string]any{"x": int32(1), "y": int32(2)}
 	res := cp.SetValue(input)
 	if res != nil {
@@ -802,7 +816,7 @@ func TestNewParamStruct_WithValue(t *testing.T) {
 }
 
 func TestNewParamStruct_NoValue(t *testing.T) {
-	p := NewParamStruct(nil).Proto
+	p := NewParamStruct().Proto
 	if p.GetType() != protos.ParamType_STRUCT {
 		t.Errorf("expected STRUCT, got %v", p.GetType())
 	}
@@ -813,7 +827,7 @@ func TestNewParamStruct_NoValue(t *testing.T) {
 
 func TestNewParamStructVariant_WithValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "kind_a", Value: int32(5)}
-	p := NewParamStructVariant(&sv).Proto
+	p := NewParamStructVariant(sv).Proto
 	if p.GetValue().GetStructVariantValue().GetStructVariantType() != "kind_a" {
 		t.Errorf("expected struct_variant_type 'kind_a', got %q",
 			p.GetValue().GetStructVariantValue().GetStructVariantType())
@@ -967,7 +981,7 @@ func TestParamTypeFromValueKind_DataPayload(t *testing.T) {
 }
 
 func TestWithParam_SelfReference(t *testing.T) {
-	cp := NewParamStruct(nil)
+	cp := NewParamStruct()
 	cp.WithParam("self", cp)
 	sub := cp.Proto.GetParams()["self"]
 	if sub == nil {
@@ -989,7 +1003,7 @@ func TestNewParamStruct_InvalidValue(t *testing.T) {
 
 func TestNewParamStructVariant_InvalidValue(t *testing.T) {
 	sv := StructVariantValue{StructVariantType: "t", Value: struct{}{}}
-	p := NewParamStructVariant(&sv).Proto
+	p := NewParamStructVariant(sv).Proto
 	if p.GetType() != protos.ParamType_STRUCT_VARIANT {
 		t.Errorf("expected STRUCT_VARIANT, got %v", p.GetType())
 	}
@@ -1044,7 +1058,7 @@ func TestNewParamData_BothPayloadAndUrl(t *testing.T) {
 
 func TestWithParam_StructVariant(t *testing.T) {
 	child := NewParamInt32(5)
-	p := NewParamStructVariant(nil).WithParam("field", child).Proto
+	p := NewParamStructVariant().WithParam("field", child).Proto
 	sub := p.GetParams()["field"]
 	if sub == nil {
 		t.Fatal("expected sub-param on STRUCT_VARIANT")
@@ -1056,7 +1070,7 @@ func TestWithParam_StructVariant(t *testing.T) {
 
 func TestWithParam_StructArray(t *testing.T) {
 	child := NewParamString("val")
-	p := NewParamStructArray(nil).WithParam("item", child).Proto
+	p := NewParamStructArray().WithParam("item", child).Proto
 	sub := p.GetParams()["item"]
 	if sub == nil {
 		t.Fatal("expected sub-param on STRUCT_ARRAY")
@@ -1068,7 +1082,7 @@ func TestWithParam_StructArray(t *testing.T) {
 
 func TestWithParam_StructVariantArray(t *testing.T) {
 	child := NewParamFloat32(1.5)
-	p := NewParamStructVariantArray(nil).WithParam("entry", child).Proto
+	p := NewParamStructVariantArray().WithParam("entry", child).Proto
 	sub := p.GetParams()["entry"]
 	if sub == nil {
 		t.Fatal("expected sub-param on STRUCT_VARIANT_ARRAY")
@@ -1135,7 +1149,7 @@ func TestSetValue_InvalidThenValid(t *testing.T) {
 }
 
 func TestWithParam_StructValuesFromSubParams(t *testing.T) {
-	param := NewParamStruct(nil).
+	param := NewParamStruct().
 		WithName(NewPolyglotText("en", "Struct Example")).
 		WithParam("number", NewParamInt32(7).WithConstraint(NewConstraintInt32Range(0, 10, 1))).
 		WithParam("text", NewParamString("hello"))
@@ -1143,14 +1157,209 @@ func TestWithParam_StructValuesFromSubParams(t *testing.T) {
 	if param.Proto.GetType() != protos.ParamType_STRUCT {
 		t.Fatalf("expected STRUCT, got %v", param.Proto.GetType())
 	}
+	fields := param.Proto.GetValue().GetStructValue().GetFields()
+	if fields["number"].GetInt32Value() != 7 {
+		t.Errorf("expected struct value field 'number'=7, got %d", fields["number"].GetInt32Value())
+	}
+	if fields["text"].GetStringValue() != "hello" {
+		t.Errorf("expected struct value field 'text'='hello', got %q", fields["text"].GetStringValue())
+	}
 	number := param.Proto.GetParams()["number"]
-	if number.GetValue().GetInt32Value() != 7 {
-		t.Errorf("expected number sub-param value 7, got %d", number.GetValue().GetInt32Value())
+	if number.GetValue() != nil {
+		t.Error("expected number descriptor to be valueless")
 	}
 	if number.GetConstraint().GetInt32Range().GetMaxValue() != 10 {
 		t.Fatal("expected nested int32 range constraint max 10")
 	}
-	if param.Proto.GetParams()["text"].GetValue().GetStringValue() != "hello" {
-		t.Errorf("expected text sub-param value 'hello', got %q", param.Proto.GetParams()["text"].GetValue().GetStringValue())
+	if param.Proto.GetParams()["text"].GetValue() != nil {
+		t.Error("expected text descriptor to be valueless")
+	}
+}
+
+// --- Variadic factory / hasValue tests ---
+
+func TestNewParamX_NoValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		param    *Param
+		wantType protos.ParamType
+	}{
+		{"int32", NewParamInt32(), protos.ParamType_INT32},
+		{"float32", NewParamFloat32(), protos.ParamType_FLOAT32},
+		{"string", NewParamString(), protos.ParamType_STRING},
+		{"struct", NewParamStruct(), protos.ParamType_STRUCT},
+		{"struct_variant", NewParamStructVariant(), protos.ParamType_STRUCT_VARIANT},
+		{"int32_array", NewParamInt32Array(), protos.ParamType_INT32_ARRAY},
+		{"float32_array", NewParamFloat32Array(), protos.ParamType_FLOAT32_ARRAY},
+		{"string_array", NewParamStringArray(), protos.ParamType_STRING_ARRAY},
+		{"binary", NewParamBinary(), protos.ParamType_BINARY},
+		{"struct_array", NewParamStructArray(), protos.ParamType_STRUCT_ARRAY},
+		{"struct_variant_array", NewParamStructVariantArray(), protos.ParamType_STRUCT_VARIANT_ARRAY},
+		{"data", NewParamData(), protos.ParamType_DATA},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.param.Proto.GetType() != tt.wantType {
+				t.Errorf("expected %v, got %v", tt.wantType, tt.param.Proto.GetType())
+			}
+			if tt.param.Proto.GetValue() != nil {
+				t.Error("expected nil value when no value given")
+			}
+			if tt.param.HasValue() {
+				t.Error("expected HasValue()=false when no value given")
+			}
+		})
+	}
+}
+
+func TestNewParamX_HasValue(t *testing.T) {
+	if !NewParamInt32(0).HasValue() {
+		t.Error("expected HasValue()=true for intentionally default value")
+	}
+	if !NewParamString("").HasValue() {
+		t.Error("expected HasValue()=true for intentionally empty string")
+	}
+	if !NewParamEmpty().HasValue() {
+		t.Error("expected HasValue()=true for EMPTY param")
+	}
+}
+
+func TestNewParamX_ExtraValuesIgnored(t *testing.T) {
+	p := NewParamInt32(1, 2, 3)
+	if p.Proto.GetValue().GetInt32Value() != 1 {
+		t.Errorf("expected first value 1 to win, got %d", p.Proto.GetValue().GetInt32Value())
+	}
+	if !p.HasValue() {
+		t.Error("expected HasValue()=true when values were given")
+	}
+}
+
+func TestWithValue_SetsHasValue(t *testing.T) {
+	v, _ := ToValue(int32(42))
+	cp := NewParamInt32().WithValue(v)
+	if !cp.HasValue() {
+		t.Error("expected HasValue()=true after WithValue")
+	}
+}
+
+func TestSetValue_SetsHasValue(t *testing.T) {
+	cp := NewParamInt32()
+	if err := cp.SetValue(int32(5)); err != nil {
+		t.Fatalf("SetValue failed: %v", err)
+	}
+	if !cp.HasValue() {
+		t.Error("expected HasValue()=true after SetValue")
+	}
+}
+
+func TestSetValue_FailureDoesNotSetHasValue(t *testing.T) {
+	cp := NewParamInt32()
+	if err := cp.SetValue("wrong type"); err == nil {
+		t.Fatal("expected SetValue to fail")
+	}
+	if cp.HasValue() {
+		t.Error("expected HasValue()=false after failed SetValue")
+	}
+}
+
+func TestNewParamStruct_AutoDescriptors(t *testing.T) {
+	p := NewParamStruct(map[string]any{
+		"number": int32(42),
+		"text":   "hi",
+		"ratio":  float32(0.5),
+		"nested": map[string]any{"inner": int32(1)},
+	}).Proto
+
+	params := p.GetParams()
+	if len(params) != 4 {
+		t.Fatalf("expected 4 auto-created descriptors, got %d", len(params))
+	}
+	wantTypes := map[string]protos.ParamType{
+		"number": protos.ParamType_INT32,
+		"text":   protos.ParamType_STRING,
+		"ratio":  protos.ParamType_FLOAT32,
+		"nested": protos.ParamType_STRUCT,
+	}
+	for oid, wantType := range wantTypes {
+		sub := params[oid]
+		if sub == nil {
+			t.Fatalf("expected auto-created descriptor for %q", oid)
+		}
+		if sub.GetType() != wantType {
+			t.Errorf("expected %q descriptor type %v, got %v", oid, wantType, sub.GetType())
+		}
+		if sub.GetValue() != nil {
+			t.Errorf("expected %q descriptor to be valueless", oid)
+		}
+	}
+	inner := params["nested"].GetParams()["inner"]
+	if inner == nil {
+		t.Fatal("expected recursive descriptor for nested field 'inner'")
+	}
+	if inner.GetType() != protos.ParamType_INT32 {
+		t.Errorf("expected nested 'inner' descriptor type INT32, got %v", inner.GetType())
+	}
+}
+
+// A valueless sub-param can refine an auto-created descriptor (name,
+// constraint, ...) without overriding the value that came from the map.
+func TestWithParam_ValuelessDoesNotOverrideMapValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"field2": int32(42)}).
+		WithParam("field2", NewParamInt32().WithName(NewPolyglotText("en", "Field 2"))).
+		Proto
+
+	if p.GetValue().GetStructValue().GetFields()["field2"].GetInt32Value() != 42 {
+		t.Errorf("expected map-provided value 42 to be kept, got %d",
+			p.GetValue().GetStructValue().GetFields()["field2"].GetInt32Value())
+	}
+	sub := p.GetParams()["field2"]
+	if sub.GetName().GetDisplayStrings()["en"] != "Field 2" {
+		t.Errorf("expected replaced descriptor to carry name 'Field 2', got %q",
+			sub.GetName().GetDisplayStrings()["en"])
+	}
+	if sub.GetValue() != nil {
+		t.Error("expected descriptor to remain valueless")
+	}
+}
+
+// A valued sub-param overrides the value that came from the map.
+func TestWithParam_ValueOverridesMapValue(t *testing.T) {
+	p := NewParamStruct(map[string]any{"field3": float32(0.0)}).
+		WithParam("field3", NewParamFloat32(1.2)).
+		Proto
+
+	if p.GetValue().GetStructValue().GetFields()["field3"].GetFloat32Value() != 1.2 {
+		t.Errorf("expected overridden value 1.2, got %f",
+			p.GetValue().GetStructValue().GetFields()["field3"].GetFloat32Value())
+	}
+}
+
+// The clean builder style produces the same struct value as passing the full
+// map up front, and a struct populated via WithParam propagates its value
+// when nested into another struct.
+func TestWithParam_CleanBuilderEquivalence(t *testing.T) {
+	clean := NewParamStruct().
+		WithParam("field1", NewParamString("value1")).
+		WithParam("field2", NewParamInt32(42))
+	upfront := NewParamStruct(map[string]any{
+		"field1": "value1",
+		"field2": int32(42),
+	})
+
+	if !proto.Equal(clean.Proto, upfront.Proto) {
+		t.Errorf("expected clean builder proto to equal up-front map proto:\nclean:   %v\nupfront: %v",
+			clean.Proto, upfront.Proto)
+	}
+	if !clean.HasValue() {
+		t.Error("expected struct built via valued WithParam calls to report HasValue()=true")
+	}
+
+	outer := NewParamStruct().WithParam("inner", clean)
+	innerValue := outer.Proto.GetValue().GetStructValue().GetFields()["inner"]
+	if innerValue.GetStructValue().GetFields()["field1"].GetStringValue() != "value1" {
+		t.Error("expected nested struct value to propagate into outer struct value")
+	}
+	if outer.Proto.GetParams()["inner"].GetValue() != nil {
+		t.Error("expected nested struct descriptor to be valueless")
 	}
 }


### PR DESCRIPTION
## 📖 Description

Makes the `NewParamX` builder API friendlier by making values optional. All `NewParamX` factory functions in `pkg/st2138` are now variadic: calling one with no arguments creates a param without a value, which is ideal for sub-param descriptors that previously required messy dummy values (e.g. `NewParamString("")`).

On a STRUCT parent, `WithParam` now moves a valued sub-param's value into the struct's own `Value.Fields[oid]` and stores the descriptor valueless. `NewParamStruct(map)` also auto-creates typed, valueless field descriptors from the map, so trivial fields need no explicit `WithParam` calls.

Before:

```go
NewParamStruct(map[string]any{
	"field1": "value1",
	"field2": 42,
}).
	WithParam("field1", NewParamString("")).
	WithParam("field2", NewParamInt32(0))
```

After:

```go
NewParamStruct().
	WithParam("field1", NewParamString("value1")).
	WithParam("field2", NewParamInt32(42))
```

or, letting the map auto-create the trivial descriptors and refining one without overriding its value:

```go
NewParamStruct(map[string]any{
	"field1": "value1",
	"field2": int32(42),
}).
	WithParam("field2", NewParamInt32().WithName(PolyglotText{"en": "Field 2"}))
```

---

## 🎯 Goal / Outcome

Struct params can be built field-by-field with only the fields you want to set, without supplying a full value map up front or giving sub-param descriptors throwaway dummy values. Whether a param carries a value is a simple `Proto.Value` nil check — no extra state.

---

## ✅ Definition of Done (DoD)

- [x] All `NewParamX` factories accept an optional (variadic) value; no-arg calls create valueless params
- [x] Extra variadic values: first value wins, extras ignored with a logger warning
- [x] `WithParam` on a STRUCT moves a valued sub-param's value into the parent struct's Value and keeps the descriptor valueless
- [x] Valueless `WithParam` refines a descriptor (name, constraint, ...) without overriding a map-provided value
- [x] `NewParamStruct(map)` auto-creates typed field descriptors (recursive for nested maps)
- [x] Tests added/updated; `go build ./...`, `go vet ./...`, and `go test ./...` all pass
- [x] `ProductParam` and the `oneOfEverything` example updated to the new style

---

## 🛠️ Implementation Notes (Optional)

- `sdks/go/pkg/st2138/param.go`
  - Converted all factories to variadic (`NewParamInt32(value ...int32)`, etc.) with a shared `pickValue` helper that warns when extra values are ignored
  - `NewParamStructVariant` signature changed from `*StructVariantValue` to variadic `StructVariantValue` (the nil-pointer state is no longer needed)
  - `NewParamStruct(map)` auto-creates valueless sub-param descriptors per field via the new `structFieldDescriptors` helper (recursive for nested structs), with types inferred by `paramTypeFromValueKind`
  - `WithParam` on a STRUCT parent propagates the cloned sub-param's value into `Value.Fields[oid]` and strips it from the stored descriptor; gated on a simple `cloned.Value != nil` check (per review — no `hasValue` field)
- `sdks/go/pkg/catena/product.go`
  - `ProductParam` simplified to a single `NewParamStruct(ProductValues(p))` call; removed the manual descriptor loop and `productFieldDescriptor()`
- `sdks/go/examples/oneOfEverything/device_handler.go`
  - `struct_example` drops its manual sub-params (auto-descriptors cover them); struct-variant/array sub-param descriptors now use valueless `NewParamInt32()` / `NewParamString()`
- `sdks/go/pkg/st2138/param_test.go`, `sdks/go/pkg/catena/param_info_test.go`
  - Updated call sites and assertions to the new value-location semantics; new coverage for no-arg factories, extra-value handling, auto-descriptor creation (incl. nested and the empty-fields guard), value move/strip on `WithParam`, valueless refine vs. valued override, and a `proto.Equal` check that the clean builder style matches passing the full map up front

---

Closes issue:
- #1441 
