### PR TITLE
[GO] Streamed Responses

### DIFF
--- a/sdks/go/examples/hello_world/main.go
+++ b/sdks/go/examples/hello_world/main.go
@@ -104,9 +104,14 @@ func main() {
 		SerialNumber: "SN-HELLO-0001",
 	})
 
-	srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext) (st2138.Device, catena.StatusResult) {
+	srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
 		logger.Info("GetDevice", "slot", slot)
-		return catena.Reply(*buildDevice())
+		// A small device fits in a single component; large devices may stream
+		// several (see the oneOfEverything example).
+		if err := stream.Send(st2138.ComponentDevice(buildDevice())); err != nil {
+			return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send device: "+err.Error())
+		}
+		return catena.StatusWithCode(catena.StatusCodeOk, "")
 	})
 
 	srv.RegisterGetValueHandler(slot, func(slot uint16, fqoid string, ctx catena.HandlerContext) (st2138.Value, catena.StatusResult) {

--- a/sdks/go/examples/oneOfEverything/asset_handler.go
+++ b/sdks/go/examples/oneOfEverything/asset_handler.go
@@ -35,15 +35,17 @@ func registerAssetHandlers(srv catena.Server, assets *sync.Map) {
 			// Stream the asset in chunks to demonstrate large-object delivery:
 			// the first chunk carries the metadata, digest, encoding, and
 			// cachable flag plus the first slice of payload bytes; later
-			// chunks carry only payload bytes, which the client concatenates
-			// in send order. Assets up to assetChunkSize (and URL-kind assets,
-			// which have no embedded bytes) go out as a single chunk.
+			// chunks carry only payload bytes (never the URL: a payload can
+			// have one or the other, and continuation chunks only ever exist
+			// for embedded payloads), which the client concatenates in send
+			// order. Assets up to assetChunkSize (and URL-kind assets, which
+			// have no embedded bytes) go out as a single chunk.
 			stored := val.(storedAsset)
 			data := stored.payload.Payload
 			sent := 0
 			for first := true; first || sent < len(data); first = false {
 				end := min(sent+assetChunkSize, len(data))
-				dp := st2138.DataPayload{Url: stored.payload.Url, Payload: data[sent:end]}
+				dp := st2138.DataPayload{Payload: data[sent:end]}
 				if first {
 					dp = stored.payload
 					dp.Payload = data[sent:end]

--- a/sdks/go/examples/oneOfEverything/asset_handler.go
+++ b/sdks/go/examples/oneOfEverything/asset_handler.go
@@ -16,26 +16,52 @@ type storedAsset struct {
 	cachable bool
 }
 
+// assetChunkSize is the maximum number of embedded payload bytes streamed per
+// ReadAsset chunk. Kept small enough to bound per-message memory but large
+// enough that small assets go out in a single chunk.
+const assetChunkSize = 64 * 1024
+
 func registerAssetHandlers(srv catena.Server, assets *sync.Map) {
 	// Slot 0-2: direct map-backed lookup, matching the sync.Map data-model example.
 	for _, slot := range slotList {
-		srv.RegisterReadAssetHandler(slot, func(slot uint16, fqoid string, ctx catena.HandlerContext) (st2138.Asset, catena.StatusResult) {
+		srv.RegisterReadAssetHandler(slot, func(slot uint16, fqoid string, ctx catena.HandlerContext, stream catena.Stream[st2138.Asset]) catena.StatusResult {
 			logger.Info("Asset download request", "slot", slot, "fqoid", fqoid)
 			val, ok := assets.Load(fqoid)
 			if !ok {
 				logger.Warning("Asset not found", "slot", slot, "fqoid", fqoid)
-				return catena.ReplyError[st2138.Asset](catena.StatusCodeNotFound, "asset not found: "+fqoid)
+				return catena.StatusWithCode(catena.StatusCodeNotFound, "asset not found: "+fqoid)
 			}
 
+			// Stream the asset in chunks to demonstrate large-object delivery:
+			// the first chunk carries the metadata, digest, encoding, and
+			// cachable flag plus the first slice of payload bytes; later
+			// chunks carry only payload bytes, which the client concatenates
+			// in send order. Assets up to assetChunkSize (and URL-kind assets,
+			// which have no embedded bytes) go out as a single chunk.
 			stored := val.(storedAsset)
-			catenaAsset, err := st2138.ToAsset(stored.payload, stored.cachable)
-			if err != nil {
-				logger.Error("Failed to convert payload to asset", "slot", slot, "fqoid", fqoid, "error", err)
-				return catena.ReplyError[st2138.Asset](catena.StatusCodeInternal, "failed to convert asset: "+err.Error())
+			data := stored.payload.Payload
+			sent := 0
+			for first := true; first || sent < len(data); first = false {
+				end := min(sent+assetChunkSize, len(data))
+				dp := st2138.DataPayload{Url: stored.payload.Url, Payload: data[sent:end]}
+				if first {
+					dp = stored.payload
+					dp.Payload = data[sent:end]
+				}
+				chunk, err := st2138.ToAsset(dp, stored.cachable)
+				if err != nil {
+					logger.Error("Failed to convert payload to asset", "slot", slot, "fqoid", fqoid, "error", err)
+					return catena.StatusWithCode(catena.StatusCodeInternal, "failed to convert asset: "+err.Error())
+				}
+				if err := stream.Send(chunk); err != nil {
+					logger.Warning("Asset download stream closed", "slot", slot, "fqoid", fqoid, "error", err)
+					return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send asset: "+err.Error())
+				}
+				sent = end
 			}
 
-			logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(stored.payload.Payload))
-			return catena.Reply(catenaAsset)
+			logger.Info("Asset download complete", "slot", slot, "fqoid", fqoid, "size", len(data))
+			return catena.StatusWithCode(catena.StatusCodeOk, "")
 		})
 
 		// POST / CreateAsset: create a new asset, conflict if one already exists.

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -17,17 +17,46 @@ func registerProductStructs(srv catena.Server, state *ExampleState) {
 }
 
 func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *ExampleState) {
-	// GetDeviceHandler returns the complete device descriptor for a slot.
-	// Build the descriptor from the same data model your app uses at runtime;
-	// this example rebuilds per request so "value" fields stay current.
+	// GetDeviceHandler streams the device descriptor for a slot as
+	// DeviceComponent chunks. Build the descriptor from the same data model
+	// your app uses at runtime; this example rebuilds per request so "value"
+	// fields stay current.
 	for _, slot := range slotList {
-		srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext) (st2138.Device, catena.StatusResult) {
+		srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
 			logger.Info("GetDevice", "slot", slot)
 			device, ok := buildDeviceDefinition(slot, counter, state)
 			if !ok {
-				return catena.ReplyError[st2138.Device](catena.StatusCodeNotFound, "device not found")
+				return catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 			}
-			return catena.Reply(*device)
+
+			// Stream the model in components to demonstrate the chunked form
+			// of DeviceRequest: first the device skeleton (everything except
+			// params and commands), then one chunk per param and command.
+			// Clients merge the components back into one device model; a small
+			// model could equally be sent as a single ComponentDevice chunk
+			// carrying the whole device (see the hello_world example).
+			params := device.Proto.Params
+			commands := device.Proto.Commands
+			device.Proto.Params = nil
+			device.Proto.Commands = nil
+
+			if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
+				logger.Warning("GetDevice stream closed", "slot", slot, "error", err)
+				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send device: "+err.Error())
+			}
+			for oid, param := range params {
+				if err := stream.Send(st2138.ComponentParam(oid, &st2138.Param{Proto: param})); err != nil {
+					logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
+					return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send param: "+err.Error())
+				}
+			}
+			for oid, command := range commands {
+				if err := stream.Send(st2138.ComponentCommand(oid, &st2138.Param{Proto: command})); err != nil {
+					logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
+					return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send command: "+err.Error())
+				}
+			}
+			return catena.StatusWithCode(catena.StatusCodeOk, "")
 		})
 	}
 }

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -20,51 +20,122 @@ func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *Exa
 	// GetDeviceHandler streams the device descriptor for a slot as
 	// DeviceComponent chunks. Build the descriptor from the same data model
 	// your app uses at runtime; this example rebuilds per request so "value"
-	// fields stay current.
+	// fields stay current. Two chunking styles are shown:
+	//
+	//   - Slot 0 assembles its chunks by hand with the st2138.ComponentXxx
+	//     constructors — the "extra fancy" form for handlers that want full
+	//     control over what goes in each chunk.
+	//   - Slots 1 and 2 build a whole st2138.Device and delegate the chunking
+	//     to catena.DeviceComponentsForRequest — the everyday form, where
+	//     business logic never touches the DeviceComponent protos. (A small
+	//     model could also be sent as a single ComponentDevice chunk carrying
+	//     the whole device; see the hello_world example.)
+
+	// Slot 0: hand-rolled chunking. First the device skeleton (slot metadata,
+	// scopes, menus), then one chunk per param and command. The chunks are
+	// built from the same slotZero* pieces buildDeviceDefinition composes (the
+	// GetParam / ParamInfo handlers use it), so the two views of slot 0 cannot
+	// drift apart. ComponentConstraint, ComponentMenu, and
+	// ComponentLanguagePack constructors exist for the other component kinds;
+	// slot 0 keeps its menus on the skeleton.
+	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
+		logger.Info("GetDevice", "slot", slot)
+		if err := stream.Send(st2138.ComponentDevice(slotZeroSkeleton())); err != nil {
+			logger.Warning("GetDevice stream closed", "slot", slot, "error", err)
+			return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send device: "+err.Error())
+		}
+		for _, entry := range slotZeroParams(counter) {
+			if err := stream.Send(st2138.ComponentParam(entry.oid, entry.param)); err != nil {
+				logger.Warning("GetDevice stream closed", "slot", slot, "oid", entry.oid, "error", err)
+				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send param: "+err.Error())
+			}
+		}
+		for _, entry := range slotZeroCommands() {
+			if err := stream.Send(st2138.ComponentCommand(entry.oid, entry.param)); err != nil {
+				logger.Warning("GetDevice stream closed", "slot", slot, "oid", entry.oid, "error", err)
+				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send command: "+err.Error())
+			}
+		}
+		return catena.StatusWithCode(catena.StatusCodeOk, "")
+	})
+
+	// Slots 1 and 2: build the device, then let the SDK chunk and stream it.
 	for _, slot := range slotList {
+		if slot == 0 {
+			continue
+		}
 		srv.RegisterGetDeviceHandler(slot, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
 			logger.Info("GetDevice", "slot", slot)
 			device, ok := buildDeviceDefinition(slot, counter, state)
 			if !ok {
 				return catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 			}
-
-			// Stream the model in components to demonstrate the chunked form
-			// of DeviceRequest: first the device skeleton (everything except
-			// params and commands), then one chunk per param and command.
-			// Clients merge the components back into one device model; a small
-			// model could equally be sent as a single ComponentDevice chunk
-			// carrying the whole device (see the hello_world example).
-			params := device.Proto.Params
-			commands := device.Proto.Commands
-			device.Proto.Params = nil
-			device.Proto.Commands = nil
-
-			if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
-				logger.Warning("GetDevice stream closed", "slot", slot, "error", err)
-				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send device: "+err.Error())
-			}
-			for oid, param := range params {
-				if err := stream.Send(st2138.ComponentParam(oid, &st2138.Param{Proto: param})); err != nil {
-					logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
-					return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send param: "+err.Error())
-				}
-			}
-			for oid, command := range commands {
-				if err := stream.Send(st2138.ComponentCommand(oid, &st2138.Param{Proto: command})); err != nil {
-					logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
-					return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send command: "+err.Error())
-				}
-			}
-			return catena.StatusWithCode(catena.StatusCodeOk, "")
+			return catena.DeviceComponentsForRequest(device, stream)
 		})
+	}
+}
+
+// namedParam pairs an oid with its descriptor so slot 0's params and commands
+// can be listed once and consumed two ways: attached to a Device by
+// buildDeviceDefinition, or streamed chunk-by-chunk by the GetDevice handler.
+type namedParam struct {
+	oid   string
+	param *st2138.Param
+}
+
+// slotZeroSkeleton returns slot 0's device minus its params and commands: slot
+// metadata, access scopes, and menus. The GetDevice handler sends it as the
+// leading ComponentDevice chunk; buildDeviceDefinition attaches the params and
+// commands to it.
+func slotZeroSkeleton() *st2138.Device {
+	return st2138.NewDevice(0).
+		WithDetailLevel(st2138.DetailLevelFull).
+		WithMultiSetEnabled(true).
+		WithSubscriptions(true).
+		WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
+		WithDefaultScope("st2138:cfg").
+		WithMenuGroup("status", st2138.NewMenuGroup().
+			WithName(st2138.NewPolyglotText("en", "Status")).
+			WithOrder(0).
+			WithMenu("status", st2138.NewMenu().
+				WithName(st2138.NewPolyglotText("en", "Status")).
+				WithParamOids("product", "counter", "running"))).
+		WithMenuGroup("config", st2138.NewMenuGroup().
+			WithName(st2138.NewPolyglotText("en", "Configuration")).
+			WithOrder(1).
+			WithMenu("control", st2138.NewMenu().
+				WithName(st2138.NewPolyglotText("en", "Control")).
+				WithCommandOids("start", "stop", "add10", "reset")))
+}
+
+// slotZeroParams lists slot 0's params in the order they are streamed.
+func slotZeroParams(counter *CounterState) []namedParam {
+	return []namedParam{
+		{"counter", makeCounterParam(counter)},
+		{"running", makeRunningParam(counter)},
+	}
+}
+
+// slotZeroCommands lists slot 0's commands in the order they are streamed.
+func slotZeroCommands() []namedParam {
+	return []namedParam{
+		{"start", st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Start Counter"))},
+		{"stop", st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Stop Counter"))},
+		{"add10", st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Add 10 to Counter"))},
+		{"reset", st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Reset Counter"))},
 	}
 }
 
 // buildDeviceDefinition returns the descriptor for one slot. It is a function
 // (not a static YAML file) so every param's value field reflects live state at
-// GetDevice time. device_handler.go calls this and returns the result directly.
-// Keep param OIDs in sync with value_handlers and param_info_handler.
+// GetDevice time. The GetParam and ParamInfo handlers call this for every slot;
+// the GetDevice handler calls it for slots 1 and 2 (slot 0's GetDevice streams
+// the same slotZero* pieces directly, see registerDeviceHandlers). Keep param
+// OIDs in sync with value_handlers and param_info_handler.
 //
 // st2138.NewDevice(slot) creates an empty device for the slot; params, commands,
 // constraints, and menus are attached with the fluent With* builders. The
@@ -81,34 +152,15 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 	switch slot {
 	case 0:
 		// Slot 0: INT32, STRUCT, EMPTY commands, INT32_CHOICE constraint.
-		device := st2138.NewDevice(0).
-			WithDetailLevel(st2138.DetailLevelFull).
-			WithMultiSetEnabled(true).
-			WithSubscriptions(true).
-			WithAccessScopes("st2138:mon", "st2138:op", "st2138:cfg", "st2138:adm").
-			WithDefaultScope("st2138:cfg").
-			WithParam("counter", makeCounterParam(counter)).
-			WithParam("running", makeRunningParam(counter)).
-			WithCommand("start", st2138.NewParamEmpty().
-				WithName(st2138.NewPolyglotText("en", "Start Counter"))).
-			WithCommand("stop", st2138.NewParamEmpty().
-				WithName(st2138.NewPolyglotText("en", "Stop Counter"))).
-			WithCommand("add10", st2138.NewParamEmpty().
-				WithName(st2138.NewPolyglotText("en", "Add 10 to Counter"))).
-			WithCommand("reset", st2138.NewParamEmpty().
-				WithName(st2138.NewPolyglotText("en", "Reset Counter"))).
-			WithMenuGroup("status", st2138.NewMenuGroup().
-				WithName(st2138.NewPolyglotText("en", "Status")).
-				WithOrder(0).
-				WithMenu("status", st2138.NewMenu().
-					WithName(st2138.NewPolyglotText("en", "Status")).
-					WithParamOids("product", "counter", "running"))).
-			WithMenuGroup("config", st2138.NewMenuGroup().
-				WithName(st2138.NewPolyglotText("en", "Configuration")).
-				WithOrder(1).
-				WithMenu("control", st2138.NewMenu().
-					WithName(st2138.NewPolyglotText("en", "Control")).
-					WithCommandOids("start", "stop", "add10", "reset")))
+		// Composed from the same slotZero* helpers the GetDevice handler
+		// streams chunk-by-chunk, so the two views stay in sync.
+		device := slotZeroSkeleton()
+		for _, entry := range slotZeroParams(counter) {
+			device.WithParam(entry.oid, entry.param)
+		}
+		for _, entry := range slotZeroCommands() {
+			device.WithCommand(entry.oid, entry.param)
+		}
 		return device, true
 	case 1:
 		// Slot 1 intentionally stores its business data in a sync.Map to show

--- a/sdks/go/examples/oneOfEverything/device_handler.go
+++ b/sdks/go/examples/oneOfEverything/device_handler.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
@@ -32,27 +34,33 @@ func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *Exa
 	//     the whole device; see the hello_world example.)
 
 	// Slot 0: hand-rolled chunking. First the device skeleton (slot metadata,
-	// scopes, menus), then one chunk per param and command. The chunks are
-	// built from the same slotZero* pieces buildDeviceDefinition composes (the
-	// GetParam / ParamInfo handlers use it), so the two views of slot 0 cannot
-	// drift apart. ComponentConstraint, ComponentMenu, and
-	// ComponentLanguagePack constructors exist for the other component kinds;
-	// slot 0 keeps its menus on the skeleton.
+	// scopes, and menu-group shells), then one chunk per menu, param, and
+	// command. The chunks are built from the same slotZero* pieces
+	// buildDeviceDefinition composes (the GetParam / ParamInfo handlers use
+	// it), so the two views of slot 0 cannot drift apart. ComponentConstraint
+	// and ComponentLanguagePack constructors exist for the other component
+	// kinds.
 	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
 		logger.Info("GetDevice", "slot", slot)
 		if err := stream.Send(st2138.ComponentDevice(slotZeroSkeleton())); err != nil {
 			logger.Warning("GetDevice stream closed", "slot", slot, "error", err)
 			return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send device: "+err.Error())
 		}
-		for _, entry := range slotZeroParams(counter) {
-			if err := stream.Send(st2138.ComponentParam(entry.oid, entry.param)); err != nil {
-				logger.Warning("GetDevice stream closed", "slot", slot, "oid", entry.oid, "error", err)
+		for oid, menu := range slotZeroMenus() {
+			if err := stream.Send(st2138.ComponentMenu(oid, menu)); err != nil {
+				logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
+				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send menu: "+err.Error())
+			}
+		}
+		for oid, param := range slotZeroParams(counter) {
+			if err := stream.Send(st2138.ComponentParam(oid, param)); err != nil {
+				logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
 				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send param: "+err.Error())
 			}
 		}
-		for _, entry := range slotZeroCommands() {
-			if err := stream.Send(st2138.ComponentCommand(entry.oid, entry.param)); err != nil {
-				logger.Warning("GetDevice stream closed", "slot", slot, "oid", entry.oid, "error", err)
+		for oid, command := range slotZeroCommands() {
+			if err := stream.Send(st2138.ComponentCommand(oid, command)); err != nil {
+				logger.Warning("GetDevice stream closed", "slot", slot, "oid", oid, "error", err)
 				return catena.StatusWithCode(catena.StatusCodeInternal, "failed to send command: "+err.Error())
 			}
 		}
@@ -75,18 +83,11 @@ func registerDeviceHandlers(srv catena.Server, counter *CounterState, state *Exa
 	}
 }
 
-// namedParam pairs an oid with its descriptor so slot 0's params and commands
-// can be listed once and consumed two ways: attached to a Device by
-// buildDeviceDefinition, or streamed chunk-by-chunk by the GetDevice handler.
-type namedParam struct {
-	oid   string
-	param *st2138.Param
-}
-
-// slotZeroSkeleton returns slot 0's device minus its params and commands: slot
-// metadata, access scopes, and menus. The GetDevice handler sends it as the
-// leading ComponentDevice chunk; buildDeviceDefinition attaches the params and
-// commands to it.
+// slotZeroSkeleton returns slot 0's device minus its params, commands, and
+// menus: slot metadata, access scopes, and menu-group shells (display name and
+// order only). The GetDevice handler sends it as the leading ComponentDevice
+// chunk; the menus themselves are streamed as ComponentMenu chunks (see
+// slotZeroMenus) and the params and commands as their own chunks.
 func slotZeroSkeleton() *st2138.Device {
 	return st2138.NewDevice(0).
 		WithDetailLevel(st2138.DetailLevelFull).
@@ -96,37 +97,45 @@ func slotZeroSkeleton() *st2138.Device {
 		WithDefaultScope("st2138:cfg").
 		WithMenuGroup("status", st2138.NewMenuGroup().
 			WithName(st2138.NewPolyglotText("en", "Status")).
-			WithOrder(0).
-			WithMenu("status", st2138.NewMenu().
-				WithName(st2138.NewPolyglotText("en", "Status")).
-				WithParamOids("product", "counter", "running"))).
+			WithOrder(0)).
 		WithMenuGroup("config", st2138.NewMenuGroup().
 			WithName(st2138.NewPolyglotText("en", "Configuration")).
-			WithOrder(1).
-			WithMenu("control", st2138.NewMenu().
-				WithName(st2138.NewPolyglotText("en", "Control")).
-				WithCommandOids("start", "stop", "add10", "reset")))
+			WithOrder(1))
 }
 
-// slotZeroParams lists slot 0's params in the order they are streamed.
-func slotZeroParams(counter *CounterState) []namedParam {
-	return []namedParam{
-		{"counter", makeCounterParam(counter)},
-		{"running", makeRunningParam(counter)},
+// slotZeroMenus returns slot 0's menus keyed by "group/menu", the oid form a
+// ComponentMenu chunk carries; clients merge each menu back into its group
+// shell on the skeleton. buildDeviceDefinition attaches them the same way.
+func slotZeroMenus() map[string]*st2138.Menu {
+	return map[string]*st2138.Menu{
+		"status/status": st2138.NewMenu().
+			WithName(st2138.NewPolyglotText("en", "Status")).
+			WithParamOids("product", "counter", "running"),
+		"config/control": st2138.NewMenu().
+			WithName(st2138.NewPolyglotText("en", "Control")).
+			WithCommandOids("start", "stop", "add10", "reset"),
 	}
 }
 
-// slotZeroCommands lists slot 0's commands in the order they are streamed.
-func slotZeroCommands() []namedParam {
-	return []namedParam{
-		{"start", st2138.NewParamEmpty().
-			WithName(st2138.NewPolyglotText("en", "Start Counter"))},
-		{"stop", st2138.NewParamEmpty().
-			WithName(st2138.NewPolyglotText("en", "Stop Counter"))},
-		{"add10", st2138.NewParamEmpty().
-			WithName(st2138.NewPolyglotText("en", "Add 10 to Counter"))},
-		{"reset", st2138.NewParamEmpty().
-			WithName(st2138.NewPolyglotText("en", "Reset Counter"))},
+// slotZeroParams returns slot 0's params keyed by oid.
+func slotZeroParams(counter *CounterState) map[string]*st2138.Param {
+	return map[string]*st2138.Param{
+		"counter": makeCounterParam(counter),
+		"running": makeRunningParam(counter),
+	}
+}
+
+// slotZeroCommands returns slot 0's commands keyed by oid.
+func slotZeroCommands() map[string]*st2138.Param {
+	return map[string]*st2138.Param{
+		"start": st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Start Counter")),
+		"stop": st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Stop Counter")),
+		"add10": st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Add 10 to Counter")),
+		"reset": st2138.NewParamEmpty().
+			WithName(st2138.NewPolyglotText("en", "Reset Counter")),
 	}
 }
 
@@ -155,11 +164,17 @@ func buildDeviceDefinition(slot uint16, counter *CounterState, state *ExampleSta
 		// Composed from the same slotZero* helpers the GetDevice handler
 		// streams chunk-by-chunk, so the two views stay in sync.
 		device := slotZeroSkeleton()
-		for _, entry := range slotZeroParams(counter) {
-			device.WithParam(entry.oid, entry.param)
+		for oid, menu := range slotZeroMenus() {
+			group, name, _ := strings.Cut(oid, "/")
+			if groupProto := device.Proto.GetMenuGroups()[group]; groupProto != nil {
+				(&st2138.MenuGroup{Proto: groupProto}).WithMenu(name, menu)
+			}
 		}
-		for _, entry := range slotZeroCommands() {
-			device.WithCommand(entry.oid, entry.param)
+		for oid, param := range slotZeroParams(counter) {
+			device.WithParam(oid, param)
+		}
+		for oid, command := range slotZeroCommands() {
+			device.WithCommand(oid, command)
 		}
 		return device, true
 	case 1:

--- a/sdks/go/pkg/catena/device_components.go
+++ b/sdks/go/pkg/catena/device_components.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief DeviceComponent chunking business logic for the Catena SDK.
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-08-07
+ * @file device_components.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package catena
+
+import (
+	"sort"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
+)
+
+// DeviceComponentsForRequest streams a complete device model as DeviceComponent
+// chunks: first a skeleton Device chunk (the device minus its params, commands,
+// shared constraints, menus, and language packs), then one chunk per shared
+// constraint, menu, top-level param, command, and language pack, each group
+// sorted by oid so the stream order is deterministic. It is a business-logic
+// helper a GetDevice handler can delegate to once it can produce a Device
+// definition; the returned StatusResult is the terminal status a handler
+// returns directly: Ok once every component has been sent, or Internal if a
+// Send fails (a failed Send stops the stream immediately).
+//
+// Menu-group metadata (display name, order) stays on the skeleton because a
+// ComponentMenu chunk carries only the menu itself; each group's menus are
+// emitted as "group/menu" chunks that clients merge back into their group.
+//
+// The component chunks reference the device's protos rather than copying them,
+// so the device must not be mutated until the call returns. Handlers that want
+// to hand-pick their own chunking can call the st2138.ComponentXxx
+// constructors directly instead.
+func DeviceComponentsForRequest(device *st2138.Device, stream Stream[st2138.DeviceComponent]) StatusResult {
+	if device == nil || device.Proto == nil {
+		return StatusWithCode(StatusCodeInternal, "invalid device")
+	}
+
+	skeleton := deviceSkeleton(device.Proto)
+	if err := stream.Send(st2138.ComponentDevice(&st2138.Device{Proto: skeleton})); err != nil {
+		return StatusWithCode(StatusCodeInternal, err.Error())
+	}
+
+	constraints := device.Proto.GetConstraints()
+	for _, oid := range sortedKeys(constraints) {
+		constraint := constraints[oid]
+		if constraint == nil {
+			continue
+		}
+		if err := stream.Send(st2138.ComponentConstraint(oid, &st2138.Constraint{Proto: constraint})); err != nil {
+			return StatusWithCode(StatusCodeInternal, err.Error())
+		}
+	}
+
+	menuGroups := device.Proto.GetMenuGroups()
+	for _, group := range sortedKeys(menuGroups) {
+		menus := menuGroups[group].GetMenus()
+		for _, name := range sortedKeys(menus) {
+			menu := menus[name]
+			if menu == nil {
+				continue
+			}
+			if err := stream.Send(st2138.ComponentMenu(group+"/"+name, &st2138.Menu{Proto: menu})); err != nil {
+				return StatusWithCode(StatusCodeInternal, err.Error())
+			}
+		}
+	}
+
+	params := device.Proto.GetParams()
+	for _, oid := range sortedKeys(params) {
+		param := params[oid]
+		if param == nil {
+			continue
+		}
+		if err := stream.Send(st2138.ComponentParam(oid, &st2138.Param{Proto: param})); err != nil {
+			return StatusWithCode(StatusCodeInternal, err.Error())
+		}
+	}
+
+	commands := device.Proto.GetCommands()
+	for _, oid := range sortedKeys(commands) {
+		command := commands[oid]
+		if command == nil {
+			continue
+		}
+		if err := stream.Send(st2138.ComponentCommand(oid, &st2138.Param{Proto: command})); err != nil {
+			return StatusWithCode(StatusCodeInternal, err.Error())
+		}
+	}
+
+	packs := device.Proto.GetLanguagePacks().GetPacks()
+	for _, code := range sortedKeys(packs) {
+		pack := packs[code]
+		if pack == nil {
+			continue
+		}
+		if err := stream.Send(st2138.ComponentLanguagePack(code, pack.GetName(), pack.GetWords())); err != nil {
+			return StatusWithCode(StatusCodeInternal, err.Error())
+		}
+	}
+
+	return StatusResult{Code: StatusCodeOk}
+}
+
+// deviceSkeleton snapshots the top-level device fields that are not streamed
+// as separate component chunks: everything except params, commands, shared
+// constraints, per-group menus, and language packs. Menu groups survive as
+// empty shells so their display name and order reach the client. The skeleton
+// is built on a clone so the source device is never touched, even briefly (it
+// may be shared with concurrent requests).
+func deviceSkeleton(device *protos.Device) *protos.Device {
+	skeleton := proto.Clone(device).(*protos.Device)
+	skeleton.Params = nil
+	skeleton.Commands = nil
+	skeleton.Constraints = nil
+	skeleton.LanguagePacks = nil
+	for _, group := range skeleton.MenuGroups {
+		if group != nil {
+			group.Menus = nil
+		}
+	}
+	return skeleton
+}
+
+// sortedKeys returns m's keys in ascending order so component chunks are
+// emitted deterministically.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/sdks/go/pkg/catena/device_components.go
+++ b/sdks/go/pkg/catena/device_components.go
@@ -39,8 +39,6 @@
 package catena
 
 import (
-	"sort"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
@@ -50,12 +48,13 @@ import (
 // DeviceComponentsForRequest streams a complete device model as DeviceComponent
 // chunks: first a skeleton Device chunk (the device minus its params, commands,
 // shared constraints, menus, and language packs), then one chunk per shared
-// constraint, menu, top-level param, command, and language pack, each group
-// sorted by oid so the stream order is deterministic. It is a business-logic
-// helper a GetDevice handler can delegate to once it can produce a Device
-// definition; the returned StatusResult is the terminal status a handler
-// returns directly: Ok once every component has been sent, or Internal if a
-// Send fails (a failed Send stops the stream immediately).
+// constraint, menu, top-level param, command, and language pack. The component
+// kinds are emitted in that fixed order, but chunks within a kind follow map
+// iteration order, so clients must not rely on oid ordering. It is a
+// business-logic helper a GetDevice handler can delegate to once it can
+// produce a Device definition; the returned StatusResult is the terminal
+// status a handler returns directly: Ok once every component has been sent, or
+// Internal if a Send fails (a failed Send stops the stream immediately).
 //
 // Menu-group metadata (display name, order) stays on the skeleton because a
 // ComponentMenu chunk carries only the menu itself; each group's menus are
@@ -75,9 +74,7 @@ func DeviceComponentsForRequest(device *st2138.Device, stream Stream[st2138.Devi
 		return StatusWithCode(StatusCodeInternal, err.Error())
 	}
 
-	constraints := device.Proto.GetConstraints()
-	for _, oid := range sortedKeys(constraints) {
-		constraint := constraints[oid]
+	for oid, constraint := range device.Proto.GetConstraints() {
 		if constraint == nil {
 			continue
 		}
@@ -86,11 +83,8 @@ func DeviceComponentsForRequest(device *st2138.Device, stream Stream[st2138.Devi
 		}
 	}
 
-	menuGroups := device.Proto.GetMenuGroups()
-	for _, group := range sortedKeys(menuGroups) {
-		menus := menuGroups[group].GetMenus()
-		for _, name := range sortedKeys(menus) {
-			menu := menus[name]
+	for group, menuGroup := range device.Proto.GetMenuGroups() {
+		for name, menu := range menuGroup.GetMenus() {
 			if menu == nil {
 				continue
 			}
@@ -100,9 +94,7 @@ func DeviceComponentsForRequest(device *st2138.Device, stream Stream[st2138.Devi
 		}
 	}
 
-	params := device.Proto.GetParams()
-	for _, oid := range sortedKeys(params) {
-		param := params[oid]
+	for oid, param := range device.Proto.GetParams() {
 		if param == nil {
 			continue
 		}
@@ -111,9 +103,7 @@ func DeviceComponentsForRequest(device *st2138.Device, stream Stream[st2138.Devi
 		}
 	}
 
-	commands := device.Proto.GetCommands()
-	for _, oid := range sortedKeys(commands) {
-		command := commands[oid]
+	for oid, command := range device.Proto.GetCommands() {
 		if command == nil {
 			continue
 		}
@@ -122,9 +112,7 @@ func DeviceComponentsForRequest(device *st2138.Device, stream Stream[st2138.Devi
 		}
 	}
 
-	packs := device.Proto.GetLanguagePacks().GetPacks()
-	for _, code := range sortedKeys(packs) {
-		pack := packs[code]
+	for code, pack := range device.Proto.GetLanguagePacks().GetPacks() {
 		if pack == nil {
 			continue
 		}
@@ -154,15 +142,4 @@ func deviceSkeleton(device *protos.Device) *protos.Device {
 		}
 	}
 	return skeleton
-}
-
-// sortedKeys returns m's keys in ascending order so component chunks are
-// emitted deterministically.
-func sortedKeys[V any](m map[string]V) []string {
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/sdks/go/pkg/catena/device_components_test.go
+++ b/sdks/go/pkg/catena/device_components_test.go
@@ -41,6 +41,8 @@ package catena
 import (
 	"errors"
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
@@ -70,8 +72,10 @@ func TestDeviceComponentsForRequest(t *testing.T) {
 			WithLanguagePack("es", "Global Spanish", map[string]string{"greeting": "Hola"})
 	}
 
-	// Skeleton first, then each component kind sorted by oid.
-	expectedOrder := []string{
+	// Skeleton first, then each component kind in a fixed sequence; chunks
+	// within a kind follow map iteration order, so tests assert set
+	// membership rather than exact position.
+	expectedComponents := []string{
 		"device",
 		"constraint:percent",
 		"menu:status/advanced",
@@ -89,7 +93,7 @@ func TestDeviceComponentsForRequest(t *testing.T) {
 		if res.Code != StatusCodeOk {
 			t.Fatalf("expected OK, got %v", res)
 		}
-		assertComponentOrder(t, stream.Items, expectedOrder)
+		assertComponentSet(t, stream.Items, expectedComponents)
 
 		skeleton := stream.Items[0].Proto.GetDevice()
 		if skeleton.GetSlot() != 3 {
@@ -114,7 +118,8 @@ func TestDeviceComponentsForRequest(t *testing.T) {
 		}
 
 		// Component chunks reference the device's protos, not copies.
-		if stream.Items[4].Proto.GetParam().GetParam() != device.Proto.GetParams()["alpha"] {
+		alphaChunk := findComponent(t, stream.Items, "param:alpha")
+		if alphaChunk.Proto.GetParam().GetParam() != device.Proto.GetParams()["alpha"] {
 			t.Error("expected param chunk to reference the device's param proto")
 		}
 
@@ -180,7 +185,7 @@ func TestDeviceComponentsForRequest(t *testing.T) {
 		// Fail each of the eight Sends in turn: the walk must stop at the
 		// failure and report INTERNAL, so every send site's error return is
 		// exercised.
-		for failAfter := range expectedOrder {
+		for failAfter := range expectedComponents {
 			stream := &sliceStream[st2138.DeviceComponent]{Err: errors.New("boom"), FailAfter: failAfter}
 			res := DeviceComponentsForRequest(componentTestDevice(), stream)
 			if res.Code != StatusCodeInternal {
@@ -207,6 +212,45 @@ func assertComponentOrder(t *testing.T, chunks []st2138.DeviceComponent, expecte
 			t.Errorf("expected chunk[%d] %q, got %q", i, want, got)
 		}
 	}
+}
+
+// assertComponentSet checks that the skeleton chunk arrives first and that the
+// remaining chunks match the expected kind:oid descriptions regardless of
+// order, since chunks within a kind follow map iteration order.
+func assertComponentSet(t *testing.T, chunks []st2138.DeviceComponent, expected []string) {
+	t.Helper()
+
+	if len(chunks) != len(expected) {
+		t.Fatalf("expected %d chunks, got %d", len(expected), len(chunks))
+	}
+	if got := describeComponent(chunks[0]); got != "device" {
+		t.Fatalf("expected first chunk %q, got %q", "device", got)
+	}
+
+	got := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		got = append(got, describeComponent(chunk))
+	}
+	want := append([]string(nil), expected...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("component set mismatch:\n got %v\nwant %v", got, want)
+	}
+}
+
+// findComponent returns the chunk whose kind:oid description matches want,
+// failing the test if it is absent.
+func findComponent(t *testing.T, chunks []st2138.DeviceComponent, want string) st2138.DeviceComponent {
+	t.Helper()
+
+	for _, chunk := range chunks {
+		if describeComponent(chunk) == want {
+			return chunk
+		}
+	}
+	t.Fatalf("no %q chunk in stream", want)
+	return st2138.DeviceComponent{}
 }
 
 // describeComponent renders a chunk as "kind" or "kind:oid" for compact

--- a/sdks/go/pkg/catena/device_components_test.go
+++ b/sdks/go/pkg/catena/device_components_test.go
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for DeviceComponent chunking business logic.
+ * @author Nelson Daniels (nelson.daniels@rossvideo.com)
+ * @date 2026-08-07
+ * @file device_components_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package catena
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
+)
+
+func TestDeviceComponentsForRequest(t *testing.T) {
+	// componentTestDevice carries at least one of every chunkable piece:
+	// two params, a command, a shared constraint, a menu group with two
+	// menus, and a language pack.
+	componentTestDevice := func() *st2138.Device {
+		return st2138.NewDevice(3).
+			WithDetailLevel(st2138.DetailLevelFull).
+			WithMultiSetEnabled(true).
+			WithAccessScopes("st2138:mon", "st2138:cfg").
+			WithDefaultScope("st2138:mon").
+			WithParam("alpha", st2138.NewParamInt32(1)).
+			WithParam("parent", st2138.NewParamStruct().
+				WithParam("child", st2138.NewParamString("x"))).
+			WithCommand("go", st2138.NewParamEmpty()).
+			WithConstraint("percent", st2138.NewConstraintInt32Range(0, 100, 1)).
+			WithMenuGroup("status", st2138.NewMenuGroup().
+				WithName(st2138.NewPolyglotText("en", "Status")).
+				WithOrder(2).
+				WithMenu("advanced", st2138.NewMenu().WithParamOids("parent")).
+				WithMenu("overview", st2138.NewMenu().WithParamOids("alpha"))).
+			WithLanguagePack("es", "Global Spanish", map[string]string{"greeting": "Hola"})
+	}
+
+	// Skeleton first, then each component kind sorted by oid.
+	expectedOrder := []string{
+		"device",
+		"constraint:percent",
+		"menu:status/advanced",
+		"menu:status/overview",
+		"param:alpha",
+		"param:parent",
+		"command:go",
+		"pack:es",
+	}
+
+	t.Run("FullDecomposition", func(t *testing.T) {
+		device := componentTestDevice()
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		res := DeviceComponentsForRequest(device, stream)
+		if res.Code != StatusCodeOk {
+			t.Fatalf("expected OK, got %v", res)
+		}
+		assertComponentOrder(t, stream.Items, expectedOrder)
+
+		skeleton := stream.Items[0].Proto.GetDevice()
+		if skeleton.GetSlot() != 3 {
+			t.Errorf("expected skeleton slot 3, got %d", skeleton.GetSlot())
+		}
+		if skeleton.GetDefaultScope() != "st2138:mon" {
+			t.Errorf("expected skeleton to keep default scope, got %q", skeleton.GetDefaultScope())
+		}
+		if len(skeleton.GetParams()) != 0 || len(skeleton.GetCommands()) != 0 {
+			t.Errorf("expected skeleton without params/commands, got %d/%d",
+				len(skeleton.GetParams()), len(skeleton.GetCommands()))
+		}
+		if len(skeleton.GetConstraints()) != 0 || skeleton.GetLanguagePacks() != nil {
+			t.Error("expected skeleton without constraints or language packs")
+		}
+		group := skeleton.GetMenuGroups()["status"]
+		if group.GetOrder() != 2 || group.GetName().GetDisplayStrings()["en"] != "Status" {
+			t.Errorf("expected menu-group shell to keep name and order, got %v", group)
+		}
+		if len(group.GetMenus()) != 0 {
+			t.Errorf("expected menu-group shell without menus, got %d", len(group.GetMenus()))
+		}
+
+		// Component chunks reference the device's protos, not copies.
+		if stream.Items[4].Proto.GetParam().GetParam() != device.Proto.GetParams()["alpha"] {
+			t.Error("expected param chunk to reference the device's param proto")
+		}
+
+		// The source device is left intact, including the menus stripped from
+		// the skeleton clone.
+		if len(device.Proto.GetParams()) != 2 || len(device.Proto.GetCommands()) != 1 {
+			t.Error("expected source device params/commands to be untouched")
+		}
+		if len(device.Proto.GetConstraints()) != 1 || device.Proto.GetLanguagePacks() == nil {
+			t.Error("expected source device constraints/language packs to be untouched")
+		}
+		if len(device.Proto.GetMenuGroups()["status"].GetMenus()) != 2 {
+			t.Error("expected source device menus to be untouched")
+		}
+	})
+
+	t.Run("SkeletonOnly", func(t *testing.T) {
+		// A device with nothing to chunk still yields its skeleton.
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		res := DeviceComponentsForRequest(st2138.NewDevice(1), stream)
+		if res.Code != StatusCodeOk {
+			t.Fatalf("expected OK, got %v", res)
+		}
+		assertComponentOrder(t, stream.Items, []string{"device"})
+	})
+
+	t.Run("NilDevice", func(t *testing.T) {
+		for _, device := range []*st2138.Device{nil, {}} {
+			stream := &sliceStream[st2138.DeviceComponent]{}
+			res := DeviceComponentsForRequest(device, stream)
+			if res.Code != StatusCodeInternal {
+				t.Fatalf("expected INTERNAL, got %v", res)
+			}
+			if len(stream.Items) != 0 {
+				t.Fatalf("expected no chunks, got %d", len(stream.Items))
+			}
+		}
+	})
+
+	t.Run("NilEntriesSkipped", func(t *testing.T) {
+		// Nil map values must be skipped, not sent or dereferenced.
+		device := st2138.NewDevice(0)
+		device.Proto.Params = map[string]*protos.Param{"ghost": nil}
+		device.Proto.Commands = map[string]*protos.Param{"ghost": nil}
+		device.Proto.Constraints = map[string]*protos.Constraint{"ghost": nil}
+		device.Proto.MenuGroups = map[string]*protos.MenuGroup{
+			"empty": nil,
+			"holed": {Menus: map[string]*protos.Menu{"ghost": nil}},
+		}
+		device.Proto.LanguagePacks = &protos.LanguagePacks{
+			Packs: map[string]*protos.LanguagePack{"ghost": nil},
+		}
+
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		res := DeviceComponentsForRequest(device, stream)
+		if res.Code != StatusCodeOk {
+			t.Fatalf("expected OK, got %v", res)
+		}
+		assertComponentOrder(t, stream.Items, []string{"device"})
+	})
+
+	t.Run("SendErrors", func(t *testing.T) {
+		// Fail each of the eight Sends in turn: the walk must stop at the
+		// failure and report INTERNAL, so every send site's error return is
+		// exercised.
+		for failAfter := range expectedOrder {
+			stream := &sliceStream[st2138.DeviceComponent]{Err: errors.New("boom"), FailAfter: failAfter}
+			res := DeviceComponentsForRequest(componentTestDevice(), stream)
+			if res.Code != StatusCodeInternal {
+				t.Fatalf("FailAfter %d: expected INTERNAL from a failed Send, got %v", failAfter, res)
+			}
+			if len(stream.Items) != failAfter {
+				t.Errorf("FailAfter %d: expected %d chunks before the failure, got %d",
+					failAfter, failAfter, len(stream.Items))
+			}
+		}
+	})
+}
+
+// assertComponentOrder checks that chunks arrive as the expected kind:oid
+// descriptions, in order.
+func assertComponentOrder(t *testing.T, chunks []st2138.DeviceComponent, expected []string) {
+	t.Helper()
+
+	if len(chunks) != len(expected) {
+		t.Fatalf("expected %d chunks, got %d", len(expected), len(chunks))
+	}
+	for i, want := range expected {
+		if got := describeComponent(chunks[i]); got != want {
+			t.Errorf("expected chunk[%d] %q, got %q", i, want, got)
+		}
+	}
+}
+
+// describeComponent renders a chunk as "kind" or "kind:oid" for compact
+// order assertions.
+func describeComponent(chunk st2138.DeviceComponent) string {
+	switch kind := chunk.Proto.GetKind().(type) {
+	case *protos.DeviceComponent_Device:
+		return "device"
+	case *protos.DeviceComponent_SharedConstraint:
+		return "constraint:" + kind.SharedConstraint.GetOid()
+	case *protos.DeviceComponent_Menu:
+		return "menu:" + kind.Menu.GetOid()
+	case *protos.DeviceComponent_Param:
+		return "param:" + kind.Param.GetOid()
+	case *protos.DeviceComponent_Command:
+		return "command:" + kind.Command.GetOid()
+	case *protos.DeviceComponent_LanguagePack:
+		return "pack:" + kind.LanguagePack.GetLanguage()
+	default:
+		return fmt.Sprintf("unknown:%T", kind)
+	}
+}

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -88,25 +88,45 @@ func expectedProductParam() *protos.Param {
 	}
 }
 
+// deviceFromStream extracts the device proto from the single Device-kind chunk
+// the handler streamed, failing the test if the stream does not carry exactly
+// one Device chunk.
+func deviceFromStream(t *testing.T, stream *sliceStream[st2138.DeviceComponent]) *protos.Device {
+	t.Helper()
+	if len(stream.Items) != 1 {
+		t.Fatalf("expected 1 streamed device component, got %d", len(stream.Items))
+	}
+	device := stream.Items[0].Proto.GetDevice()
+	if device == nil {
+		t.Fatalf("expected a Device-kind chunk, got %v", stream.Items[0].Proto)
+	}
+	return device
+}
+
 // TestServer_GetDevice_InjectsProduct verifies GetDevice overwrites the product
-// param in whatever the business logic returned with the SDK-managed product.
+// param in whatever the business logic streamed with the SDK-managed product.
 func TestServer_GetDevice_InjectsProduct(t *testing.T) {
 	srv := newTestServer(t, false)
 	srv.RegisterProductStruct(0, testProduct())
-	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext) (st2138.Device, StatusResult) {
-		// Business logic returns a device with a bogus product that must be
+	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
+		// Business logic sends a device with a bogus product that must be
 		// overwritten, plus its own param that must be preserved.
-		return Reply(*st2138.NewDevice(0).
+		device := st2138.NewDevice(0).
 			WithParam("product", st2138.NewParamString("wrong")).
-			WithParam("brightness", st2138.NewParamInt32(50)))
+			WithParam("brightness", st2138.NewParamInt32(50))
+		if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
+			return StatusWithCode(StatusCodeInternal, err.Error())
+		}
+		return StatusWithCode(StatusCodeOk, "")
 	})
 
-	device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+	stream := &sliceStream[st2138.DeviceComponent]{}
+	res := srv.InvokeGetDeviceHandler(0, stream, TransportContext{})
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
 
-	params := device.Proto.GetParams()
+	params := deviceFromStream(t, stream).GetParams()
 	if _, ok := params["brightness"]; !ok {
 		t.Error("expected business-logic 'brightness' param to be preserved")
 	}
@@ -119,19 +139,67 @@ func TestServer_GetDevice_InjectsProduct(t *testing.T) {
 	}
 }
 
+// TestServer_GetDevice_ProductParamChunk verifies the SDK's product policy on
+// standalone ComponentParam chunks: a chunk for the product oid itself is
+// rewritten to the SDK-managed param, and product/* sub-param chunks are
+// dropped since the SDK owns the product struct's contents.
+func TestServer_GetDevice_ProductParamChunk(t *testing.T) {
+	srv := newTestServer(t, false)
+	srv.RegisterProductStruct(0, testProduct())
+	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
+		chunks := []st2138.DeviceComponent{
+			st2138.ComponentParam("product", st2138.NewParamString("wrong")),
+			st2138.ComponentParam("product/name", st2138.NewParamString("wrong")),
+			st2138.ComponentParam("brightness", st2138.NewParamInt32(50)),
+		}
+		for _, chunk := range chunks {
+			if err := stream.Send(chunk); err != nil {
+				return StatusWithCode(StatusCodeInternal, err.Error())
+			}
+		}
+		return StatusWithCode(StatusCodeOk, "")
+	})
+
+	stream := &sliceStream[st2138.DeviceComponent]{}
+	res := srv.InvokeGetDeviceHandler(0, stream, TransportContext{})
+	if res.Code != StatusCodeOk {
+		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
+	}
+
+	// product/name is dropped; product and brightness pass (product rewritten).
+	if len(stream.Items) != 2 {
+		t.Fatalf("expected 2 delivered chunks, got %d", len(stream.Items))
+	}
+	product := stream.Items[0].Proto.GetParam()
+	if product.GetOid() != "product" {
+		t.Fatalf("expected first chunk oid 'product', got %q", product.GetOid())
+	}
+	if !proto.Equal(product.GetParam(), expectedProductParam()) {
+		t.Errorf("product chunk was not rewritten to the SDK-managed param, got %v", product.GetParam())
+	}
+	if got := stream.Items[1].Proto.GetParam().GetOid(); got != "brightness" {
+		t.Errorf("expected second chunk oid 'brightness', got %q", got)
+	}
+}
+
 // TestServer_GetDevice_NoProductRegistered verifies the device is passed through
 // untouched when no product is registered for the slot.
 func TestServer_GetDevice_NoProductRegistered(t *testing.T) {
 	srv := newTestServer(t, false)
-	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext) (st2138.Device, StatusResult) {
-		return Reply(*st2138.NewDevice(0).WithParam("brightness", st2138.NewParamInt32(50)))
+	srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
+		device := st2138.NewDevice(0).WithParam("brightness", st2138.NewParamInt32(50))
+		if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
+			return StatusWithCode(StatusCodeInternal, err.Error())
+		}
+		return StatusWithCode(StatusCodeOk, "")
 	})
 
-	device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+	stream := &sliceStream[st2138.DeviceComponent]{}
+	res := srv.InvokeGetDeviceHandler(0, stream, TransportContext{})
 	if res.Code != StatusCodeOk {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
-	if _, ok := device.Proto.GetParams()["product"]; ok {
+	if _, ok := deviceFromStream(t, stream).GetParams()["product"]; ok {
 		t.Error("did not expect a product param when none is registered")
 	}
 }
@@ -365,11 +433,15 @@ func TestServer_GetDevice_ProductScope(t *testing.T) {
 		srv := newTestServer(t, true)
 		srv.RegisterProductStruct(0, testProduct())
 		called := false
-		srv.RegisterGetDeviceHandler(0, func(slot uint16, hctx HandlerContext) (st2138.Device, StatusResult) {
+		srv.RegisterGetDeviceHandler(0, func(slot uint16, hctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
 			called = true
-			return Reply(*st2138.NewDevice(0).
+			device := st2138.NewDevice(0).
 				WithParam("product", st2138.NewParamString("wrong")).
-				WithParam("brightness", st2138.NewParamInt32(50)))
+				WithParam("brightness", st2138.NewParamInt32(50))
+			if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
+				return StatusWithCode(StatusCodeInternal, err.Error())
+			}
+			return StatusWithCode(StatusCodeOk, "")
 		})
 		mockInvokeGateFn(t, srv, EndpointGetDevice, false, ctx, StatusWithCode(StatusCodeOk, ""))
 		return srv, &called
@@ -377,14 +449,15 @@ func TestServer_GetDevice_ProductScope(t *testing.T) {
 
 	t.Run("MonInjectsProduct", func(t *testing.T) {
 		srv, called := newDeviceServer(t, monScopeContext())
-		device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		res := srv.InvokeGetDeviceHandler(0, stream, TransportContext{})
 		if res.Code != StatusCodeOk {
 			t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 		}
 		if !*called {
 			t.Error("expected business-logic GetDevice to be called")
 		}
-		params := device.Proto.GetParams()
+		params := deviceFromStream(t, stream).GetParams()
 		if _, ok := params["brightness"]; !ok {
 			t.Error("expected business-logic 'brightness' param to be preserved")
 		}
@@ -399,14 +472,15 @@ func TestServer_GetDevice_ProductScope(t *testing.T) {
 
 	t.Run("NonMonStripsProduct", func(t *testing.T) {
 		srv, called := newDeviceServer(t, nonMonScopeContext())
-		device, res := srv.InvokeGetDeviceHandler(0, TransportContext{})
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		res := srv.InvokeGetDeviceHandler(0, stream, TransportContext{})
 		if res.Code != StatusCodeOk {
 			t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 		}
 		if !*called {
 			t.Error("expected business-logic GetDevice to be called")
 		}
-		params := device.Proto.GetParams()
+		params := deviceFromStream(t, stream).GetParams()
 		if _, ok := params["brightness"]; !ok {
 			t.Error("expected business-logic 'brightness' param to be preserved")
 		}

--- a/sdks/go/pkg/catena/product_server_test.go
+++ b/sdks/go/pkg/catena/product_server_test.go
@@ -140,9 +140,9 @@ func TestServer_GetDevice_InjectsProduct(t *testing.T) {
 }
 
 // TestServer_GetDevice_ProductParamChunk verifies the SDK's product policy on
-// standalone ComponentParam chunks: a chunk for the product oid itself is
-// rewritten to the SDK-managed param, and product/* sub-param chunks are
-// dropped since the SDK owns the product struct's contents.
+// standalone ComponentParam chunks: chunks targeting product or product/* are
+// dropped, since the SDK owns the product struct and already delivers it on
+// the Device chunk.
 func TestServer_GetDevice_ProductParamChunk(t *testing.T) {
 	srv := newTestServer(t, false)
 	srv.RegisterProductStruct(0, testProduct())
@@ -166,19 +166,12 @@ func TestServer_GetDevice_ProductParamChunk(t *testing.T) {
 		t.Fatalf("expected OK, got %v: %s", res.Code, res.Error)
 	}
 
-	// product/name is dropped; product and brightness pass (product rewritten).
-	if len(stream.Items) != 2 {
-		t.Fatalf("expected 2 delivered chunks, got %d", len(stream.Items))
+	// product and product/name are dropped; only brightness passes through.
+	if len(stream.Items) != 1 {
+		t.Fatalf("expected 1 delivered chunk, got %d", len(stream.Items))
 	}
-	product := stream.Items[0].Proto.GetParam()
-	if product.GetOid() != "product" {
-		t.Fatalf("expected first chunk oid 'product', got %q", product.GetOid())
-	}
-	if !proto.Equal(product.GetParam(), expectedProductParam()) {
-		t.Errorf("product chunk was not rewritten to the SDK-managed param, got %v", product.GetParam())
-	}
-	if got := stream.Items[1].Proto.GetParam().GetOid(); got != "brightness" {
-		t.Errorf("expected second chunk oid 'brightness', got %q", got)
+	if got := stream.Items[0].Proto.GetParam().GetOid(); got != "brightness" {
+		t.Errorf("expected delivered chunk oid 'brightness', got %q", got)
 	}
 }
 

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -146,7 +146,9 @@ func (e EndpointType) String() string {
 // error means the chunk could not be delivered - the client may have
 // disconnected, the transport hit an encoding or write failure, or the server
 // is shutting down (the SDK wraps the stream so Send fails once shutdown
-// begins) - so the handler should stop and return.
+// begins) - so the handler should stop and return. A handler that can produce
+// a whole st2138.Device can delegate the chunking to
+// DeviceComponentsForRequest in device_components.go.
 type DeviceHandler func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult
 
 // GetValueHandler returns the current value of the parameter at fqoid for a

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -1041,7 +1041,7 @@ func (s *server) InvokeGetDeviceHandler(slot uint16, stream Stream[st2138.Device
 				out = productDeviceStream{
 					inner:   stream,
 					product: product,
-					hasMon:  ctx.RequireReadScope(st2138.ScopeMon).IsOk(),
+					hasMon:  ctx.HasReadScope(st2138.ScopeMon),
 				}
 			}
 			return struct{}{}, handler(slot, ctx, out)

--- a/sdks/go/pkg/catena/server.go
+++ b/sdks/go/pkg/catena/server.go
@@ -135,10 +135,19 @@ func (e EndpointType) String() string {
 // RegisterProductStruct), the SDK owns product/* requests and handlers never
 // see them; otherwise product/* requests fall through to the handler.
 
-// DeviceHandler returns the full device model for a slot (GetDevice). It
-// returns the device with an Ok status, or a zero Device with an error status
-// (e.g. StatusCodeNotFound) when the slot has no device to report.
-type DeviceHandler func(slot uint16, ctx HandlerContext) (st2138.Device, StatusResult)
+// DeviceHandler streams the device model for a slot (GetDevice /
+// DeviceRequest). A small device is typically emitted as a single
+// st2138.ComponentDevice chunk through stream.Send; a large one may be broken
+// into a ComponentDevice skeleton followed by ComponentParam /
+// ComponentConstraint / ComponentMenu / ComponentCommand /
+// ComponentLanguagePack chunks that fill in the pieces. The handler returns a
+// terminal StatusResult: Ok once every chunk has been sent, or an error status
+// (e.g. StatusCodeNotFound) when the slot has no device to report. A Send
+// error means the chunk could not be delivered - the client may have
+// disconnected, the transport hit an encoding or write failure, or the server
+// is shutting down (the SDK wraps the stream so Send fails once shutdown
+// begins) - so the handler should stop and return.
+type DeviceHandler func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult
 
 // GetValueHandler returns the current value of the parameter at fqoid for a
 // slot (GetValue). It returns the value with an Ok status, or a zero Value
@@ -163,10 +172,18 @@ type SetValueEntry struct {
 // an error status. On success it returns an Ok status.
 type SetValueHandler func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult
 
-// ReadAssetHandler returns the asset stored at fqoid for a slot (ReadAsset).
-// It returns the asset with an Ok status, or a zero Asset with an error status
-// (e.g. StatusCodeNotFound for an unknown fqoid).
-type ReadAssetHandler func(slot uint16, fqoid string, ctx HandlerContext) (st2138.Asset, StatusResult)
+// ReadAssetHandler streams the asset stored at fqoid for a slot (ReadAsset /
+// ExternalObjectRequest). A small asset is typically emitted as a single
+// st2138.Asset chunk through stream.Send; a large one may be broken into
+// several chunks whose embedded payload bytes the client concatenates in send
+// order (metadata, digest, and cachable are taken from the first chunk). The
+// handler returns a terminal StatusResult: Ok once every chunk has been sent,
+// or an error status (e.g. StatusCodeNotFound for an unknown fqoid). A Send
+// error means the chunk could not be delivered - the client may have
+// disconnected, the transport hit an encoding or write failure, or the server
+// is shutting down (the SDK wraps the stream so Send fails once shutdown
+// begins) - so the handler should stop and return.
+type ReadAssetHandler func(slot uint16, fqoid string, ctx HandlerContext, stream Stream[st2138.Asset]) StatusResult
 
 // CreateAssetHandler stores a new asset at fqoid (HTTP POST / CreateAsset).
 // Business logic decides create-vs-conflict semantics and reports the outcome
@@ -296,12 +313,13 @@ type Server interface {
 	// restates the handler signature so it can be read at the call site; the
 	// handler type's doc carries the full implementation contract.
 
-	// RegisterGetDeviceHandler registers the GetDevice handler for a slot.
-	// See DeviceHandler.
+	// RegisterGetDeviceHandler registers the GetDevice handler for a slot. The
+	// handler streams device components through stream.Send, stops on a Send
+	// error, and returns a terminal status; see DeviceHandler.
 	//
 	// Handler signature:
 	//
-	//	func(slot uint16, ctx HandlerContext) (st2138.Device, StatusResult)
+	//	func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult
 	RegisterGetDeviceHandler(slot uint16, handler DeviceHandler)
 
 	// RegisterGetValueHandler registers the GetValue handler for a slot.
@@ -329,12 +347,13 @@ type Server interface {
 	//	func(slot uint16, entries []SetValueEntry, ctx HandlerContext) StatusResult
 	RegisterSetValueHandler(slot uint16, handler SetValueHandler)
 
-	// RegisterReadAssetHandler registers the ReadAsset handler for a slot.
-	// See ReadAssetHandler.
+	// RegisterReadAssetHandler registers the ReadAsset handler for a slot. The
+	// handler streams asset chunks through stream.Send, stops on a Send error,
+	// and returns a terminal status; see ReadAssetHandler.
 	//
 	// Handler signature:
 	//
-	//	func(slot uint16, fqoid string, ctx HandlerContext) (st2138.Asset, StatusResult)
+	//	func(slot uint16, fqoid string, ctx HandlerContext, stream Stream[st2138.Asset]) StatusResult
 	RegisterReadAssetHandler(slot uint16, handler ReadAssetHandler)
 
 	// RegisterCreateAssetHandler registers the CreateAsset handler for a slot.
@@ -463,11 +482,11 @@ type Server interface {
 type ServerRuntime interface {
 	IsDev() bool
 	GetSlots(transportContext TransportContext) ([]uint16, StatusResult)
-	InvokeGetDeviceHandler(slot uint16, transportContext TransportContext) (st2138.Device, StatusResult)
+	InvokeGetDeviceHandler(slot uint16, stream Stream[st2138.DeviceComponent], transportContext TransportContext) StatusResult
 	InvokeGetValueHandler(slot uint16, fqoid string, transportContext TransportContext) (st2138.Value, StatusResult)
 	InvokeGetParamHandler(slot uint16, fqoid string, transportContext TransportContext) (st2138.Param, StatusResult)
 	InvokeSetValueHandler(slot uint16, entries []SetValueEntry, transportContext TransportContext) StatusResult
-	InvokeReadAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (st2138.Asset, StatusResult)
+	InvokeReadAssetHandler(slot uint16, fqoid string, stream Stream[st2138.Asset], transportContext TransportContext) StatusResult
 	InvokeCreateAssetHandler(slot uint16, fqoid string, asset st2138.Asset, transportContext TransportContext) StatusResult
 	InvokeUpdateAssetHandler(slot uint16, fqoid string, asset st2138.Asset, transportContext TransportContext) StatusResult
 	InvokeDeleteAssetHandler(slot uint16, fqoid string, transportContext TransportContext) StatusResult
@@ -999,30 +1018,33 @@ func (s *server) productForSlot(slot uint16) (ProductStruct, bool) {
 	return product, ok
 }
 
-func (s *server) InvokeGetDeviceHandler(slot uint16, transportContext TransportContext) (st2138.Device, StatusResult) {
-	return invokeHandler(s, transportContext, EndpointGetDevice, false, s.getDeviceHandlers, slot,
+func (s *server) InvokeGetDeviceHandler(slot uint16, stream Stream[st2138.DeviceComponent], transportContext TransportContext) StatusResult {
+	// Wrap the transport's stream so Send also fails on server shutdown, not just
+	// client disconnect. Cancellation is then transparent to the handler: it just
+	// gets an error from the next Send once the server is shutting down.
+	stream = shutdownStream[st2138.DeviceComponent]{inner: stream, shutdown: s.ctx}
+	_, res := invokeHandler(s, transportContext, EndpointGetDevice, false, s.getDeviceHandlers, slot,
 		"No device defined at slot",
-		func(handler DeviceHandler, ctx HandlerContext) (st2138.Device, StatusResult) {
-			device, res := handler(slot, ctx)
-			// Only touch the device return when the SDK manages the product for this
-			// slot; otherwise leave whatever the business logic produced untouched.
-			if res.IsOk() && device.Proto != nil {
-				// Only enforce the product's st2138:mon read scope when the SDK manages
-				// the product struct for this slot. Callers with mon get the SDK-managed
-				// product injected (overwriting whatever the business logic returned);
-				// callers without mon get no product param at all, even one the business
-				// logic added, since the SDK-managed product struct is read-only and
-				// mon-scoped regardless of who created it.
-				if product, has := s.productForSlot(slot); has {
-					if ctx.RequireReadScope(st2138.ScopeMon).IsOk() {
-						device.WithParam(ProductOid, ProductParam(product))
-					} else {
-						delete(device.Proto.Params, ProductOid)
-					}
+		func(handler DeviceHandler, ctx HandlerContext) (struct{}, StatusResult) {
+			out := stream
+			// Only touch the handler's chunks when the SDK manages the product for
+			// this slot; otherwise deliver whatever the business logic produces
+			// untouched. The wrapper enforces the product's st2138:mon read scope:
+			// callers with mon get the SDK-managed product injected into Device
+			// chunks (overwriting whatever the business logic sent); callers
+			// without mon get no product param at all, even one the business logic
+			// added, since the SDK-managed product struct is read-only and
+			// mon-scoped regardless of who created it.
+			if product, has := s.productForSlot(slot); has {
+				out = productDeviceStream{
+					inner:   stream,
+					product: product,
+					hasMon:  ctx.RequireReadScope(st2138.ScopeMon).IsOk(),
 				}
 			}
-			return device, res
+			return struct{}{}, handler(slot, ctx, out)
 		})
+	return res
 }
 
 func (s *server) InvokeGetValueHandler(slot uint16, fqoid string, transportContext TransportContext) (st2138.Value, StatusResult) {
@@ -1089,12 +1111,17 @@ func (s *server) InvokeSetValueHandler(slot uint16, entries []SetValueEntry, tra
 	return res
 }
 
-func (s *server) InvokeReadAssetHandler(slot uint16, fqoid string, transportContext TransportContext) (st2138.Asset, StatusResult) {
-	return invokeHandler(s, transportContext, EndpointReadAsset, false, s.readAssetHandlers, slot,
+func (s *server) InvokeReadAssetHandler(slot uint16, fqoid string, stream Stream[st2138.Asset], transportContext TransportContext) StatusResult {
+	// Wrap the transport's stream so Send also fails on server shutdown, not just
+	// client disconnect. Cancellation is then transparent to the handler: it just
+	// gets an error from the next Send once the server is shutting down.
+	stream = shutdownStream[st2138.Asset]{inner: stream, shutdown: s.ctx}
+	_, res := invokeHandler(s, transportContext, EndpointReadAsset, false, s.readAssetHandlers, slot,
 		"fqoid "+fqoid+" not found at slot "+strconv.Itoa(int(slot)),
-		func(handler ReadAssetHandler, ctx HandlerContext) (st2138.Asset, StatusResult) {
-			return handler(slot, fqoid, ctx)
+		func(handler ReadAssetHandler, ctx HandlerContext) (struct{}, StatusResult) {
+			return struct{}{}, handler(slot, fqoid, ctx, stream)
 		})
+	return res
 }
 
 // enforceAssetWriteScope authorizes an asset mutation. Per ST 2138 the asset

--- a/sdks/go/pkg/catena/server_test.go
+++ b/sdks/go/pkg/catena/server_test.go
@@ -723,8 +723,8 @@ func TestServer_RegisterEndpoint(t *testing.T) {
 		{
 			endpoint: EndpointGetDevice,
 			register: func(srv *server, slot uint16) {
-				srv.RegisterGetDeviceHandler(slot, func(uint16, HandlerContext) (st2138.Device, StatusResult) {
-					return Reply(st2138.Device{})
+				srv.RegisterGetDeviceHandler(slot, func(uint16, HandlerContext, Stream[st2138.DeviceComponent]) StatusResult {
+					return StatusWithCode(StatusCodeOk, "")
 				})
 			},
 			has: func(srv *server, slot uint16) bool { return srv.getDeviceHandlers[slot] != nil },
@@ -759,8 +759,8 @@ func TestServer_RegisterEndpoint(t *testing.T) {
 		{
 			endpoint: EndpointReadAsset,
 			register: func(srv *server, slot uint16) {
-				srv.RegisterReadAssetHandler(slot, func(uint16, string, HandlerContext) (st2138.Asset, StatusResult) {
-					return Reply(st2138.Asset{})
+				srv.RegisterReadAssetHandler(slot, func(uint16, string, HandlerContext, Stream[st2138.Asset]) StatusResult {
+					return StatusWithCode(StatusCodeOk, "")
 				})
 			},
 			has: func(srv *server, slot uint16) bool { return srv.readAssetHandlers[slot] != nil },
@@ -1236,9 +1236,9 @@ func TestServer_InvokeGetDeviceHandler(t *testing.T) {
 		knownCtx := HandlerContext{Token: &jwt.Token{Raw: "known"}}
 		mockInvokeGateFn(t, srv, EndpointGetDevice, false, knownCtx, StatusWithCode(StatusCodeOk, ""))
 
-		expected := st2138.Device{Proto: &protos.Device{}}
+		expected := st2138.ComponentDevice(&st2138.Device{Proto: &protos.Device{Slot: 11}})
 		handlerCalled := 0
-		srv.getDeviceHandlers[11] = func(slot uint16, ctx HandlerContext) (st2138.Device, StatusResult) {
+		srv.getDeviceHandlers[11] = func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
 			handlerCalled++
 			if slot != 11 {
 				t.Errorf("expected slot 11, got %d", slot)
@@ -1246,10 +1246,14 @@ func TestServer_InvokeGetDeviceHandler(t *testing.T) {
 			if ctx.Token != knownCtx.Token {
 				t.Error("expected the gate's handler context to be passed through to the handler")
 			}
-			return Reply(expected)
+			if err := stream.Send(expected); err != nil {
+				t.Errorf("unexpected Send error: %v", err)
+			}
+			return StatusWithCode(StatusCodeOk, "")
 		}
 
-		actual, status := srv.InvokeGetDeviceHandler(11, validTestTransportContext(nil))
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		status := srv.InvokeGetDeviceHandler(11, stream, validTestTransportContext(nil))
 
 		if handlerCalled != 1 {
 			t.Errorf("expected handler to be called once, got %d", handlerCalled)
@@ -1257,8 +1261,36 @@ func TestServer_InvokeGetDeviceHandler(t *testing.T) {
 		if status.IsError() {
 			t.Errorf("expected OK status, got %v", status)
 		}
-		if actual.Proto != expected.Proto {
-			t.Errorf("expected device %v, got %v", expected, actual)
+		if len(stream.Items) != 1 {
+			t.Fatalf("expected 1 streamed device component, got %d", len(stream.Items))
+		}
+		if stream.Items[0].Proto != expected.Proto {
+			t.Errorf("expected device component %v, got %v", expected, stream.Items[0])
+		}
+	})
+
+	t.Run("SendFailsAfterShutdown", func(t *testing.T) {
+		srv := newTestServer(t, true)
+		knownCtx := HandlerContext{Token: &jwt.Token{Raw: "known"}}
+		mockInvokeGateFn(t, srv, EndpointGetDevice, false, knownCtx, StatusWithCode(StatusCodeOk, ""))
+
+		srv.getDeviceHandlers[11] = func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
+			// Simulate the server shutting down mid-stream; the shutdownStream
+			// wrapper must surface it as a Send error.
+			srv.ctxCancel()
+			if err := stream.Send(st2138.ComponentDevice(nil)); err == nil {
+				t.Error("expected Send to fail after shutdown began")
+			}
+			return StatusWithCode(StatusCodeInternal, "send failed")
+		}
+
+		stream := &sliceStream[st2138.DeviceComponent]{}
+		status := srv.InvokeGetDeviceHandler(11, stream, validTestTransportContext(nil))
+		if status.Code != StatusCodeInternal {
+			t.Errorf("expected internal status from handler, got %v", status)
+		}
+		if len(stream.Items) != 0 {
+			t.Errorf("expected no chunks delivered after shutdown, got %d", len(stream.Items))
 		}
 	})
 }
@@ -1425,7 +1457,7 @@ func TestServer_InvokeReadAssetHandler(t *testing.T) {
 		expected, _ := st2138.ToAsset(dp, false)
 
 		handlerCalled := 0
-		srv.readAssetHandlers[5] = func(slot uint16, fqoid string, ctx HandlerContext) (st2138.Asset, StatusResult) {
+		srv.readAssetHandlers[5] = func(slot uint16, fqoid string, ctx HandlerContext, stream Stream[st2138.Asset]) StatusResult {
 			handlerCalled++
 			if slot != 5 {
 				t.Errorf("expected slot 5, got %d", slot)
@@ -1436,10 +1468,14 @@ func TestServer_InvokeReadAssetHandler(t *testing.T) {
 			if ctx.Token != knownCtx.Token {
 				t.Error("expected the gate's handler context to be passed through to the handler")
 			}
-			return Reply(expected)
+			if err := stream.Send(expected); err != nil {
+				t.Errorf("unexpected Send error: %v", err)
+			}
+			return StatusWithCode(StatusCodeOk, "")
 		}
 
-		actual, status := srv.InvokeReadAssetHandler(5, "test/asset", validTestTransportContext(nil))
+		stream := &sliceStream[st2138.Asset]{}
+		status := srv.InvokeReadAssetHandler(5, "test/asset", stream, validTestTransportContext(nil))
 
 		if handlerCalled != 1 {
 			t.Errorf("expected handler to be called once, got %d", handlerCalled)
@@ -1447,8 +1483,36 @@ func TestServer_InvokeReadAssetHandler(t *testing.T) {
 		if status.IsError() {
 			t.Errorf("expected OK status, got %v", status)
 		}
-		if !proto.Equal(actual.Proto, expected.Proto) {
-			t.Errorf("expected asset %v, got %v", expected, actual)
+		if len(stream.Items) != 1 {
+			t.Fatalf("expected 1 streamed asset chunk, got %d", len(stream.Items))
+		}
+		if !proto.Equal(stream.Items[0].Proto, expected.Proto) {
+			t.Errorf("expected asset %v, got %v", expected, stream.Items[0])
+		}
+	})
+
+	t.Run("SendFailsAfterShutdown", func(t *testing.T) {
+		srv := newTestServer(t, true)
+		knownCtx := HandlerContext{Token: &jwt.Token{Raw: "known"}}
+		mockInvokeGateFn(t, srv, EndpointReadAsset, false, knownCtx, StatusWithCode(StatusCodeOk, ""))
+
+		srv.readAssetHandlers[5] = func(slot uint16, fqoid string, ctx HandlerContext, stream Stream[st2138.Asset]) StatusResult {
+			// Simulate the server shutting down mid-stream; the shutdownStream
+			// wrapper must surface it as a Send error.
+			srv.ctxCancel()
+			if err := stream.Send(st2138.Asset{}); err == nil {
+				t.Error("expected Send to fail after shutdown began")
+			}
+			return StatusWithCode(StatusCodeInternal, "send failed")
+		}
+
+		stream := &sliceStream[st2138.Asset]{}
+		status := srv.InvokeReadAssetHandler(5, "test/asset", stream, validTestTransportContext(nil))
+		if status.Code != StatusCodeInternal {
+			t.Errorf("expected internal status from handler, got %v", status)
+		}
+		if len(stream.Items) != 0 {
+			t.Errorf("expected no chunks delivered after shutdown, got %d", len(stream.Items))
 		}
 	})
 }
@@ -1886,12 +1950,11 @@ func TestServer_InvokeEndpointsRouteThroughGate(t *testing.T) {
 		{
 			endpoint: EndpointGetDevice,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterGetDeviceHandler(0, func(uint16, HandlerContext) (st2138.Device, StatusResult) {
+				srv.RegisterGetDeviceHandler(0, func(uint16, HandlerContext, Stream[st2138.DeviceComponent]) StatusResult {
 					*handlerCalled = true
-					return Reply(st2138.Device{})
+					return StatusWithCode(StatusCodeOk, "")
 				})
-				_, status := srv.InvokeGetDeviceHandler(0, invalidContext)
-				return status
+				return srv.InvokeGetDeviceHandler(0, &sliceStream[st2138.DeviceComponent]{}, invalidContext)
 			},
 		},
 		{
@@ -1929,12 +1992,11 @@ func TestServer_InvokeEndpointsRouteThroughGate(t *testing.T) {
 		{
 			endpoint: EndpointReadAsset,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterReadAssetHandler(0, func(uint16, string, HandlerContext) (st2138.Asset, StatusResult) {
+				srv.RegisterReadAssetHandler(0, func(uint16, string, HandlerContext, Stream[st2138.Asset]) StatusResult {
 					*handlerCalled = true
-					return Reply(st2138.Asset{})
+					return StatusWithCode(StatusCodeOk, "")
 				})
-				_, status := srv.InvokeReadAssetHandler(0, "test/asset", invalidContext)
-				return status
+				return srv.InvokeReadAssetHandler(0, "test/asset", &sliceStream[st2138.Asset]{}, invalidContext)
 			},
 		},
 		{
@@ -2311,12 +2373,11 @@ func TestServer_AuthzDisabledAllowsRequestsWithoutToken(t *testing.T) {
 			endpoint:          EndpointGetDevice,
 			expectHandlerCall: true,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext) (st2138.Device, StatusResult) {
+				srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx HandlerContext, stream Stream[st2138.DeviceComponent]) StatusResult {
 					*handlerCalled = true
-					return Reply(st2138.Device{})
+					return StatusWithCode(StatusCodeOk, "")
 				})
-				_, status := srv.InvokeGetDeviceHandler(0, TransportContext{})
-				return status
+				return srv.InvokeGetDeviceHandler(0, &sliceStream[st2138.DeviceComponent]{}, TransportContext{})
 			},
 		},
 		{
@@ -2358,12 +2419,11 @@ func TestServer_AuthzDisabledAllowsRequestsWithoutToken(t *testing.T) {
 			endpoint:          EndpointReadAsset,
 			expectHandlerCall: true,
 			invoke: func(srv *server, handlerCalled *bool) StatusResult {
-				srv.RegisterReadAssetHandler(0, func(slot uint16, fqoid string, ctx HandlerContext) (st2138.Asset, StatusResult) {
+				srv.RegisterReadAssetHandler(0, func(slot uint16, fqoid string, ctx HandlerContext, stream Stream[st2138.Asset]) StatusResult {
 					*handlerCalled = true
-					return Reply(st2138.Asset{})
+					return StatusWithCode(StatusCodeOk, "")
 				})
-				_, status := srv.InvokeReadAssetHandler(0, "test/asset", TransportContext{})
-				return status
+				return srv.InvokeReadAssetHandler(0, "test/asset", &sliceStream[st2138.Asset]{}, TransportContext{})
 			},
 		},
 		{

--- a/sdks/go/pkg/catena/stream.go
+++ b/sdks/go/pkg/catena/stream.go
@@ -133,6 +133,9 @@ func (s productDeviceStream) Send(chunk st2138.DeviceComponent) error {
 	case *protos.DeviceComponent_Device:
 		if device := kind.Device; device != nil {
 			if s.hasMon {
+				if device.Params == nil {
+					device.Params = map[string]*protos.Param{}
+				}
 				device.Params[ProductOid] = ProductParam(s.product).Proto
 			} else {
 				delete(device.Params, ProductOid)

--- a/sdks/go/pkg/catena/stream.go
+++ b/sdks/go/pkg/catena/stream.go
@@ -110,11 +110,10 @@ func (nullStream[T]) Send(chunk T) error { return nil }
 //   - Device chunks: with mon, the SDK-managed product param is injected
 //     (overwriting any product param the business logic added); without mon,
 //     any product param is stripped.
-//   - ComponentParam chunks targeting product or product/*: without mon the
-//     chunk is silently dropped (Send returns nil so the handler keeps
-//     streaming). With mon, a chunk for the product oid itself is rewritten to
-//     the SDK-managed param, and product/* sub-param chunks are dropped since
-//     the SDK already delivers the whole product struct and owns its contents.
+//   - ComponentParam chunks targeting product or product/*: always dropped
+//     (Send returns nil so the handler keeps streaming). The SDK owns the
+//     product struct and already delivers it on the Device chunk when the
+//     caller holds mon, so a standalone product chunk is never needed.
 type productDeviceStream struct {
 	inner   Stream[st2138.DeviceComponent]
 	product ProductStruct
@@ -141,10 +140,7 @@ func (s productDeviceStream) Send(chunk st2138.DeviceComponent) error {
 		}
 	case *protos.DeviceComponent_Param:
 		if kind.Param != nil && isProductOid(kind.Param.GetOid()) {
-			if !s.hasMon || kind.Param.GetOid() != ProductOid {
-				return nil
-			}
-			kind.Param.Param = ProductParam(s.product).Proto
+			return nil
 		}
 	}
 	return s.inner.Send(chunk)

--- a/sdks/go/pkg/catena/stream.go
+++ b/sdks/go/pkg/catena/stream.go
@@ -133,7 +133,7 @@ func (s productDeviceStream) Send(chunk st2138.DeviceComponent) error {
 	case *protos.DeviceComponent_Device:
 		if device := kind.Device; device != nil {
 			if s.hasMon {
-				(&st2138.Device{Proto: device}).WithParam(ProductOid, ProductParam(s.product))
+				device.Params[ProductOid] = ProductParam(s.product).Proto
 			} else {
 				delete(device.Params, ProductOid)
 			}

--- a/sdks/go/pkg/catena/stream.go
+++ b/sdks/go/pkg/catena/stream.go
@@ -39,6 +39,7 @@ package catena
 import (
 	"context"
 
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 )
 
@@ -98,3 +99,53 @@ var _ Stream[Message] = (*nullStream[Message])(nil)
 
 // Send discards the chunk and always returns nil.
 func (nullStream[T]) Send(chunk T) error { return nil }
+
+// productDeviceStream wraps a DeviceRequest stream so the SDK-managed product
+// struct is enforced on the chunks a handler sends. The server installs it in
+// InvokeGetDeviceHandler only when a product struct is registered for the slot;
+// otherwise the handler's chunks pass through untouched.
+//
+// hasMon records whether the caller holds the st2138:mon read scope (the
+// product param's scope):
+//   - Device chunks: with mon, the SDK-managed product param is injected
+//     (overwriting any product param the business logic added); without mon,
+//     any product param is stripped.
+//   - ComponentParam chunks targeting product or product/*: without mon the
+//     chunk is silently dropped (Send returns nil so the handler keeps
+//     streaming). With mon, a chunk for the product oid itself is rewritten to
+//     the SDK-managed param, and product/* sub-param chunks are dropped since
+//     the SDK already delivers the whole product struct and owns its contents.
+type productDeviceStream struct {
+	inner   Stream[st2138.DeviceComponent]
+	product ProductStruct
+	hasMon  bool
+}
+
+var _ Stream[st2138.DeviceComponent] = productDeviceStream{}
+
+// Send applies the product policy to the chunk, then delivers it to the inner
+// stream (or drops it, returning nil, when the policy says the caller may not
+// see it).
+func (s productDeviceStream) Send(chunk st2138.DeviceComponent) error {
+	if chunk.Proto == nil {
+		return s.inner.Send(chunk)
+	}
+	switch kind := chunk.Proto.Kind.(type) {
+	case *protos.DeviceComponent_Device:
+		if device := kind.Device; device != nil {
+			if s.hasMon {
+				(&st2138.Device{Proto: device}).WithParam(ProductOid, ProductParam(s.product))
+			} else {
+				delete(device.Params, ProductOid)
+			}
+		}
+	case *protos.DeviceComponent_Param:
+		if kind.Param != nil && isProductOid(kind.Param.GetOid()) {
+			if !s.hasMon || kind.Param.GetOid() != ProductOid {
+				return nil
+			}
+			kind.Param.Param = ProductParam(s.product).Proto
+		}
+	}
+	return s.inner.Send(chunk)
+}

--- a/sdks/go/pkg/catena/stream_test.go
+++ b/sdks/go/pkg/catena/stream_test.go
@@ -123,6 +123,44 @@ func TestProductDeviceStream(t *testing.T) {
 			t.Errorf("chunk proto = %v, want it delivered untouched (nil)", inner.Items[0].Proto)
 		}
 	})
+
+	t.Run("injects product into a device chunk whose params map is nil", func(t *testing.T) {
+		// NewDevice leaves Params nil, and handlers may stream such a
+		// skeleton (oneOfEverything slot 0 does); injection must initialize
+		// the map rather than assign into nil.
+		inner := &sliceStream[st2138.DeviceComponent]{}
+		stream := productDeviceStream{inner: inner, product: testProduct(), hasMon: true}
+
+		if err := stream.Send(st2138.ComponentDevice(st2138.NewDevice(0))); err != nil {
+			t.Fatalf("Send returned error: %v", err)
+		}
+		if len(inner.Items) != 1 {
+			t.Fatalf("inner received %d chunks, want 1", len(inner.Items))
+		}
+		device := inner.Items[0].Proto.GetDevice()
+		if device == nil {
+			t.Fatal("chunk carries no device")
+		}
+		if device.GetParams()[ProductOid] == nil {
+			t.Errorf("product param not injected; params = %v", device.GetParams())
+		}
+	})
+
+	t.Run("strips product from a device chunk without mon scope", func(t *testing.T) {
+		device := st2138.NewDevice(0).WithParam(ProductOid, ProductParam(testProduct()))
+		inner := &sliceStream[st2138.DeviceComponent]{}
+		stream := productDeviceStream{inner: inner, product: testProduct(), hasMon: false}
+
+		if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
+			t.Fatalf("Send returned error: %v", err)
+		}
+		if len(inner.Items) != 1 {
+			t.Fatalf("inner received %d chunks, want 1", len(inner.Items))
+		}
+		if params := inner.Items[0].Proto.GetDevice().GetParams(); params[ProductOid] != nil {
+			t.Errorf("product param not stripped; params = %v", params)
+		}
+	})
 }
 
 // This is just testing the test infrastructure

--- a/sdks/go/pkg/catena/stream_test.go
+++ b/sdks/go/pkg/catena/stream_test.go
@@ -42,6 +42,8 @@ import (
 	"testing"
 
 	"google.golang.org/protobuf/proto"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 )
 
 type stubMessage struct {
@@ -98,6 +100,27 @@ func TestNullStream(t *testing.T) {
 
 		if err := stream.Send(stubMessage{id: 1}); err != nil {
 			t.Fatalf("Send returned error: %v", err)
+		}
+	})
+}
+
+// The product policy in productDeviceStream is exercised end-to-end through the
+// server in product_server_test.go; this covers the wrapper's own guard.
+func TestProductDeviceStream(t *testing.T) {
+	t.Run("passes a bodyless chunk straight through", func(t *testing.T) {
+		// A chunk with no proto body carries no device and no param oid, so
+		// there is nothing for the policy to inject, strip, or drop.
+		inner := &sliceStream[st2138.DeviceComponent]{}
+		stream := productDeviceStream{inner: inner, product: testProduct(), hasMon: true}
+
+		if err := stream.Send(st2138.DeviceComponent{}); err != nil {
+			t.Fatalf("Send returned error: %v", err)
+		}
+		if len(inner.Items) != 1 {
+			t.Fatalf("inner received %d chunks, want 1", len(inner.Items))
+		}
+		if inner.Items[0].Proto != nil {
+			t.Errorf("chunk proto = %v, want it delivered untouched (nil)", inner.Items[0].Proto)
 		}
 	})
 }

--- a/sdks/go/pkg/st2138/asset.go
+++ b/sdks/go/pkg/st2138/asset.go
@@ -88,6 +88,16 @@ type Asset struct {
 	Proto *protos.ExternalObjectPayload
 }
 
+// Ensure Asset can be streamed as a Message (one chunk of a streamed
+// ReadAsset / ExternalObjectRequest response).
+var _ Message = Asset{}
+
+// Wire returns the underlying protos.ExternalObjectPayload as the streamed
+// chunk's wire representation.
+func (a Asset) Wire() proto.Message {
+	return a.Proto
+}
+
 // DataPayload is a helper type for business logic to create assets
 // It mirrors protos.DataPayload structure for convenient construction
 type DataPayload struct {

--- a/sdks/go/pkg/st2138/asset_test.go
+++ b/sdks/go/pkg/st2138/asset_test.go
@@ -1062,6 +1062,16 @@ func TestCompressDeflateTo_CloseError(t *testing.T) {
 	}
 }
 
+func TestAsset_Wire(t *testing.T) {
+	asset, err := ToAsset(DataPayload{Payload: []byte("data")}, false)
+	if err != nil {
+		t.Fatalf("ToAsset failed: %v", err)
+	}
+	if wire := asset.Wire(); wire != asset.Proto {
+		t.Errorf("expected Wire() to return the underlying proto, got %v", wire)
+	}
+}
+
 func TestEncoding_String(t *testing.T) {
 	tests := []struct {
 		enc  Encoding

--- a/sdks/go/pkg/st2138/device_component.go
+++ b/sdks/go/pkg/st2138/device_component.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief DeviceComponent chunk type for streamed DeviceRequest responses.
+ * @file device_component.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package st2138
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+// DeviceComponent wraps protos.DeviceComponent, one chunk of a streamed
+// DeviceRequest response. A small device model is typically sent as a single
+// ComponentDevice chunk; a large one may be broken into a ComponentDevice
+// skeleton followed by ComponentParam / ComponentConstraint / ComponentMenu /
+// ComponentCommand / ComponentLanguagePack chunks that fill in the pieces.
+// Proto is the underlying proto message; it may be read or replaced directly.
+type DeviceComponent struct {
+	Proto *protos.DeviceComponent
+}
+
+// Ensure DeviceComponent can be streamed as a Message.
+var _ Message = DeviceComponent{}
+
+// Wire returns the underlying protos.DeviceComponent as the streamed chunk's
+// wire representation.
+func (c DeviceComponent) Wire() proto.Message {
+	return c.Proto
+}
+
+// ComponentDevice wraps a whole device model (or the top-level skeleton of
+// one) as a DeviceComponent chunk. The device's proto is referenced, not
+// copied, so it must not be mutated after being sent.
+func ComponentDevice(device *Device) DeviceComponent {
+	var protoDevice *protos.Device
+	if device != nil {
+		protoDevice = device.Proto
+	}
+	return DeviceComponent{
+		Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_Device{Device: protoDevice},
+		},
+	}
+}
+
+// ComponentParam wraps one parameter descriptor as a DeviceComponent chunk.
+// oid locates the param within device["params"] (RFC 6901 JSON pointer, e.g.
+// "monitor" or "monitor/eq").
+func ComponentParam(oid string, param *Param) DeviceComponent {
+	var protoParam *protos.Param
+	if param != nil {
+		protoParam = param.Proto
+	}
+	return DeviceComponent{
+		Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_Param{
+				Param: &protos.DeviceComponent_ComponentParam{
+					Oid:   oid,
+					Param: protoParam,
+				},
+			},
+		},
+	}
+}
+
+// ComponentConstraint wraps one shared constraint as a DeviceComponent chunk.
+// oid is relative to the device's top-level constraints object.
+func ComponentConstraint(oid string, constraint *Constraint) DeviceComponent {
+	var protoConstraint *protos.Constraint
+	if constraint != nil {
+		protoConstraint = constraint.Proto
+	}
+	return DeviceComponent{
+		Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_SharedConstraint{
+				SharedConstraint: &protos.DeviceComponent_ComponentConstraint{
+					Oid:        oid,
+					Constraint: protoConstraint,
+				},
+			},
+		},
+	}
+}
+
+// ComponentMenu wraps one menu as a DeviceComponent chunk. oid identifies the
+// menu relative to the device's top-level menu-groups object as
+// "menu-group-name/menu-name", e.g. "status/vendor_info".
+func ComponentMenu(oid string, menu *Menu) DeviceComponent {
+	var protoMenu *protos.Menu
+	if menu != nil {
+		protoMenu = menu.Proto
+	}
+	return DeviceComponent{
+		Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_Menu{
+				Menu: &protos.DeviceComponent_ComponentMenu{
+					Oid:  oid,
+					Menu: protoMenu,
+				},
+			},
+		},
+	}
+}
+
+// ComponentCommand wraps one command descriptor as a DeviceComponent chunk.
+// oid locates the command within device["commands"].
+func ComponentCommand(oid string, command *Param) DeviceComponent {
+	var protoCommand *protos.Param
+	if command != nil {
+		protoCommand = command.Proto
+	}
+	return DeviceComponent{
+		Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_Command{
+				Command: &protos.DeviceComponent_ComponentCommand{
+					Oid:     oid,
+					Command: protoCommand,
+				},
+			},
+		},
+	}
+}
+
+// ComponentLanguagePack wraps one language pack as a DeviceComponent chunk.
+// language is the language code that identifies the pack (e.g. "en"), name is
+// the pack's display name (e.g. "Global Spanish"), and words maps word keys to
+// display strings. The words map is referenced, not copied.
+func ComponentLanguagePack(language, name string, words map[string]string) DeviceComponent {
+	return DeviceComponent{
+		Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_LanguagePack{
+				LanguagePack: &protos.DeviceComponent_ComponentLanguagePack{
+					Language: language,
+					LanguagePack: &protos.LanguagePack{
+						Name:  name,
+						Words: words,
+					},
+				},
+			},
+		},
+	}
+}

--- a/sdks/go/pkg/st2138/device_component_test.go
+++ b/sdks/go/pkg/st2138/device_component_test.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Tests for DeviceComponent chunk constructors.
+ * @file device_component_test.go
+ * @copyright Copyright © 2026 Ross Video Ltd
+ */
+
+package st2138
+
+import (
+	"testing"
+
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+)
+
+func TestComponentDevice(t *testing.T) {
+	device := NewDevice(3)
+	chunk := ComponentDevice(device)
+
+	got := chunk.Proto.GetDevice()
+	if got != device.Proto {
+		t.Errorf("expected the chunk to reference the device's proto, got %v", got)
+	}
+	if got.GetSlot() != 3 {
+		t.Errorf("expected slot 3, got %d", got.GetSlot())
+	}
+}
+
+func TestComponentDevice_Nil(t *testing.T) {
+	chunk := ComponentDevice(nil)
+	if _, ok := chunk.Proto.GetKind().(*protos.DeviceComponent_Device); !ok {
+		t.Errorf("expected a Device-kind chunk, got %v", chunk.Proto.GetKind())
+	}
+	if chunk.Proto.GetDevice() != nil {
+		t.Errorf("expected nil device, got %v", chunk.Proto.GetDevice())
+	}
+}
+
+func TestComponentParam(t *testing.T) {
+	param := NewParamInt32(42)
+	chunk := ComponentParam("brightness", param)
+
+	component := chunk.Proto.GetParam()
+	if component.GetOid() != "brightness" {
+		t.Errorf("expected oid 'brightness', got %q", component.GetOid())
+	}
+	if component.GetParam() != param.Proto {
+		t.Errorf("expected the chunk to reference the param's proto, got %v", component.GetParam())
+	}
+}
+
+func TestComponentConstraint(t *testing.T) {
+	constraint := NewConstraintInt32Range(0, 100, 1)
+	chunk := ComponentConstraint("range", constraint)
+
+	component := chunk.Proto.GetSharedConstraint()
+	if component.GetOid() != "range" {
+		t.Errorf("expected oid 'range', got %q", component.GetOid())
+	}
+	if component.GetConstraint() != constraint.Proto {
+		t.Errorf("expected the chunk to reference the constraint's proto, got %v", component.GetConstraint())
+	}
+}
+
+func TestComponentMenu(t *testing.T) {
+	menu := NewMenu().WithParamOids("brightness")
+	chunk := ComponentMenu("status/main", menu)
+
+	component := chunk.Proto.GetMenu()
+	if component.GetOid() != "status/main" {
+		t.Errorf("expected oid 'status/main', got %q", component.GetOid())
+	}
+	if component.GetMenu() != menu.Proto {
+		t.Errorf("expected the chunk to reference the menu's proto, got %v", component.GetMenu())
+	}
+}
+
+func TestComponentCommand(t *testing.T) {
+	command := NewParamEmpty()
+	chunk := ComponentCommand("reset", command)
+
+	component := chunk.Proto.GetCommand()
+	if component.GetOid() != "reset" {
+		t.Errorf("expected oid 'reset', got %q", component.GetOid())
+	}
+	if component.GetCommand() != command.Proto {
+		t.Errorf("expected the chunk to reference the command's proto, got %v", component.GetCommand())
+	}
+}
+
+func TestComponentLanguagePack(t *testing.T) {
+	chunk := ComponentLanguagePack("en", "English", map[string]string{"greeting": "Hello"})
+
+	component := chunk.Proto.GetLanguagePack()
+	if component.GetLanguage() != "en" {
+		t.Errorf("expected language 'en', got %q", component.GetLanguage())
+	}
+	pack := component.GetLanguagePack()
+	if pack.GetName() != "English" {
+		t.Errorf("expected pack name 'English', got %q", pack.GetName())
+	}
+	if pack.GetWords()["greeting"] != "Hello" {
+		t.Errorf("expected greeting 'Hello', got %q", pack.GetWords()["greeting"])
+	}
+}
+
+func TestDeviceComponent_Wire(t *testing.T) {
+	chunk := ComponentDevice(NewDevice(1))
+	wire := chunk.Wire()
+	if wire != chunk.Proto {
+		t.Errorf("expected Wire() to return the underlying proto, got %v", wire)
+	}
+}

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -44,9 +44,12 @@ func main() {
     })
 
     // Register handlers once. All registered transports share this runtime.
-    srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext) (st2138.Device, catena.StatusResult) {
+    srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
         device := st2138.NewDevice(slot)
-        return catena.Reply(*device)
+        if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
+            return catena.StatusWithCode(catena.StatusCodeInternal, err.Error())
+        }
+        return catena.StatusWithCode(catena.StatusCodeOk, "")
     })
 
     if err := srv.RegisterTransport(grpc.NewTransport(grpc.DefaultOptions())); err != nil {

--- a/sdks/go/pkg/transports/README.md
+++ b/sdks/go/pkg/transports/README.md
@@ -44,12 +44,11 @@ func main() {
     })
 
     // Register handlers once. All registered transports share this runtime.
+    // catena.DeviceComponentsForRequest chunks a whole device into
+    // DeviceComponent stream sends; a small model could equally be sent as a
+    // single st2138.ComponentDevice chunk.
     srv.RegisterGetDeviceHandler(0, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
-        device := st2138.NewDevice(slot)
-        if err := stream.Send(st2138.ComponentDevice(device)); err != nil {
-            return catena.StatusWithCode(catena.StatusCodeInternal, err.Error())
-        }
-        return catena.StatusWithCode(catena.StatusCodeOk, "")
+        return catena.DeviceComponentsForRequest(st2138.NewDevice(slot), stream)
     })
 
     if err := srv.RegisterTransport(grpc.NewTransport(grpc.DefaultOptions())); err != nil {

--- a/sdks/go/pkg/transports/grpc/GRPC.md
+++ b/sdks/go/pkg/transports/grpc/GRPC.md
@@ -55,12 +55,12 @@ Behavior:
 Implemented against shared runtime handlers:
 
 - `GetPopulatedSlots`
-- `DeviceRequest`
+- `DeviceRequest` (server-streaming response)
 - `GetValue`
 - `GetParam`
 - `SetValue`
 - `MultiSetValue`
-- `ExternalObjectRequest`
+- `ExternalObjectRequest` (server-streaming response)
 - `ExecuteCommand` (server-streaming response)
 - `ParamInfoRequest` (server-streaming response)
 - `Connect`
@@ -86,16 +86,27 @@ RPC methods invoke the same handlers registered on `catena.Server`:
 - `ExecuteCommand` -> `RegisterExecuteCommandHandler`
 - `ParamInfoRequest` -> `RegisterParamInfoHandler`
 
-## Streaming Responses (`ParamInfoRequest`, `ExecuteCommand`)
+## Streaming Responses (`DeviceRequest`, `ExternalObjectRequest`, `ParamInfoRequest`, `ExecuteCommand`)
 
-`ParamInfoRequest` and `ExecuteCommand` are server-streaming RPCs. Each response
-chunk is sent over the gRPC stream as its wire proto (`ParamInfoResponse` /
-`CommandResponse`).
+`DeviceRequest`, `ExternalObjectRequest`, `ParamInfoRequest`, and
+`ExecuteCommand` are server-streaming RPCs. The registered handler receives a
+`catena.Stream[T]` and calls `stream.Send(chunk)` for each response; every
+chunk is sent over the gRPC stream as its wire proto (`DeviceComponent` /
+`ExternalObjectPayload` / `ParamInfoResponse` / `CommandResponse`).
 
 - A stream that produces no chunks completes as an empty successful stream
   (EOF), not an error.
 - A terminal error is returned as the RPC status via `ToGRPCCode`; any chunks
   already sent remain on the stream.
+- `DeviceRequest`: a small device model is typically one `ComponentDevice`
+  chunk; a large one may be broken into a device skeleton followed by
+  param / shared-constraint / menu / command / language-pack components
+  (built with the `st2138.Component*` constructors). Clients merge the
+  components back into one device model.
+- `ExternalObjectRequest`: a large asset may be broken into several
+  `ExternalObjectPayload` chunks; the client concatenates the embedded
+  payload bytes in send order (metadata, digest, and cachable come from the
+  first chunk).
 - `ExecuteCommand` reads `req.Respond` (a proto bool, defaulting to `false`) to
   gate responses. When `Respond` is `false` the stream completes with no
   `CommandResponse` messages; a client must set `Respond=true` to receive them.

--- a/sdks/go/pkg/transports/grpc/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport.go
@@ -46,7 +46,6 @@ import (
 	"fmt"
 	"maps"
 	"net"
-	"strings"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
@@ -267,13 +266,6 @@ func (t *Transport) retrieveMetadataFromContext(ctx context.Context) catena.Tran
 	return transportContext
 }
 
-// normalizeFqoid strips the leading slash some clients (e.g. DashBoard) put on
-// wire oids, so handlers always see the slash-free form the spec defines and
-// the REST transport already produces from URL path segments.
-func normalizeFqoid(fqoid string) string {
-	return strings.TrimPrefix(fqoid, "/")
-}
-
 // struct to hold the endpoint implementations for the gRPC service. We embed the unimplemented server
 type catenaService struct {
 	transport *Transport
@@ -324,7 +316,7 @@ func (s *catenaService) GetValue(ctx context.Context, req *protos.GetValuePayloa
 		return nil, status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	fqoid := normalizeFqoid(req.Oid)
+	fqoid := req.Oid
 	logger.Info("GetValue", "slot", slot, "fqoid", fqoid)
 
 	transportContext := s.transport.retrieveMetadataFromContext(ctx)
@@ -349,7 +341,7 @@ func (s *catenaService) SetValue(ctx context.Context, req *protos.SingleSetValue
 		return nil, status.Error(codes.InvalidArgument, "value payload is nil")
 	}
 
-	fqoid := normalizeFqoid(req.Value.Oid)
+	fqoid := req.Value.Oid
 	logger.Info("SetValue", "slot", slot, "fqoid", fqoid)
 
 	// Convert proto value to native Go type
@@ -382,7 +374,7 @@ func (s *catenaService) MultiSetValue(ctx context.Context, req *protos.MultiSetV
 
 	entries := make([]catena.SetValueEntry, 0, len(req.Values))
 	for _, setValue := range req.Values {
-		fqoid := normalizeFqoid(setValue.Oid)
+		fqoid := setValue.Oid
 
 		nativeValue, errProto := st2138.FromProto(setValue.Value)
 		if errProto != nil {
@@ -409,7 +401,7 @@ func (s *catenaService) ExternalObjectRequest(req *protos.ExternalObjectRequestP
 		return status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	fqoid := normalizeFqoid(req.Oid)
+	fqoid := req.Oid
 	logger.Info("ExternalObjectRequest", "slot", slot, "fqoid", fqoid)
 
 	transportContext := s.transport.retrieveMetadataFromContext(stream.Context())
@@ -431,7 +423,7 @@ func (s *catenaService) ExecuteCommand(req *protos.ExecuteCommandPayload, stream
 		return status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	commandFqoid := normalizeFqoid(req.Oid)
+	commandFqoid := req.Oid
 	logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid)
 
 	var payload any
@@ -463,7 +455,7 @@ func (s *catenaService) GetParam(ctx context.Context, req *protos.GetParamPayloa
 		return nil, status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	fqoid := normalizeFqoid(req.Oid)
+	fqoid := req.Oid
 	logger.Info("GetParam", "slot", slot, "fqoid", fqoid)
 
 	transportContext := s.transport.retrieveMetadataFromContext(ctx)
@@ -490,7 +482,7 @@ func (s *catenaService) ParamInfoRequest(req *protos.ParamInfoRequestPayload, st
 		return status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	oidPrefix := normalizeFqoid(req.GetOidPrefix())
+	oidPrefix := req.GetOidPrefix()
 	recursive := req.GetRecursive()
 	logger.Info("ParamInfoRequest", "slot", slot, "oid_prefix", oidPrefix, "recursive", recursive)
 

--- a/sdks/go/pkg/transports/grpc/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport.go
@@ -298,26 +298,15 @@ func (s *catenaService) DeviceRequest(req *protos.DeviceRequestPayload, stream g
 	logger.Info("DeviceRequest", "slot", slot)
 
 	transportContext := s.transport.retrieveMetadataFromContext(stream.Context())
-	device, res := s.transport.runtime.InvokeGetDeviceHandler(slot, transportContext)
+
+	adapter := &grpcStream[st2138.DeviceComponent]{ss: stream}
+	res := s.transport.runtime.InvokeGetDeviceHandler(slot, adapter, transportContext)
 	if res.IsError() {
 		logger.Error("DeviceRequest handler error", "slot", slot, "error", res.Error)
 		return status.Error(ToGRPCCode(res.Code), res.Error)
 	}
 
-	protoDevice := device.Proto
-	if protoDevice == nil {
-		logger.Error("DeviceRequest device returned nil", "slot", slot)
-		return status.Error(codes.Internal, "device returned nil")
-	}
-
-	// Wrap the device in a DeviceComponent
-	component := &protos.DeviceComponent{
-		Kind: &protos.DeviceComponent_Device{
-			Device: protoDevice,
-		},
-	}
-
-	return stream.Send(component)
+	return nil
 }
 
 // GetValue returns the value of a parameter
@@ -417,19 +406,14 @@ func (s *catenaService) ExternalObjectRequest(req *protos.ExternalObjectRequestP
 
 	transportContext := s.transport.retrieveMetadataFromContext(stream.Context())
 
-	asset, result := s.transport.runtime.InvokeReadAssetHandler(slot, fqoid, transportContext)
+	adapter := &grpcStream[st2138.Asset]{ss: stream}
+	result := s.transport.runtime.InvokeReadAssetHandler(slot, fqoid, adapter, transportContext)
 	if result.IsError() {
 		logger.Error("ExternalObjectRequest handler error", "slot", slot, "fqoid", fqoid, "error", result.Error)
 		return status.Error(ToGRPCCode(result.Code), result.Error)
 	}
 
-	protoAsset := asset.Proto
-	if protoAsset == nil {
-		logger.Error("ExternalObjectRequest asset returned nil", "slot", slot, "fqoid", fqoid)
-		return status.Error(codes.Internal, "asset returned nil")
-	}
-
-	return stream.Send(protoAsset)
+	return nil
 }
 
 // ExecuteCommand executes a command and streams the response

--- a/sdks/go/pkg/transports/grpc/grpc_transport.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport.go
@@ -46,6 +46,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"strings"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
 	"github.com/rossvideo/catena/sdks/go/pkg/logger"
@@ -266,6 +267,13 @@ func (t *Transport) retrieveMetadataFromContext(ctx context.Context) catena.Tran
 	return transportContext
 }
 
+// normalizeFqoid strips the leading slash some clients (e.g. DashBoard) put on
+// wire oids, so handlers always see the slash-free form the spec defines and
+// the REST transport already produces from URL path segments.
+func normalizeFqoid(fqoid string) string {
+	return strings.TrimPrefix(fqoid, "/")
+}
+
 // struct to hold the endpoint implementations for the gRPC service. We embed the unimplemented server
 type catenaService struct {
 	transport *Transport
@@ -316,7 +324,7 @@ func (s *catenaService) GetValue(ctx context.Context, req *protos.GetValuePayloa
 		return nil, status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	fqoid := req.Oid
+	fqoid := normalizeFqoid(req.Oid)
 	logger.Info("GetValue", "slot", slot, "fqoid", fqoid)
 
 	transportContext := s.transport.retrieveMetadataFromContext(ctx)
@@ -341,7 +349,7 @@ func (s *catenaService) SetValue(ctx context.Context, req *protos.SingleSetValue
 		return nil, status.Error(codes.InvalidArgument, "value payload is nil")
 	}
 
-	fqoid := req.Value.Oid
+	fqoid := normalizeFqoid(req.Value.Oid)
 	logger.Info("SetValue", "slot", slot, "fqoid", fqoid)
 
 	// Convert proto value to native Go type
@@ -374,7 +382,7 @@ func (s *catenaService) MultiSetValue(ctx context.Context, req *protos.MultiSetV
 
 	entries := make([]catena.SetValueEntry, 0, len(req.Values))
 	for _, setValue := range req.Values {
-		fqoid := setValue.Oid
+		fqoid := normalizeFqoid(setValue.Oid)
 
 		nativeValue, errProto := st2138.FromProto(setValue.Value)
 		if errProto != nil {
@@ -401,7 +409,7 @@ func (s *catenaService) ExternalObjectRequest(req *protos.ExternalObjectRequestP
 		return status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	fqoid := req.Oid
+	fqoid := normalizeFqoid(req.Oid)
 	logger.Info("ExternalObjectRequest", "slot", slot, "fqoid", fqoid)
 
 	transportContext := s.transport.retrieveMetadataFromContext(stream.Context())
@@ -423,7 +431,7 @@ func (s *catenaService) ExecuteCommand(req *protos.ExecuteCommandPayload, stream
 		return status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	commandFqoid := req.Oid
+	commandFqoid := normalizeFqoid(req.Oid)
 	logger.Info("ExecuteCommand", "slot", slot, "command", commandFqoid)
 
 	var payload any
@@ -455,7 +463,7 @@ func (s *catenaService) GetParam(ctx context.Context, req *protos.GetParamPayloa
 		return nil, status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	fqoid := req.Oid
+	fqoid := normalizeFqoid(req.Oid)
 	logger.Info("GetParam", "slot", slot, "fqoid", fqoid)
 
 	transportContext := s.transport.retrieveMetadataFromContext(ctx)
@@ -482,7 +490,7 @@ func (s *catenaService) ParamInfoRequest(req *protos.ParamInfoRequestPayload, st
 		return status.Error(ToGRPCCode(err.Code), err.Error)
 	}
 
-	oidPrefix := req.GetOidPrefix()
+	oidPrefix := normalizeFqoid(req.GetOidPrefix())
 	recursive := req.GetRecursive()
 	logger.Info("ParamInfoRequest", "slot", slot, "oid_prefix", oidPrefix, "recursive", recursive)
 

--- a/sdks/go/pkg/transports/grpc/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport_test.go
@@ -805,6 +805,30 @@ func TestTransport_SetValue_Success(t *testing.T) {
 	}
 }
 
+// Clients such as DashBoard send oids with a leading slash; the transport must
+// strip it so handlers see the slash-free form the REST transport produces.
+func TestTransport_SetValue_LeadingSlashNormalized(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestTransport(t, []uint16{0})
+	defer cleanup()
+
+	runtime.SetValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(entries))
+		}
+		if entries[0].Fqoid != "brightness" {
+			t.Errorf("expected fqoid 'brightness', got %q", entries[0].Fqoid)
+		}
+		return catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	_, err := makeSetValueRequest(t, client, ctx, 0, "/brightness", int32(50))
+	assertNoError(t, err)
+}
+
 func TestTransport_SetValue_InvalidSlot(t *testing.T) {
 	ctx := context.Background()
 	_, _, lis, cleanup := setupTestTransport(t, []uint16{0})

--- a/sdks/go/pkg/transports/grpc/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport_test.go
@@ -258,10 +258,9 @@ func TestTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "device request",
 			setup: func(t *testing.T, runtime *transporttest.StubServerRuntime) {
-				runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+				runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
 					assertContext(t, ctx)
-					device := *st2138.NewDevice(slot)
-					return catena.Reply(device)
+					return []st2138.DeviceComponent{st2138.ComponentDevice(st2138.NewDevice(slot))}, catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
 			},
 			run: func(t *testing.T, client rpc.CatenaServiceClient, ctx context.Context, cancel context.CancelFunc) {
@@ -386,11 +385,11 @@ func TestTransport_DeviceRequest_Success(t *testing.T) {
 
 	// Register mock handler
 	handlerCalled := false
-	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
 		handlerCalled = true
-		device := *st2138.NewDevice(slot).
+		device := st2138.NewDevice(slot).
 			WithDetailLevel(st2138.DetailLevelFull)
-		return catena.Reply(device)
+		return []st2138.DeviceComponent{st2138.ComponentDevice(device)}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -408,6 +407,46 @@ func TestTransport_DeviceRequest_Success(t *testing.T) {
 	}
 
 	// Verify stream is closed
+	_, err = stream.Recv()
+	if err != io.EOF {
+		t.Errorf("expected EOF, got %v", err)
+	}
+}
+
+func TestTransport_DeviceRequest_MultipleChunks(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestTransport(t, []uint16{0})
+	defer cleanup()
+
+	// The handler streams the device in pieces: a skeleton Device chunk
+	// followed by a param and a command component.
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+		return []st2138.DeviceComponent{
+			st2138.ComponentDevice(st2138.NewDevice(slot)),
+			st2138.ComponentParam("brightness", st2138.NewParamInt32(50)),
+			st2138.ComponentCommand("reset", st2138.NewParamEmpty()),
+		}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	stream, err := makeDeviceRequest(t, client, ctx, 0)
+	assertNoError(t, err)
+
+	first := receiveDeviceComponent(t, stream)
+	assertDevice(t, first.GetDevice(), 0)
+
+	second := receiveDeviceComponent(t, stream)
+	if got := second.GetParam().GetOid(); got != "brightness" {
+		t.Errorf("expected param chunk oid 'brightness', got %q", got)
+	}
+
+	third := receiveDeviceComponent(t, stream)
+	if got := third.GetCommand().GetOid(); got != "reset" {
+		t.Errorf("expected command chunk oid 'reset', got %q", got)
+	}
+
 	_, err = stream.Recv()
 	if err != io.EOF {
 		t.Errorf("expected EOF, got %v", err)
@@ -455,8 +494,8 @@ func TestTransport_DeviceRequest_HandlerError(t *testing.T) {
 	defer cleanup()
 
 	// Register handler that returns error
-	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
-		return catena.ReplyError[st2138.Device](catena.StatusCodeNotFound, "device not found")
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -928,14 +967,14 @@ func TestTransport_ExternalObjectRequest_Success(t *testing.T) {
 	defer cleanup()
 
 	handlerCalled := false
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 		handlerCalled = true
 		if fqoid != "device.image1" {
 			t.Errorf("expected fqoid 'device.image1', got %s", fqoid)
 		}
 		payload := st2138.ToPayloadFromURL("http://example.com/asset.jpg")
 		asset, _ := st2138.ToAsset(payload, true)
-		return catena.Reply(asset)
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -952,6 +991,41 @@ func TestTransport_ExternalObjectRequest_Success(t *testing.T) {
 	}
 
 	// Verify stream is closed
+	assertStreamEOF(t, stream)
+}
+
+func TestTransport_ExternalObjectRequest_MultipleChunks(t *testing.T) {
+	ctx := context.Background()
+	_, runtime, lis, cleanup := setupTestTransport(t, []uint16{0})
+	defer cleanup()
+
+	// The handler streams a large asset as several chunks whose payload bytes
+	// the client concatenates in send order.
+	chunks := [][]byte{[]byte("first-"), []byte("second-"), []byte("third")}
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		assets := make([]st2138.Asset, 0, len(chunks))
+		for _, data := range chunks {
+			asset, _ := st2138.ToAsset(st2138.ToPayload(data, "application/octet-stream", "blob.bin"), false)
+			assets = append(assets, asset)
+		}
+		return assets, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	client, cleanup := setupGRPCClient(t, ctx, lis)
+	defer cleanup()
+
+	stream, err := makeExternalObjectRequest(t, client, ctx, 0, "device.image1")
+	assertNoError(t, err)
+
+	var received []byte
+	for range chunks {
+		msg := receiveExternalObject(t, stream)
+		received = append(received, msg.GetPayload().GetPayload()...)
+	}
+	if got, want := string(received), "first-second-third"; got != want {
+		t.Errorf("concatenated payload = %q, want %q", got, want)
+	}
+
 	assertStreamEOF(t, stream)
 }
 
@@ -978,8 +1052,8 @@ func TestTransport_ExternalObjectRequest_HandlerError(t *testing.T) {
 	_, runtime, lis, cleanup := setupTestTransport(t, []uint16{0})
 	defer cleanup()
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
-		return catena.ReplyError[st2138.Asset](catena.StatusCodeNotFound, "asset not found")
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "asset not found")
 	}
 
 	client, cleanup := setupGRPCClient(t, ctx, lis)
@@ -1653,8 +1727,8 @@ func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
 			devMessage: "device not found",
 			grpcCode:   codes.NotFound,
 			setupHandlers: func(runtime *transporttest.StubServerRuntime) {
-				runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
-					return catena.ReplyError[st2138.Device](catena.StatusCodeNotFound, "device not found")
+				runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+					return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 				}
 			},
 			callEndpoint: func(client rpc.CatenaServiceClient, ctx context.Context) error {
@@ -1671,8 +1745,8 @@ func TestErrorMessages_DevVsProd_Streaming(t *testing.T) {
 			devMessage: "asset not found",
 			grpcCode:   codes.NotFound,
 			setupHandlers: func(runtime *transporttest.StubServerRuntime) {
-				runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
-					return catena.ReplyError[st2138.Asset](catena.StatusCodeNotFound, "asset not found")
+				runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+					return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "asset not found")
 				}
 			},
 			callEndpoint: func(client rpc.CatenaServiceClient, ctx context.Context) error {
@@ -2222,10 +2296,10 @@ func TestTransport_Start_EndpointsReachable(t *testing.T) {
 		return catena.Reply(value)
 	}
 
-	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
-		device := *st2138.NewDevice(slot).
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+		device := st2138.NewDevice(slot).
 			WithDetailLevel(st2138.DetailLevelFull)
-		return catena.Reply(device)
+		return []st2138.DeviceComponent{st2138.ComponentDevice(device)}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	// Start server in background. Port 0 makes net.Listen pick an available

--- a/sdks/go/pkg/transports/grpc/grpc_transport_test.go
+++ b/sdks/go/pkg/transports/grpc/grpc_transport_test.go
@@ -805,30 +805,6 @@ func TestTransport_SetValue_Success(t *testing.T) {
 	}
 }
 
-// Clients such as DashBoard send oids with a leading slash; the transport must
-// strip it so handlers see the slash-free form the REST transport produces.
-func TestTransport_SetValue_LeadingSlashNormalized(t *testing.T) {
-	ctx := context.Background()
-	_, runtime, lis, cleanup := setupTestTransport(t, []uint16{0})
-	defer cleanup()
-
-	runtime.SetValueFn = func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult {
-		if len(entries) != 1 {
-			t.Fatalf("expected 1 entry, got %d", len(entries))
-		}
-		if entries[0].Fqoid != "brightness" {
-			t.Errorf("expected fqoid 'brightness', got %q", entries[0].Fqoid)
-		}
-		return catena.StatusWithCode(catena.StatusCodeOk, "")
-	}
-
-	client, cleanup := setupGRPCClient(t, ctx, lis)
-	defer cleanup()
-
-	_, err := makeSetValueRequest(t, client, ctx, 0, "/brightness", int32(50))
-	assertNoError(t, err)
-}
-
 func TestTransport_SetValue_InvalidSlot(t *testing.T) {
 	ctx := context.Background()
 	_, _, lis, cleanup := setupTestTransport(t, []uint16{0})

--- a/sdks/go/pkg/transports/internal/transporttest/stub_server.go
+++ b/sdks/go/pkg/transports/internal/transporttest/stub_server.go
@@ -115,7 +115,6 @@ func (s *StubServerRuntime) InvokeGetDeviceHandler(slot uint16, stream catena.St
 		return status
 	}
 	s.panicf("GetDevice handler not implemented in stubServerRuntime for slot %d", slot)
-	return catena.StatusResult{Code: catena.StatusCodeInternal, Error: "GetDevice handler not implemented"}
 }
 
 func (s *StubServerRuntime) InvokeGetValueHandler(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Value, catena.StatusResult) {

--- a/sdks/go/pkg/transports/internal/transporttest/stub_server.go
+++ b/sdks/go/pkg/transports/internal/transporttest/stub_server.go
@@ -115,6 +115,7 @@ func (s *StubServerRuntime) InvokeGetDeviceHandler(slot uint16, stream catena.St
 		return status
 	}
 	s.panicf("GetDevice handler not implemented in stubServerRuntime for slot %d", slot)
+	return catena.StatusResult{Code: catena.StatusCodeInternal, Error: "GetDevice handler not implemented"}
 }
 
 func (s *StubServerRuntime) InvokeGetValueHandler(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Value, catena.StatusResult) {

--- a/sdks/go/pkg/transports/internal/transporttest/stub_server.go
+++ b/sdks/go/pkg/transports/internal/transporttest/stub_server.go
@@ -152,8 +152,7 @@ func (s *StubServerRuntime) InvokeReadAssetHandler(slot uint16, fqoid string, st
 		}
 		return status
 	}
-	s.panicf("ReadAsset handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid)
-	return catena.StatusResult{Code: catena.StatusCodeInternal, Error: "ReadAsset handler not implemented"}
+	panic(fmt.Sprintf("ReadAsset handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid))
 }
 
 func (s *StubServerRuntime) InvokeCreateAssetHandler(slot uint16, fqoid string, asset st2138.Asset, ctx catena.TransportContext) catena.StatusResult {

--- a/sdks/go/pkg/transports/internal/transporttest/stub_server.go
+++ b/sdks/go/pkg/transports/internal/transporttest/stub_server.go
@@ -54,11 +54,11 @@ type StubServerRuntime struct {
 	Dev                      bool
 	Slots                    []uint16
 	GetSlotsFn               func(ctx catena.TransportContext) ([]uint16, catena.StatusResult)
-	GetDeviceFn              func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult)
+	GetDeviceFn              func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult)
 	GetValueFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Value, catena.StatusResult)
 	GetParamFn               func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Param, catena.StatusResult)
 	SetValueFn               func(slot uint16, entries []catena.SetValueEntry, ctx catena.TransportContext) catena.StatusResult
-	ReadAssetFn              func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult)
+	ReadAssetFn              func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult)
 	CreateAssetFn            func(slot uint16, fqoid string, asset st2138.Asset, ctx catena.TransportContext) catena.StatusResult
 	UpdateAssetFn            func(slot uint16, fqoid string, asset st2138.Asset, ctx catena.TransportContext) catena.StatusResult
 	DeleteAssetFn            func(slot uint16, fqoid string, ctx catena.TransportContext) catena.StatusResult
@@ -104,12 +104,18 @@ func (s *StubServerRuntime) GetSlots(ctx catena.TransportContext) ([]uint16, cat
 	return s.Slots, catena.StatusResult{Code: catena.StatusCodeOk}
 }
 
-func (s *StubServerRuntime) InvokeGetDeviceHandler(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+func (s *StubServerRuntime) InvokeGetDeviceHandler(slot uint16, stream catena.Stream[st2138.DeviceComponent], ctx catena.TransportContext) catena.StatusResult {
 	if s.GetDeviceFn != nil {
-		return s.GetDeviceFn(slot, ctx)
+		components, status := s.GetDeviceFn(slot, ctx)
+		for _, component := range components {
+			if err := stream.Send(component); err != nil {
+				return catena.StatusWithCode(catena.StatusCodeInternal, err.Error())
+			}
+		}
+		return status
 	}
 	s.panicf("GetDevice handler not implemented in stubServerRuntime for slot %d", slot)
-	return catena.ReplyError[st2138.Device](catena.StatusCodeInternal, "GetDevice handler not implemented")
+	return catena.StatusResult{Code: catena.StatusCodeInternal, Error: "GetDevice handler not implemented"}
 }
 
 func (s *StubServerRuntime) InvokeGetValueHandler(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Value, catena.StatusResult) {
@@ -136,12 +142,18 @@ func (s *StubServerRuntime) InvokeSetValueHandler(slot uint16, entries []catena.
 	return catena.StatusResult{Code: catena.StatusCodeInternal}
 }
 
-func (s *StubServerRuntime) InvokeReadAssetHandler(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+func (s *StubServerRuntime) InvokeReadAssetHandler(slot uint16, fqoid string, stream catena.Stream[st2138.Asset], ctx catena.TransportContext) catena.StatusResult {
 	if s.ReadAssetFn != nil {
-		return s.ReadAssetFn(slot, fqoid, ctx)
+		chunks, status := s.ReadAssetFn(slot, fqoid, ctx)
+		for _, chunk := range chunks {
+			if err := stream.Send(chunk); err != nil {
+				return catena.StatusWithCode(catena.StatusCodeInternal, err.Error())
+			}
+		}
+		return status
 	}
 	s.panicf("ReadAsset handler not implemented in stubServerRuntime for slot %d, fqoid %s", slot, fqoid)
-	return catena.ReplyError[st2138.Asset](catena.StatusCodeInternal, "ReadAsset handler not implemented")
+	return catena.StatusResult{Code: catena.StatusCodeInternal, Error: "ReadAsset handler not implemented"}
 }
 
 func (s *StubServerRuntime) InvokeCreateAssetHandler(slot uint16, fqoid string, asset st2138.Asset, ctx catena.TransportContext) catena.StatusResult {

--- a/sdks/go/pkg/transports/rest/REST.md
+++ b/sdks/go/pkg/transports/rest/REST.md
@@ -52,12 +52,14 @@ Behavior:
 
 Core routes:
 
-- `GET /st2138-api/v1/{slot}` - DeviceRequest equivalent
+- `GET /st2138-api/v1/{slot}` - DeviceRequest equivalent (unary; aggregates the component stream into one device)
+- `GET /st2138-api/v1/{slot}/stream` - SSE DeviceRequest component stream
 - `GET /st2138-api/v1/{slot}/value/{oid}` - GetValue
 - `PUT /st2138-api/v1/{slot}/value/{oid}` - SetValue
 - `PUT /st2138-api/v1/{slot}/values` - SetValues (MultiSetValue)
 - `GET /st2138-api/v1/{slot}/param/{oid...}` - GetParam (full param: metadata + value)
-- `GET /st2138-api/v1/{slot}/asset/{oid}` - ExternalObjectRequest equivalent (ReadAsset)
+- `GET /st2138-api/v1/{slot}/asset/{oid}` - ExternalObjectRequest equivalent (ReadAsset; unary, aggregates the chunk stream into one asset)
+- `GET /st2138-api/v1/{slot}/asset/{oid}/stream` - SSE ReadAsset chunk stream
 - `POST /st2138-api/v1/{slot}/asset/{oid}` - CreateAsset (store a new asset, returns 204)
 - `PUT /st2138-api/v1/{slot}/asset/{oid}` - UpdateAsset (replace an asset, returns 204)
 - `DELETE /st2138-api/v1/{slot}/asset/{oid}` - DeleteAsset (remove an asset, returns 204)
@@ -78,20 +80,20 @@ Fallback and root behavior:
 
 REST routes invoke handlers registered on `catena.Server`:
 
-- Device route -> `RegisterGetDeviceHandler`
+- Device routes -> `RegisterGetDeviceHandler` (both the unary and `/stream` routes invoke the same streaming handler)
 - Value routes -> `RegisterGetValueHandler`, `RegisterSetValueHandler` (the set route delivers a one-element `[]SetValueEntry`)
 - Param route -> `RegisterGetParamHandler`
 - Values route -> `RegisterSetValueHandler` (delivers the full `[]SetValueEntry` for atomic application)
-- Asset routes -> `RegisterReadAssetHandler` (GET), `RegisterCreateAssetHandler` (POST), `RegisterUpdateAssetHandler` (PUT), `RegisterDeleteAssetHandler` (DELETE)
+- Asset routes -> `RegisterReadAssetHandler` (GET, both unary and `/stream`), `RegisterCreateAssetHandler` (POST), `RegisterUpdateAssetHandler` (PUT), `RegisterDeleteAssetHandler` (DELETE)
 - Command routes -> `RegisterExecuteCommandHandler` (both the unary and `/stream` routes invoke the same streaming handler)
 - Param-info routes -> `RegisterParamInfoHandler` (both the unary and `/stream` routes invoke the same streaming handler)
 
 ## Streaming Responses (SSE)
 
-Param-info and command each expose a unary route and a `/stream` route. The
-transport adapts the underlying response stream to the requested shape: the
-unary route collapses the stream to a single JSON body, while the `/stream`
-route emits Server-Sent Events.
+Device, asset read, param-info, and command each expose a unary route and a
+`/stream` route. The transport adapts the underlying response stream to the
+requested shape: the unary route collapses the stream to a single JSON body,
+while the `/stream` route emits Server-Sent Events.
 
 SSE framing:
 
@@ -109,6 +111,26 @@ Mid-stream errors (`SseError`):
   frame whose data is `{"code": <http-status>, "message": <text>}`.
 - The detailed message is only exposed in dev mode; otherwise it is generalized
   to the standard HTTP status text (and omitted when blank).
+
+Device routes:
+
+- The unary route aggregates the handler's `DeviceComponent` chunks back into
+  one complete device JSON body: a `device` chunk is the base, and later
+  `param` / `shared_constraint` / `menu` / `command` / `language_pack` chunks
+  are merged into the corresponding device maps. A success with no chunks is
+  reported as an internal error.
+- The `/stream` route forwards each `DeviceComponent` as one SSE frame.
+
+Asset routes:
+
+- The unary GET aggregates the handler's chunk stream into one
+  `external_object_payload` JSON body: metadata, digest, cachable, and the
+  payload encoding come from the first chunk, and the embedded payload bytes of
+  every chunk are concatenated in send order. A success with no chunks is
+  reported as an internal error.
+- The `/stream` route forwards each `ExternalObjectPayload` chunk as one SSE
+  frame; the client concatenates the embedded payload bytes. `?compression=` is
+  not supported on the streaming route (transcoding needs the whole payload).
 
 Param-info routes:
 
@@ -178,11 +200,14 @@ In production mode, error payload messages are sanitized to HTTP status text.
 
 ## Asset Compression
 
-Asset reads support optional payload transcoding via query parameter:
+Unary asset reads support optional payload transcoding via query parameter:
 
 - `GET /st2138-api/v1/{slot}/asset/{oid}?compression=<encoding>`
 
-If the requested encoding is invalid or transcoding fails, the transport returns a Catena error mapped to HTTP.
+Transcoding is applied to the fully assembled payload after chunk aggregation.
+If the requested encoding is invalid or transcoding fails, the transport
+returns a Catena error mapped to HTTP. The `/stream` route does not support
+`?compression=`.
 
 ## Graceful Shutdown
 

--- a/sdks/go/pkg/transports/rest/json_utils.go
+++ b/sdks/go/pkg/transports/rest/json_utils.go
@@ -119,6 +119,32 @@ func MarshalAssetJSON(asset *protos.ExternalObjectPayload) ([]byte, error) {
 	return protoMarshalOpts.Marshal(asset)
 }
 
+// MarshalDeviceComponentJSON marshals one streamed DeviceComponent chunk to
+// JSON with the same SMPTE-compliant treatment as MarshalDeviceJSON: it uses
+// EmitUnpopulated so meaningful proto3 defaults survive (e.g. a constraint's
+// min_value:0, or a current value of 0/0.0/""), then strips the
+// schema-forbidden extras from whichever oneof shape the chunk carries.
+func MarshalDeviceComponentJSON(component *protos.DeviceComponent) ([]byte, error) {
+	if component == nil {
+		return nil, nil
+	}
+	data, err := deviceMarshalOpts.Marshal(component)
+	if err != nil {
+		return nil, err
+	}
+	return cleanDeviceComponentJSON(data)
+}
+
+// marshalDeviceComponentWire adapts MarshalDeviceComponentJSON to the
+// restStream marshal signature, which hands over the chunk's wire proto.
+func marshalDeviceComponentWire(msg proto.Message) ([]byte, error) {
+	component, ok := msg.(*protos.DeviceComponent)
+	if !ok {
+		return nil, fmt.Errorf("expected *protos.DeviceComponent, got %T", msg)
+	}
+	return MarshalDeviceComponentJSON(component)
+}
+
 type jsonPrimitive interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
@@ -330,6 +356,34 @@ func cleanDeviceJSON(data []byte) ([]byte, error) {
 
 	deleteDefaultFields(v)
 	deleteResponseFromParams(v)
+	deleteEmptyFields(v)
+
+	return v.MarshalTo(nil), nil
+}
+
+// cleanDeviceComponentJSON strips the same schema-forbidden extras as
+// cleanDeviceJSON but for one streamed DeviceComponent chunk, whose oneof
+// determines where the device-shaped subtree lives: a device chunk nests the
+// full device under "device", a param chunk carries {"oid","param"} under
+// "param", and a command chunk keeps its "response" field since response is
+// valid on commands.
+func cleanDeviceComponentJSON(data []byte) ([]byte, error) {
+	var p fastjson.Parser
+	v, err := p.ParseBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("cleanDeviceComponentJSON parse: %w", err)
+	}
+
+	deleteDefaultFields(v)
+
+	if deviceVal := v.Get("device"); deviceVal != nil {
+		deleteResponseFromParams(deviceVal)
+	}
+	// "response" is only valid on commands; strip it from a param chunk's subtree.
+	if paramVal := v.Get("param"); paramVal != nil {
+		deleteResponseFalse(paramVal)
+	}
+
 	deleteEmptyFields(v)
 
 	return v.MarshalTo(nil), nil

--- a/sdks/go/pkg/transports/rest/json_utils_test.go
+++ b/sdks/go/pkg/transports/rest/json_utils_test.go
@@ -950,6 +950,54 @@ func TestMarshalDeviceJSON_CompleteDevice(t *testing.T) {
 	}
 }
 
+// --- MarshalDeviceComponentJSON tests ---
+
+func TestMarshalDeviceComponentJSON(t *testing.T) {
+	component := st2138.ComponentParam("brightness", st2138.NewParamInt32(0).
+		WithName(st2138.NewPolyglotText("en", "Brightness")))
+
+	jsonData, err := MarshalDeviceComponentJSON(component.Proto)
+	if err != nil {
+		t.Fatalf("MarshalDeviceComponentJSON error: %v", err)
+	}
+	body := string(jsonData)
+	if !strings.Contains(body, `"oid":"brightness"`) {
+		t.Errorf("expected the chunk's oid in output, got %s", body)
+	}
+	// EmitUnpopulated keeps a meaningful zero value on a bare param.
+	if !strings.Contains(body, `"int32_value":0`) {
+		t.Errorf("expected the param's zero value to survive, got %s", body)
+	}
+}
+
+func TestMarshalDeviceComponentJSON_Nil(t *testing.T) {
+	jsonData, err := MarshalDeviceComponentJSON(nil)
+	if err != nil {
+		t.Fatalf("MarshalDeviceComponentJSON error: %v", err)
+	}
+	if jsonData != nil {
+		t.Error("expected nil JSON data for a nil component")
+	}
+}
+
+func TestMarshalDeviceComponentJSON_MarshalError(t *testing.T) {
+	// An invalid UTF-8 string cannot be marshalled, so the error surfaces
+	// before the cleanup step ever runs.
+	component := st2138.ComponentParam("label", st2138.NewParamString("\xff"))
+
+	if _, err := MarshalDeviceComponentJSON(component.Proto); err == nil {
+		t.Fatal("expected error for invalid UTF-8 string")
+	}
+}
+
+func TestMarshalDeviceComponentWire_WrongType(t *testing.T) {
+	// The restStream hands over a bare proto.Message, so the adapter reports a
+	// chunk that is not a DeviceComponent rather than panicking on the cast.
+	if _, err := marshalDeviceComponentWire(&protos.Device{}); err == nil {
+		t.Fatal("expected error for a non-DeviceComponent message")
+	}
+}
+
 // --- MarshalAssetJSON tests (migrated from catena/asset_test.go) ---
 
 func TestInjectJSONField_String(t *testing.T) {

--- a/sdks/go/pkg/transports/rest/rest_transport.go
+++ b/sdks/go/pkg/transports/rest/rest_transport.go
@@ -440,10 +440,18 @@ func (t *Transport) registerRoutes() {
 
 		// Route based on path structure
 		if len(parts) == 3 && r.Method == http.MethodGet {
-			// GET /st2138-api/v1/{slot} - Get device info
-			transportContext := t.retrieveMetadataFromRequest(r)
-			device, result := t.runtime.InvokeGetDeviceHandler(slot, transportContext)
-			t.writeHTTPResult(w, result, device)
+			// GET /st2138-api/v1/{slot} - Get device info (unary)
+			t.handleGetDevice(w, r, slot)
+			return
+		}
+
+		if len(parts) == 4 && parts[3] == "stream" {
+			// GET /st2138-api/v1/{slot}/stream - SSE device component stream
+			if r.Method != http.MethodGet {
+				t.writeHTTPMethodNotAllowed(w, "only GET allowed")
+				return
+			}
+			t.streamDeviceRequest(w, r, slot)
 			return
 		}
 
@@ -625,12 +633,97 @@ func (t *Transport) handleValuesEndpoint(w http.ResponseWriter, r *http.Request,
 	t.writeHTTPStatusResultNoBody(w, res)
 }
 
+// handleGetDevice serves GET /st2138-api/v1/{slot} (unary DeviceRequest). The
+// handler streams DeviceComponent chunks; they are assembled back into one
+// complete device for the single JSON response.
+func (t *Transport) handleGetDevice(w http.ResponseWriter, r *http.Request, slot uint16) {
+	transportContext := t.retrieveMetadataFromRequest(r)
+
+	stream := &deviceAggregateStream{}
+	result := t.runtime.InvokeGetDeviceHandler(slot, stream, transportContext)
+	if result.IsError() {
+		t.writeHTTPStatusResult(w, result)
+		return
+	}
+
+	device, ok := stream.result()
+	if !ok {
+		// A unary device request must resolve to a device. A handler that
+		// reports success yet emits nothing has violated that contract; surface
+		// it as an internal error rather than inventing a NotFound over what may
+		// be a genuine handler bug. Handlers own NotFound for missing devices.
+		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "device handler reported success but produced no device"))
+		return
+	}
+
+	t.writeHTTPResult(w, result, device)
+}
+
+// streamDeviceRequest serves GET /st2138-api/v1/{slot}/stream, forwarding each
+// DeviceComponent chunk the handler sends as one Server-Sent Events frame. The
+// restStream writes SSE headers lazily on the first chunk, so if the handler
+// emits nothing before erroring this method can still report a status; once
+// chunks have been sent, a later error is reported in-band as an SSE "error"
+// event carrying the HTTP status code.
+func (t *Transport) streamDeviceRequest(w http.ResponseWriter, r *http.Request, slot uint16) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
+		return
+	}
+
+	transportContext := t.retrieveMetadataFromRequest(r)
+
+	stream := &restStream[st2138.DeviceComponent]{
+		w:       w,
+		flusher: flusher,
+		marshal: marshalDeviceComponentWire,
+		ctx:     r.Context(),
+		devMode: t.isDevMode(),
+	}
+	result := t.runtime.InvokeGetDeviceHandler(slot, stream, transportContext)
+
+	if result.IsError() {
+		// With nothing sent yet the HTTP status is still uncommitted, so we can
+		// set a normal error status. Once any chunk has been streamed the 200 is
+		// already on the wire, so the error is reported in-band as an SSE "error"
+		// event carrying the status code that would have been returned.
+		if stream.sent == 0 {
+			t.writeHTTPStatusResult(w, result)
+		} else if err := stream.sendError(result); err != nil {
+			logger.Error("failed to send device SSE error event", "slot", slot, "error", err)
+		}
+		return
+	}
+
+	// A successful handler that produced no chunks still gets a well-formed empty
+	// event stream so the client receives a valid 200 response.
+	if stream.sent == 0 {
+		stream.writeHeaders()
+	}
+}
+
 // handleAssetEndpoint dispatches /st2138-api/v1/{slot}/asset/{fqoid} across
 // the four asset operations: GET (ReadAsset), POST (CreateAsset), PUT
 // (UpdateAsset) and DELETE (DeleteAsset). The three write operations return
-// 204 No Content on success per the OpenAPI spec.
+// 204 No Content on success per the OpenAPI spec. A trailing "stream" path
+// segment selects the SSE variant of the GET read; what remains is the fqoid.
 func (t *Transport) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, slot uint16, pathParts []string) {
+	streaming := false
+	if len(pathParts) > 0 && pathParts[len(pathParts)-1] == "stream" {
+		streaming = true
+		pathParts = pathParts[:len(pathParts)-1]
+	}
 	fqoid := strings.Join(pathParts, "/")
+
+	if streaming {
+		if r.Method != http.MethodGet {
+			t.writeHTTPMethodNotAllowed(w, "only GET allowed")
+			return
+		}
+		t.streamReadAsset(w, r, slot, fqoid)
+		return
+	}
 
 	switch r.Method {
 	case http.MethodGet:
@@ -648,30 +741,94 @@ func (t *Transport) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, 
 	}
 }
 
-// handleReadAsset serves GET /st2138-api/v1/{slot}/asset/{fqoid}, with optional
-// payload transcoding via the ?compression= query parameter.
+// handleReadAsset serves GET /st2138-api/v1/{slot}/asset/{fqoid} (unary
+// ReadAsset), with optional payload transcoding via the ?compression= query
+// parameter. The handler streams asset chunks; their embedded payload bytes
+// are concatenated back into one complete asset for the single JSON response
+// (so transcoding operates on the assembled payload).
 func (t *Transport) handleReadAsset(w http.ResponseWriter, r *http.Request, slot uint16, fqoid string) {
 	transportContext := t.retrieveMetadataFromRequest(r)
-	asset, result := t.runtime.InvokeReadAssetHandler(slot, fqoid, transportContext)
 
-	if result.IsOk() {
-		if compressionStr := r.URL.Query().Get("compression"); compressionStr != "" {
-			targetEncoding, encErr := st2138.ParsePayloadEncoding(compressionStr)
-			if encErr != nil {
-				val, errRes := catena.ReplyError[st2138.Value](catena.StatusCodeInvalidArgument, encErr.Error())
-				t.writeHTTPResult(w, errRes, val)
-				return
-			}
-			if tcErr := st2138.TranscodeAssetPayload(&asset, targetEncoding); tcErr != nil {
-				logger.Error("failed to transcode asset payload", "error", tcErr)
-				val, errRes := catena.ReplyError[st2138.Value](catena.StatusCodeInternal, "failed to transcode payload: "+tcErr.Error())
-				t.writeHTTPResult(w, errRes, val)
-				return
-			}
+	stream := &assetAggregateStream{}
+	result := t.runtime.InvokeReadAssetHandler(slot, fqoid, stream, transportContext)
+	if result.IsError() {
+		t.writeHTTPStatusResult(w, result)
+		return
+	}
+
+	asset, ok := stream.result()
+	if !ok {
+		// A unary asset request must resolve to an asset. A handler that reports
+		// success yet emits nothing has violated that contract; surface it as an
+		// internal error rather than inventing a NotFound over what may be a
+		// genuine handler bug. Handlers own NotFound for missing fqoids.
+		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "asset handler reported success but produced no asset"))
+		return
+	}
+
+	if compressionStr := r.URL.Query().Get("compression"); compressionStr != "" {
+		targetEncoding, encErr := st2138.ParsePayloadEncoding(compressionStr)
+		if encErr != nil {
+			val, errRes := catena.ReplyError[st2138.Value](catena.StatusCodeInvalidArgument, encErr.Error())
+			t.writeHTTPResult(w, errRes, val)
+			return
+		}
+		if tcErr := st2138.TranscodeAssetPayload(&asset, targetEncoding); tcErr != nil {
+			logger.Error("failed to transcode asset payload", "error", tcErr)
+			val, errRes := catena.ReplyError[st2138.Value](catena.StatusCodeInternal, "failed to transcode payload: "+tcErr.Error())
+			t.writeHTTPResult(w, errRes, val)
+			return
 		}
 	}
 
 	t.writeHTTPResult(w, result, asset)
+}
+
+// streamReadAsset serves GET /st2138-api/v1/{slot}/asset/{fqoid}/stream,
+// forwarding each asset chunk the handler sends as one Server-Sent Events
+// frame (the client concatenates the chunks' embedded payload bytes in send
+// order). The ?compression= query parameter is not supported on the streaming
+// route: transcoding requires the whole payload, which the transport never
+// assembles here. The restStream writes SSE headers lazily on the first chunk,
+// so if the handler emits nothing before erroring this method can still report
+// a status; once chunks have been sent, a later error is reported in-band as
+// an SSE "error" event carrying the HTTP status code.
+func (t *Transport) streamReadAsset(w http.ResponseWriter, r *http.Request, slot uint16, fqoid string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
+		return
+	}
+
+	transportContext := t.retrieveMetadataFromRequest(r)
+
+	stream := &restStream[st2138.Asset]{
+		w:       w,
+		flusher: flusher,
+		marshal: MarshalProtoJSON,
+		ctx:     r.Context(),
+		devMode: t.isDevMode(),
+	}
+	result := t.runtime.InvokeReadAssetHandler(slot, fqoid, stream, transportContext)
+
+	if result.IsError() {
+		// With nothing sent yet the HTTP status is still uncommitted, so we can
+		// set a normal error status. Once any chunk has been streamed the 200 is
+		// already on the wire, so the error is reported in-band as an SSE "error"
+		// event carrying the status code that would have been returned.
+		if stream.sent == 0 {
+			t.writeHTTPStatusResult(w, result)
+		} else if err := stream.sendError(result); err != nil {
+			logger.Error("failed to send asset SSE error event", "slot", slot, "fqoid", fqoid, "error", err)
+		}
+		return
+	}
+
+	// A successful handler that produced no chunks still gets a well-formed empty
+	// event stream so the client receives a valid 200 response.
+	if stream.sent == 0 {
+		stream.writeHeaders()
+	}
 }
 
 // handleWriteAsset handles POST (CreateAsset) and PUT (UpdateAsset). Both read

--- a/sdks/go/pkg/transports/rest/rest_transport.go
+++ b/sdks/go/pkg/transports/rest/rest_transport.go
@@ -637,22 +637,12 @@ func (t *Transport) handleValuesEndpoint(w http.ResponseWriter, r *http.Request,
 // handler streams DeviceComponent chunks; they are assembled back into one
 // complete device for the single JSON response.
 func (t *Transport) handleGetDevice(w http.ResponseWriter, r *http.Request, slot uint16) {
-	transportContext := t.retrieveMetadataFromRequest(r)
-
-	stream := &deviceAggregateStream{}
-	result := t.runtime.InvokeGetDeviceHandler(slot, stream, transportContext)
+	device, result := resolveUnary(&deviceAggregateStream{}, "device",
+		func(stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
+			return t.runtime.InvokeGetDeviceHandler(slot, stream, t.retrieveMetadataFromRequest(r))
+		})
 	if result.IsError() {
 		t.writeHTTPStatusResult(w, result)
-		return
-	}
-
-	device, ok := stream.result()
-	if !ok {
-		// A unary device request must resolve to a device. A handler that
-		// reports success yet emits nothing has violated that contract; surface
-		// it as an internal error rather than inventing a NotFound over what may
-		// be a genuine handler bug. Handlers own NotFound for missing devices.
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "device handler reported success but produced no device"))
 		return
 	}
 
@@ -660,47 +650,14 @@ func (t *Transport) handleGetDevice(w http.ResponseWriter, r *http.Request, slot
 }
 
 // streamDeviceRequest serves GET /st2138-api/v1/{slot}/stream, forwarding each
-// DeviceComponent chunk the handler sends as one Server-Sent Events frame. The
-// restStream writes SSE headers lazily on the first chunk, so if the handler
-// emits nothing before erroring this method can still report a status; once
-// chunks have been sent, a later error is reported in-band as an SSE "error"
-// event carrying the HTTP status code.
+// DeviceComponent chunk the handler sends as one Server-Sent Events frame. See
+// streamSSE for the shared SSE semantics.
 func (t *Transport) streamDeviceRequest(w http.ResponseWriter, r *http.Request, slot uint16) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
-		return
-	}
-
-	transportContext := t.retrieveMetadataFromRequest(r)
-
-	stream := &restStream[st2138.DeviceComponent]{
-		w:       w,
-		flusher: flusher,
-		marshal: marshalDeviceComponentWire,
-		ctx:     r.Context(),
-		devMode: t.isDevMode(),
-	}
-	result := t.runtime.InvokeGetDeviceHandler(slot, stream, transportContext)
-
-	if result.IsError() {
-		// With nothing sent yet the HTTP status is still uncommitted, so we can
-		// set a normal error status. Once any chunk has been streamed the 200 is
-		// already on the wire, so the error is reported in-band as an SSE "error"
-		// event carrying the status code that would have been returned.
-		if stream.sent == 0 {
-			t.writeHTTPStatusResult(w, result)
-		} else if err := stream.sendError(result); err != nil {
-			logger.Error("failed to send device SSE error event", "slot", slot, "error", err)
-		}
-		return
-	}
-
-	// A successful handler that produced no chunks still gets a well-formed empty
-	// event stream so the client receives a valid 200 response.
-	if stream.sent == 0 {
-		stream.writeHeaders()
-	}
+	streamSSE(t, w, r, marshalDeviceComponentWire,
+		func(stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
+			return t.runtime.InvokeGetDeviceHandler(slot, stream, t.retrieveMetadataFromRequest(r))
+		},
+		"endpoint", "device", "slot", slot)
 }
 
 // handleAssetEndpoint dispatches /st2138-api/v1/{slot}/asset/{fqoid} across
@@ -747,22 +704,12 @@ func (t *Transport) handleAssetEndpoint(w http.ResponseWriter, r *http.Request, 
 // are concatenated back into one complete asset for the single JSON response
 // (so transcoding operates on the assembled payload).
 func (t *Transport) handleReadAsset(w http.ResponseWriter, r *http.Request, slot uint16, fqoid string) {
-	transportContext := t.retrieveMetadataFromRequest(r)
-
-	stream := &assetAggregateStream{}
-	result := t.runtime.InvokeReadAssetHandler(slot, fqoid, stream, transportContext)
+	asset, result := resolveUnary(&assetAggregateStream{}, "asset",
+		func(stream catena.Stream[st2138.Asset]) catena.StatusResult {
+			return t.runtime.InvokeReadAssetHandler(slot, fqoid, stream, t.retrieveMetadataFromRequest(r))
+		})
 	if result.IsError() {
 		t.writeHTTPStatusResult(w, result)
-		return
-	}
-
-	asset, ok := stream.result()
-	if !ok {
-		// A unary asset request must resolve to an asset. A handler that reports
-		// success yet emits nothing has violated that contract; surface it as an
-		// internal error rather than inventing a NotFound over what may be a
-		// genuine handler bug. Handlers own NotFound for missing fqoids.
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "asset handler reported success but produced no asset"))
 		return
 	}
 
@@ -789,46 +736,13 @@ func (t *Transport) handleReadAsset(w http.ResponseWriter, r *http.Request, slot
 // frame (the client concatenates the chunks' embedded payload bytes in send
 // order). The ?compression= query parameter is not supported on the streaming
 // route: transcoding requires the whole payload, which the transport never
-// assembles here. The restStream writes SSE headers lazily on the first chunk,
-// so if the handler emits nothing before erroring this method can still report
-// a status; once chunks have been sent, a later error is reported in-band as
-// an SSE "error" event carrying the HTTP status code.
+// assembles here. See streamSSE for the shared SSE semantics.
 func (t *Transport) streamReadAsset(w http.ResponseWriter, r *http.Request, slot uint16, fqoid string) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
-		return
-	}
-
-	transportContext := t.retrieveMetadataFromRequest(r)
-
-	stream := &restStream[st2138.Asset]{
-		w:       w,
-		flusher: flusher,
-		marshal: MarshalProtoJSON,
-		ctx:     r.Context(),
-		devMode: t.isDevMode(),
-	}
-	result := t.runtime.InvokeReadAssetHandler(slot, fqoid, stream, transportContext)
-
-	if result.IsError() {
-		// With nothing sent yet the HTTP status is still uncommitted, so we can
-		// set a normal error status. Once any chunk has been streamed the 200 is
-		// already on the wire, so the error is reported in-band as an SSE "error"
-		// event carrying the status code that would have been returned.
-		if stream.sent == 0 {
-			t.writeHTTPStatusResult(w, result)
-		} else if err := stream.sendError(result); err != nil {
-			logger.Error("failed to send asset SSE error event", "slot", slot, "fqoid", fqoid, "error", err)
-		}
-		return
-	}
-
-	// A successful handler that produced no chunks still gets a well-formed empty
-	// event stream so the client receives a valid 200 response.
-	if stream.sent == 0 {
-		stream.writeHeaders()
-	}
+	streamSSE(t, w, r, MarshalProtoJSON,
+		func(stream catena.Stream[st2138.Asset]) catena.StatusResult {
+			return t.runtime.InvokeReadAssetHandler(slot, fqoid, stream, t.retrieveMetadataFromRequest(r))
+		},
+		"endpoint", "asset", "slot", slot, "fqoid", fqoid)
 }
 
 // handleWriteAsset handles POST (CreateAsset) and PUT (UpdateAsset). Both read
@@ -939,23 +853,16 @@ func (t *Transport) handleParamInfoEndpoint(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Unary: the handler still streams, so collect its first message and discard the rest.
-	stream := &firstStream[st2138.ParamInfo]{}
-	result := t.runtime.InvokeParamInfoHandler(slot, oidPrefix, recursive, stream, transportContext)
+	info, result := resolveUnary(&firstStream[st2138.ParamInfo]{}, "param info",
+		func(stream catena.Stream[st2138.ParamInfo]) catena.StatusResult {
+			return t.runtime.InvokeParamInfoHandler(slot, oidPrefix, recursive, stream, transportContext)
+		})
 	if result.IsError() {
 		t.writeHTTPStatusResult(w, result)
 		return
 	}
 
-	if !stream.has {
-		// A unary request must resolve to exactly one parameter. A handler that
-		// reports success yet emits nothing has violated that contract; surface
-		// it as an internal error rather than inventing a NotFound over what may
-		// be a genuine handler bug. Handlers own NotFound for missing oids.
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "param info handler reported success but produced no result"))
-		return
-	}
-
-	if err := WriteProtoJSON(w, stream.item.Wire(), http.StatusOK); err != nil {
+	if err := WriteProtoJSON(w, info.Wire(), http.StatusOK); err != nil {
 		logger.Error("failed to write param info response", "error", err)
 	}
 }
@@ -1041,45 +948,15 @@ func (t *Transport) handleLanguagePackEndpoint(w http.ResponseWriter, r *http.Re
 }
 
 // streamParamInfo streams param info entries to the client as Server-Sent
-// Events. The restStream writes SSE headers lazily on the first chunk, so if the
-// handler emits nothing before erroring this method can still report a status;
-// once chunks have been sent, a later error is reported in-band as an SSE
-// "error" event carrying the HTTP status code.
+// Events. See streamSSE for the shared SSE semantics; here a successful handler
+// that produced no chunks is a legitimate empty result (e.g. a device with no
+// top-level params), not a NotFound, and yields an empty event stream.
 func (t *Transport) streamParamInfo(w http.ResponseWriter, r *http.Request, slot uint16, oidPrefix string, recursive bool, transportContext catena.TransportContext) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
-		return
-	}
-
-	stream := &restStream[st2138.ParamInfo]{
-		w:       w,
-		flusher: flusher,
-		marshal: MarshalProtoJSON,
-		ctx:     r.Context(),
-		devMode: t.isDevMode(),
-	}
-	result := t.runtime.InvokeParamInfoHandler(slot, oidPrefix, recursive, stream, transportContext)
-
-	if result.IsError() {
-		// With nothing sent yet the HTTP status is still uncommitted, so we can
-		// set a normal error status. Once any chunk has been streamed the 200 is
-		// already on the wire, so the error is reported in-band as an SSE "error"
-		// event carrying the status code that would have been returned.
-		if stream.sent == 0 {
-			t.writeHTTPStatusResult(w, result)
-		} else if err := stream.sendError(result); err != nil {
-			logger.Error("failed to send param-info SSE error event", "slot", slot, "oid_prefix", oidPrefix, "error", err)
-		}
-		return
-	}
-
-	// A successful handler that produced no chunks is a legitimate empty result
-	// (e.g. a device with no top-level params), not a NotFound. Commit the SSE
-	// headers so the client still receives a well-formed empty event stream.
-	if stream.sent == 0 {
-		stream.writeHeaders()
-	}
+	streamSSE(t, w, r, MarshalProtoJSON,
+		func(stream catena.Stream[st2138.ParamInfo]) catena.StatusResult {
+			return t.runtime.InvokeParamInfoHandler(slot, oidPrefix, recursive, stream, transportContext)
+		},
+		"endpoint", "param-info", "slot", slot, "oid_prefix", oidPrefix)
 }
 
 func (t *Transport) handleCommandEndpoint(w http.ResponseWriter, r *http.Request, slot uint16, pathParts []string) {
@@ -1165,10 +1042,12 @@ func (t *Transport) handleCommandEndpoint(w http.ResponseWriter, r *http.Request
 
 	// Reply with the final CommandResponse the handler sent. When the caller opted
 	// out (respond=false) the server gobbled every chunk, so nothing was retained
-	// and we reply with an explicit no_response.
+	// and we reply with an explicit no_response. That makes an empty stream
+	// legitimate here, which is why this route resolves the stream itself instead
+	// of going through resolveUnary.
 	cmdResult := st2138.CommandNoResponse()
-	if stream.has {
-		cmdResult = stream.item
+	if item, ok := stream.result(); ok {
+		cmdResult = item
 	}
 
 	if err := WriteProtoJSON(w, cmdResult.Proto, http.StatusOK); err != nil {
@@ -1177,42 +1056,14 @@ func (t *Transport) handleCommandEndpoint(w http.ResponseWriter, r *http.Request
 }
 
 // streamExecuteCommand streams command responses to the client as Server-Sent
-// Events. The restStream writes SSE headers lazily on the first chunk, so if the
-// handler emits nothing before erroring this method can still report a status.
-// respond is passed through so a smart handler can skip emitting responses.
+// Events. See streamSSE for the shared SSE semantics. respond is passed through
+// so a smart handler can skip emitting responses.
 func (t *Transport) streamExecuteCommand(w http.ResponseWriter, r *http.Request, slot uint16, commandOid string, payload any, respond bool, transportContext catena.TransportContext) {
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
-		return
-	}
-
-	stream := &restStream[st2138.CommandResponse]{
-		w:       w,
-		flusher: flusher,
-		marshal: MarshalProtoJSON,
-		ctx:     r.Context(),
-		devMode: t.isDevMode(),
-	}
-	result := t.runtime.InvokeExecuteCommandHandler(slot, commandOid, payload, respond, stream, transportContext)
-
-	if result.IsError() {
-		// Once any chunk has been streamed the HTTP status is committed, so a
-		// late error can only be logged. With nothing sent yet we can still set
-		// the error status.
-		if stream.sent == 0 {
-			t.writeHTTPStatusResult(w, result)
-		} else if err := stream.sendError(result); err != nil {
-			logger.Error("failed to send command SSE error event", "slot", slot, "command", commandOid, "error", err)
-		}
-		return
-	}
-
-	// A successful handler that produced no chunks still gets a well-formed empty
-	// event stream so the client receives a valid 200 response.
-	if stream.sent == 0 {
-		stream.writeHeaders()
-	}
+	streamSSE(t, w, r, MarshalProtoJSON,
+		func(stream catena.Stream[st2138.CommandResponse]) catena.StatusResult {
+			return t.runtime.InvokeExecuteCommandHandler(slot, commandOid, payload, respond, stream, transportContext)
+		},
+		"endpoint", "command", "slot", slot, "command_oid", commandOid)
 }
 
 // ToHTTPStatus converts a transport-neutral StatusCode to an HTTP status code.

--- a/sdks/go/pkg/transports/rest/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest/rest_transport_test.go
@@ -42,6 +42,7 @@ package rest
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -122,10 +123,9 @@ func TestTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "get device",
 			setup: func(t *testing.T, runtime *transporttest.StubServerRuntime) {
-				runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+				runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
 					assertContext(t, ctx)
-					device := *st2138.NewDevice(slot)
-					return catena.Reply(device)
+					return []st2138.DeviceComponent{st2138.ComponentDevice(st2138.NewDevice(slot))}, catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
 			},
 			run: func(t *testing.T, transport *Transport) {
@@ -190,10 +190,10 @@ func TestTransport_PropagatesTransportContext(t *testing.T) {
 		{
 			name: "get asset",
 			setup: func(t *testing.T, runtime *transporttest.StubServerRuntime) {
-				runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+				runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 					assertContext(t, ctx)
 					asset, _ := st2138.ToAsset(st2138.DataPayload{Payload: []byte("asset")}, false)
-					return catena.Reply(asset)
+					return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 				}
 			},
 			run: func(t *testing.T, transport *Transport) {
@@ -282,15 +282,15 @@ func TestTransport_GetDevice_Route(t *testing.T) {
 	transport, runtime := makeTestTransport(t)
 
 	handlerCalled := false
-	device := *st2138.NewDevice(0).
+	device := st2138.NewDevice(0).
 		WithDetailLevel(st2138.DetailLevelFull)
 
-	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
 		handlerCalled = true
 		if slot != 0 {
 			t.Errorf("expected slot 0, got %d", slot)
 		}
-		return catena.Reply(device)
+		return []st2138.DeviceComponent{st2138.ComponentDevice(device)}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0", "")
@@ -301,16 +301,170 @@ func TestTransport_GetDevice_Route(t *testing.T) {
 	}
 }
 
+// TestTransport_GetDevice_AggregatesComponents verifies the unary device route
+// assembles a multi-chunk stream (device skeleton plus param, command, shared
+// constraint, menu, and language-pack components) into one device JSON body.
+func TestTransport_GetDevice_AggregatesComponents(t *testing.T) {
+	transport, runtime := makeTestTransport(t)
+
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+		return []st2138.DeviceComponent{
+			st2138.ComponentDevice(st2138.NewDevice(slot).WithDetailLevel(st2138.DetailLevelFull)),
+			st2138.ComponentParam("brightness", st2138.NewParamInt32(50)),
+			st2138.ComponentCommand("reset", st2138.NewParamEmpty()),
+			st2138.ComponentConstraint("range", st2138.NewConstraintInt32Range(0, 100, 1)),
+			st2138.ComponentMenu("status/main", st2138.NewMenu().WithParamOids("brightness")),
+			st2138.ComponentLanguagePack("en", "English", map[string]string{"greeting": "Hello"}),
+		}, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0", "")
+	assertStatus(t, rec, http.StatusOK)
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	params, _ := result["params"].(map[string]any)
+	if _, ok := params["brightness"]; !ok {
+		t.Error("expected aggregated 'brightness' param in device body")
+	}
+	commands, _ := result["commands"].(map[string]any)
+	if _, ok := commands["reset"]; !ok {
+		t.Error("expected aggregated 'reset' command in device body")
+	}
+	constraints, _ := result["constraints"].(map[string]any)
+	if _, ok := constraints["range"]; !ok {
+		t.Error("expected aggregated 'range' constraint in device body")
+	}
+	menuGroups, _ := result["menu_groups"].(map[string]any)
+	statusGroup, _ := menuGroups["status"].(map[string]any)
+	menus, _ := statusGroup["menus"].(map[string]any)
+	if _, ok := menus["main"]; !ok {
+		t.Error("expected aggregated 'status/main' menu in device body")
+	}
+	languagePacks, _ := result["language_packs"].(map[string]any)
+	packs, _ := languagePacks["packs"].(map[string]any)
+	if _, ok := packs["en"]; !ok {
+		t.Error("expected aggregated 'en' language pack in device body")
+	}
+}
+
+// TestTransport_GetDevice_EmptyStream verifies a handler that reports success
+// without sending any chunk is surfaced as an internal error on the unary route.
+func TestTransport_GetDevice_EmptyStream(t *testing.T) {
+	transport, runtime := makeTestTransport(t)
+
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0", "")
+	assertStatus(t, rec, http.StatusInternalServerError)
+}
+
+func TestTransport_DeviceStream(t *testing.T) {
+	t.Run("StreamRoute", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+			return []st2138.DeviceComponent{
+				st2138.ComponentDevice(st2138.NewDevice(slot)),
+				st2138.ComponentParam("brightness", st2138.NewParamInt32(50)),
+			}, catena.StatusWithCode(catena.StatusCodeOk, "")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/stream", "")
+		assertStatus(t, rec, http.StatusOK)
+		assertContentType(t, rec, "text/event-stream")
+
+		body := rec.Body.String()
+		if dataCount := strings.Count(body, "data:"); dataCount != 2 {
+			t.Errorf("expected 2 SSE data events, got %d\nbody:\n%s", dataCount, body)
+		}
+		if !strings.Contains(body, `"device"`) {
+			t.Errorf("expected a device-kind SSE event, got body:\n%s", body)
+		}
+		if !strings.Contains(body, `"brightness"`) {
+			t.Errorf("expected a param-kind SSE event for 'brightness', got body:\n%s", body)
+		}
+	})
+
+	// If the handler errors before sending anything, the stream has not committed
+	// a status yet, so the transport can still report the error as an HTTP status.
+	t.Run("StreamErrorNoneSent", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+			return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/stream", "")
+		assertStatus(t, rec, http.StatusNotFound)
+		if err := assertHasError(t, rec); !strings.Contains(err, "device not found") {
+			t.Errorf("expected 'device not found' message, got %q", err)
+		}
+	})
+
+	// A mid-stream error is reported in-band as an SSE error event once chunks
+	// have already been sent.
+	t.Run("StreamErrorAfterSomeSent", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+			return []st2138.DeviceComponent{
+				st2138.ComponentDevice(st2138.NewDevice(slot)),
+			}, catena.StatusWithCode(catena.StatusCodeInternal, "internal error")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/stream", "")
+		assertStatus(t, rec, http.StatusOK)
+		assertContentType(t, rec, "text/event-stream")
+		body := rec.Body.String()
+		if !strings.Contains(body, "event: error\n") {
+			t.Errorf("expected an SSE error event, got body:\n%s", body)
+		}
+		if !strings.Contains(body, `"code":500`) {
+			t.Errorf("expected the error event to carry status code 500, got body:\n%s", body)
+		}
+	})
+
+	// A successful handler that streams nothing yields a well-formed empty event
+	// stream (200), not an error.
+	t.Run("StreamEmptyOk", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
+			return nil, catena.StatusWithCode(catena.StatusCodeOk, "")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/stream", "")
+		assertStatus(t, rec, http.StatusOK)
+		if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+			t.Errorf("expected Content-Type 'text/event-stream', got %q", ct)
+		}
+		if body := rec.Body.String(); strings.Contains(body, "data:") {
+			t.Errorf("expected no data events, got %q", body)
+		}
+	})
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		transport, _ := makeTestTransport(t)
+		rec := makeRequest(t, transport, http.MethodPost, "/st2138-api/v1/0/stream", "")
+		assertStatus(t, rec, http.StatusMethodNotAllowed)
+	})
+}
+
 func TestTransport_GetDevice_NotFound(t *testing.T) {
 	transport, runtime := makeTestTransport(t)
 
 	handlerCalled := false
-	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
 		handlerCalled = true
 		if slot != 99 {
 			t.Errorf("expected slot 99, got %d", slot)
 		}
-		return catena.ReplyError[st2138.Device](catena.StatusCodeNotFound, "device not found")
+		return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "device not found")
 	}
 
 	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/99", "")
@@ -326,12 +480,12 @@ func TestTransport_GetDevice_InvalidSlot(t *testing.T) {
 	transport, runtime := makeTestTransport(t)
 
 	handlerCalled := false
-	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) (st2138.Device, catena.StatusResult) {
+	runtime.GetDeviceFn = func(slot uint16, ctx catena.TransportContext) ([]st2138.DeviceComponent, catena.StatusResult) {
 		handlerCalled = true
 		if slot != 0 {
 			t.Errorf("expected slot 0, got %d", slot)
 		}
-		return catena.ReplyError[st2138.Device](catena.StatusCodeInvalidArgument, "invalid slot")
+		return nil, catena.StatusWithCode(catena.StatusCodeInvalidArgument, "invalid slot")
 	}
 
 	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/invalid", "")
@@ -618,24 +772,144 @@ func TestTransport_ReadAsset_Route(t *testing.T) {
 	}
 	asset, _ := st2138.ToAsset(dp, true)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 		if fqoid != "logo" {
 			t.Errorf("expected fqoid 'logo', got %s", fqoid)
 		}
-		return catena.Reply(asset)
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/logo", "")
 	assertStatus(t, rec, http.StatusOK)
 }
 
+// TestTransport_ReadAsset_AggregatesChunks verifies the unary asset route
+// concatenates the embedded payload bytes of a multi-chunk stream into one
+// response, keeping the first chunk's metadata.
+func TestTransport_ReadAsset_AggregatesChunks(t *testing.T) {
+	transport, runtime := makeTestTransport(t)
+
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		var assets []st2138.Asset
+		for _, data := range [][]byte{[]byte("first-"), []byte("second-"), []byte("third")} {
+			asset, _ := st2138.ToAsset(st2138.DataPayload{
+				Metadata: map[string]string{"content-type": "text/plain"},
+				Payload:  data,
+			}, false)
+			assets = append(assets, asset)
+		}
+		return assets, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/big.txt", "")
+	assertStatus(t, rec, http.StatusOK)
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	payload, _ := result["payload"].(map[string]any)
+	encoded, _ := payload["payload"].(string)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("payload is not valid base64: %v", err)
+	}
+	if got, want := string(decoded), "first-second-third"; got != want {
+		t.Errorf("aggregated payload = %q, want %q", got, want)
+	}
+}
+
+// TestTransport_ReadAsset_EmptyStream verifies a handler that reports success
+// without sending any chunk is surfaced as an internal error on the unary route.
+func TestTransport_ReadAsset_EmptyStream(t *testing.T) {
+	transport, runtime := makeTestTransport(t)
+
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeOk, "")
+	}
+
+	rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/logo", "")
+	assertStatus(t, rec, http.StatusInternalServerError)
+}
+
+func TestTransport_AssetStream(t *testing.T) {
+	t.Run("StreamRoute", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+			if fqoid != "big.txt" {
+				t.Errorf("expected fqoid 'big.txt', got %s", fqoid)
+			}
+			var assets []st2138.Asset
+			for _, data := range [][]byte{[]byte("first"), []byte("second")} {
+				asset, _ := st2138.ToAsset(st2138.DataPayload{Payload: data}, false)
+				assets = append(assets, asset)
+			}
+			return assets, catena.StatusWithCode(catena.StatusCodeOk, "")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/big.txt/stream", "")
+		assertStatus(t, rec, http.StatusOK)
+		assertContentType(t, rec, "text/event-stream")
+
+		body := rec.Body.String()
+		if dataCount := strings.Count(body, "data:"); dataCount != 2 {
+			t.Errorf("expected 2 SSE data events, got %d\nbody:\n%s", dataCount, body)
+		}
+	})
+
+	// If the handler errors before sending anything, the stream has not committed
+	// a status yet, so the transport can still report the error as an HTTP status.
+	t.Run("StreamErrorNoneSent", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+			return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "asset not found")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/missing/stream", "")
+		assertStatus(t, rec, http.StatusNotFound)
+		if err := assertHasError(t, rec); !strings.Contains(err, "asset not found") {
+			t.Errorf("expected 'asset not found' message, got %q", err)
+		}
+	})
+
+	// A mid-stream error is reported in-band as an SSE error event once chunks
+	// have already been sent.
+	t.Run("StreamErrorAfterSomeSent", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+			asset, _ := st2138.ToAsset(st2138.DataPayload{Payload: []byte("first")}, false)
+			return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeInternal, "internal error")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/big.txt/stream", "")
+		assertStatus(t, rec, http.StatusOK)
+		assertContentType(t, rec, "text/event-stream")
+		body := rec.Body.String()
+		if !strings.Contains(body, "event: error\n") {
+			t.Errorf("expected an SSE error event, got body:\n%s", body)
+		}
+		if !strings.Contains(body, `"code":500`) {
+			t.Errorf("expected the error event to carry status code 500, got body:\n%s", body)
+		}
+	})
+
+	t.Run("MethodNotAllowed", func(t *testing.T) {
+		transport, _ := makeTestTransport(t)
+		rec := makeRequest(t, transport, http.MethodPost, "/st2138-api/v1/0/asset/big.txt/stream", "")
+		assertStatus(t, rec, http.StatusMethodNotAllowed)
+	})
+}
+
 func TestTransport_Asset_MethodNotAllowed(t *testing.T) {
 	transport, runtime := makeTestTransport(t)
 
 	getCalled := false
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 		getCalled = true
-		return catena.Reply(st2138.Asset{})
+		return []st2138.Asset{{}}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	// PATCH is not a supported asset method.
@@ -1749,11 +2023,11 @@ func TestTransport_ReadAsset_CompressionQueryParam_Gzip(t *testing.T) {
 	}
 	asset, _ := st2138.ToAsset(dp, true)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 		if fqoid != "test.txt" {
 			t.Errorf("expected fqoid 'test.txt', got %s", fqoid)
 		}
-		return catena.Reply(asset)
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/test.txt?compression=GZIP", nil)
@@ -1783,11 +2057,11 @@ func TestTransport_ReadAsset_CompressionQueryParam_Deflate(t *testing.T) {
 	}
 	asset, _ := st2138.ToAsset(dp, true)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 		if fqoid != "test.txt" {
 			t.Errorf("expected fqoid 'test.txt', got %s", fqoid)
 		}
-		return catena.Reply(asset)
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/test.txt?compression=DEFLATE", nil)
@@ -1820,11 +2094,11 @@ func TestTransport_ReadAsset_CompressionQueryParam_Uncompressed(t *testing.T) {
 	}
 	asset, _ := st2138.ToAsset(dp, true)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
 		if fqoid != "test.txt" {
 			t.Errorf("expected fqoid 'test.txt', got %s", fqoid)
 		}
-		return catena.Reply(asset)
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/test.txt?compression=UNCOMPRESSED", nil)
@@ -2058,8 +2332,8 @@ func TestTransport_ReadAsset_CompressionQueryParam_Invalid(t *testing.T) {
 	}
 	asset, _ := st2138.ToAsset(dp, true)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
-		return catena.Reply(asset)
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/test.txt?compression=INVALID", nil)
@@ -2080,8 +2354,8 @@ func TestTransport_ReadAsset_NoCompressionParam(t *testing.T) {
 	}
 	asset, _ := st2138.ToAsset(dp, true)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
-		return catena.Reply(asset)
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		return []st2138.Asset{asset}, catena.StatusWithCode(catena.StatusCodeOk, "")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/test.txt", nil)
@@ -2096,8 +2370,8 @@ func TestTransport_ReadAsset_NoCompressionParam(t *testing.T) {
 func TestTransport_ReadAsset_CompressionWithError(t *testing.T) {
 	transport, runtime := makeTestTransport(t)
 
-	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) (st2138.Asset, catena.StatusResult) {
-		return catena.ReplyError[st2138.Asset](catena.StatusCodeNotFound, "asset not found")
+	runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+		return nil, catena.StatusWithCode(catena.StatusCodeNotFound, "asset not found")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/st2138-api/v1/0/asset/missing?compression=GZIP", nil)

--- a/sdks/go/pkg/transports/rest/rest_transport_test.go
+++ b/sdks/go/pkg/transports/rest/rest_transport_test.go
@@ -896,6 +896,23 @@ func TestTransport_AssetStream(t *testing.T) {
 		}
 	})
 
+	// A successful handler that streams nothing yields a well-formed empty event
+	// stream (200), not an error.
+	t.Run("StreamEmptyOk", func(t *testing.T) {
+		transport, runtime := makeTestTransport(t)
+
+		runtime.ReadAssetFn = func(slot uint16, fqoid string, ctx catena.TransportContext) ([]st2138.Asset, catena.StatusResult) {
+			return nil, catena.StatusWithCode(catena.StatusCodeOk, "")
+		}
+
+		rec := makeRequest(t, transport, http.MethodGet, "/st2138-api/v1/0/asset/empty/stream", "")
+		assertStatus(t, rec, http.StatusOK)
+		assertContentType(t, rec, "text/event-stream")
+		if body := rec.Body.String(); strings.Contains(body, "data:") {
+			t.Errorf("expected no data events, got %q", body)
+		}
+	})
+
 	t.Run("MethodNotAllowed", func(t *testing.T) {
 		transport, _ := makeTestTransport(t)
 		rec := makeRequest(t, transport, http.MethodPost, "/st2138-api/v1/0/asset/big.txt/stream", "")

--- a/sdks/go/pkg/transports/rest/stream.go
+++ b/sdks/go/pkg/transports/rest/stream.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/logger"
 	"github.com/rossvideo/catena/sdks/go/pkg/protos"
 	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 )
@@ -138,6 +139,102 @@ func (s *restStream[T]) sendError(result catena.StatusResult) error {
 	return nil
 }
 
+// streamSSE runs one server-streaming endpoint as a Server-Sent Events
+// response. Every SSE route has the same shape - check the writer can flush,
+// hand the handler a restStream, then turn the terminal StatusResult into
+// either an HTTP status or an in-band error event - so only the chunk type, its
+// JSON marshaller, and the runtime call it wraps are per-endpoint. invoke
+// receives the stream to pass to the handler; logContext carries the key/value
+// pairs identifying the request (slot, oid, ...) for the one failure that can
+// only be logged. It is a plain function rather than a method because Go
+// methods cannot have type parameters.
+//
+// The restStream writes SSE headers lazily on the first chunk, so if the
+// handler emits nothing before erroring the status is still uncommitted and a
+// normal HTTP error status can be set. Once any chunk has been streamed the 200
+// is already on the wire, so a later error is reported in-band as an SSE
+// "error" event carrying the status code that would have been returned. A
+// successful handler that produced no chunks still gets committed headers, so
+// the client receives a well-formed empty event stream rather than a bare 200.
+func streamSSE[T catena.Message](
+	t *Transport,
+	w http.ResponseWriter,
+	r *http.Request,
+	marshal func(proto.Message) ([]byte, error),
+	invoke func(stream catena.Stream[T]) catena.StatusResult,
+	logContext ...any,
+) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.writeHTTPStatusResult(w, catena.StatusWithCode(catena.StatusCodeInternal, "streaming not supported"))
+		return
+	}
+
+	stream := &restStream[T]{
+		w:       w,
+		flusher: flusher,
+		marshal: marshal,
+		ctx:     r.Context(),
+		devMode: t.isDevMode(),
+	}
+	result := invoke(stream)
+
+	if result.IsError() {
+		if stream.sent == 0 {
+			t.writeHTTPStatusResult(w, result)
+		} else if err := stream.sendError(result); err != nil {
+			logger.Error("failed to send SSE error event", append([]any{"error", err}, logContext...)...)
+		}
+		return
+	}
+
+	if stream.sent == 0 {
+		stream.writeHeaders()
+	}
+}
+
+// unaryStream is the shape shared by the collector streams the unary REST
+// routes use: a catena.Stream that reduces the chunks a streaming handler sends
+// to the single value the HTTP response body carries. T is the chunk type the
+// handler streams; R is what the collector resolves to, which is T itself for
+// the first/last collectors and an assembled Device or Asset for the
+// aggregating ones.
+type unaryStream[T catena.Message, R any] interface {
+	catena.Stream[T]
+	// result returns the resolved value. ok is false when the handler sent
+	// nothing at all.
+	result() (R, bool)
+}
+
+// resolveUnary runs a streaming handler for a unary route and reduces its
+// stream to the one value that route replies with. A handler error is returned
+// unchanged; otherwise the returned status is Ok and the value is ready to
+// write.
+//
+// A unary route must resolve to exactly one value, so a handler that reports
+// success yet sends nothing has violated that contract: that is reported as an
+// Internal error naming noun (e.g. "device") rather than a NotFound invented
+// over what may be a genuine handler bug. Handlers own NotFound for missing
+// devices and oids. ExecuteCommand is the one unary route that does not use
+// this helper, because an empty stream there is a legitimate no_response.
+func resolveUnary[T catena.Message, R any](
+	collector unaryStream[T, R],
+	noun string,
+	invoke func(stream catena.Stream[T]) catena.StatusResult,
+) (R, catena.StatusResult) {
+	var zero R
+
+	if result := invoke(collector); result.IsError() {
+		return zero, result
+	}
+
+	value, ok := collector.result()
+	if !ok {
+		return zero, catena.StatusWithCode(catena.StatusCodeInternal, noun+" handler reported success but produced no result")
+	}
+	return value, catena.StatusResult{Code: catena.StatusCodeOk}
+}
+
 // firstStream retains only the first sent chunk, silently discarding the rest.
 // The REST transport uses it for unary param-info requests, where the streaming
 // handler still emits chunks but only the first is written back as a single JSON
@@ -158,6 +255,11 @@ func (s *firstStream[T]) Send(chunk T) error {
 	return nil
 }
 
+// result returns the retained chunk. ok is false when nothing was sent.
+func (s *firstStream[T]) result() (T, bool) {
+	return s.item, s.has
+}
+
 // lastStream retains only the most recently sent chunk. The REST ExecuteCommand
 // endpoint is unary: the handler may stream several CommandResponses, but the HTTP
 // reply carries a single response, so only the final Send is kept (earlier ones
@@ -174,6 +276,11 @@ func (s *lastStream[T]) Send(chunk T) error {
 	return nil
 }
 
+// result returns the retained chunk. ok is false when nothing was sent.
+func (s *lastStream[T]) result() (T, bool) {
+	return s.item, s.has
+}
+
 // deviceAggregateStream assembles a streamed DeviceRequest response back into
 // one complete device. The REST unary device route uses it: the handler may
 // stream a Device chunk plus component chunks (params, constraints, menus,
@@ -184,7 +291,7 @@ type deviceAggregateStream struct {
 	device *protos.Device
 }
 
-var _ catena.Stream[st2138.DeviceComponent] = (*deviceAggregateStream)(nil)
+var _ unaryStream[st2138.DeviceComponent, st2138.Device] = (*deviceAggregateStream)(nil)
 
 // Send merges one DeviceComponent chunk into the accumulating device. A Device
 // chunk becomes the base (a second Device chunk is proto-merged into it);
@@ -329,7 +436,7 @@ type assetAggregateStream struct {
 	hasData bool
 }
 
-var _ catena.Stream[st2138.Asset] = (*assetAggregateStream)(nil)
+var _ unaryStream[st2138.Asset, st2138.Asset] = (*assetAggregateStream)(nil)
 
 // Send accumulates one asset chunk. Chunks with a nil proto are ignored.
 func (s *assetAggregateStream) Send(chunk st2138.Asset) error {

--- a/sdks/go/pkg/transports/rest/stream.go
+++ b/sdks/go/pkg/transports/rest/stream.go
@@ -41,10 +41,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 )
 
 // restStream adapts an HTTP response to catena.Stream, emitting each chunk as a
@@ -169,4 +172,186 @@ func (s *lastStream[T]) Send(chunk T) error {
 	s.item = chunk
 	s.has = true
 	return nil
+}
+
+// deviceAggregateStream assembles a streamed DeviceRequest response back into
+// one complete device. The REST unary device route uses it: the handler may
+// stream a Device chunk plus component chunks (params, constraints, menus,
+// commands, language packs), but the HTTP reply carries a single device JSON
+// body, so each component is merged into the accumulating device. Send always
+// returns nil so the handler runs to completion.
+type deviceAggregateStream struct {
+	device *protos.Device
+}
+
+var _ catena.Stream[st2138.DeviceComponent] = (*deviceAggregateStream)(nil)
+
+// Send merges one DeviceComponent chunk into the accumulating device. A Device
+// chunk becomes the base (a second Device chunk is proto-merged into it);
+// component chunks are placed at the location their oid names, creating the
+// device skeleton and any intermediate params on demand so chunk order does
+// not matter. Chunks with a nil body are ignored.
+func (s *deviceAggregateStream) Send(chunk st2138.DeviceComponent) error {
+	if chunk.Proto == nil {
+		return nil
+	}
+	switch kind := chunk.Proto.Kind.(type) {
+	case *protos.DeviceComponent_Device:
+		if kind.Device == nil {
+			return nil
+		}
+		if s.device == nil {
+			s.device = kind.Device
+		} else {
+			proto.Merge(s.device, kind.Device)
+		}
+	case *protos.DeviceComponent_Param:
+		if kind.Param.GetParam() == nil {
+			return nil
+		}
+		s.ensureDevice()
+		s.device.Params = setNestedParam(s.device.Params, kind.Param.GetOid(), kind.Param.GetParam())
+	case *protos.DeviceComponent_SharedConstraint:
+		if kind.SharedConstraint.GetConstraint() == nil {
+			return nil
+		}
+		s.ensureDevice()
+		if s.device.Constraints == nil {
+			s.device.Constraints = map[string]*protos.Constraint{}
+		}
+		s.device.Constraints[kind.SharedConstraint.GetOid()] = kind.SharedConstraint.GetConstraint()
+	case *protos.DeviceComponent_Menu:
+		if kind.Menu.GetMenu() == nil {
+			return nil
+		}
+		// The oid identifies the menu as "menu-group-name/menu-name".
+		group, menu, found := strings.Cut(kind.Menu.GetOid(), "/")
+		if !found {
+			return nil
+		}
+		s.ensureDevice()
+		if s.device.MenuGroups == nil {
+			s.device.MenuGroups = map[string]*protos.MenuGroup{}
+		}
+		menuGroup, ok := s.device.MenuGroups[group]
+		if !ok || menuGroup == nil {
+			menuGroup = &protos.MenuGroup{}
+			s.device.MenuGroups[group] = menuGroup
+		}
+		if menuGroup.Menus == nil {
+			menuGroup.Menus = map[string]*protos.Menu{}
+		}
+		menuGroup.Menus[menu] = kind.Menu.GetMenu()
+	case *protos.DeviceComponent_Command:
+		if kind.Command.GetCommand() == nil {
+			return nil
+		}
+		s.ensureDevice()
+		s.device.Commands = setNestedParam(s.device.Commands, kind.Command.GetOid(), kind.Command.GetCommand())
+	case *protos.DeviceComponent_LanguagePack:
+		if kind.LanguagePack.GetLanguagePack() == nil {
+			return nil
+		}
+		s.ensureDevice()
+		if s.device.LanguagePacks == nil {
+			s.device.LanguagePacks = &protos.LanguagePacks{}
+		}
+		if s.device.LanguagePacks.Packs == nil {
+			s.device.LanguagePacks.Packs = map[string]*protos.LanguagePack{}
+		}
+		s.device.LanguagePacks.Packs[kind.LanguagePack.GetLanguage()] = kind.LanguagePack.GetLanguagePack()
+	}
+	return nil
+}
+
+// ensureDevice creates an empty base device when a component chunk arrives
+// before (or without) a Device chunk.
+func (s *deviceAggregateStream) ensureDevice() {
+	if s.device == nil {
+		s.device = &protos.Device{}
+	}
+}
+
+// result returns the assembled device. ok is false when the handler produced
+// no chunks at all.
+func (s *deviceAggregateStream) result() (st2138.Device, bool) {
+	if s.device == nil {
+		return st2138.Device{}, false
+	}
+	return st2138.Device{Proto: s.device}, true
+}
+
+// setNestedParam places param at the location oid names inside a params map,
+// walking the oid's JSON-pointer segments through sub-param maps and creating
+// intermediate params on demand (so a "monitor/eq" chunk can arrive before, or
+// without, its "monitor" parent). It returns the (possibly newly created) map.
+func setNestedParam(params map[string]*protos.Param, oid string, param *protos.Param) map[string]*protos.Param {
+	if params == nil {
+		params = map[string]*protos.Param{}
+	}
+	segments := strings.Split(oid, "/")
+	current := params
+	for i, segment := range segments {
+		if i == len(segments)-1 {
+			current[segment] = param
+			break
+		}
+		parent, ok := current[segment]
+		if !ok || parent == nil {
+			parent = &protos.Param{}
+			current[segment] = parent
+		}
+		if parent.Params == nil {
+			parent.Params = map[string]*protos.Param{}
+		}
+		current = parent.Params
+	}
+	return params
+}
+
+// assetAggregateStream assembles a streamed ReadAsset response back into one
+// complete asset. The REST unary asset route uses it: the handler may break a
+// large asset into several chunks, but the HTTP reply carries a single
+// external_object_payload JSON body, so the embedded payload bytes of every
+// chunk are concatenated in send order while metadata, digest, cachable, and
+// the payload encoding are taken from the first chunk. Send always returns nil
+// so the handler runs to completion.
+type assetAggregateStream struct {
+	first   *protos.ExternalObjectPayload
+	data    []byte
+	hasData bool
+}
+
+var _ catena.Stream[st2138.Asset] = (*assetAggregateStream)(nil)
+
+// Send accumulates one asset chunk. Chunks with a nil proto are ignored.
+func (s *assetAggregateStream) Send(chunk st2138.Asset) error {
+	if chunk.Proto == nil {
+		return nil
+	}
+	if s.first == nil {
+		s.first = chunk.Proto
+	}
+	if payload := chunk.Proto.GetPayload().GetPayload(); len(payload) > 0 {
+		s.data = append(s.data, payload...)
+		s.hasData = true
+	}
+	return nil
+}
+
+// result returns the assembled asset. ok is false when the handler produced no
+// chunks at all. The returned asset clones the first chunk's proto so the
+// concatenated payload does not alias any handler-owned buffer.
+func (s *assetAggregateStream) result() (st2138.Asset, bool) {
+	if s.first == nil {
+		return st2138.Asset{}, false
+	}
+	out := proto.Clone(s.first).(*protos.ExternalObjectPayload)
+	if s.hasData {
+		if out.Payload == nil {
+			out.Payload = &protos.DataPayload{}
+		}
+		out.Payload.Kind = &protos.DataPayload_Payload{Payload: s.data}
+	}
+	return st2138.Asset{Proto: out}, true
 }

--- a/sdks/go/pkg/transports/rest/stream.go
+++ b/sdks/go/pkg/transports/rest/stream.go
@@ -284,7 +284,10 @@ func (s *deviceAggregateStream) result() (st2138.Device, bool) {
 // setNestedParam places param at the location oid names inside a params map,
 // walking the oid's JSON-pointer segments through sub-param maps and creating
 // intermediate params on demand (so a "monitor/eq" chunk can arrive before, or
-// without, its "monitor" parent). It returns the (possibly newly created) map.
+// without, its "monitor" parent). If an entry already exists at the final
+// segment — for example a parent synthesized while placing an earlier child —
+// the incoming param is proto-merged into it so nested children are preserved.
+// It returns the (possibly newly created) map.
 func setNestedParam(params map[string]*protos.Param, oid string, param *protos.Param) map[string]*protos.Param {
 	if params == nil {
 		params = map[string]*protos.Param{}
@@ -293,7 +296,11 @@ func setNestedParam(params map[string]*protos.Param, oid string, param *protos.P
 	current := params
 	for i, segment := range segments {
 		if i == len(segments)-1 {
-			current[segment] = param
+			if existing, ok := current[segment]; ok && existing != nil {
+				proto.Merge(existing, param)
+			} else {
+				current[segment] = param
+			}
 			break
 		}
 		parent, ok := current[segment]

--- a/sdks/go/pkg/transports/rest/stream_test.go
+++ b/sdks/go/pkg/transports/rest/stream_test.go
@@ -183,6 +183,70 @@ func TestDeviceAggregateStream_NestedCommandOrderIndependent(t *testing.T) {
 	}
 }
 
+func TestDeviceAggregateStream_IgnoresChunksWithNothingToMerge(t *testing.T) {
+	// Every component kind guards against a missing body, and a menu oid that
+	// does not name its group cannot be placed. None of these chunks contribute
+	// anything, so no device is assembled at all.
+	chunks := []st2138.DeviceComponent{
+		{}, // no proto at all
+		st2138.ComponentDevice(nil),
+		st2138.ComponentParam("brightness", nil),
+		st2138.ComponentConstraint("range", nil),
+		st2138.ComponentMenu("status/main", nil),
+		// A menu oid must be "menu-group-name/menu-name".
+		st2138.ComponentMenu("groupless", st2138.NewMenu()),
+		st2138.ComponentCommand("reset", nil),
+		// ComponentLanguagePack always builds a pack, so the empty-pack chunk is
+		// assembled by hand.
+		{Proto: &protos.DeviceComponent{
+			Kind: &protos.DeviceComponent_LanguagePack{
+				LanguagePack: &protos.DeviceComponent_ComponentLanguagePack{Language: "en"},
+			},
+		}},
+	}
+
+	stream := &deviceAggregateStream{}
+	for i, chunk := range chunks {
+		if err := stream.Send(chunk); err != nil {
+			t.Fatalf("Send(chunks[%d]) returned error: %v", i, err)
+		}
+	}
+
+	if device, ok := stream.result(); ok {
+		t.Errorf("expected no assembled device, got %v", device.Proto)
+	}
+}
+
+func TestDeviceAggregateStream_MergesSecondDeviceChunk(t *testing.T) {
+	// A handler may split the device itself across two Device chunks; the second
+	// is merged into the first rather than replacing it.
+	stream := &deviceAggregateStream{}
+	for _, chunk := range []st2138.DeviceComponent{
+		st2138.ComponentDevice(st2138.NewDevice(1).WithDetailLevel(st2138.DetailLevelMinimal)),
+		st2138.ComponentDevice(st2138.NewDevice(1).
+			WithMultiSetEnabled(true).
+			WithParam("brightness", st2138.NewParamInt32(50))),
+	} {
+		if err := stream.Send(chunk); err != nil {
+			t.Fatalf("Send returned error: %v", err)
+		}
+	}
+
+	device, ok := stream.result()
+	if !ok {
+		t.Fatal("expected an assembled device")
+	}
+	if got := device.Proto.GetDetailLevel(); got != st2138.DetailLevelMinimal {
+		t.Errorf("detail level = %v, want MINIMAL to survive the merge", got)
+	}
+	if !device.Proto.GetMultiSetEnabled() {
+		t.Error("expected multi_set_enabled from the second chunk")
+	}
+	if device.Proto.GetParams()["brightness"] == nil {
+		t.Error("expected params.brightness from the second chunk")
+	}
+}
+
 func TestFirstStream(t *testing.T) {
 	// firstStream retains only the first chunk sent, discarding any subsequent chunks.
 	t.Run("KeepsFirst", func(t *testing.T) {

--- a/sdks/go/pkg/transports/rest/stream_test.go
+++ b/sdks/go/pkg/transports/rest/stream_test.go
@@ -48,6 +48,8 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/protos"
+	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 )
 
 // failingResponseWriter is an http.ResponseWriter+http.Flusher whose Write
@@ -79,6 +81,106 @@ var _ catena.Message = stubMessage{}
 
 func (m stubMessage) Wire() proto.Message {
 	return wrapperspb.String(m.value)
+}
+
+func TestDeviceAggregateStream_NestedParamOrderIndependent(t *testing.T) {
+	// Component chunk order must not matter: a parent arriving after a nested
+	// child must keep children already hung under a synthesized intermediate.
+	sendOrders := []struct {
+		name   string
+		chunks func() []st2138.DeviceComponent
+	}{
+		{
+			name: "childBeforeParent",
+			chunks: func() []st2138.DeviceComponent {
+				parent := st2138.NewParamEmpty()
+				parent.Proto.Type = protos.ParamType_STRUCT
+				return []st2138.DeviceComponent{
+					st2138.ComponentParam("monitor/eq", st2138.NewParamInt32(42)),
+					st2138.ComponentParam("monitor", parent),
+				}
+			},
+		},
+		{
+			name: "parentBeforeChild",
+			chunks: func() []st2138.DeviceComponent {
+				parent := st2138.NewParamEmpty()
+				parent.Proto.Type = protos.ParamType_STRUCT
+				return []st2138.DeviceComponent{
+					st2138.ComponentParam("monitor", parent),
+					st2138.ComponentParam("monitor/eq", st2138.NewParamInt32(42)),
+				}
+			},
+		},
+	}
+
+	for _, tc := range sendOrders {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := &deviceAggregateStream{}
+			for _, chunk := range tc.chunks() {
+				if err := stream.Send(chunk); err != nil {
+					t.Fatalf("Send returned error: %v", err)
+				}
+			}
+
+			device, ok := stream.result()
+			if !ok {
+				t.Fatal("expected an assembled device")
+			}
+			monitor := device.Proto.GetParams()["monitor"]
+			if monitor == nil {
+				t.Fatal("expected params.monitor")
+			}
+			if monitor.GetType() != protos.ParamType_STRUCT {
+				t.Errorf("monitor type = %v, want STRUCT", monitor.GetType())
+			}
+			eq := monitor.GetParams()["eq"]
+			if eq == nil {
+				t.Fatal("expected params.monitor.params.eq to survive aggregation")
+			}
+			if got := eq.GetValue().GetInt32Value(); got != 42 {
+				t.Errorf("eq value = %d, want 42", got)
+			}
+		})
+	}
+}
+
+func TestDeviceAggregateStream_NestedCommandOrderIndependent(t *testing.T) {
+	// Commands nest the same way as params; parent-after-child must not wipe
+	// a nested command hung under a synthesized intermediate.
+	parent := st2138.NewParamEmpty()
+	parent.Proto.Type = protos.ParamType_STRUCT
+	child := st2138.NewParamEmpty()
+	child.Proto.Type = protos.ParamType_INT32
+
+	stream := &deviceAggregateStream{}
+	for _, chunk := range []st2138.DeviceComponent{
+		st2138.ComponentCommand("group/action", child),
+		st2138.ComponentCommand("group", parent),
+	} {
+		if err := stream.Send(chunk); err != nil {
+			t.Fatalf("Send returned error: %v", err)
+		}
+	}
+
+	device, ok := stream.result()
+	if !ok {
+		t.Fatal("expected an assembled device")
+	}
+	group := device.Proto.GetCommands()["group"]
+	if group == nil {
+		t.Fatal("expected commands.group")
+	}
+	if group.GetType() != protos.ParamType_STRUCT {
+		t.Errorf("group type = %v, want STRUCT", group.GetType())
+	}
+	action := group.GetParams()["action"]
+	if action == nil {
+		t.Fatal("expected commands.group.params.action to survive aggregation")
+	}
+	if action.GetType() != protos.ParamType_INT32 {
+		t.Errorf("action type = %v, want INT32", action.GetType())
+	}
 }
 
 func TestFirstStream(t *testing.T) {

--- a/sdks/go/pkg/transports/rest/stream_test.go
+++ b/sdks/go/pkg/transports/rest/stream_test.go
@@ -52,11 +52,14 @@ import (
 	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
 )
 
-// failingResponseWriter is an http.ResponseWriter+http.Flusher whose Write
-// always fails, used to exercise the SSE write-error branch.
+// failingResponseWriter is an http.ResponseWriter+http.Flusher that serves the
+// first failAfter writes and fails every one after that, used to exercise the
+// SSE write-error branches. The zero value fails the very first write.
 type failingResponseWriter struct {
-	header http.Header
-	status int
+	header    http.Header
+	status    int
+	writes    int
+	failAfter int
 }
 
 func (w *failingResponseWriter) Header() http.Header {
@@ -65,9 +68,31 @@ func (w *failingResponseWriter) Header() http.Header {
 	}
 	return w.header
 }
-func (w *failingResponseWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
-func (w *failingResponseWriter) WriteHeader(status int)    { w.status = status }
-func (w *failingResponseWriter) Flush()                    {}
+func (w *failingResponseWriter) Write(b []byte) (int, error) {
+	w.writes++
+	if w.writes > w.failAfter {
+		return 0, errors.New("write failed")
+	}
+	return len(b), nil
+}
+func (w *failingResponseWriter) WriteHeader(status int) { w.status = status }
+func (w *failingResponseWriter) Flush()                 {}
+
+// unflushableResponseWriter is an http.ResponseWriter that deliberately does not
+// implement http.Flusher, which SSE routes require.
+type unflushableResponseWriter struct {
+	header http.Header
+	status int
+}
+
+func (w *unflushableResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+func (w *unflushableResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *unflushableResponseWriter) WriteHeader(status int)      { w.status = status }
 
 // stubMessage is a minimal catena.Message for exercising the generic stream
 // adapters without depending on any domain chunk type. Wire returns a real
@@ -81,6 +106,52 @@ var _ catena.Message = stubMessage{}
 
 func (m stubMessage) Wire() proto.Message {
 	return wrapperspb.String(m.value)
+}
+
+// Each SSE route's own tests cover streamSSE's normal paths through the mux;
+// these two cases are easier to reach by driving it directly.
+func TestStreamSSE(t *testing.T) {
+	t.Run("rejects a writer that cannot flush", func(t *testing.T) {
+		// SSE has to push each frame as it is produced, so a writer that cannot
+		// flush is rejected before the handler runs.
+		w := &unflushableResponseWriter{}
+		invoked := false
+
+		streamSSE(&Transport{}, w, httptest.NewRequest(http.MethodGet, "/", nil), MarshalProtoJSON,
+			func(catena.Stream[stubMessage]) catena.StatusResult {
+				invoked = true
+				return catena.StatusWithCode(catena.StatusCodeOk, "")
+			})
+
+		if invoked {
+			t.Error("handler should not run without a flushable writer")
+		}
+		if w.status != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.status, http.StatusInternalServerError)
+		}
+	})
+
+	t.Run("tolerates a failed error event after a chunk was sent", func(t *testing.T) {
+		// The chunk commits a 200, so the handler's late error can only go out as
+		// an SSE error event; when that write fails too there is nothing left to
+		// do but log it.
+		w := &failingResponseWriter{failAfter: 1}
+
+		streamSSE(&Transport{}, w, httptest.NewRequest(http.MethodGet, "/", nil), MarshalProtoJSON,
+			func(stream catena.Stream[stubMessage]) catena.StatusResult {
+				if err := stream.Send(stubMessage{value: "a"}); err != nil {
+					t.Fatalf("first Send returned error: %v", err)
+				}
+				return catena.StatusWithCode(catena.StatusCodeInternal, "boom")
+			})
+
+		if w.writes < 2 {
+			t.Errorf("writes = %d, want the chunk plus an attempted error event", w.writes)
+		}
+		if w.status != http.StatusOK {
+			t.Errorf("status = %d, want the already-committed %d", w.status, http.StatusOK)
+		}
+	})
 }
 
 func TestDeviceAggregateStream_NestedParamOrderIndependent(t *testing.T) {


### PR DESCRIPTION
## 📖 Description
<!-- A clear, concise summary of what this PR does. -->
Converts the Go SDK's `DeviceRequest`  and `Asset` handlers from single-return signatures to the streaming `Stream[T]` "yield" pattern already used by `ExecuteCommand` and `ParamInfo`. Handlers now receive a stream and call `stream.Send(chunk)` for each response chunk, which flows end-to-end through both the gRPC and REST transports.

Key pieces:
- New `st2138.DeviceComponent` chunk type with constructors mirroring the proto oneof (`ComponentDevice`, `ComponentParam`, `ComponentConstraint`, `ComponentMenu`, `ComponentCommand`, `ComponentLanguagePack`), and `Wire()` on `st2138.Asset` so both satisfy `Message`.
- `DeviceHandler` / `ReadAssetHandler` signatures replaced in place; `InvokeGetDeviceHandler` / `InvokeReadAssetHandler` now take a stream, wrap it in `shutdownStream`, and return only a `StatusResult`.
- SDK-managed product-struct injection moved from a post-return mutation into a `productDeviceStream` wrapper that enforces the `st2138:mon` scope policy per chunk (inject/overwrite on Device chunks, rewrite or drop product `ComponentParam` chunks).
- gRPC: `DeviceRequest` and `ExternalObjectRequest` forward each `Send` as one gRPC message via `grpcStream` adapters.
- REST: unary routes aggregate the stream into one JSON body (`deviceAggregateStream` merges components into a full device, order-independently; `assetAggregateStream` concatenates payload bytes, first chunk wins for metadata/digest/cachable). New SSE routes `GET /{slot}/stream` and `GET /{slot}/asset/{oid}/stream`. `?compression=` still applies to the assembled unary asset payload.

---

## 🎯 Goal / Outcome
<!-- What should be achieved once this PR is merged? -->
All four server-streaming endpoints (`DeviceRequest`, `ExternalObjectRequest`, `ExecuteCommand`, `ParamInfoRequest`) expose a consistent streaming handler API, so business logic can deliver large device models and assets in chunks instead of building one monolithic response — completing the remaining work from #1273 (DeviceRequest DoD in #1272).

---

## ✅ Definition of Done (DoD)
<!-- Checklist derived from the actual changes: -->
- [x] `DeviceHandler` and `ReadAssetHandler` converted to `Stream[T]` signatures matching the ExecuteCommand/ParamInfo precedent
- [x] gRPC `DeviceRequest` and `ExternalObjectRequest` stream one proto per handler `Send`
- [x] REST unary routes aggregate multi-chunk streams into a single JSON response; new `/stream` SSE routes for device and asset
- [x] Product-struct injection/stripping preserved through the streaming path (mon-scope policy on Device and product param chunks)
- [x] Tests added or updated across `st2138`, `catena`, gRPC, REST, and the transport test stub
- [x] Documentation updated (`GRPC.md`, `REST.md`, transports `README.md`, `Server` interface doc comments) and examples reworked (`hello_world`, `oneOfEverything`)

---

## 🛠️ Implementation Notes (Optional)
<!-- Technical details, architectural decisions, or constraints visible in the diff. -->
- **Breaking API change (intentional):** the unary handler signatures were replaced in place rather than adding parallel streaming variants, per the ExecuteCommand/ParamInfo precedent. Existing adopters must migrate their `RegisterGetDeviceHandler` / `RegisterReadAssetHandler` callbacks.
- REST unary aggregation lives in new stream adapters (`deviceAggregateStream`, `assetAggregateStream`) alongside the existing `firstStream`/`lastStream`, keeping the transport's "adapt the stream to the route shape" pattern.
- `setNestedParam` proto-merges into existing entries so component chunk order doesn't matter (a parent arriving after a nested child keeps the synthesized child) — hardened in the follow-up commit with order-independence tests.
- SSE device frames use a new `MarshalDeviceComponentJSON` with the same SMPTE cleanup rules as the unary device marshaller (meaningful zeros survive, schema-forbidden defaults stripped).
- The `oneOfEverything` example demonstrates both chunked forms: device skeleton + per-param/command components, and 64 KiB-chunked asset payloads; `hello_world` shows the simple single-`ComponentDevice` case.

---

## 🔗 Related Issues / Links

Closes issues:
- #1272 
- #1273 
