### PR TITLE
[GO] TLS for REST and gRPC

### DIFF
--- a/.devcontainer/go/toolchain.env
+++ b/.devcontainer/go/toolchain.env
@@ -1,7 +1,7 @@
 # Docker image labels
 IMAGE_TITLE="Catena Toolchain Go"
 IMAGE_DESCRIPTION="The Go toolchain for building Catena"
-IMAGE_VERSION="v0.0.2"
+IMAGE_VERSION="v0.0.1"
 IMAGE_VENDOR="Rossvideo"
 
 # Tool versions used across build system

--- a/.devcontainer/go/toolchain.env
+++ b/.devcontainer/go/toolchain.env
@@ -7,7 +7,7 @@ IMAGE_VENDOR="Rossvideo"
 # Tool versions used across build system
 DOXYGEN_VERSION=1.9.8+ds-2ubuntu0.1
 NODEJS_VERSION=24
-OPENSSL_VERSION=3.0.13-0ubuntu3.11
+OPENSSL_VERSION=3.0.13-0ubuntu3.12
 UBUNTU_VERSION=24.04
 VALGRIND_VERSION=1:3.22.0-0ubuntu3
 GO_VERSION=go1.26.0.linux-amd64

--- a/.devcontainer/go/toolchain.env
+++ b/.devcontainer/go/toolchain.env
@@ -1,7 +1,7 @@
 # Docker image labels
 IMAGE_TITLE="Catena Toolchain Go"
 IMAGE_DESCRIPTION="The Go toolchain for building Catena"
-IMAGE_VERSION="v0.0.1"
+IMAGE_VERSION="v0.0.2"
 IMAGE_VENDOR="Rossvideo"
 
 # Tool versions used across build system

--- a/sdks/go/Makefile
+++ b/sdks/go/Makefile
@@ -70,10 +70,11 @@ clean-protos:
 # Test targets
 .PHONY: test race coverage coverage-html coverage-lcov coverage-cobertura clean-coverage
 
-# Exclude generated protos from tests + coverage accounting
+# Exclude generated protos and test-only helper packages from tests + coverage accounting
 PROTO_PKG := github.com/rossvideo/catena/sdks/go/pkg/protos
 TRANSPORTTEST_PKG := github.com/rossvideo/catena/sdks/go/pkg/transports/internal/transporttest
-TEST_PACKAGES := $(shell go list ./pkg/... | grep -vE '^($(PROTO_PKG)|$(TRANSPORTTEST_PKG))($$|/)')
+TESTCERTS_PKG := github.com/rossvideo/catena/sdks/go/pkg/internal/testcerts
+TEST_PACKAGES := $(shell go list ./pkg/... | grep -vE '^($(PROTO_PKG)|$(TRANSPORTTEST_PKG)|$(TESTCERTS_PKG))($$|/)')
 
 COVERAGE_DIR ?= $(HOME)/Catena/coverage
 COVERAGE_OUT := $(COVERAGE_DIR)/go_coverage.out

--- a/sdks/go/pkg/catena/types.go
+++ b/sdks/go/pkg/catena/types.go
@@ -45,6 +45,7 @@ type ServerOptions = config.ServerOptions
 type JwtValidationOptions = config.JwtValidationOptions
 type DashboardOptions = config.DashboardOptions
 type ConnectionProtocol = config.ConnectionProtocol
+type TLSOptions = config.TLSOptions
 
 const (
 	ProtocolST2138Rest   = config.ProtocolST2138Rest

--- a/sdks/go/pkg/config/README.md
+++ b/sdks/go/pkg/config/README.md
@@ -212,6 +212,25 @@ All options can be configured via env and CLI.
 - `PREFIX_USE_GRPC` <-> `--use-grpc`
 - `PREFIX_USE_REST` <-> `--use-rest`
 
+### REST Transport
+
+- `PREFIX_REST_PORT` <-> `--rest-port`
+- `PREFIX_REST_TLS_ENABLED` <-> `--rest-tls-enabled`
+- `PREFIX_REST_TLS_CERT_FILE` <-> `--rest-tls-cert-file`
+- `PREFIX_REST_TLS_KEY_FILE` <-> `--rest-tls-key-file`
+- `PREFIX_REST_TLS_CA_FILE` <-> `--rest-tls-ca-file`
+- `PREFIX_REST_TLS_MUTUAL_AUTH` <-> `--rest-tls-mutual-auth`
+
+### gRPC Transport
+
+- `PREFIX_GRPC_PORT` <-> `--grpc-port`
+- `PREFIX_GRPC_REFLECTION` <-> `--grpc-reflection`
+- `PREFIX_GRPC_TLS_ENABLED` <-> `--grpc-tls-enabled`
+- `PREFIX_GRPC_TLS_CERT_FILE` <-> `--grpc-tls-cert-file`
+- `PREFIX_GRPC_TLS_KEY_FILE` <-> `--grpc-tls-key-file`
+- `PREFIX_GRPC_TLS_CA_FILE` <-> `--grpc-tls-ca-file`
+- `PREFIX_GRPC_TLS_MUTUAL_AUTH` <-> `--grpc-tls-mutual-auth`
+
 ### Server
 
 - `PREFIX_MAX_CONNECTIONS` <-> `--max-connections`
@@ -252,6 +271,25 @@ All options can be configured via env and CLI.
 - `-vvv` sets debug
 
 If `--log-level` is explicitly set, it takes priority over these shortcuts.
+
+## Transport TLS
+
+The REST and gRPC transports each accept an independent `TLSOptions` (`Rest.TLS` / `Grpc.TLS`), so one can run with TLS while the other runs plaintext. All file options take full paths to PEM-encoded files.
+
+- `*_TLS_ENABLED`: turn TLS on for that transport's listener (default off).
+- `*_TLS_CERT_FILE` / `*_TLS_KEY_FILE`: server certificate and private key. Both are required when TLS is enabled; the transport fails to start if either is missing or unreadable.
+- `*_TLS_MUTUAL_AUTH`: require clients to present a certificate signed by the CA in `*_TLS_CA_FILE` (mTLS).
+- `*_TLS_CA_FILE`: client CA bundle. Required when mutual auth is enabled; ignored (with a warning) otherwise.
+
+Example:
+
+```bash
+export CATENA_GRPC_TLS_ENABLED=true
+export CATENA_GRPC_TLS_CERT_FILE=/etc/catena/certs/server.crt
+export CATENA_GRPC_TLS_KEY_FILE=/etc/catena/certs/server.key
+```
+
+Note: `PREFIX_DASHBOARD_SERVICE_TLS_ENABLED` only controls what is *advertised* to DashBoard; it does not enable TLS on any listener. When you enable transport TLS on the service advertised to DashBoard, set `PREFIX_DASHBOARD_SERVICE_TLS_ENABLED=true` as well so the advertisement matches.
 
 ## Parsing Notes
 

--- a/sdks/go/pkg/config/README.md
+++ b/sdks/go/pkg/config/README.md
@@ -278,7 +278,7 @@ The REST and gRPC transports each accept an independent `TLSOptions` (`Rest.TLS`
 
 - `*_TLS_ENABLED`: turn TLS on for that transport's listener (default off).
 - `*_TLS_CERT_FILE` / `*_TLS_KEY_FILE`: server certificate and private key. Both are required when TLS is enabled; the transport fails to start if either is missing or unreadable.
-- `*_TLS_MUTUAL_AUTH`: require clients to present a certificate signed by the CA in `*_TLS_CLIENT_CA_FILE` (mTLS).
+- `*_TLS_MUTUAL_AUTH`: require clients to present a certificate signed by the CA in `*_TLS_CLIENT_CA_FILE` (mTLS, default off).
 - `*_TLS_CLIENT_CA_FILE`: client CA bundle. Required when mutual auth is enabled; ignored otherwise.
 
 Example:

--- a/sdks/go/pkg/config/README.md
+++ b/sdks/go/pkg/config/README.md
@@ -218,7 +218,7 @@ All options can be configured via env and CLI.
 - `PREFIX_REST_TLS_ENABLED` <-> `--rest-tls-enabled`
 - `PREFIX_REST_TLS_CERT_FILE` <-> `--rest-tls-cert-file`
 - `PREFIX_REST_TLS_KEY_FILE` <-> `--rest-tls-key-file`
-- `PREFIX_REST_TLS_CA_FILE` <-> `--rest-tls-ca-file`
+- `PREFIX_REST_TLS_CLIENT_CA_FILE` <-> `--rest-tls-client-ca-file`
 - `PREFIX_REST_TLS_MUTUAL_AUTH` <-> `--rest-tls-mutual-auth`
 
 ### gRPC Transport
@@ -228,7 +228,7 @@ All options can be configured via env and CLI.
 - `PREFIX_GRPC_TLS_ENABLED` <-> `--grpc-tls-enabled`
 - `PREFIX_GRPC_TLS_CERT_FILE` <-> `--grpc-tls-cert-file`
 - `PREFIX_GRPC_TLS_KEY_FILE` <-> `--grpc-tls-key-file`
-- `PREFIX_GRPC_TLS_CA_FILE` <-> `--grpc-tls-ca-file`
+- `PREFIX_GRPC_TLS_CLIENT_CA_FILE` <-> `--grpc-tls-client-ca-file`
 - `PREFIX_GRPC_TLS_MUTUAL_AUTH` <-> `--grpc-tls-mutual-auth`
 
 ### Server
@@ -278,8 +278,8 @@ The REST and gRPC transports each accept an independent `TLSOptions` (`Rest.TLS`
 
 - `*_TLS_ENABLED`: turn TLS on for that transport's listener (default off).
 - `*_TLS_CERT_FILE` / `*_TLS_KEY_FILE`: server certificate and private key. Both are required when TLS is enabled; the transport fails to start if either is missing or unreadable.
-- `*_TLS_MUTUAL_AUTH`: require clients to present a certificate signed by the CA in `*_TLS_CA_FILE` (mTLS).
-- `*_TLS_CA_FILE`: client CA bundle. Required when mutual auth is enabled; ignored (with a warning) otherwise.
+- `*_TLS_MUTUAL_AUTH`: require clients to present a certificate signed by the CA in `*_TLS_CLIENT_CA_FILE` (mTLS).
+- `*_TLS_CLIENT_CA_FILE`: client CA bundle. Required when mutual auth is enabled; ignored otherwise.
 
 Example:
 

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -57,10 +57,35 @@ type RuntimeOptions struct {
 	Dashboard DashboardOptions
 }
 
+// TLSOptions configures optional TLS for a transport listener.
+//
+// TLSOptions is shared between the REST and gRPC transports, so the env var
+// and CLI flag names are prefixed per transport: {REST|GRPC}_TLS_* and
+// --{rest|grpc}-tls-* respectively (e.g. CATENA_REST_TLS_CERT_FILE,
+// --grpc-tls-key-file).
+type TLSOptions struct {
+	// Enabled turns on TLS for the transport listener (default false).
+	Enabled bool
+	// CertFile is the path to the PEM-encoded server certificate.
+	// Required when Enabled is true.
+	CertFile string
+	// KeyFile is the path to the PEM-encoded server private key.
+	// Required when Enabled is true.
+	KeyFile string
+	// CAFile is the path to a PEM-encoded CA bundle used to verify client
+	// certificates. Required when MutualAuth is true; ignored otherwise.
+	CAFile string
+	// MutualAuth requires clients to present a certificate signed by the CA
+	// in CAFile (mTLS). Default false.
+	MutualAuth bool
+}
+
 // RestOptions configures the REST transport.
 type RestOptions struct {
 	// Port is the TCP port the REST/HTTP server listens on (default 9080).
 	Port int `env:"REST_PORT" flag:"rest-port"`
+	// TLS configures optional TLS for the REST listener (env: REST_TLS_*).
+	TLS TLSOptions
 }
 
 // GrpcOptions configures the gRPC transport.
@@ -70,6 +95,8 @@ type GrpcOptions struct {
 	// Reflection enables the gRPC server reflection service, which lets tools
 	// like grpcurl discover services at runtime (default false).
 	Reflection bool `env:"GRPC_REFLECTION" flag:"grpc-reflection"`
+	// TLS configures optional TLS for the gRPC listener (env: GRPC_TLS_*).
+	TLS TLSOptions
 }
 
 type ServerOptions struct {
@@ -242,6 +269,7 @@ func DefaultLoggerOptions() LoggerOptions {
 var _ slog.LogValuer = RuntimeOptions{}
 var _ slog.LogValuer = RestOptions{}
 var _ slog.LogValuer = GrpcOptions{}
+var _ slog.LogValuer = TLSOptions{}
 var _ slog.LogValuer = ServerOptions{}
 var _ slog.LogValuer = JwtValidationOptions{}
 var _ slog.LogValuer = LoggerOptions{}
@@ -281,6 +309,7 @@ func (o LoggerOptions) LogValue() slog.Value {
 func (o RestOptions) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Int("port", o.Port),
+		slog.Any("tls", o.TLS),
 	)
 }
 
@@ -288,6 +317,17 @@ func (o GrpcOptions) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Int("port", o.Port),
 		slog.Bool("reflection", o.Reflection),
+		slog.Any("tls", o.TLS),
+	)
+}
+
+func (o TLSOptions) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("enabled", o.Enabled),
+		slog.String("cert_file", o.CertFile),
+		slog.String("key_file", o.KeyFile),
+		slog.String("ca_file", o.CAFile),
+		slog.Bool("mutual_auth", o.MutualAuth),
 	)
 }
 

--- a/sdks/go/pkg/config/config.go
+++ b/sdks/go/pkg/config/config.go
@@ -72,11 +72,11 @@ type TLSOptions struct {
 	// KeyFile is the path to the PEM-encoded server private key.
 	// Required when Enabled is true.
 	KeyFile string
-	// CAFile is the path to a PEM-encoded CA bundle used to verify client
-	// certificates. Required when MutualAuth is true; ignored otherwise.
-	CAFile string
+	// ClientCAFile is the path to a PEM-encoded CA bundle used to verify
+	// client certificates. Required when MutualAuth is true; ignored otherwise.
+	ClientCAFile string
 	// MutualAuth requires clients to present a certificate signed by the CA
-	// in CAFile (mTLS). Default false.
+	// in ClientCAFile (mTLS). Default false.
 	MutualAuth bool
 }
 
@@ -326,7 +326,7 @@ func (o TLSOptions) LogValue() slog.Value {
 		slog.Bool("enabled", o.Enabled),
 		slog.String("cert_file", o.CertFile),
 		slog.String("key_file", o.KeyFile),
-		slog.String("ca_file", o.CAFile),
+		slog.String("client_ca_file", o.ClientCAFile),
 		slog.Bool("mutual_auth", o.MutualAuth),
 	)
 }

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -151,10 +151,24 @@ func TestRuntimeOptions_LogValuer(t *testing.T) {
 		"use_rest": false,
 		"rest": map[string]any{
 			"port": json.Number("0"),
+			"tls": map[string]any{
+				"enabled":     false,
+				"cert_file":   "",
+				"key_file":    "",
+				"ca_file":     "",
+				"mutual_auth": false,
+			},
 		},
 		"grpc": map[string]any{
 			"port":       json.Number("0"),
 			"reflection": false,
+			"tls": map[string]any{
+				"enabled":     false,
+				"cert_file":   "",
+				"key_file":    "",
+				"ca_file":     "",
+				"mutual_auth": false,
+			},
 		},
 		"server": map[string]any{
 			"dev":             true,
@@ -256,5 +270,48 @@ func TestDefaultOptions_TransportFlags(t *testing.T) {
 	}
 	if opts.UseRest != false {
 		t.Errorf("expected default UseRest=false, got %v", opts.UseRest)
+	}
+	if !reflect.DeepEqual(opts.Rest.TLS, TLSOptions{}) {
+		t.Errorf("expected default Rest.TLS to be disabled/zero, got %+v", opts.Rest.TLS)
+	}
+	if !reflect.DeepEqual(opts.Grpc.TLS, TLSOptions{}) {
+		t.Errorf("expected default Grpc.TLS to be disabled/zero, got %+v", opts.Grpc.TLS)
+	}
+}
+
+func TestTLSOptions_LogValuer(t *testing.T) {
+	opts := TLSOptions{
+		Enabled:    true,
+		CertFile:   "/certs/server.crt",
+		KeyFile:    "/certs/server.key",
+		CAFile:     "/certs/ca.crt",
+		MutualAuth: true,
+	}
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	log.Info("tls options", "options", opts)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("decode slog output: %v\noutput: %s", err, buf.String())
+	}
+
+	got, ok := entry["options"].(map[string]any)
+	if !ok {
+		t.Fatalf("options field missing or wrong type: %#v", entry["options"])
+	}
+
+	want := map[string]any{
+		"enabled":     true,
+		"cert_file":   "/certs/server.crt",
+		"key_file":    "/certs/server.key",
+		"ca_file":     "/certs/ca.crt",
+		"mutual_auth": true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("logged tls options mismatch\n got: %#v\nwant: %#v", got, want)
 	}
 }

--- a/sdks/go/pkg/config/config_test.go
+++ b/sdks/go/pkg/config/config_test.go
@@ -152,22 +152,22 @@ func TestRuntimeOptions_LogValuer(t *testing.T) {
 		"rest": map[string]any{
 			"port": json.Number("0"),
 			"tls": map[string]any{
-				"enabled":     false,
-				"cert_file":   "",
-				"key_file":    "",
-				"ca_file":     "",
-				"mutual_auth": false,
+				"enabled":        false,
+				"cert_file":      "",
+				"key_file":       "",
+				"client_ca_file": "",
+				"mutual_auth":    false,
 			},
 		},
 		"grpc": map[string]any{
 			"port":       json.Number("0"),
 			"reflection": false,
 			"tls": map[string]any{
-				"enabled":     false,
-				"cert_file":   "",
-				"key_file":    "",
-				"ca_file":     "",
-				"mutual_auth": false,
+				"enabled":        false,
+				"cert_file":      "",
+				"key_file":       "",
+				"client_ca_file": "",
+				"mutual_auth":    false,
 			},
 		},
 		"server": map[string]any{
@@ -281,11 +281,11 @@ func TestDefaultOptions_TransportFlags(t *testing.T) {
 
 func TestTLSOptions_LogValuer(t *testing.T) {
 	opts := TLSOptions{
-		Enabled:    true,
-		CertFile:   "/certs/server.crt",
-		KeyFile:    "/certs/server.key",
-		CAFile:     "/certs/ca.crt",
-		MutualAuth: true,
+		Enabled:      true,
+		CertFile:     "/certs/server.crt",
+		KeyFile:      "/certs/server.key",
+		ClientCAFile: "/certs/ca.crt",
+		MutualAuth:   true,
 	}
 
 	var buf bytes.Buffer
@@ -305,11 +305,11 @@ func TestTLSOptions_LogValuer(t *testing.T) {
 	}
 
 	want := map[string]any{
-		"enabled":     true,
-		"cert_file":   "/certs/server.crt",
-		"key_file":    "/certs/server.key",
-		"ca_file":     "/certs/ca.crt",
-		"mutual_auth": true,
+		"enabled":        true,
+		"cert_file":      "/certs/server.crt",
+		"key_file":       "/certs/server.key",
+		"client_ca_file": "/certs/ca.crt",
+		"mutual_auth":    true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("logged tls options mismatch\n got: %#v\nwant: %#v", got, want)

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -139,8 +139,18 @@ func InitOptions(appName string, args []string, initOpts ...InitOption) (Runtime
 		extractBool("USE_REST", "use-rest", "Enable REST transport", &opts.UseRest).
 		// transport options
 		extractInt("REST_PORT", "rest-port", "Port the REST transport listens on", &opts.Rest.Port).
+		extractBool("REST_TLS_ENABLED", "rest-tls-enabled", "Enable TLS on the REST transport listener", &opts.Rest.TLS.Enabled).
+		extractString("REST_TLS_CERT_FILE", "rest-tls-cert-file", "Path to the PEM server certificate for the REST transport", &opts.Rest.TLS.CertFile).
+		extractString("REST_TLS_KEY_FILE", "rest-tls-key-file", "Path to the PEM server private key for the REST transport", &opts.Rest.TLS.KeyFile).
+		extractString("REST_TLS_CA_FILE", "rest-tls-ca-file", "Path to the PEM client CA bundle for REST mutual TLS", &opts.Rest.TLS.CAFile).
+		extractBool("REST_TLS_MUTUAL_AUTH", "rest-tls-mutual-auth", "Require and verify client certificates on the REST transport (mTLS)", &opts.Rest.TLS.MutualAuth).
 		extractInt("GRPC_PORT", "grpc-port", "Port the gRPC transport listens on", &opts.Grpc.Port).
 		extractBool("GRPC_REFLECTION", "grpc-reflection", "Enable gRPC server reflection", &opts.Grpc.Reflection).
+		extractBool("GRPC_TLS_ENABLED", "grpc-tls-enabled", "Enable TLS on the gRPC transport listener", &opts.Grpc.TLS.Enabled).
+		extractString("GRPC_TLS_CERT_FILE", "grpc-tls-cert-file", "Path to the PEM server certificate for the gRPC transport", &opts.Grpc.TLS.CertFile).
+		extractString("GRPC_TLS_KEY_FILE", "grpc-tls-key-file", "Path to the PEM server private key for the gRPC transport", &opts.Grpc.TLS.KeyFile).
+		extractString("GRPC_TLS_CA_FILE", "grpc-tls-ca-file", "Path to the PEM client CA bundle for gRPC mutual TLS", &opts.Grpc.TLS.CAFile).
+		extractBool("GRPC_TLS_MUTUAL_AUTH", "grpc-tls-mutual-auth", "Require and verify client certificates on the gRPC transport (mTLS)", &opts.Grpc.TLS.MutualAuth).
 		//server options
 		extractInt("MAX_CONNECTIONS", "max-connections", "Maximum number of concurrent connections", &opts.Server.MaxConnections).
 		extractBool("DEV_MODE", "dev", "Enable development mode", &opts.Server.IsDev).

--- a/sdks/go/pkg/config/load.go
+++ b/sdks/go/pkg/config/load.go
@@ -142,14 +142,14 @@ func InitOptions(appName string, args []string, initOpts ...InitOption) (Runtime
 		extractBool("REST_TLS_ENABLED", "rest-tls-enabled", "Enable TLS on the REST transport listener", &opts.Rest.TLS.Enabled).
 		extractString("REST_TLS_CERT_FILE", "rest-tls-cert-file", "Path to the PEM server certificate for the REST transport", &opts.Rest.TLS.CertFile).
 		extractString("REST_TLS_KEY_FILE", "rest-tls-key-file", "Path to the PEM server private key for the REST transport", &opts.Rest.TLS.KeyFile).
-		extractString("REST_TLS_CA_FILE", "rest-tls-ca-file", "Path to the PEM client CA bundle for REST mutual TLS", &opts.Rest.TLS.CAFile).
+		extractString("REST_TLS_CLIENT_CA_FILE", "rest-tls-client-ca-file", "Path to the PEM client CA bundle for REST mutual TLS", &opts.Rest.TLS.ClientCAFile).
 		extractBool("REST_TLS_MUTUAL_AUTH", "rest-tls-mutual-auth", "Require and verify client certificates on the REST transport (mTLS)", &opts.Rest.TLS.MutualAuth).
 		extractInt("GRPC_PORT", "grpc-port", "Port the gRPC transport listens on", &opts.Grpc.Port).
 		extractBool("GRPC_REFLECTION", "grpc-reflection", "Enable gRPC server reflection", &opts.Grpc.Reflection).
 		extractBool("GRPC_TLS_ENABLED", "grpc-tls-enabled", "Enable TLS on the gRPC transport listener", &opts.Grpc.TLS.Enabled).
 		extractString("GRPC_TLS_CERT_FILE", "grpc-tls-cert-file", "Path to the PEM server certificate for the gRPC transport", &opts.Grpc.TLS.CertFile).
 		extractString("GRPC_TLS_KEY_FILE", "grpc-tls-key-file", "Path to the PEM server private key for the gRPC transport", &opts.Grpc.TLS.KeyFile).
-		extractString("GRPC_TLS_CA_FILE", "grpc-tls-ca-file", "Path to the PEM client CA bundle for gRPC mutual TLS", &opts.Grpc.TLS.CAFile).
+		extractString("GRPC_TLS_CLIENT_CA_FILE", "grpc-tls-client-ca-file", "Path to the PEM client CA bundle for gRPC mutual TLS", &opts.Grpc.TLS.ClientCAFile).
 		extractBool("GRPC_TLS_MUTUAL_AUTH", "grpc-tls-mutual-auth", "Require and verify client certificates on the gRPC transport (mTLS)", &opts.Grpc.TLS.MutualAuth).
 		//server options
 		extractInt("MAX_CONNECTIONS", "max-connections", "Maximum number of concurrent connections", &opts.Server.MaxConnections).

--- a/sdks/go/pkg/config/load_test.go
+++ b/sdks/go/pkg/config/load_test.go
@@ -394,6 +394,89 @@ func TestInitOptions_Transport(t *testing.T) {
 			t.Errorf("expected CLI flag to override env (Rest.Port=4444), got %d", opts.Rest.Port)
 		}
 	})
+
+	t.Run("rest tls from env", func(t *testing.T) {
+		t.Setenv("TESTCFG_REST_TLS_ENABLED", "true")
+		t.Setenv("TESTCFG_REST_TLS_CERT_FILE", "/certs/rest.crt")
+		t.Setenv("TESTCFG_REST_TLS_KEY_FILE", "/certs/rest.key")
+		t.Setenv("TESTCFG_REST_TLS_CA_FILE", "/certs/rest-ca.crt")
+		t.Setenv("TESTCFG_REST_TLS_MUTUAL_AUTH", "true")
+		opts := init(t)
+		want := TLSOptions{
+			Enabled:    true,
+			CertFile:   "/certs/rest.crt",
+			KeyFile:    "/certs/rest.key",
+			CAFile:     "/certs/rest-ca.crt",
+			MutualAuth: true,
+		}
+		if !reflect.DeepEqual(opts.Rest.TLS, want) {
+			t.Errorf("expected Rest.TLS %+v, got %+v", want, opts.Rest.TLS)
+		}
+	})
+
+	t.Run("grpc tls from env", func(t *testing.T) {
+		t.Setenv("TESTCFG_GRPC_TLS_ENABLED", "true")
+		t.Setenv("TESTCFG_GRPC_TLS_CERT_FILE", "/certs/grpc.crt")
+		t.Setenv("TESTCFG_GRPC_TLS_KEY_FILE", "/certs/grpc.key")
+		t.Setenv("TESTCFG_GRPC_TLS_CA_FILE", "/certs/grpc-ca.crt")
+		t.Setenv("TESTCFG_GRPC_TLS_MUTUAL_AUTH", "true")
+		opts := init(t)
+		want := TLSOptions{
+			Enabled:    true,
+			CertFile:   "/certs/grpc.crt",
+			KeyFile:    "/certs/grpc.key",
+			CAFile:     "/certs/grpc-ca.crt",
+			MutualAuth: true,
+		}
+		if !reflect.DeepEqual(opts.Grpc.TLS, want) {
+			t.Errorf("expected Grpc.TLS %+v, got %+v", want, opts.Grpc.TLS)
+		}
+	})
+
+	// the rest and grpc TLS env vars must not bleed into each other
+	t.Run("rest and grpc tls are independent", func(t *testing.T) {
+		t.Setenv("TESTCFG_REST_TLS_ENABLED", "true")
+		t.Setenv("TESTCFG_REST_TLS_CERT_FILE", "/certs/rest.crt")
+		opts := init(t)
+		if !opts.Rest.TLS.Enabled || opts.Rest.TLS.CertFile != "/certs/rest.crt" {
+			t.Errorf("expected Rest.TLS to be set from env, got %+v", opts.Rest.TLS)
+		}
+		if opts.Grpc.TLS.Enabled || opts.Grpc.TLS.CertFile != "" {
+			t.Errorf("expected Grpc.TLS to stay at defaults, got %+v", opts.Grpc.TLS)
+		}
+	})
+
+	t.Run("tls defaults to disabled when unset", func(t *testing.T) {
+		opts := init(t)
+		if !reflect.DeepEqual(opts.Rest.TLS, TLSOptions{}) {
+			t.Errorf("expected default Rest.TLS to be zero, got %+v", opts.Rest.TLS)
+		}
+		if !reflect.DeepEqual(opts.Grpc.TLS, TLSOptions{}) {
+			t.Errorf("expected default Grpc.TLS to be zero, got %+v", opts.Grpc.TLS)
+		}
+	})
+
+	t.Run("cli overrides tls env", func(t *testing.T) {
+		t.Setenv("TESTCFG_GRPC_TLS_CERT_FILE", "/env/grpc.crt")
+		opts := init(t, "--grpc-tls-cert-file=/cli/grpc.crt", "--rest-tls-enabled", "--rest-tls-mutual-auth")
+		if opts.Grpc.TLS.CertFile != "/cli/grpc.crt" {
+			t.Errorf("expected CLI flag to override env (Grpc.TLS.CertFile=/cli/grpc.crt), got %q", opts.Grpc.TLS.CertFile)
+		}
+		if !opts.Rest.TLS.Enabled {
+			t.Error("expected --rest-tls-enabled to set Rest.TLS.Enabled")
+		}
+		if !opts.Rest.TLS.MutualAuth {
+			t.Error("expected --rest-tls-mutual-auth to set Rest.TLS.MutualAuth")
+		}
+	})
+
+	t.Run("invalid tls bool env errors", func(t *testing.T) {
+		t.Setenv("TESTCFG_REST_TLS_ENABLED", "notabool")
+		_, err := InitOptions("test_app", []string{}, WithPrefix("TESTCFG"))
+		if err == nil {
+			t.Error("expected error for invalid TESTCFG_REST_TLS_ENABLED, got nil")
+		}
+	})
 }
 
 func makeTestLoader(t *testing.T) *configLoader {

--- a/sdks/go/pkg/config/load_test.go
+++ b/sdks/go/pkg/config/load_test.go
@@ -399,15 +399,15 @@ func TestInitOptions_Transport(t *testing.T) {
 		t.Setenv("TESTCFG_REST_TLS_ENABLED", "true")
 		t.Setenv("TESTCFG_REST_TLS_CERT_FILE", "/certs/rest.crt")
 		t.Setenv("TESTCFG_REST_TLS_KEY_FILE", "/certs/rest.key")
-		t.Setenv("TESTCFG_REST_TLS_CA_FILE", "/certs/rest-ca.crt")
+		t.Setenv("TESTCFG_REST_TLS_CLIENT_CA_FILE", "/certs/rest-ca.crt")
 		t.Setenv("TESTCFG_REST_TLS_MUTUAL_AUTH", "true")
 		opts := init(t)
 		want := TLSOptions{
-			Enabled:    true,
-			CertFile:   "/certs/rest.crt",
-			KeyFile:    "/certs/rest.key",
-			CAFile:     "/certs/rest-ca.crt",
-			MutualAuth: true,
+			Enabled:      true,
+			CertFile:     "/certs/rest.crt",
+			KeyFile:      "/certs/rest.key",
+			ClientCAFile: "/certs/rest-ca.crt",
+			MutualAuth:   true,
 		}
 		if !reflect.DeepEqual(opts.Rest.TLS, want) {
 			t.Errorf("expected Rest.TLS %+v, got %+v", want, opts.Rest.TLS)
@@ -418,15 +418,15 @@ func TestInitOptions_Transport(t *testing.T) {
 		t.Setenv("TESTCFG_GRPC_TLS_ENABLED", "true")
 		t.Setenv("TESTCFG_GRPC_TLS_CERT_FILE", "/certs/grpc.crt")
 		t.Setenv("TESTCFG_GRPC_TLS_KEY_FILE", "/certs/grpc.key")
-		t.Setenv("TESTCFG_GRPC_TLS_CA_FILE", "/certs/grpc-ca.crt")
+		t.Setenv("TESTCFG_GRPC_TLS_CLIENT_CA_FILE", "/certs/grpc-ca.crt")
 		t.Setenv("TESTCFG_GRPC_TLS_MUTUAL_AUTH", "true")
 		opts := init(t)
 		want := TLSOptions{
-			Enabled:    true,
-			CertFile:   "/certs/grpc.crt",
-			KeyFile:    "/certs/grpc.key",
-			CAFile:     "/certs/grpc-ca.crt",
-			MutualAuth: true,
+			Enabled:      true,
+			CertFile:     "/certs/grpc.crt",
+			KeyFile:      "/certs/grpc.key",
+			ClientCAFile: "/certs/grpc-ca.crt",
+			MutualAuth:   true,
 		}
 		if !reflect.DeepEqual(opts.Grpc.TLS, want) {
 			t.Errorf("expected Grpc.TLS %+v, got %+v", want, opts.Grpc.TLS)

--- a/sdks/go/pkg/config/tls.go
+++ b/sdks/go/pkg/config/tls.go
@@ -33,6 +33,7 @@
  * @file tls.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @date 2026-07-30
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
  */
 
 package config

--- a/sdks/go/pkg/config/tls.go
+++ b/sdks/go/pkg/config/tls.go
@@ -42,16 +42,17 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log/slog"
 	"os"
 )
 
 // ServerTLSConfig builds a *tls.Config for a server listener from the options.
 //
 // It returns (nil, nil) when TLS is not enabled. When enabled, CertFile and
-// KeyFile are required, and CAFile is required when MutualAuth is true. Any
-// missing or unparseable file results in an error so callers can fail startup
-// instead of silently serving plaintext.
+// KeyFile are required, and ClientCAFile is required when MutualAuth is true.
+// Any missing or unparseable file results in an error so callers can fail
+// startup instead of silently serving plaintext.
+//
+// ClientCAFile is ignored when MutualAuth is false.
 func (o TLSOptions) ServerTLSConfig() (*tls.Config, error) {
 	if !o.Enabled {
 		return nil, nil
@@ -75,22 +76,19 @@ func (o TLSOptions) ServerTLSConfig() (*tls.Config, error) {
 	}
 
 	if o.MutualAuth {
-		if o.CAFile == "" {
+		if o.ClientCAFile == "" {
 			return nil, fmt.Errorf("TLS mutual auth is enabled but no client CA file was provided")
 		}
-		caPEM, err := os.ReadFile(o.CAFile)
+		caPEM, err := os.ReadFile(o.ClientCAFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read client CA file %q: %w", o.CAFile, err)
+			return nil, fmt.Errorf("failed to read client CA file %q: %w", o.ClientCAFile, err)
 		}
 		caPool := x509.NewCertPool()
 		if !caPool.AppendCertsFromPEM(caPEM) {
-			return nil, fmt.Errorf("client CA file %q contains no valid PEM certificates", o.CAFile)
+			return nil, fmt.Errorf("client CA file %q contains no valid PEM certificates", o.ClientCAFile)
 		}
 		tlsConfig.ClientCAs = caPool
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
-	} else if o.CAFile != "" {
-		slog.Warn("TLS client CA file is set but mutual auth is disabled; the CA file will be ignored",
-			"ca_file", o.CAFile)
 	}
 
 	return tlsConfig, nil

--- a/sdks/go/pkg/config/tls.go
+++ b/sdks/go/pkg/config/tls.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief TLS configuration builder for transport listeners.
+ * @file tls.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @date 2026-07-30
+ */
+
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// ServerTLSConfig builds a *tls.Config for a server listener from the options.
+//
+// It returns (nil, nil) when TLS is not enabled. When enabled, CertFile and
+// KeyFile are required, and CAFile is required when MutualAuth is true. Any
+// missing or unparseable file results in an error so callers can fail startup
+// instead of silently serving plaintext.
+func (o TLSOptions) ServerTLSConfig() (*tls.Config, error) {
+	if !o.Enabled {
+		return nil, nil
+	}
+
+	if o.CertFile == "" {
+		return nil, fmt.Errorf("TLS is enabled but no certificate file was provided")
+	}
+	if o.KeyFile == "" {
+		return nil, fmt.Errorf("TLS is enabled but no private key file was provided")
+	}
+
+	cert, err := tls.LoadX509KeyPair(o.CertFile, o.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load TLS key pair (cert %q, key %q): %w", o.CertFile, o.KeyFile, err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if o.MutualAuth {
+		if o.CAFile == "" {
+			return nil, fmt.Errorf("TLS mutual auth is enabled but no client CA file was provided")
+		}
+		caPEM, err := os.ReadFile(o.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read client CA file %q: %w", o.CAFile, err)
+		}
+		caPool := x509.NewCertPool()
+		if !caPool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("client CA file %q contains no valid PEM certificates", o.CAFile)
+		}
+		tlsConfig.ClientCAs = caPool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	} else if o.CAFile != "" {
+		slog.Warn("TLS client CA file is set but mutual auth is disabled; the CA file will be ignored",
+			"ca_file", o.CAFile)
+	}
+
+	return tlsConfig, nil
+}

--- a/sdks/go/pkg/config/tls_test.go
+++ b/sdks/go/pkg/config/tls_test.go
@@ -33,6 +33,7 @@
  * @file tls_test.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @date 2026-07-30
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
  */
 
 package config

--- a/sdks/go/pkg/config/tls_test.go
+++ b/sdks/go/pkg/config/tls_test.go
@@ -150,11 +150,11 @@ func TestTLSOptions_ServerTLSConfig(t *testing.T) {
 
 	t.Run("mutual auth with CA file", func(t *testing.T) {
 		cfg, err := TLSOptions{
-			Enabled:    true,
-			CertFile:   certs.ServerCertFile,
-			KeyFile:    certs.ServerKeyFile,
-			CAFile:     certs.CACertFile,
-			MutualAuth: true,
+			Enabled:      true,
+			CertFile:     certs.ServerCertFile,
+			KeyFile:      certs.ServerKeyFile,
+			ClientCAFile: certs.CACertFile,
+			MutualAuth:   true,
 		}.ServerTLSConfig()
 		if err != nil {
 			t.Fatalf("expected no error, got: %v", err)
@@ -169,11 +169,11 @@ func TestTLSOptions_ServerTLSConfig(t *testing.T) {
 
 	t.Run("mutual auth with nonexistent CA file errors", func(t *testing.T) {
 		_, err := TLSOptions{
-			Enabled:    true,
-			CertFile:   certs.ServerCertFile,
-			KeyFile:    certs.ServerKeyFile,
-			CAFile:     filepath.Join(t.TempDir(), "does-not-exist-ca.crt"),
-			MutualAuth: true,
+			Enabled:      true,
+			CertFile:     certs.ServerCertFile,
+			KeyFile:      certs.ServerKeyFile,
+			ClientCAFile: filepath.Join(t.TempDir(), "does-not-exist-ca.crt"),
+			MutualAuth:   true,
 		}.ServerTLSConfig()
 		if err == nil {
 			t.Fatal("expected error for nonexistent CA file, got nil")
@@ -186,11 +186,11 @@ func TestTLSOptions_ServerTLSConfig(t *testing.T) {
 			t.Fatalf("failed to write bad CA: %v", err)
 		}
 		_, err := TLSOptions{
-			Enabled:    true,
-			CertFile:   certs.ServerCertFile,
-			KeyFile:    certs.ServerKeyFile,
-			CAFile:     badCA,
-			MutualAuth: true,
+			Enabled:      true,
+			CertFile:     certs.ServerCertFile,
+			KeyFile:      certs.ServerKeyFile,
+			ClientCAFile: badCA,
+			MutualAuth:   true,
 		}.ServerTLSConfig()
 		if err == nil {
 			t.Fatal("expected error for invalid CA PEM, got nil")
@@ -199,10 +199,10 @@ func TestTLSOptions_ServerTLSConfig(t *testing.T) {
 
 	t.Run("CA file without mutual auth is ignored", func(t *testing.T) {
 		cfg, err := TLSOptions{
-			Enabled:  true,
-			CertFile: certs.ServerCertFile,
-			KeyFile:  certs.ServerKeyFile,
-			CAFile:   certs.CACertFile,
+			Enabled:      true,
+			CertFile:     certs.ServerCertFile,
+			KeyFile:      certs.ServerKeyFile,
+			ClientCAFile: certs.CACertFile,
 		}.ServerTLSConfig()
 		if err != nil {
 			t.Fatalf("expected no error, got: %v", err)

--- a/sdks/go/pkg/config/tls_test.go
+++ b/sdks/go/pkg/config/tls_test.go
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for the TLS configuration builder.
+ * @file tls_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @date 2026-07-30
+ */
+
+package config
+
+import (
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/internal/testcerts"
+)
+
+func TestTLSOptions_ServerTLSConfig(t *testing.T) {
+	certs := testcerts.Generate(t)
+
+	t.Run("disabled returns nil config and nil error", func(t *testing.T) {
+		// even with files set, disabled means no TLS config
+		cfg, err := TLSOptions{
+			CertFile: certs.ServerCertFile,
+			KeyFile:  certs.ServerKeyFile,
+		}.ServerTLSConfig()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if cfg != nil {
+			t.Fatalf("expected nil config when disabled, got: %+v", cfg)
+		}
+	})
+
+	t.Run("valid cert and key", func(t *testing.T) {
+		cfg, err := TLSOptions{
+			Enabled:  true,
+			CertFile: certs.ServerCertFile,
+			KeyFile:  certs.ServerKeyFile,
+		}.ServerTLSConfig()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected non-nil config")
+		}
+		if len(cfg.Certificates) != 1 {
+			t.Errorf("expected 1 certificate, got %d", len(cfg.Certificates))
+		}
+		if cfg.MinVersion != tls.VersionTLS12 {
+			t.Errorf("expected MinVersion TLS 1.2, got %x", cfg.MinVersion)
+		}
+		if cfg.ClientAuth != tls.NoClientCert {
+			t.Errorf("expected no client cert requirement, got %v", cfg.ClientAuth)
+		}
+		if cfg.ClientCAs != nil {
+			t.Error("expected nil ClientCAs without mutual auth")
+		}
+	})
+
+	t.Run("missing cert file path errors", func(t *testing.T) {
+		_, err := TLSOptions{
+			Enabled: true,
+			KeyFile: certs.ServerKeyFile,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for missing cert file, got nil")
+		}
+	})
+
+	t.Run("missing key file path errors", func(t *testing.T) {
+		_, err := TLSOptions{
+			Enabled:  true,
+			CertFile: certs.ServerCertFile,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for missing key file, got nil")
+		}
+	})
+
+	t.Run("nonexistent cert file errors", func(t *testing.T) {
+		_, err := TLSOptions{
+			Enabled:  true,
+			CertFile: filepath.Join(t.TempDir(), "does-not-exist.crt"),
+			KeyFile:  certs.ServerKeyFile,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for nonexistent cert file, got nil")
+		}
+	})
+
+	t.Run("invalid PEM cert errors", func(t *testing.T) {
+		badCert := filepath.Join(t.TempDir(), "bad.crt")
+		if err := os.WriteFile(badCert, []byte("not a certificate"), 0o600); err != nil {
+			t.Fatalf("failed to write bad cert: %v", err)
+		}
+		_, err := TLSOptions{
+			Enabled:  true,
+			CertFile: badCert,
+			KeyFile:  certs.ServerKeyFile,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for invalid PEM cert, got nil")
+		}
+	})
+
+	t.Run("mutual auth without CA file errors", func(t *testing.T) {
+		_, err := TLSOptions{
+			Enabled:    true,
+			CertFile:   certs.ServerCertFile,
+			KeyFile:    certs.ServerKeyFile,
+			MutualAuth: true,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for mutual auth without CA file, got nil")
+		}
+	})
+
+	t.Run("mutual auth with CA file", func(t *testing.T) {
+		cfg, err := TLSOptions{
+			Enabled:    true,
+			CertFile:   certs.ServerCertFile,
+			KeyFile:    certs.ServerKeyFile,
+			CAFile:     certs.CACertFile,
+			MutualAuth: true,
+		}.ServerTLSConfig()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+			t.Errorf("expected RequireAndVerifyClientCert, got %v", cfg.ClientAuth)
+		}
+		if cfg.ClientCAs == nil {
+			t.Error("expected ClientCAs to be set for mutual auth")
+		}
+	})
+
+	t.Run("mutual auth with nonexistent CA file errors", func(t *testing.T) {
+		_, err := TLSOptions{
+			Enabled:    true,
+			CertFile:   certs.ServerCertFile,
+			KeyFile:    certs.ServerKeyFile,
+			CAFile:     filepath.Join(t.TempDir(), "does-not-exist-ca.crt"),
+			MutualAuth: true,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for nonexistent CA file, got nil")
+		}
+	})
+
+	t.Run("mutual auth with invalid CA PEM errors", func(t *testing.T) {
+		badCA := filepath.Join(t.TempDir(), "bad-ca.crt")
+		if err := os.WriteFile(badCA, []byte("not a certificate"), 0o600); err != nil {
+			t.Fatalf("failed to write bad CA: %v", err)
+		}
+		_, err := TLSOptions{
+			Enabled:    true,
+			CertFile:   certs.ServerCertFile,
+			KeyFile:    certs.ServerKeyFile,
+			CAFile:     badCA,
+			MutualAuth: true,
+		}.ServerTLSConfig()
+		if err == nil {
+			t.Fatal("expected error for invalid CA PEM, got nil")
+		}
+	})
+
+	t.Run("CA file without mutual auth is ignored", func(t *testing.T) {
+		cfg, err := TLSOptions{
+			Enabled:  true,
+			CertFile: certs.ServerCertFile,
+			KeyFile:  certs.ServerKeyFile,
+			CAFile:   certs.CACertFile,
+		}.ServerTLSConfig()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if cfg.ClientCAs != nil {
+			t.Error("expected ClientCAs to be nil when mutual auth is disabled")
+		}
+		if cfg.ClientAuth != tls.NoClientCert {
+			t.Errorf("expected no client cert requirement, got %v", cfg.ClientAuth)
+		}
+	})
+}

--- a/sdks/go/pkg/internal/testcerts/testcerts.go
+++ b/sdks/go/pkg/internal/testcerts/testcerts.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Ephemeral TLS certificate generation for tests.
+ * @file testcerts.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @date 2026-07-30
+ */
+
+// Package testcerts generates ephemeral self-signed certificate chains for
+// TLS tests. Certificates are created at test time and written to a temp
+// directory, so no fixtures are checked in that could expire.
+package testcerts
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Bundle holds paths to a generated CA plus server and client certificates,
+// all signed by the same CA. All files are PEM encoded.
+type Bundle struct {
+	// CACertFile is the CA certificate, usable both as a client's RootCAs and
+	// as a server's ClientCAs for mTLS.
+	CACertFile string
+	// ServerCertFile / ServerKeyFile are a server key pair valid for
+	// "localhost" and 127.0.0.1/::1.
+	ServerCertFile string
+	ServerKeyFile  string
+	// ClientCertFile / ClientKeyFile are a client key pair for mTLS tests.
+	ClientCertFile string
+	ClientKeyFile  string
+}
+
+// Generate creates a CA, a server certificate, and a client certificate in
+// t.TempDir() and returns the file paths. It fails the test on any error.
+func Generate(t testing.TB) Bundle {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, caCert, caDER := newCA(t)
+	caPEM := certPEM(caDER)
+
+	serverCertPEM, serverKeyPEM := newLeaf(t, caCert, caKey, x509.ExtKeyUsageServerAuth, true)
+	clientCertPEM, clientKeyPEM := newLeaf(t, caCert, caKey, x509.ExtKeyUsageClientAuth, false)
+
+	b := Bundle{
+		CACertFile:     filepath.Join(dir, "ca.crt"),
+		ServerCertFile: filepath.Join(dir, "server.crt"),
+		ServerKeyFile:  filepath.Join(dir, "server.key"),
+		ClientCertFile: filepath.Join(dir, "client.crt"),
+		ClientKeyFile:  filepath.Join(dir, "client.key"),
+	}
+	writeFile(t, b.CACertFile, caPEM)
+	writeFile(t, b.ServerCertFile, serverCertPEM)
+	writeFile(t, b.ServerKeyFile, serverKeyPEM)
+	writeFile(t, b.ClientCertFile, clientCertPEM)
+	writeFile(t, b.ClientKeyFile, clientKeyPEM)
+	return b
+}
+
+func newCA(t testing.TB) (*ecdsa.PrivateKey, *x509.Certificate, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          newSerial(t),
+		Subject:               pkix.Name{CommonName: "catena-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+	return key, cert, der
+}
+
+func newLeaf(t testing.TB, caCert *x509.Certificate, caKey *ecdsa.PrivateKey, usage x509.ExtKeyUsage, server bool) (certPEMBytes, keyPEMBytes []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: newSerial(t),
+		Subject:      pkix.Name{CommonName: "catena-test-leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{usage},
+	}
+	if server {
+		template.DNSNames = []string{"localhost"}
+		template.IPAddresses = []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal leaf key: %v", err)
+	}
+	return certPEM(der), pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func newSerial(t testing.TB) *big.Int {
+	t.Helper()
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("failed to generate serial number: %v", err)
+	}
+	return serial
+}
+
+func certPEM(der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func writeFile(t testing.TB, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}

--- a/sdks/go/pkg/internal/testcerts/testcerts.go
+++ b/sdks/go/pkg/internal/testcerts/testcerts.go
@@ -33,6 +33,7 @@
  * @file testcerts.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @date 2026-07-30
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
  */
 
 // Package testcerts generates ephemeral self-signed certificate chains for

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -175,17 +175,17 @@ grpcTransport := grpc.NewTransport(grpc.Options{
 restTransport := rest.NewTransport(rest.Options{
     Port: 9080,
     TLS: config.TLSOptions{
-        Enabled:    true,
-        CertFile:   "/etc/catena/certs/server.crt",
-        KeyFile:    "/etc/catena/certs/server.key",
-        CAFile:     "/etc/catena/certs/clients-ca.crt",
-        MutualAuth: true, // require client certificates (mTLS)
+        Enabled:      true,
+        CertFile:     "/etc/catena/certs/server.crt",
+        KeyFile:      "/etc/catena/certs/server.key",
+        ClientCAFile: "/etc/catena/certs/clients-ca.crt",
+        MutualAuth:   true, // require client certificates (mTLS)
     },
 })
 ```
 
 - `CertFile` and `KeyFile` are required when `Enabled` is true; a missing or unreadable file causes transport startup to fail rather than silently serving plaintext.
-- `MutualAuth` requires clients to present a certificate signed by the CA bundle in `CAFile`.
+- `MutualAuth` requires clients to present a certificate signed by the CA bundle in `ClientCAFile`.
 - The minimum accepted protocol version is TLS 1.2.
 - When loading options from env/CLI via `config.InitOptions`, the corresponding inputs are `{PREFIX}_REST_TLS_*` / `--rest-tls-*` and `{PREFIX}_GRPC_TLS_*` / `--grpc-tls-*` (see `pkg/config/README.md`).
 

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -156,6 +156,38 @@ Caller guidance:
 - REST default port: `9080`
 - gRPC default port: `6254`
 - gRPC reflection default: disabled
+- TLS default: disabled on both transports
+
+## TLS
+
+Both transports support optional server-side TLS, configured independently via the `TLS` field on their options (`config.TLSOptions`):
+
+```go
+grpcTransport := grpc.NewTransport(grpc.Options{
+    Port: 6254,
+    TLS: config.TLSOptions{
+        Enabled:  true,
+        CertFile: "/etc/catena/certs/server.crt",
+        KeyFile:  "/etc/catena/certs/server.key",
+    },
+})
+
+restTransport := rest.NewTransport(rest.Options{
+    Port: 9080,
+    TLS: config.TLSOptions{
+        Enabled:    true,
+        CertFile:   "/etc/catena/certs/server.crt",
+        KeyFile:    "/etc/catena/certs/server.key",
+        CAFile:     "/etc/catena/certs/clients-ca.crt",
+        MutualAuth: true, // require client certificates (mTLS)
+    },
+})
+```
+
+- `CertFile` and `KeyFile` are required when `Enabled` is true; a missing or unreadable file causes transport startup to fail rather than silently serving plaintext.
+- `MutualAuth` requires clients to present a certificate signed by the CA bundle in `CAFile`.
+- The minimum accepted protocol version is TLS 1.2.
+- When loading options from env/CLI via `config.InitOptions`, the corresponding inputs are `{PREFIX}_REST_TLS_*` / `--rest-tls-*` and `{PREFIX}_GRPC_TLS_*` / `--grpc-tls-*` (see `pkg/config/README.md`).
 
 ## Related Docs
 

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -160,28 +160,22 @@ Caller guidance:
 
 ## TLS
 
-Both transports support optional server-side TLS, configured independently via the `TLS` field on their options (`config.TLSOptions`):
+Both transports support optional server-side TLS, configured independently via the `TLS` field on their options structs. Example:
 
 ```go
-grpcTransport := grpc.NewTransport(grpc.Options{
-    Port: 6254,
-    TLS: config.TLSOptions{
-        Enabled:  true,
-        CertFile: "/etc/catena/certs/server.crt",
-        KeyFile:  "/etc/catena/certs/server.key",
-    },
-})
+grpcOpts := grpc.DefaultOptions()
+grpcOpts.TLS.Enabled = true
+grpcOpts.TLS.CertFile = "/etc/catena/certs/server.crt"
+grpcOpts.TLS.KeyFile = "/etc/catena/certs/server.key"
+grpcTransport := grpc.NewTransport(grpcOpts)
 
-restTransport := rest.NewTransport(rest.Options{
-    Port: 9080,
-    TLS: config.TLSOptions{
-        Enabled:      true,
-        CertFile:     "/etc/catena/certs/server.crt",
-        KeyFile:      "/etc/catena/certs/server.key",
-        ClientCAFile: "/etc/catena/certs/clients-ca.crt",
-        MutualAuth:   true, // require client certificates (mTLS)
-    },
-})
+restOpts := rest.DefaultOptions()
+restOpts.TLS.Enabled = true
+restOpts.TLS.CertFile = "/etc/catena/certs/server.crt"
+restOpts.TLS.KeyFile = "/etc/catena/certs/server.key"
+restOpts.TLS.ClientCAFile = "/etc/catena/certs/clients-ca.crt"
+restOpts.TLS.MutualAuth = true // require client certificates (mTLS)
+restTransport := rest.NewTransport(restOpts)
 ```
 
 - `CertFile` and `KeyFile` are required when `Enabled` is true; a missing or unreadable file causes transport startup to fail rather than silently serving plaintext.

--- a/sdks/go/pkg/transports/grpc/GRPC.md
+++ b/sdks/go/pkg/transports/grpc/GRPC.md
@@ -36,8 +36,8 @@ grpcTransport := grpc.NewTransport(grpc.Options{
         CertFile: "/etc/catena/certs/server.crt", // PEM server certificate
         KeyFile:  "/etc/catena/certs/server.key", // PEM private key
         // Optional mutual TLS (client certificate verification):
-        // CAFile:     "/etc/catena/certs/clients-ca.crt",
-        // MutualAuth: true,
+        // ClientCAFile: "/etc/catena/certs/clients-ca.crt",
+        // MutualAuth:   true,
     },
 })
 ```
@@ -45,10 +45,10 @@ grpcTransport := grpc.NewTransport(grpc.Options{
 Behavior:
 
 - `CertFile` and `KeyFile` are required when TLS is enabled. Because gRPC credentials must be supplied at server construction, an invalid TLS configuration is recorded by `NewTransport` and returned as an error from `Start` (registration via `RegisterTransport` fails).
-- With `MutualAuth`, clients must present a certificate signed by the CA bundle in `CAFile` or the TLS handshake is rejected.
+- With `MutualAuth`, clients must present a certificate signed by the CA bundle in `ClientCAFile` or the TLS handshake is rejected.
 - Minimum accepted protocol version is TLS 1.2.
 - Clients must then dial with TLS credentials, e.g. `grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{...}))`; plaintext (insecure) clients will fail to connect.
-- Env/CLI configuration: `{PREFIX}_GRPC_TLS_ENABLED`, `{PREFIX}_GRPC_TLS_CERT_FILE`, `{PREFIX}_GRPC_TLS_KEY_FILE`, `{PREFIX}_GRPC_TLS_CA_FILE`, `{PREFIX}_GRPC_TLS_MUTUAL_AUTH` (flags `--grpc-tls-*`).
+- Env/CLI configuration: `{PREFIX}_GRPC_TLS_ENABLED`, `{PREFIX}_GRPC_TLS_CERT_FILE`, `{PREFIX}_GRPC_TLS_KEY_FILE`, `{PREFIX}_GRPC_TLS_CLIENT_CA_FILE`, `{PREFIX}_GRPC_TLS_MUTUAL_AUTH` (flags `--grpc-tls-*`).
 
 ## Implemented RPCs
 

--- a/sdks/go/pkg/transports/grpc/GRPC.md
+++ b/sdks/go/pkg/transports/grpc/GRPC.md
@@ -24,6 +24,32 @@ if err := srv.RegisterTransport(grpcTransport); err != nil {
 }
 ```
 
+## TLS
+
+The server uses TLS transport credentials when `Options.TLS.Enabled` is true:
+
+```go
+grpcTransport := grpc.NewTransport(grpc.Options{
+    Port: 6254,
+    TLS: config.TLSOptions{
+        Enabled:  true,
+        CertFile: "/etc/catena/certs/server.crt", // PEM server certificate
+        KeyFile:  "/etc/catena/certs/server.key", // PEM private key
+        // Optional mutual TLS (client certificate verification):
+        // CAFile:     "/etc/catena/certs/clients-ca.crt",
+        // MutualAuth: true,
+    },
+})
+```
+
+Behavior:
+
+- `CertFile` and `KeyFile` are required when TLS is enabled. Because gRPC credentials must be supplied at server construction, an invalid TLS configuration is recorded by `NewTransport` and returned as an error from `Start` (registration via `RegisterTransport` fails).
+- With `MutualAuth`, clients must present a certificate signed by the CA bundle in `CAFile` or the TLS handshake is rejected.
+- Minimum accepted protocol version is TLS 1.2.
+- Clients must then dial with TLS credentials, e.g. `grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{...}))`; plaintext (insecure) clients will fail to connect.
+- Env/CLI configuration: `{PREFIX}_GRPC_TLS_ENABLED`, `{PREFIX}_GRPC_TLS_CERT_FILE`, `{PREFIX}_GRPC_TLS_KEY_FILE`, `{PREFIX}_GRPC_TLS_CA_FILE`, `{PREFIX}_GRPC_TLS_MUTUAL_AUTH` (flags `--grpc-tls-*`).
+
 ## Implemented RPCs
 
 Implemented against shared runtime handlers:

--- a/sdks/go/pkg/transports/grpc/GRPC.md
+++ b/sdks/go/pkg/transports/grpc/GRPC.md
@@ -10,9 +10,12 @@ import "github.com/rossvideo/catena/sdks/go/pkg/transports/grpc"
 ## Constructor
 
 ```go
-grpcTransport := grpc.NewTransport(grpc.Options{Port: 6254, Reflection: false})
-// or with defaults
 grpcTransport := grpc.NewTransport(grpc.DefaultOptions())
+// or start from the defaults and customize
+opts := grpc.DefaultOptions()
+opts.Port = 6254
+opts.Reflection = false
+grpcTransport := grpc.NewTransport(opts)
 ```
 
 Register it on the shared server:
@@ -29,17 +32,14 @@ if err := srv.RegisterTransport(grpcTransport); err != nil {
 The server uses TLS transport credentials when `Options.TLS.Enabled` is true:
 
 ```go
-grpcTransport := grpc.NewTransport(grpc.Options{
-    Port: 6254,
-    TLS: config.TLSOptions{
-        Enabled:  true,
-        CertFile: "/etc/catena/certs/server.crt", // PEM server certificate
-        KeyFile:  "/etc/catena/certs/server.key", // PEM private key
-        // Optional mutual TLS (client certificate verification):
-        // ClientCAFile: "/etc/catena/certs/clients-ca.crt",
-        // MutualAuth:   true,
-    },
-})
+opts := grpc.DefaultOptions()
+opts.TLS.Enabled = true
+opts.TLS.CertFile = "/etc/catena/certs/server.crt" // PEM server certificate
+opts.TLS.KeyFile = "/etc/catena/certs/server.key"  // PEM private key
+// Optional mutual TLS (client certificate verification):
+// opts.TLS.ClientCAFile = "/etc/catena/certs/clients-ca.crt"
+// opts.TLS.MutualAuth = true
+grpcTransport := grpc.NewTransport(opts)
 ```
 
 Behavior:
@@ -142,7 +142,9 @@ In production mode, detailed error text is sanitized to status code names.
 Reflection can be enabled at construction time:
 
 ```go
-grpcTransport := grpc.NewTransport(grpc.Options{Port: 6254, Reflection: true})
+opts := grpc.DefaultOptions()
+opts.Reflection = true
+grpcTransport := grpc.NewTransport(opts)
 ```
 
 When enabled, tools such as `grpcurl` can discover services and methods dynamically.

--- a/sdks/go/pkg/transports/grpc/grpc_tls_test.go
+++ b/sdks/go/pkg/transports/grpc/grpc_tls_test.go
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for TLS on the gRPC transport.
+ * @file grpc_tls_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @date 2026-07-30
+ */
+
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/config"
+	"github.com/rossvideo/catena/sdks/go/pkg/internal/testcerts"
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+	"github.com/rossvideo/catena/sdks/go/pkg/protos/rpc"
+	"github.com/rossvideo/catena/sdks/go/pkg/transports/internal/transporttest"
+)
+
+// reserveTestPort finds a free TCP port for a transport to listen on.
+func reserveTestPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+	return port
+}
+
+// startTLSTransport starts a gRPC transport with the given TLS options on a
+// free TCP port and registers shutdown cleanup. Returns the server address.
+func startTLSTransport(t *testing.T, tlsOpts config.TLSOptions) string {
+	t.Helper()
+	port := reserveTestPort(t)
+	transport := NewTransport(config.GrpcOptions{Port: port, TLS: tlsOpts})
+	runtime := transporttest.MakeStubServerRuntime(t)
+	runtime.Slots = []uint16{0}
+	runtime.ShutdownTransportConnsFn = func(ctx context.Context, gotTransport catena.Transport) {}
+
+	if err := transport.Start(context.Background(), runtime); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		transport.Shutdown(ctx)
+	})
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+// clientTLSConfig builds client TLS credentials trusting the test CA, with an
+// optional client certificate for mTLS.
+func clientTLSConfig(t *testing.T, certs testcerts.Bundle, withClientCert bool) *tls.Config {
+	t.Helper()
+	caPEM, err := os.ReadFile(certs.CACertFile)
+	if err != nil {
+		t.Fatalf("read CA file: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to parse test CA")
+	}
+	cfg := &tls.Config{RootCAs: pool}
+	if withClientCert {
+		clientCert, err := tls.LoadX509KeyPair(certs.ClientCertFile, certs.ClientKeyFile)
+		if err != nil {
+			t.Fatalf("load client cert: %v", err)
+		}
+		cfg.Certificates = []tls.Certificate{clientCert}
+	}
+	return cfg
+}
+
+// callGetPopulatedSlots dials the address with the given credentials and
+// performs a unary RPC, returning the RPC error (nil on success).
+func callGetPopulatedSlots(t *testing.T, addr string, creds credentials.TransportCredentials) error {
+	t.Helper()
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	client := rpc.NewCatenaServiceClient(conn)
+	_, err = client.GetPopulatedSlots(ctx, &protos.Empty{})
+	return err
+}
+
+func TestTransport_Start_TLS(t *testing.T) {
+	certs := testcerts.Generate(t)
+	addr := startTLSTransport(t, config.TLSOptions{
+		Enabled:  true,
+		CertFile: certs.ServerCertFile,
+		KeyFile:  certs.ServerKeyFile,
+	})
+
+	t.Run("tls client succeeds", func(t *testing.T) {
+		creds := credentials.NewTLS(clientTLSConfig(t, certs, false))
+		if err := callGetPopulatedSlots(t, addr, creds); err != nil {
+			t.Fatalf("expected TLS RPC to succeed, got: %v", err)
+		}
+	})
+
+	t.Run("insecure client fails", func(t *testing.T) {
+		if err := callGetPopulatedSlots(t, addr, insecure.NewCredentials()); err == nil {
+			t.Fatal("expected plaintext RPC against TLS server to fail, got nil")
+		}
+	})
+}
+
+func TestTransport_Start_TLS_MutualAuth(t *testing.T) {
+	certs := testcerts.Generate(t)
+	addr := startTLSTransport(t, config.TLSOptions{
+		Enabled:    true,
+		CertFile:   certs.ServerCertFile,
+		KeyFile:    certs.ServerKeyFile,
+		CAFile:     certs.CACertFile,
+		MutualAuth: true,
+	})
+
+	t.Run("client with certificate succeeds", func(t *testing.T) {
+		creds := credentials.NewTLS(clientTLSConfig(t, certs, true))
+		if err := callGetPopulatedSlots(t, addr, creds); err != nil {
+			t.Fatalf("expected mTLS RPC to succeed, got: %v", err)
+		}
+	})
+
+	t.Run("client without certificate is rejected", func(t *testing.T) {
+		creds := credentials.NewTLS(clientTLSConfig(t, certs, false))
+		if err := callGetPopulatedSlots(t, addr, creds); err == nil {
+			t.Fatal("expected RPC without client cert to fail, got nil")
+		}
+	})
+}
+
+func TestTransport_New_TLS_BadConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  config.TLSOptions
+	}{
+		{
+			name: "missing cert and key paths",
+			tls:  config.TLSOptions{Enabled: true},
+		},
+		{
+			name: "nonexistent cert file",
+			tls: config.TLSOptions{
+				Enabled:  true,
+				CertFile: filepath.Join(t.TempDir(), "missing.crt"),
+				KeyFile:  filepath.Join(t.TempDir(), "missing.key"),
+			},
+		},
+		{
+			name: "mutual auth without CA",
+			tls: func() config.TLSOptions {
+				certs := testcerts.Generate(t)
+				return config.TLSOptions{
+					Enabled:    true,
+					CertFile:   certs.ServerCertFile,
+					KeyFile:    certs.ServerKeyFile,
+					MutualAuth: true,
+				}
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewTransport(config.GrpcOptions{Port: reserveTestPort(t), TLS: tt.tls})
+			if transport.initErr == nil {
+				t.Error("expected initErr to be set for bad TLS config")
+			}
+
+			runtime := transporttest.MakeStubServerRuntime(t)
+			err := transport.Start(context.Background(), runtime)
+			if err == nil {
+				t.Fatal("expected Start to return the TLS configuration error, got nil")
+			}
+
+			// Shutdown on a transport that failed construction must be a no-op
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err := transport.Shutdown(ctx); err != nil {
+				t.Errorf("expected Shutdown to be a no-op, got: %v", err)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/transports/grpc/grpc_tls_test.go
+++ b/sdks/go/pkg/transports/grpc/grpc_tls_test.go
@@ -159,11 +159,11 @@ func TestTransport_Start_TLS(t *testing.T) {
 func TestTransport_Start_TLS_MutualAuth(t *testing.T) {
 	certs := testcerts.Generate(t)
 	addr := startTLSTransport(t, config.TLSOptions{
-		Enabled:    true,
-		CertFile:   certs.ServerCertFile,
-		KeyFile:    certs.ServerKeyFile,
-		CAFile:     certs.CACertFile,
-		MutualAuth: true,
+		Enabled:      true,
+		CertFile:     certs.ServerCertFile,
+		KeyFile:      certs.ServerKeyFile,
+		ClientCAFile: certs.CACertFile,
+		MutualAuth:   true,
 	})
 
 	t.Run("client with certificate succeeds", func(t *testing.T) {

--- a/sdks/go/pkg/transports/grpc/grpc_tls_test.go
+++ b/sdks/go/pkg/transports/grpc/grpc_tls_test.go
@@ -33,6 +33,7 @@
  * @file grpc_tls_test.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @date 2026-07-30
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
  */
 
 package grpc

--- a/sdks/go/pkg/transports/grpc/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport.go
@@ -54,6 +54,7 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
@@ -67,11 +68,19 @@ type Transport struct {
 
 	port       int
 	reflection bool
+	tlsEnabled bool
+	// initErr records a construction-time failure (e.g. invalid TLS config).
+	// grpc.Creds must be supplied when the server is created, but NewTransport
+	// cannot return an error, so the error is surfaced from Start instead.
+	initErr error
 }
 
 var _ catena.Transport = (*Transport)(nil)
 
 // NewTransport creates a new gRPC transport with the given configuration.
+//
+// If the TLS configuration is invalid, the returned transport is unusable and
+// Start will return the configuration error.
 func NewTransport(cfg Options) *Transport {
 	transport := &Transport{
 		catenaService: &catenaService{},
@@ -79,23 +88,41 @@ func NewTransport(cfg Options) *Transport {
 		reflection:    cfg.Reflection,
 	}
 	transport.catenaService.transport = transport
-	transport.grpcServer = grpc.NewServer(
+
+	serverOpts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(transport.unaryInterceptor),
 		grpc.StreamInterceptor(transport.streamInterceptor),
-	)
+	}
+
+	tlsConfig, err := cfg.TLS.ServerTLSConfig()
+	if err != nil {
+		logger.Error("gRPC Transport TLS configuration error", "error", err)
+		transport.initErr = fmt.Errorf("gRPC transport TLS configuration error: %w", err)
+		return transport
+	}
+	if tlsConfig != nil {
+		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+		transport.tlsEnabled = true
+	}
+
+	transport.grpcServer = grpc.NewServer(serverOpts...)
 
 	rpc.RegisterCatenaServiceServer(transport.grpcServer, transport.catenaService)
 
 	if cfg.Reflection {
 		reflection.Register(transport.grpcServer)
-		logger.Info("gRPC server created with reflection enabled")
+		logger.Info("gRPC server created with reflection enabled", "tls", transport.tlsEnabled)
 	} else {
-		logger.Info("gRPC server created")
+		logger.Info("gRPC server created", "tls", transport.tlsEnabled)
 	}
 	return transport
 }
 
 func (t *Transport) Start(ctx context.Context, runtime catena.ServerRuntime) error {
+	if t.initErr != nil {
+		return t.initErr
+	}
+
 	t.runtime = runtime
 
 	if t.listener == nil {
@@ -123,6 +150,10 @@ func (t *Transport) Start(ctx context.Context, runtime catena.ServerRuntime) err
 }
 
 func (t *Transport) Shutdown(ctx context.Context) error {
+	if t.grpcServer == nil {
+		// construction failed (see initErr); there is nothing to shut down
+		return nil
+	}
 	logger.Info("Shutting down gRPC transport")
 
 	// Gracefully stop the gRPC server in a goroutine so we can also listen for context

--- a/sdks/go/pkg/transports/rest/REST.md
+++ b/sdks/go/pkg/transports/rest/REST.md
@@ -36,8 +36,8 @@ restTransport := rest.NewTransport(rest.Options{
         CertFile: "/etc/catena/certs/server.crt", // PEM server certificate
         KeyFile:  "/etc/catena/certs/server.key", // PEM private key
         // Optional mutual TLS (client certificate verification):
-        // CAFile:     "/etc/catena/certs/clients-ca.crt",
-        // MutualAuth: true,
+        // ClientCAFile: "/etc/catena/certs/clients-ca.crt",
+        // MutualAuth:   true,
     },
 })
 ```
@@ -45,9 +45,9 @@ restTransport := rest.NewTransport(rest.Options{
 Behavior:
 
 - `CertFile` and `KeyFile` are required when TLS is enabled; `Start` returns an error if either is missing, unreadable, or invalid PEM.
-- With `MutualAuth`, clients must present a certificate signed by the CA bundle in `CAFile` or the TLS handshake is rejected.
+- With `MutualAuth`, clients must present a certificate signed by the CA bundle in `ClientCAFile` or the TLS handshake is rejected.
 - Minimum accepted protocol version is TLS 1.2.
-- Env/CLI configuration: `{PREFIX}_REST_TLS_ENABLED`, `{PREFIX}_REST_TLS_CERT_FILE`, `{PREFIX}_REST_TLS_KEY_FILE`, `{PREFIX}_REST_TLS_CA_FILE`, `{PREFIX}_REST_TLS_MUTUAL_AUTH` (flags `--rest-tls-*`).
+- Env/CLI configuration: `{PREFIX}_REST_TLS_ENABLED`, `{PREFIX}_REST_TLS_CERT_FILE`, `{PREFIX}_REST_TLS_KEY_FILE`, `{PREFIX}_REST_TLS_CLIENT_CA_FILE`, `{PREFIX}_REST_TLS_MUTUAL_AUTH` (flags `--rest-tls-*`).
 
 ## Implemented Endpoints
 

--- a/sdks/go/pkg/transports/rest/REST.md
+++ b/sdks/go/pkg/transports/rest/REST.md
@@ -10,9 +10,11 @@ import "github.com/rossvideo/catena/sdks/go/pkg/transports/rest"
 ## Constructor
 
 ```go
-restTransport := rest.NewTransport(rest.Options{Port: 9080})
-// or with defaults
 restTransport := rest.NewTransport(rest.DefaultOptions())
+// or start from the defaults and customize
+opts := rest.DefaultOptions()
+opts.Port = 9080
+restTransport := rest.NewTransport(opts)
 ```
 
 Register it on the shared server:
@@ -29,17 +31,14 @@ if err := srv.RegisterTransport(restTransport); err != nil {
 The listener serves HTTPS when `Options.TLS.Enabled` is true:
 
 ```go
-restTransport := rest.NewTransport(rest.Options{
-    Port: 9080,
-    TLS: config.TLSOptions{
-        Enabled:  true,
-        CertFile: "/etc/catena/certs/server.crt", // PEM server certificate
-        KeyFile:  "/etc/catena/certs/server.key", // PEM private key
-        // Optional mutual TLS (client certificate verification):
-        // ClientCAFile: "/etc/catena/certs/clients-ca.crt",
-        // MutualAuth:   true,
-    },
-})
+opts := rest.DefaultOptions()
+opts.TLS.Enabled = true
+opts.TLS.CertFile = "/etc/catena/certs/server.crt" // PEM server certificate
+opts.TLS.KeyFile = "/etc/catena/certs/server.key"  // PEM private key
+// Optional mutual TLS (client certificate verification):
+// opts.TLS.ClientCAFile = "/etc/catena/certs/clients-ca.crt"
+// opts.TLS.MutualAuth = true
+restTransport := rest.NewTransport(opts)
 ```
 
 Behavior:

--- a/sdks/go/pkg/transports/rest/REST.md
+++ b/sdks/go/pkg/transports/rest/REST.md
@@ -24,6 +24,31 @@ if err := srv.RegisterTransport(restTransport); err != nil {
 }
 ```
 
+## TLS
+
+The listener serves HTTPS when `Options.TLS.Enabled` is true:
+
+```go
+restTransport := rest.NewTransport(rest.Options{
+    Port: 9080,
+    TLS: config.TLSOptions{
+        Enabled:  true,
+        CertFile: "/etc/catena/certs/server.crt", // PEM server certificate
+        KeyFile:  "/etc/catena/certs/server.key", // PEM private key
+        // Optional mutual TLS (client certificate verification):
+        // CAFile:     "/etc/catena/certs/clients-ca.crt",
+        // MutualAuth: true,
+    },
+})
+```
+
+Behavior:
+
+- `CertFile` and `KeyFile` are required when TLS is enabled; `Start` returns an error if either is missing, unreadable, or invalid PEM.
+- With `MutualAuth`, clients must present a certificate signed by the CA bundle in `CAFile` or the TLS handshake is rejected.
+- Minimum accepted protocol version is TLS 1.2.
+- Env/CLI configuration: `{PREFIX}_REST_TLS_ENABLED`, `{PREFIX}_REST_TLS_CERT_FILE`, `{PREFIX}_REST_TLS_KEY_FILE`, `{PREFIX}_REST_TLS_CA_FILE`, `{PREFIX}_REST_TLS_MUTUAL_AUTH` (flags `--rest-tls-*`).
+
 ## Implemented Endpoints
 
 Core routes:

--- a/sdks/go/pkg/transports/rest/rest_tls_test.go
+++ b/sdks/go/pkg/transports/rest/rest_tls_test.go
@@ -33,6 +33,7 @@
  * @file rest_tls_test.go
  * @copyright Copyright © 2026 Ross Video Ltd
  * @date 2026-07-30
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
  */
 
 package rest

--- a/sdks/go/pkg/transports/rest/rest_tls_test.go
+++ b/sdks/go/pkg/transports/rest/rest_tls_test.go
@@ -150,11 +150,11 @@ func TestTransport_Start_TLS(t *testing.T) {
 func TestTransport_Start_TLS_MutualAuth(t *testing.T) {
 	certs := testcerts.Generate(t)
 	port := startTLSTransport(t, config.TLSOptions{
-		Enabled:    true,
-		CertFile:   certs.ServerCertFile,
-		KeyFile:    certs.ServerKeyFile,
-		CAFile:     certs.CACertFile,
-		MutualAuth: true,
+		Enabled:      true,
+		CertFile:     certs.ServerCertFile,
+		KeyFile:      certs.ServerKeyFile,
+		ClientCAFile: certs.CACertFile,
+		MutualAuth:   true,
 	})
 	url := fmt.Sprintf("https://127.0.0.1:%d/st2138-api/v1", port)
 

--- a/sdks/go/pkg/transports/rest/rest_tls_test.go
+++ b/sdks/go/pkg/transports/rest/rest_tls_test.go
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for TLS on the REST transport.
+ * @file rest_tls_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ * @date 2026-07-30
+ */
+
+package rest
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/config"
+	"github.com/rossvideo/catena/sdks/go/pkg/internal/testcerts"
+	"github.com/rossvideo/catena/sdks/go/pkg/transports/internal/transporttest"
+)
+
+// reserveTestPort finds a free TCP port for a transport to listen on.
+func reserveTestPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+	return port
+}
+
+// startTLSTransport starts a REST transport with the given TLS options on a
+// free port and registers shutdown cleanup. Returns the port it listens on.
+func startTLSTransport(t *testing.T, tlsOpts config.TLSOptions) int {
+	t.Helper()
+	port := reserveTestPort(t)
+	transport := NewTransport(config.RestOptions{Port: port, TLS: tlsOpts})
+	runtime := transporttest.MakeStubServerRuntime(t)
+	runtime.ShutdownTransportConnsFn = func(ctx context.Context, gotTransport catena.Transport) {}
+
+	if err := transport.Start(context.Background(), runtime); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		transport.Shutdown(ctx)
+	})
+	// give the serve goroutine a moment to begin accepting
+	time.Sleep(100 * time.Millisecond)
+	return port
+}
+
+// caPool loads the test CA into a cert pool for client-side verification.
+func caPool(t *testing.T, caFile string) *x509.CertPool {
+	t.Helper()
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		t.Fatalf("read CA file: %v", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to parse test CA")
+	}
+	return pool
+}
+
+func TestTransport_Start_TLS(t *testing.T) {
+	certs := testcerts.Generate(t)
+	port := startTLSTransport(t, config.TLSOptions{
+		Enabled:  true,
+		CertFile: certs.ServerCertFile,
+		KeyFile:  certs.ServerKeyFile,
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: caPool(t, certs.CACertFile)},
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	// any unknown path is fine; a well-formed HTTP response proves the TLS
+	// handshake and HTTP serving both work
+	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/st2138-api/v1", port))
+	if err != nil {
+		t.Fatalf("HTTPS GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, resp.StatusCode)
+	}
+	if resp.TLS == nil {
+		t.Error("expected response to have TLS connection state")
+	}
+
+	// a plain HTTP request against the TLS listener must be rejected. Go's
+	// http.Server answers such requests with a plaintext "400 Bad Request"
+	// ("client sent an HTTP request to an HTTPS server") rather than
+	// dropping the connection, so accept either an error or that 400.
+	plainClient := &http.Client{Timeout: 2 * time.Second}
+	plainResp, err := plainClient.Get(fmt.Sprintf("http://127.0.0.1:%d/st2138-api/v1", port))
+	if err == nil {
+		defer plainResp.Body.Close()
+		if plainResp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected plain HTTP request to be rejected with 400, got status %d", plainResp.StatusCode)
+		}
+	}
+}
+
+func TestTransport_Start_TLS_MutualAuth(t *testing.T) {
+	certs := testcerts.Generate(t)
+	port := startTLSTransport(t, config.TLSOptions{
+		Enabled:    true,
+		CertFile:   certs.ServerCertFile,
+		KeyFile:    certs.ServerKeyFile,
+		CAFile:     certs.CACertFile,
+		MutualAuth: true,
+	})
+	url := fmt.Sprintf("https://127.0.0.1:%d/st2138-api/v1", port)
+
+	t.Run("client with certificate succeeds", func(t *testing.T) {
+		clientCert, err := tls.LoadX509KeyPair(certs.ClientCertFile, certs.ClientKeyFile)
+		if err != nil {
+			t.Fatalf("load client cert: %v", err)
+		}
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:      caPool(t, certs.CACertFile),
+					Certificates: []tls.Certificate{clientCert},
+				},
+			},
+			Timeout: 2 * time.Second,
+		}
+		resp, err := client.Get(url)
+		if err != nil {
+			t.Fatalf("HTTPS GET with client cert: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, resp.StatusCode)
+		}
+	})
+
+	t.Run("client without certificate is rejected", func(t *testing.T) {
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: caPool(t, certs.CACertFile)},
+			},
+			Timeout: 2 * time.Second,
+		}
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			t.Errorf("expected request without client cert to fail, got status %d", resp.StatusCode)
+		}
+	})
+}
+
+func TestTransport_Start_TLS_BadConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		tls  config.TLSOptions
+	}{
+		{
+			name: "missing cert and key paths",
+			tls:  config.TLSOptions{Enabled: true},
+		},
+		{
+			name: "nonexistent cert file",
+			tls: config.TLSOptions{
+				Enabled:  true,
+				CertFile: filepath.Join(t.TempDir(), "missing.crt"),
+				KeyFile:  filepath.Join(t.TempDir(), "missing.key"),
+			},
+		},
+		{
+			name: "mutual auth without CA",
+			tls: func() config.TLSOptions {
+				certs := testcerts.Generate(t)
+				return config.TLSOptions{
+					Enabled:    true,
+					CertFile:   certs.ServerCertFile,
+					KeyFile:    certs.ServerKeyFile,
+					MutualAuth: true,
+				}
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := NewTransport(config.RestOptions{Port: reserveTestPort(t), TLS: tt.tls})
+			runtime := transporttest.MakeStubServerRuntime(t)
+			err := transport.Start(context.Background(), runtime)
+			if err == nil {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				transport.Shutdown(ctx)
+				t.Fatal("expected Start to return a TLS configuration error, got nil")
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/transports/rest/rest_transport.go
+++ b/sdks/go/pkg/transports/rest/rest_transport.go
@@ -52,6 +52,7 @@ import (
 	"sync"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/config"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
@@ -68,6 +69,7 @@ type Transport struct {
 	fallbackHandler FallbackHandler
 
 	port int
+	tls  config.TLSOptions
 }
 
 var _ catena.Transport = (*Transport)(nil)
@@ -76,6 +78,7 @@ var _ catena.Transport = (*Transport)(nil)
 func NewTransport(cfg Options) *Transport {
 	t := &Transport{
 		port: cfg.Port,
+		tls:  cfg.TLS,
 		mux:  http.NewServeMux(),
 	}
 	t.registerRoutes()
@@ -84,6 +87,14 @@ func NewTransport(cfg Options) *Transport {
 
 // Start starts the HTTP server on the specified port using this server's mux
 func (t *Transport) Start(ctx context.Context, runtime catena.ServerRuntime) error {
+	// Build the TLS config up front so misconfiguration (missing cert/key,
+	// unreadable files, etc.) fails Start instead of silently serving plaintext.
+	tlsConfig, err := t.tls.ServerTLSConfig()
+	if err != nil {
+		logger.Error("REST Transport TLS configuration error", "error", err)
+		return fmt.Errorf("REST transport TLS configuration error: %w", err)
+	}
+
 	addr := fmt.Sprintf(":%d", t.port)
 	// Bind synchronously so that startup errors (privileged port, address
 	// already in use, invalid address, etc.) are returned to the caller
@@ -96,16 +107,24 @@ func (t *Transport) Start(ctx context.Context, runtime catena.ServerRuntime) err
 	}
 
 	t.server = &http.Server{
-		Addr:    addr,
-		Handler: t.mux,
+		Addr:      addr,
+		Handler:   t.mux,
+		TLSConfig: tlsConfig,
 	}
 	t.runtime = runtime
 
 	// http server does not use context
 	// serve blocks so do it in a goroutine
 	go func() {
-		logger.Info("REST Transport listening", "address", addr)
-		err := t.server.Serve(listener)
+		logger.Info("REST Transport listening", "address", addr, "tls", tlsConfig != nil)
+		var err error
+		if tlsConfig != nil {
+			// cert and key files are empty because the certificates are
+			// already loaded into TLSConfig
+			err = t.server.ServeTLS(listener, "", "")
+		} else {
+			err = t.server.Serve(listener)
+		}
 		if err != nil && err != http.ErrServerClosed {
 			logger.Error("HTTP server error", "error", err)
 		}


### PR DESCRIPTION
## 📖 Description

Adds optional TLS and mutual TLS (mTLS) support to both the REST and gRPC transports in the Go SDK. A shared `config.TLSOptions` struct is embedded in `RestOptions` and `GrpcOptions`, configurable via transport-prefixed environment variables and CLI Flags

Env Variable: `CATENA_REST_TLS_*`, `CATENA_GRPC_TLS_*`

CLI Flags: `--rest-tls-*`, `--grpc-tls-*`

---

## 🎯 Goal / Outcome

- Servers built with the Go SDK can serve HTTPS on the REST transport and TLS-encrypted gRPC, including optional client-certificate verification (mTLS), configured entirely through the existing config system.

---

## ✅ Definition of Done (DoD)

- [x] REST transport serves TLS via `http.Server.ServeTLS` when `REST_TLS_ENABLED` is set
- [x] gRPC transport serves TLS via `grpc.Creds` when `GRPC_TLS_ENABLED` is set
- [x] mTLS supported on both transports (`*_TLS_MUTUAL_AUTH` + `*_TLS_CA_FILE`, enforced with `RequireAndVerifyClientCert`)
- [x] Tests added: config loading (env + flags), `ServerTLSConfig()` validation cases, `LogValue` output, and TLS/mTLS integration tests for both transports (handshake success, plaintext/insecure rejection, missing client cert rejection, bad-config startup failure)
- [x] Documentation updated: `config/README.md` env/flag tables, `transports/README.md`, `REST.md`, `GRPC.md`
---

## 🛠️ Implementation Notes

- **Shared `TLSOptions` struct** (`pkg/config/config.go`) embedded in both transport option structs; `ServerTLSConfig()` (`pkg/config/tls.go`) centralizes validation and builds a `*tls.Config` with `MinVersion: TLS 1.2`. Returns `(nil, nil)` when disabled so callers keep the plaintext path.
- **REST**: TLS config is built at `Start` so misconfiguration returns a synchronous startup error.
- **gRPC**: `grpc.Creds` must be supplied at server construction, but `NewTransport` cannot return an error, so a TLS config failure is recorded in `initErr` and surfaced from `Start`. `Shutdown` is nil-safe for this case.
- **Test certificates**: new internal package `pkg/internal/testcerts` generates ephemeral self-signed CA/server/client certs at test runtime — no fixture files or long-lived keys checked in.
- **`TLSOptions` re-exported** from the top-level `catena` package for SDK consumers.
- **CI toolchain fix** (`.devcontainer/go/toolchain.env`): `IMAGE_VERSION` v0.0.1 → v0.0.2 forces the toolchain-delta workflow to rebuild the Go image with Go 1.26.0; `OPENSSL_VERSION` updated because Ubuntu removed `3.0.13-0ubuntu3.11` from the archive on 2026-07-31, which broke the image build.

---

## 🔗 Related Issues / Links

Closes issues:
- #1461 
- #1462 
