### PR TITLE
Authz example

### DIFF
--- a/sdks/go/examples/oneOfEverything/authz.go
+++ b/sdks/go/examples/oneOfEverything/authz.go
@@ -43,9 +43,10 @@ const authzSlot = 3
 
 func registerAuthz(srv catena.Server) {
 	const (
-		userAccess = "user_access"
-		claims     = "claims"
-		rolesTable = "roles_table"
+		userAccess  = "user_access"
+		claims      = "claims"
+		rolesTable  = "roles_table"
+		authzStatus = "authz_status"
 	)
 
 	makeUserAccess := func(ctx catena.HandlerContext) *st2138.Param {
@@ -106,17 +107,19 @@ func registerAuthz(srv catena.Server) {
 	}
 
 	makeClaims := func(ctx catena.HandlerContext) *st2138.Param {
-		claims, ok := ctx.Token.Claims.(jwt.MapClaims)
 		valMap := make([]map[string]any, 0)
-		if ok {
-			for k, v := range claims {
-				if sec, ok := v.(float64); ok && (k == "exp" || k == "iat") {
-					v = time.Unix(int64(sec), 0).UTC().Format(time.RFC3339)
+		if ctx.Token != nil {
+			claims, ok := ctx.Token.Claims.(jwt.MapClaims)
+			if ok {
+				for k, v := range claims {
+					if sec, ok := v.(float64); ok && (k == "exp" || k == "iat") {
+						v = time.Unix(int64(sec), 0).UTC().Format(time.RFC3339)
+					}
+					valMap = append(valMap, map[string]any{
+						"key":   k,
+						"value": fmt.Sprint(v),
+					})
 				}
-				valMap = append(valMap, map[string]any{
-					"key":   k,
-					"value": fmt.Sprint(v),
-				})
 			}
 		}
 		return st2138.NewParamStructArray(valMap).
@@ -124,6 +127,14 @@ func registerAuthz(srv catena.Server) {
 			WithName(st2138.PolyglotText{"en": "JWT Claims"}).
 			WithParam("key", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Key"))).
 			WithParam("value", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Value")))
+	}
+
+	// Shown in place of the scope/claims params when authz is disabled: the
+	// scope helpers grant everything, so per-user access can't be reported.
+	makeAuthzStatus := func() *st2138.Param {
+		return st2138.NewParamString("Authorization is disabled; scope information cannot be shown.").
+			WithReadOnly(true).
+			WithName(st2138.PolyglotText{"en": "Authorization"})
 	}
 
 	srv.RegisterProductStruct(authzSlot, catena.ProductStruct{
@@ -145,14 +156,15 @@ func registerAuthz(srv catena.Server) {
 			return catena.StatusError(err)
 		}
 
+		// hardcode so we're not at the mercy of map iteration order
+		loginOids := []string{userAccess, claims}
+		if !ctx.AuthzEnabled() {
+			loginOids = []string{authzStatus}
+		}
 		if err := stream.Send(
 			st2138.ComponentMenu("status/login", st2138.NewMenu().
 				WithName(st2138.PolyglotText{"en": "Login"}).
-				// hardcode so we're not at the mercy of map iteration order
-				WithParamOids(
-					userAccess,
-					claims,
-				),
+				WithParamOids(loginOids...),
 			),
 		); err != nil {
 			return catena.StatusError(err)
@@ -171,10 +183,14 @@ func registerAuthz(srv catena.Server) {
 		}
 
 		if ctx.HasReadScope(st2138.ScopeMon) {
-			if err := stream.Send(st2138.ComponentParam(userAccess, makeUserAccess(ctx))); err != nil {
-				return catena.StatusError(err)
-			}
-			if err := stream.Send(st2138.ComponentParam(claims, makeClaims(ctx))); err != nil {
+			if ctx.AuthzEnabled() {
+				if err := stream.Send(st2138.ComponentParam(userAccess, makeUserAccess(ctx))); err != nil {
+					return catena.StatusError(err)
+				}
+				if err := stream.Send(st2138.ComponentParam(claims, makeClaims(ctx))); err != nil {
+					return catena.StatusError(err)
+				}
+			} else if err := stream.Send(st2138.ComponentParam(authzStatus, makeAuthzStatus())); err != nil {
 				return catena.StatusError(err)
 			}
 			if err := stream.Send(st2138.ComponentParam(rolesTable, makeRolesTable())); err != nil {
@@ -188,9 +204,17 @@ func registerAuthz(srv catena.Server) {
 		if ctx.HasReadScope(st2138.ScopeMon) {
 			switch fqoid {
 			case userAccess:
-				return catena.Reply(*makeUserAccess(ctx))
+				if ctx.AuthzEnabled() {
+					return catena.Reply(*makeUserAccess(ctx))
+				}
 			case claims:
-				return catena.Reply(*makeClaims(ctx))
+				if ctx.AuthzEnabled() {
+					return catena.Reply(*makeClaims(ctx))
+				}
+			case authzStatus:
+				if !ctx.AuthzEnabled() {
+					return catena.Reply(*makeAuthzStatus())
+				}
 			case rolesTable:
 				return catena.Reply(*makeRolesTable())
 			}
@@ -202,9 +226,17 @@ func registerAuthz(srv catena.Server) {
 		if ctx.HasReadScope(st2138.ScopeMon) {
 			switch fqoid {
 			case userAccess:
-				return catena.Reply(st2138.Value{Proto: makeUserAccess(ctx).Proto.Value})
+				if ctx.AuthzEnabled() {
+					return catena.Reply(st2138.Value{Proto: makeUserAccess(ctx).Proto.Value})
+				}
 			case claims:
-				return catena.Reply(st2138.Value{Proto: makeClaims(ctx).Proto.Value})
+				if ctx.AuthzEnabled() {
+					return catena.Reply(st2138.Value{Proto: makeClaims(ctx).Proto.Value})
+				}
+			case authzStatus:
+				if !ctx.AuthzEnabled() {
+					return catena.Reply(st2138.Value{Proto: makeAuthzStatus().Proto.Value})
+				}
 			case rolesTable:
 				return catena.Reply(st2138.Value{Proto: makeRolesTable().Proto.Value})
 			}

--- a/sdks/go/examples/oneOfEverything/authz.go
+++ b/sdks/go/examples/oneOfEverything/authz.go
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Ross Video Ltd
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rossvideo/catena/sdks/go/pkg/catena"
+	"github.com/rossvideo/catena/sdks/go/pkg/st2138"
+)
+
+const authzSlot = 3
+
+func registerAuthz(srv catena.Server) {
+	const (
+		userAccess = "user_access"
+		claims     = "claims"
+		rolesTable = "roles_table"
+	)
+
+	makeUserAccess := func(ctx catena.HandlerContext) *st2138.Param {
+		accessMap := map[string]any{}
+		if ctx.HasWriteScope(st2138.ScopeMon) {
+			accessMap["mon"] = "Read\nWrite"
+		} else if ctx.HasReadScope(st2138.ScopeMon) {
+			accessMap["mon"] = "Read\n---"
+		} else {
+			accessMap["mon"] = "---\n---"
+		}
+		if ctx.HasWriteScope(st2138.ScopeOp) {
+			accessMap["op"] = "Read\nWrite"
+		} else if ctx.HasReadScope(st2138.ScopeOp) {
+			accessMap["op"] = "Read\n---"
+		} else {
+			accessMap["op"] = "---\n---"
+		}
+		if ctx.HasWriteScope(st2138.ScopeCfg) {
+			accessMap["cfg"] = "Read\nWrite"
+		} else if ctx.HasReadScope(st2138.ScopeCfg) {
+			accessMap["cfg"] = "Read\n---"
+		} else {
+			accessMap["cfg"] = "---\n---"
+		}
+		if ctx.HasWriteScope(st2138.ScopeAdm) {
+			accessMap["adm"] = "Read\nWrite"
+		} else if ctx.HasReadScope(st2138.ScopeAdm) {
+			accessMap["adm"] = "Read\n---"
+		} else {
+			accessMap["adm"] = "---\n---"
+		}
+		return st2138.NewParamStruct(accessMap).
+			WithReadOnly(true).
+			WithName(st2138.PolyglotText{"en": "Scopes"}).
+			WithParam("mon", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Monitor"))).
+			WithParam("op", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Operate"))).
+			WithParam("cfg", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Configure"))).
+			WithParam("adm", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Administer")))
+	}
+
+	makeRolesTable := func() *st2138.Param {
+		roles := []map[string]any{
+			{"role": "commissioner", "mon": "Read\nWrite", "op": "Read\nWrite", "cfg": "Read\nWrite", "adm": "Read\nWrite"},
+			{"role": "it-admin", "mon": "Read\nWrite", "op": "Read\n---", "cfg": "Read\nWrite", "adm": "---\n---"},
+			{"role": "journalist", "mon": "Read\nWrite", "op": "Read\nWrite", "cfg": "Read\n---", "adm": "---\n---"},
+			{"role": "runner", "mon": "Read\n---", "op": "Read\n---", "cfg": "---\n---", "adm": "---\n---"},
+			{"role": "producer", "mon": "Read\nWrite", "op": "Read\n---", "cfg": "Read\n---", "adm": "---\n---"},
+			{"role": "tech-director", "mon": "Read\nWrite", "op": "Read\nWrite", "cfg": "Read\nWrite", "adm": "Read\n---"},
+		}
+		return st2138.NewParamStructArray(roles).
+			WithReadOnly(true).
+			WithParam("role", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Role"))).
+			WithParam("mon", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Monitor"))).
+			WithParam("op", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Operate"))).
+			WithParam("cfg", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Configure"))).
+			WithParam("adm", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Administer")))
+	}
+
+	makeClaims := func(ctx catena.HandlerContext) *st2138.Param {
+		claims, ok := ctx.Token.Claims.(jwt.MapClaims)
+		valMap := make([]map[string]any, 0)
+		if ok {
+			for k, v := range claims {
+				if sec, ok := v.(float64); ok && (k == "exp" || k == "iat") {
+					v = time.Unix(int64(sec), 0).UTC().Format(time.RFC3339)
+				}
+				valMap = append(valMap, map[string]any{
+					"key":   k,
+					"value": fmt.Sprint(v),
+				})
+			}
+		}
+		return st2138.NewParamStructArray(valMap).
+			WithReadOnly(true).
+			WithName(st2138.PolyglotText{"en": "JWT Claims"}).
+			WithParam("key", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Key"))).
+			WithParam("value", st2138.NewParamString().WithName(st2138.NewPolyglotText("en", "Value")))
+	}
+
+	srv.RegisterProductStruct(authzSlot, catena.ProductStruct{
+		Name:         "Authz Demo",
+		Vendor:       "Ross Video",
+		Version:      "v1.0.0",
+		SerialNumber: "1234567890",
+	})
+
+	srv.RegisterGetDeviceHandler(authzSlot, func(slot uint16, ctx catena.HandlerContext, stream catena.Stream[st2138.DeviceComponent]) catena.StatusResult {
+		if err := stream.Send(
+			st2138.ComponentDevice(st2138.NewDevice(authzSlot).
+				WithDefaultScope(st2138.ScopeMon).
+				WithMultiSetEnabled(false).
+				WithAccessScopes(st2138.ScopeMon, st2138.ScopeOp, st2138.ScopeCfg, st2138.ScopeAdm).
+				WithMenuGroup("status", st2138.NewMenuGroup().WithName(st2138.PolyglotText{"en": "Status"})).
+				WithMenuGroup("config", st2138.NewMenuGroup().WithName(st2138.PolyglotText{"en": "Config"}))),
+		); err != nil {
+			return catena.StatusError(err)
+		}
+
+		if err := stream.Send(
+			st2138.ComponentMenu("status/login", st2138.NewMenu().
+				WithName(st2138.PolyglotText{"en": "Login"}).
+				// hardcode so we're not at the mercy of map iteration order
+				WithParamOids(
+					userAccess,
+					claims,
+				),
+			),
+		); err != nil {
+			return catena.StatusError(err)
+		}
+
+		if err := stream.Send(
+			st2138.ComponentMenu("config/roles", st2138.NewMenu().
+				WithName(st2138.PolyglotText{"en": "Roles"}).
+				// hardcode so we're not at the mercy of map iteration order
+				WithParamOids(
+					rolesTable,
+				),
+			),
+		); err != nil {
+			return catena.StatusError(err)
+		}
+
+		if ctx.HasReadScope(st2138.ScopeMon) {
+			if err := stream.Send(st2138.ComponentParam(userAccess, makeUserAccess(ctx))); err != nil {
+				return catena.StatusError(err)
+			}
+			if err := stream.Send(st2138.ComponentParam(claims, makeClaims(ctx))); err != nil {
+				return catena.StatusError(err)
+			}
+			if err := stream.Send(st2138.ComponentParam(rolesTable, makeRolesTable())); err != nil {
+				return catena.StatusError(err)
+			}
+		}
+		return catena.StatusOk()
+	})
+
+	srv.RegisterGetParamHandler(authzSlot, func(slot uint16, fqoid string, ctx catena.HandlerContext) (st2138.Param, catena.StatusResult) {
+		if ctx.HasReadScope(st2138.ScopeMon) {
+			switch fqoid {
+			case userAccess:
+				return catena.Reply(*makeUserAccess(ctx))
+			case claims:
+				return catena.Reply(*makeClaims(ctx))
+			case rolesTable:
+				return catena.Reply(*makeRolesTable())
+			}
+		}
+		return catena.ReplyError[st2138.Param](catena.StatusCodeNotFound, "param not found")
+	})
+
+	srv.RegisterGetValueHandler(authzSlot, func(slot uint16, fqoid string, ctx catena.HandlerContext) (st2138.Value, catena.StatusResult) {
+		if ctx.HasReadScope(st2138.ScopeMon) {
+			switch fqoid {
+			case userAccess:
+				return catena.Reply(st2138.Value{Proto: makeUserAccess(ctx).Proto.Value})
+			case claims:
+				return catena.Reply(st2138.Value{Proto: makeClaims(ctx).Proto.Value})
+			case rolesTable:
+				return catena.Reply(st2138.Value{Proto: makeRolesTable().Proto.Value})
+			}
+		}
+		return catena.ReplyError[st2138.Value](catena.StatusCodeNotFound, "value not found")
+	})
+
+	srv.RegisterSetValueHandler(authzSlot, func(slot uint16, entries []catena.SetValueEntry, ctx catena.HandlerContext) catena.StatusResult {
+		if len(entries) > 1 {
+			return catena.StatusWithCode(catena.StatusCodePermissionDenied, "multi set not allowed")
+		}
+
+		return catena.StatusWithCode(catena.StatusCodePermissionDenied, "write not allowed")
+	})
+}

--- a/sdks/go/examples/oneOfEverything/main.go
+++ b/sdks/go/examples/oneOfEverything/main.go
@@ -361,6 +361,8 @@ func main() {
 
 	srv.StartHeartbeat(5 * time.Second)
 
+	registerAuthz(srv)
+
 	if !options.UseGrpc && !options.UseRest {
 		logger.Error("No transports enabled", "error", "at least one of gRPC or REST transport must be enabled in config")
 		os.Exit(1)

--- a/sdks/go/pkg/catena/handler_context.go
+++ b/sdks/go/pkg/catena/handler_context.go
@@ -101,6 +101,15 @@ func (ctx HandlerContext) HasWriteScope(scopeName string) bool {
 	return ok
 }
 
+// AuthzEnabled reports whether the server is enforcing authorization for this
+// request. When false, the HasReadScope/HasWriteScope helpers return true for
+// every scope regardless of the caller, so handlers that surface per-user,
+// token-derived information should branch on this rather than trusting the
+// scope helpers.
+func (ctx HandlerContext) AuthzEnabled() bool {
+	return ctx.authzEnabled
+}
+
 // RequireReadScope is the enforcing counterpart to HasReadScope: it returns an
 // OK StatusResult when the caller holds the named read scope and a
 // PermissionDenied result with a standard message otherwise. Prefer it over

--- a/sdks/go/pkg/catena/handler_context_test.go
+++ b/sdks/go/pkg/catena/handler_context_test.go
@@ -55,6 +55,18 @@ func TestHandlerContext(t *testing.T) {
 		}
 	})
 
+	t.Run("AuthzEnabled", func(t *testing.T) {
+		enabled := HandlerContext{authzEnabled: true}
+		if !enabled.AuthzEnabled() {
+			t.Fatal("expected AuthzEnabled to return true when authz is enabled")
+		}
+
+		disabled := HandlerContext{authzEnabled: false}
+		if disabled.AuthzEnabled() {
+			t.Fatal("expected AuthzEnabled to return false when authz is disabled")
+		}
+	})
+
 	t.Run("ScopeChecksUseSeparateReadAndWriteScopes", func(t *testing.T) {
 		readOnly := HandlerContext{
 			readScopes:   map[string]struct{}{st2138.ScopeMon: {}},

--- a/sdks/go/pkg/catena/status_code.go
+++ b/sdks/go/pkg/catena/status_code.go
@@ -170,3 +170,13 @@ func ReplyError[T ResponseType](code StatusCode, msg string) (T, StatusResult) {
 func StatusWithCode(code StatusCode, msg string) StatusResult {
 	return StatusResult{Code: code, Error: msg}
 }
+
+// StatusOk returns a StatusResult with StatusCodeOk and no message.
+func StatusOk() StatusResult {
+	return StatusWithCode(StatusCodeOk, "")
+}
+
+// StatusError returns a StatusResult with StatusCodeInternal and the error message.
+func StatusError(err error) StatusResult {
+	return StatusWithCode(StatusCodeInternal, err.Error())
+}

--- a/sdks/go/pkg/catena/status_code_test.go
+++ b/sdks/go/pkg/catena/status_code_test.go
@@ -167,6 +167,29 @@ func TestStatusWithCode_NoMessage(t *testing.T) {
 	}
 }
 
+func TestStatusOk(t *testing.T) {
+	status := StatusOk()
+
+	if status.Code != StatusCodeOk {
+		t.Errorf("StatusOk code = %d, want %d", status.Code, StatusCodeOk)
+	}
+	if status.Error != "" {
+		t.Errorf("StatusOk error = %q, want empty", status.Error)
+	}
+}
+
+func TestStatusError(t *testing.T) {
+	err := fmt.Errorf("something went wrong")
+	status := StatusError(err)
+
+	if status.Code != StatusCodeInternal {
+		t.Errorf("StatusError code = %d, want %d", status.Code, StatusCodeInternal)
+	}
+	if status.Error != "something went wrong" {
+		t.Errorf("StatusError error = %q, want 'something went wrong'", status.Error)
+	}
+}
+
 func TestStatusResult_Fields(t *testing.T) {
 	result := StatusResult{
 		Code:  StatusCodeNotFound,


### PR DESCRIPTION
Making an authz slot to demo login with DB

Also 2 quick status code helpers:
- `StatusOk()` makes a `StatusResult` with code: `StatusCodeOk`. Equivalent to `StatusWithCode(StatusCodeOk, "")`
- `StatusError()` makes a `StatusResult` out of a go `error`. Equivalent to `StatusWithCode(StatusCodeInternal, err.Error())`

And a `AuthzEnabled()` getter to `HandlerContext` to simplify handlers checking if authz is enabled or not. Its not leaking secret information as its the BL that declared if authz is enabled or not, this just saves BL from passing `ServerOptions` around everywhere.